### PR TITLE
Enable Clang frontend to handle simple C++ axpy example

### DIFF
--- a/docs/axpy_clang_frontend.md
+++ b/docs/axpy_clang_frontend.md
@@ -1,0 +1,89 @@
+# AXPY End-to-End Runbook with Clang/Flang
+
+This note captures the steps, roadblocks, and fixes required to get a pure C++
+AXPY example working end-to-end with the experimental Clang frontend in REX.
+
+## Toolchain & Build
+
+- Configured a fresh `build-clang` tree with `clang-20`, `clang++-20`, and
+  `flang-20` as the backend compilers:
+  ```sh
+  cmake -S . -B build-clang \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=/usr/lib/llvm-20/bin/clang \
+    -DCMAKE_CXX_COMPILER=/usr/lib/llvm-20/bin/clang++ \
+    -DCMAKE_Fortran_COMPILER=/usr/lib/llvm-20/bin/flang \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -Denable-c=ON -Denable-fortran=ON
+  cmake --build build-clang -j$(nproc)
+  ```
+- All invocations of `rose-compiler` require `LD_LIBRARY_PATH` to point at the
+  freshly built `build-clang/lib` directory.
+
+## Source Example
+
+- Added `tests/nonsmoke/functional/input_codes/axpy.cpp` as a minimal C++
+  example that avoids STL usage and anonymous namespaces so that the current
+  frontend can process it.
+- The program initialises two fixed-size buffers, performs the AXPY loop, and
+  returns `0`/`1` based on a relative-error check (no runtime I/O needed).
+
+## Frontend Issues & Fixes
+
+1. **Missing language defaults for C++**  
+   - *Symptom*: Including even `<cmath>` produced thousands of errors like
+     `unknown type name 'bool'` and missing `__builtin_*` intrinsics.  
+   - *Root cause*: We were never initialising `clang::LangOptions` with C++
+     defaults; the invocation inherited C-like settings from
+     `CompilerInvocation::CreateFromArgs`.  
+   - *Fix*: Call `clang::LangOptions::setLangDefaults` with the host triple and
+     `lang_gnucxx17` (see `src/frontend/CxxFrontend/Clang/clang-frontend.cpp:268`).
+     We collect any implicit include paths returned by that helper and append
+     them back into the active `PreprocessorOptions`.
+
+2. **Unhandled `LinkageSpecDecl` (extern "C"/"C++")**  
+   - *Symptom*: Parsing headers that contain `extern "C"` blocks aborted with
+     `Unknown declaration kind: LinkageSpec !`.  
+   - *Fix*: Added a traversal case for `clang::Decl::LinkageSpec` that recursively
+     visits contained declarations and reuses the current scope when appending
+     the resulting `SgDeclarationStatement` nodes
+     (`src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp:666`).
+   - *Limitation*: We currently do not emit dedicated `SgClinkage*` nodes, so
+     linkage metadata is dropped, but this is sufficient for ingestion.
+
+3. **Anonymous namespace handling**  
+   - *Symptom*: The translator asserted inside
+     `buildDefiningFunctionDeclaration_T` when processing a file that declared
+     helper routines inside `namespace { ... }`.  
+   - *Workaround*: Keep helper routines at global scope and mark them `static`.
+     This sidesteps unimplemented namespace support in the current frontend.
+
+## Validation Flow
+
+1. Run the translator to generate `rose_axpy.cpp`:
+   ```sh
+   LD_LIBRARY_PATH=$PWD/build-clang/lib \
+     ./build-clang/bin/rose-compiler tests/nonsmoke/functional/input_codes/axpy.cpp
+   ```
+   Output appears at the repository root.
+2. Verify both the original and generated sources compile and execute cleanly:
+   ```sh
+   clang++ tests/nonsmoke/functional/input_codes/axpy.cpp -O2 -o /tmp/axpy_orig
+   clang++ rose_axpy.cpp -O2 -o /tmp/axpy_rose
+   /tmp/axpy_orig && /tmp/axpy_rose   # both exit 0
+   ```
+
+## Limitations & Next Steps
+
+- **Scope leakage for loop indices**: the current Clang bridge appends `for`-loop induction variables to the surrounding `SgBasicBlock` (see `src/frontend/CxxFrontend/Clang/clang-frontend.cpp:125` onward). When multiple loops reuse the name `i`, the containing block reports duplicate `SgVariableSymbol`s, which triggers the name-qualification warning even though the source is well-formed.
+- **Root cause**: the translator never attaches those declarations to the loop-specific `SgForInitStatement`. Instead, it pushes the surrounding block scope and emits the declaration there. Name qualification therefore believes two unrelated loops share a single scope.
+- **Proposed fix**: adjust the Clang frontend to build a dedicated scope for each `SgForStatement` init clause and append the induction variable there (mirroring EDG and Clang AST semantics). After that, the duplicated-symbol warning can be reinstated without noise.
+- **Follow-up**: track this as a frontend bug (e.g. `ROSE-XXXX`) and add a regression test that exercises consecutive loops with the same index name.
+
+## Known Gaps
+
+- The frontend still struggles with standard C++ library headers, templates,
+  and richer language constructs. Keep examples limited to plain C-style
+  constructs for now.
+- Linkage specifications are flattened; follow-up work is needed if downstream
+  analyses require exact `extern` metadata.

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
@@ -36,6 +36,7 @@
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/LangStandard.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
@@ -45,6 +46,7 @@
 
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/PreprocessorOptions.h"
 
 #include "clang/Basic/DiagnosticOptions.h"
 
@@ -65,6 +67,7 @@
 #include "llvm/Config/llvm-config.h"
 
 #include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/raw_os_ostream.h"
 
@@ -225,6 +228,7 @@ class ClangToSageTranslator : public clang::ASTConsumer {
                 virtual bool VisitLabelDecl(clang::LabelDecl * label_decl, SgNode ** node);
                 virtual bool VisitNamespaceAliasDecl(clang::NamespaceAliasDecl * namespace_alias_decl, SgNode ** node);
                 virtual bool VisitNamespaceDecl(clang::NamespaceDecl * namespace_decl, SgNode ** node);
+                virtual bool VisitLinkageSpecDecl(clang::LinkageSpecDecl * linkage_spec_decl, SgNode ** node);
               //virtual bool VisitObjCCompatibleAliasDecl
               //virtual bool VisitObjCContainerDecl
                   //virtual bool VisitObjCCategoryDecl
@@ -638,4 +642,3 @@ class PreprocessorInserter : public AstTopDownProcessing<NextPreprocessorToInser
 };
 
 #endif /* _CLANG_FRONTEND_PRIVATE_HPP_ */
-

--- a/tests/nonsmoke/functional/input_codes/axpy.cpp
+++ b/tests/nonsmoke/functional/input_codes/axpy.cpp
@@ -1,0 +1,42 @@
+static void axpy(double a, const double *x, double *y, int n) {
+  for (int i = 0; i < n; ++i) {
+    y[i] = a * x[i] + y[i];
+  }
+}
+
+static double checksum(const double *values, int n) {
+  double sum = 0.0;
+  for (int i = 0; i < n; ++i) {
+    sum += values[i];
+  }
+  return sum;
+}
+
+int main() {
+  const int n = 1 << 10; // 1024 elements
+  const double a = 2.5;
+
+  double x[1 << 10];
+  double y[1 << 10];
+
+  for (int i = 0; i < n; ++i) {
+    x[i] = (double)i;
+    y[i] = (double)(2 * i);
+  }
+
+  axpy(a, x, y, n);
+
+  const double result = checksum(y, n);
+  const double expected = (a + 2.0) * (double)((n - 1) * n) * 0.5;
+
+  double diff = result - expected;
+  if (diff < 0.0) {
+    diff = -diff;
+  }
+  const double rel_error = diff / expected;
+  if (rel_error > 1e-9) {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
- initialise Clang LangOptions with setLangDefaults and keep implicit includes\n- visit LinkageSpecDecl by reattaching child decls to the active scope\n- add minimal axpy smoke input plus docs covering the end-to-end
  workflow