### PR TITLE
Fix Clang name qualification symbol duplication

### DIFF
--- a/src/backend/unparser/nameQualificationSupport.C
+++ b/src/backend/unparser/nameQualificationSupport.C
@@ -7,55 +7,6 @@ using namespace std;
 
 namespace si = SageInterface;
 
-namespace {
-
-int countDeclarationsInList(const SgStatementPtrList &stmts, const SgName &name) {
-    int count = 0;
-    for (SgStatement *stmt : stmts) {
-        if (auto *var_decl = isSgVariableDeclaration(stmt)) {
-            for (SgInitializedName *init : var_decl->get_variables()) {
-                if (init->get_name() == name)
-                    ++count;
-            }
-        } else if (auto *for_stmt = isSgForStatement(stmt)) {
-            if (SgForInitStatement *init = for_stmt->get_for_init_stmt()) {
-                count += countDeclarationsInList(init->get_init_stmt(), name);
-            }
-        }
-    }
-    return count;
-}
-
-int countDeclarationsInList(const SgDeclarationStatementPtrList &decls, const SgName &name) {
-    int count = 0;
-    for (SgDeclarationStatement *decl : decls) {
-        if (auto *var_decl = isSgVariableDeclaration(decl)) {
-            for (SgInitializedName *init : var_decl->get_variables()) {
-                if (init->get_name() == name)
-                    ++count;
-            }
-        }
-    }
-    return count;
-}
-
-int countLocalVariableDeclarations(SgScopeStatement *scope, const SgName &name) {
-    if (auto *block = isSgBasicBlock(scope)) {
-        return countDeclarationsInList(block->get_statements(), name);
-    }
-    if (auto *global = isSgGlobal(scope)) {
-        return countDeclarationsInList(global->get_declarations(), name);
-    }
-    if (auto *for_stmt = isSgForStatement(scope)) {
-        if (SgForInitStatement *init = for_stmt->get_for_init_stmt())
-            return countDeclarationsInList(init->get_init_stmt(), name);
-        return 0;
-    }
-    return -1;
-}
-
-} // namespace
-
 // This value must be greater than 3 to cause most output to be generated.
 #define DEBUG_NAME_QUALIFICATION_LEVEL 0
 
@@ -12739,9 +12690,6 @@ NameQualificationTraversal::evaluateInheritedAttribute(SgNode* n, NameQualificat
                            // DQ (12/23/2015): Note that this is not a count of the SgVariableSymbol IR nodes.
                            // size_t numberOfSymbolsWithSameName = currentScope->count_symbol(name);
                               int numberOfSymbolsWithSameName = (int)currentScope->count_symbol(name);
-                              int localDeclCount = countLocalVariableDeclarations(currentScope, name);
-                              if (localDeclCount >= 0)
-                                  numberOfSymbolsWithSameName = localDeclCount;
 
 #if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
                               MLOG_WARN_C(MLOG_UNPARSER, "SgVarRefExp's SgDeclarationStatement: numberOfSymbolsWithSameName       = %d \n",numberOfSymbolsWithSameName);

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -1985,9 +1985,6 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl * var_decl, SgNode ** no
     ROSE_ASSERT(var_def != NULL);
     applySourceRange(var_def, var_decl->getSourceRange());
 
-    SgVariableSymbol * var_symbol = new SgVariableSymbol(init_name);
-    SageBuilder::topScopeStack()->insert_symbol(name, var_symbol);
-
     // Pei-Hung (06/16/22) added "extern" modifier
     bool hasExternalStorage = var_decl->hasExternalStorage();
     if(hasExternalStorage)


### PR DESCRIPTION
## Summary

This PR fixes a critical symbol duplication bug in the Clang frontend that was causing excessive name-qualification warnings in the unparser for block-local variables, particularly `for`-loop indices.

### Root Cause

The Clang bridge in `clang-frontend-decl.cpp` was manually inserting a `SgVariableSymbol` into the current scope after calling `SageBuilder::buildVariableDeclaration_nfi`, but the builder already inserts the symbol automatically. This double insertion inflated the scope's symbol table, fooling the unparser into thinking multiple declarations existed.

### Changes

1. **`src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp`**
   - Removed manual `insert_symbol` call after variable declaration (lines 1988-1990)
   - Now rely on `SageBuilder` to manage the symbol table correctly

2. **`src/backend/unparser/nameQualificationSupport.C`**
   - Removed workaround code that tried to count "real" declarations vs. duplicate symbols (52 lines)
   - Reverted to using scope's `count_symbol()` directly since duplicates no longer exist

3. **`docs/axpy_clang_frontend.md`**
   - Updated documentation to reflect the fix
   - Added Issue #4 describing the problem and solution

### Impact

- Eliminates false name-qualification warnings for block-local variables
- Simplifies the unparser logic by removing workaround code
- Fixes symbol table integrity in the Clang frontend

### Testing

The AXPY C++ example now compiles cleanly without spurious warnings about variable references needing qualification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)