### PR TITLE
Enable Clang OpenMP pragma passthrough

### DIFF
--- a/docs/clang-openmp-notes.md
+++ b/docs/clang-openmp-notes.md
@@ -1,0 +1,44 @@
+## Clang Frontend OpenMP Handling Notes
+
+### Context
+- Target input: `tests/nonsmoke/functional/input_codes/axpy_omp.c`.
+- Goal: compile the source with `./build/bin/rose-compiler` while ensuring generated code (`rose_axpy_omp.c`) preserves OpenMP pragmas and is accepted by stock `clang`.
+- Environment: Clang/LLVM 20 frontend in ROSE (“rex”).
+
+### Findings & Fixes
+- **Clang builtin redeclarations**: local prototypes for `__builtin_va_start/__builtin_va_end/__builtin_alloca` conflicted with the Clang 20 headers. Added `__has_builtin` guards and adjusted signatures to match Clang’s runtime expectations.
+- **OpenMP command-line detection**: prior behaviour never forwarded `-fopenmp` to Clang, so OpenMP constructs were ignored. The frontend now:
+  - Detects `-fopenmp`, `-fopenmp-simd`, and `_OPENMP` defines.
+  - Sets `LangOptions::OpenMP/OpenMPSimd` when present.
+  - For pure passthrough mode it suppresses reinsertion of `_OPENMP` into `define_list`, avoiding macro redefinition.
+- **Loop condition canonicalization**: Clang unparses `for (int i = 0; ((long)((int)i)) < ((long)n); ++i)` inside OpenMP regions. Clang’s OMP semantic checks reject that. `VisitForStmt` now strips redundant cast layers before rebuilding the test expression so the unparser emits `i < n`.
+- **Pragma preservation**: Instead of dropping the directive or asserting, `VisitOMPExecutableDirective` captures the source text (`#pragma ...`) and attaches it as `PreprocessingInfo` to the associated statement. During unparsing the original directive is reproduced verbatim, satisfying the passthrough requirement.
+- **Captured statements**: OpenMP target regions introduce `CapturedStmt` nodes. The previous `ROSE_ASSERT(FAIL_TODO==0)` aborted. The traversal now simply forwards the captured body (or inserts a null statement), enabling the generic pragma path.
+- **Array subscripting casts**: the earlier generated code used nested casts such as `((char *)((char **)argv)[1])`. `VisitArraySubscriptExpr` now normalises pointer casts when the base expression originates from an array decaying to a pointer, preventing `-Wint-to-pointer-cast`.
+
+### Proposed Mode Strategy
+
+1. **Pure passthrough (current focus)**  
+   - Triggered when users supply `-fopenmp` without ROSE-specific OpenMP controls.  
+   - Behaviour: treat OpenMP directives as opaque text, attach them (as `SgPragmaDeclaration` or `PreprocessingInfo`), do *not* build ROSE OpenMP IR. Unparser emits original pragmas. Generated C is accepted by `clang -fopenmp`.  
+   - Status: implemented with `PreprocessingInfo` attachment.
+
+2. **ROSE OpenMP AST construction + lowering (future)**  
+   - Triggered by `-fopenmp` plus existing `-rose:openmp:*` options.  
+   - Behaviour: reuse the mature EDG-based pipeline—parse pragmas, build ROSE OpenMP IR, then generate lowered multithreaded code. Clang frontend would need parity with the EDG path (currently incomplete).
+
+3. **Clang-native OpenMP-to-SAGE translation (long-term)**  
+   - Triggered by an explicit `--rex-openmp-clang` or similar.  
+   - Behaviour: rely on Clang’s OpenMP AST nodes to build precise ROSE IR, bypassing text-based handling.  
+   - Status: not yet implemented; would require comprehensive mapping from Clang OpenMP classes to `SgOmp*` nodes.
+
+### Outstanding Items
+- Evaluate whether pure passthrough should use `SgPragmaDeclaration` instead of raw `PreprocessingInfo` for improved tooling compatibility.
+- Investigate compatibility of existing ROSE OpenMP lowering passes when driven from Clang ASTs (mode 2).
+- Design command-line UX for selecting between modes 1–3 without confusing EDG users.
+- Add regression coverage: run `rose-compiler -fopenmp` and verify that the emitted pragmas and loop headers remain canonical.
+
+### Practical Notes
+- The current passthrough path allows the user to recompile the generated file with `clang-20 -fopenmp` successfully.
+- When no OpenMP flags are supplied, pragmas remain untouched but Clang also does not attempt to parse them as structured directives, matching EDG’s historical behaviour.
+- Mode selection logic lives entirely in `clang-frontend.cpp`; no build-system changes are required.

--- a/src/frontend/CxxFrontend/Clang/clang-builtin-c.h
+++ b/src/frontend/CxxFrontend/Clang/clang-builtin-c.h
@@ -5,8 +5,20 @@
 // the input code is defined using -DSKIP_ROSE_BUILTIN_DECLARATIONS
 #ifndef SKIP_ROSE_BUILTIN_DECLARATIONS
 
-void * __builtin_va_start(__builtin_va_list, ...);
-void * __builtin_va_end(__builtin_va_list);
-void *__builtin_alloca (unsigned size);
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if !__has_builtin(__builtin_va_start)
+void __builtin_va_start(__builtin_va_list, ...);
+#endif
+
+#if !__has_builtin(__builtin_va_end)
+void __builtin_va_end(__builtin_va_list);
+#endif
+
+#if !__has_builtin(__builtin_alloca)
+void *__builtin_alloca(__SIZE_TYPE__ size);
+#endif
 
 #endif


### PR DESCRIPTION
## Summary

This PR enables OpenMP pragma passthrough in the Clang frontend, allowing REX to preserve OpenMP directives when processing C code with `-fopenmp` flags. The generated code can be successfully recompiled with `clang -fopenmp`.

### Key Changes

- **OpenMP Command-Line Detection**: The frontend now detects `-fopenmp`, `-fopenmp-simd`, and `_OPENMP` defines, enabling OpenMP language options without macro redefinition
- **Pragma Preservation**: OpenMP directives are captured from source and attached as `PreprocessingInfo`, ensuring they're reproduced verbatim during unparsing
- **Captured Statement Handling**: Fixed crashes on OpenMP target regions by properly handling `CapturedStmt` nodes
- **Loop Condition Canonicalization**: Strip redundant cast layers in loop conditions to satisfy Clang's OpenMP semantic checks
- **Array Subscripting Cast Normalization**: Fixed pointer cast issues in array subscript expressions to prevent compiler warnings
- **Builtin Declaration Guards**: Added `__has_builtin` guards to prevent conflicts with Clang 20 headers

### Files Changed

- `docs/clang-openmp-notes.md` (new): Comprehensive documentation of OpenMP handling modes and implementation details
- `src/frontend/CxxFrontend/Clang/clang-frontend.cpp`: OpenMP flag detection and language option configuration
- `src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp`: Statement translation improvements for OpenMP constructs
- `src/frontend/CxxFrontend/Clang/clang-builtin-c.h`: Builtin declaration fixes

### Implementation Details

**Pure Passthrough Mode (Current)**: When users supply `-fopenmp` without ROSE-specific controls, OpenMP directives are treated as opaque text and attached to the AST. The unparser emits the original pragmas, ensuring generated code compiles with `clang -fopenmp`.

**Future Modes**:
- ROSE OpenMP AST construction + lowering (reuse existing EDG-based pipeline)
- Clang-native OpenMP-to-SAGE translation (leverage Clang's OpenMP AST nodes)

### Test Case

Successfully processes `tests/nonsmoke/functional/input_codes/axpy_omp.c` with OpenMP pragmas preserved in the generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)