### PR TITLE
Handle wrapped inline tags in compound literals

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -2909,6 +2909,73 @@ bool ClangToSageTranslator::VisitCompoundLiteralExpr(clang::CompoundLiteralExpr 
 
     scope->insert_symbol(name,vsym);
 
+    // REX FIX: Check if the type is defined inside the compound literal
+    // If so, mark the declaration as non-autonomous so it gets unparsed
+    // correctly
+    if (clang::TypeSourceInfo *TInfo = compound_literal->getTypeSourceInfo()) {
+      clang::TypeLoc TL = TInfo->getTypeLoc();
+      // Drill down to the underlying TagTypeLoc, stripping common wrappers
+      // (const qualifiers, parens, attributes, arrays, pointers, elaborations).
+      while (true) {
+        bool advanced = false;
+
+        // Strip top-level qualifiers
+        TL = TL.getUnqualifiedLoc();
+
+        if (auto ParenTL = TL.getAs<clang::ParenTypeLoc>()) {
+          TL = ParenTL.getInnerLoc();
+          advanced = true;
+        } else if (auto AttrTL = TL.getAs<clang::AttributedTypeLoc>()) {
+          TL = AttrTL.getModifiedLoc();
+          advanced = true;
+        } else if (auto AdjTL = TL.getAs<clang::AdjustedTypeLoc>()) {
+          TL = AdjTL.getOriginalLoc();
+          advanced = true;
+        } else if (auto ETL = TL.getAs<clang::ElaboratedTypeLoc>()) {
+          TL = ETL.getNamedTypeLoc();
+          advanced = true;
+        } else if (auto ATL = TL.getAs<clang::ArrayTypeLoc>()) {
+          TL = ATL.getElementLoc();
+          advanced = true;
+        } else if (auto PTL = TL.getAs<clang::PointerTypeLoc>()) {
+          TL = PTL.getPointeeLoc();
+          advanced = true;
+        }
+
+        if (!advanced)
+          break;
+      }
+
+      if (auto TagTL = TL.getAs<clang::TagTypeLoc>()) {
+        if (TagTL.isDefinition()) {
+          clang::TagDecl *TD = TagTL.getDecl();
+          std::map<clang::Decl *, SgNode *>::iterator it =
+              p_decl_translation_map.find(TD);
+          if (it != p_decl_translation_map.end()) {
+            SgNode *node = it->second;
+            if (SgClassDeclaration *classDecl = isSgClassDeclaration(node)) {
+              classDecl->set_isAutonomousDeclaration(false);
+              if (classDecl->get_definingDeclaration()) {
+                if (SgClassDeclaration *defDecl = isSgClassDeclaration(
+                        classDecl->get_definingDeclaration())) {
+                  defDecl->set_isAutonomousDeclaration(false);
+                }
+              }
+            } else if (SgEnumDeclaration *enumDecl =
+                           isSgEnumDeclaration(node)) {
+              enumDecl->set_isAutonomousDeclaration(false);
+              if (enumDecl->get_definingDeclaration()) {
+                if (SgEnumDeclaration *defDecl = isSgEnumDeclaration(
+                        enumDecl->get_definingDeclaration())) {
+                  defDecl->set_isAutonomousDeclaration(false);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     *node = SageBuilder::buildCompoundLiteralExp_nfi(vsym);
 
     return VisitExpr(compound_literal, node);

--- a/tests/nonsmoke/functional/CompileTests/C_tests/C_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/C_Testcodes.cmake
@@ -709,6 +709,7 @@ set(TESTCODES_REQUIRED_TO_PASS
   test2022_01.c
   test2022_02.c
   test2022_03.c
+  rex_compound_literal_wrapped.c
   testAnsiC.c
   testCvsCpp.c
   test_CplusplusMacro_C.c

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_compound_literal_wrapped.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_compound_literal_wrapped.c
@@ -1,0 +1,18 @@
+// Verifies that compound literals with inline tag definitions wrapped in
+// qualifiers/attributes keep the definition embedded (not emitted
+// autonomously).
+
+int take(void);
+
+int wrapped_compound_literal(void) {
+  // Type is qualified, attributed, and parenthesized: (const struct
+  // __attribute__((aligned(32))) { int x; }) The inline struct definition must
+  // stay with the literal during unparsing.
+  return ((const struct __attribute__((aligned(32))) { int x; }){.x = 5}).x +
+         take();
+}
+
+int take(void) {
+  // Another variant with nested parentheses to exercise ParenTypeLoc handling.
+  return (((const struct __attribute__((aligned(8))) { int y; }){.y = 7})).y;
+}


### PR DESCRIPTION
## Summary
- Ensure compound literals keep inline tag definitions embedded even when the type is wrapped in qualifiers/attributes/paren layers.
- Add regression coverage for wrapped inline-tag compound literals in C_tests.

## Problem
- C compound literals can define a struct/union/enum inline, and the written type may be wrapped (e.g., `(const struct __attribute__((aligned(32))) { int x; }){ .x = 5 }`).
- The Clang frontend only peeled elaborated/array/pointer layers before looking for a `TagTypeLoc`, so wrapped inline tags were missed and left `isAutonomousDeclaration=true`.
- The unparser then emitted the tag definition separately or dropped it, breaking correctness. Previously reproduced in C_tests_test2012_46, C_tests_test2012_47, C_tests_test2013_34, C_tests_test2019_01.

## Root cause
- In `VisitCompoundLiteralExpr`, type unwrapping stopped too early: `TagTypeLoc` inside qualifiers/attributes/parens was never reached, so inline tag definitions were treated as standalone.

## Fix
- Strip qualifiers, parens, attributes, and adjusted types (alongside elaborated/array/pointer) before checking for `TagTypeLoc`.
- When the `TagTypeLoc` is a definition, mark both the first and defining declarations as non-autonomous so the definition stays embedded with the compound literal.
- Add regression test `rex_compound_literal_wrapped.c` to cover inline tag definitions wrapped in qualifiers/attributes and ensure the literal unparses correctly.

## Testing
- ./build/bin/testTranslator -rose:verbose 0 -c tests/nonsmoke/functional/CompileTests/C_tests/rex_compound_literal_wrapped.c
- Previously failing cases now passing with this change: C_tests_test2012_46, C_tests_test2012_47, C_tests_test2013_34, C_tests_test2019_01.
