### PR TITLE
Reduce doc build scope to headers

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -15,6 +15,7 @@ GENERATE_TREEVIEW      = NO
 INPUT                  = src tools tutorial exampleTranslators README.md
 RECURSIVE              = YES
 FILE_PATTERNS          = *.h *.hh *.hpp *.hxx *.md
+EXCLUDE                = src/frontend/SageIII/ompparser src/frontend/SageIII/accparser
 EXCLUDE_PATTERNS       = */tests/* */external/* */third_party/* */3rdPartyLibraries/* */build/* docs/_build/* */.git/*
 STRIP_FROM_PATH        = .
 SOURCE_BROWSER         = NO

--- a/docs/Doxyfile.dev
+++ b/docs/Doxyfile.dev
@@ -14,7 +14,8 @@ GENERATE_TREEVIEW      = NO
 
 INPUT                  = src tools tutorial exampleTranslators README.md
 RECURSIVE              = YES
-FILE_PATTERNS          = *.h *.hh *.hpp *.hxx *.c *.cc *.cpp *.cxx *.md
+FILE_PATTERNS          = *.h *.hh *.hpp *.hxx *.md
+EXCLUDE                = src/frontend/SageIII/ompparser src/frontend/SageIII/accparser
 EXCLUDE_PATTERNS       = */tests/* */external/* */third_party/* */3rdPartyLibraries/* */build/* docs/_build/* */.git/*
 STRIP_FROM_PATH        = .
 SOURCE_BROWSER         = NO


### PR DESCRIPTION
## Summary
- limit both user and dev Doxygen configs to header files (retain markdown) to shrink doc build size/time
- exclude submodule trees  and  from docs input

## Rationale
- upstream ROSE dev docs are header-only; dropping cpp/c files and submodules should cut node count and runtime while keeping API coverage

## Testing
- configuration-only change (no build run in this PR)