### PR TITLE
Preserve explicit template arguments for function calls

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
@@ -395,6 +395,14 @@ class ClangToSageTranslator : public clang::ASTConsumer {
         // Helper: Build template arguments from Clang
         SgTemplateArgumentPtrList buildTemplateArguments(
             const clang::TemplateSpecializationType* clang_type);
+        SgTemplateArgumentPtrList
+        buildTemplateArguments(const clang::TemplateArgumentListInfo &arg_info,
+                               bool explicitlySpecified = false);
+
+        // Helper: Translate a single template argument
+        SgTemplateArgument *
+        translateTemplateArgument(const clang::TemplateArgument &arg,
+                                  bool explicitlySpecified = false);
 
         // Helper: Build template parameters (inferred from arguments)
         SgTemplateParameterPtrList* buildTemplateParameters(

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -3770,74 +3770,159 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr * decl_ref_expr,
           if (var_sym != NULL) 
              {
                *node = SageBuilder::buildVarRefExp(var_sym);
-             }
-            else 
-             {
-               if (func_sym != NULL)
-                  {
-                    *node = SageBuilder::buildFunctionRefExp(func_sym);
+          } else {
+            if (func_sym != NULL) {
+              SgFunctionSymbol *ref_func_sym = func_sym;
 
-                    // ROOT CAUSE FIX: Set qualified name prefix (namespace) from Clang declaration
-                    // This preserves namespace information (e.g., std::) even when scope is global
-                    SgFunctionRefExp* func_ref = isSgFunctionRefExp(*node);
-                    if (func_ref != NULL) {
-                        clang::FunctionDecl* func_decl = llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl());
-                        if (func_decl != NULL) {
-                            std::string qualified_name = func_decl->getQualifiedNameAsString();
-                            std::string simple_name = func_decl->getNameAsString();
-                            // Extract namespace prefix by removing simple name from qualified name
-                            if (qualified_name.length() > simple_name.length() &&
-                                qualified_name.substr(qualified_name.length() - simple_name.length()) == simple_name) {
-                                // Remove the simple name and the trailing ::
-                                std::string namespace_prefix = qualified_name.substr(0, qualified_name.length() - simple_name.length());
-                                if (namespace_prefix.length() >= 2 && namespace_prefix.substr(namespace_prefix.length() - 2) == "::") {
-                                    namespace_prefix = namespace_prefix.substr(0, namespace_prefix.length() - 2);
-                                }
-                                if (!namespace_prefix.empty()) {
-                                    // Add to global qualified name map so unparser can retrieve it
-                                    SgNode::get_globalQualifiedNameMapForNames()[func_ref] = namespace_prefix + "::";
-                                }
-                            }
-                        }
+              if (decl_ref_expr->hasExplicitTemplateArgs()) {
+                clang::TemplateArgumentListInfo arg_info;
+                decl_ref_expr->copyTemplateArgumentsInto(arg_info);
+
+                // Mark arguments as explicitly specified so the unparser keeps
+                // them
+                SgTemplateArgumentPtrList template_args =
+                    buildTemplateArguments(arg_info, true);
+
+                SgScopeStatement *func_scope = func_sym->get_scope();
+                if (func_scope == NULL) {
+                  func_scope = SageBuilder::topScopeStack();
+                }
+
+                SgFunctionType *func_type =
+                    isSgFunctionType(func_sym->get_type());
+                SgType *ret_type =
+                    func_type != NULL ? func_type->get_return_type() : NULL;
+                if (ret_type == NULL) {
+                  ret_type = SageBuilder::buildUnknownType();
+                }
+
+                SgFunctionParameterList *param_list = NULL;
+                if (func_type != NULL &&
+                    func_type->get_argument_list() != NULL) {
+                  param_list = SageBuilder::buildFunctionParameterList_nfi(
+                      func_type->get_argument_list());
+                } else {
+                  param_list = SageBuilder::buildFunctionParameterList_nfi();
+                }
+
+                SgTemplateInstantiationFunctionDecl *inst_decl =
+                    isSgTemplateInstantiationFunctionDecl(
+                        SageBuilder::buildNondefiningFunctionDeclaration(
+                            func_sym->get_name(), ret_type, param_list,
+                            func_scope,
+                            /*decoratorList=*/NULL,
+                            /*buildTemplateInstantiation=*/true, &template_args,
+                            SgStorageModifier::e_default,
+                            /*forceFreeFunctionScope=*/false));
+
+                if (inst_decl != NULL) {
+                  inst_decl->set_template_argument_list_is_explicit(true);
+                  inst_decl->get_templateArguments() = template_args;
+
+                  SgFunctionDeclaration *base_decl =
+                      isSgFunctionDeclaration(func_sym->get_declaration());
+                  if (base_decl != NULL) {
+                    if (SgTemplateFunctionDeclaration *tmpl_decl =
+                            isSgTemplateFunctionDeclaration(base_decl)) {
+                      inst_decl->set_templateDeclaration(tmpl_decl);
+                      inst_decl->set_templateName(tmpl_decl->get_name());
+                    } else if (
+                        SgTemplateFunctionDeclaration *first_nondef =
+                            isSgTemplateFunctionDeclaration(
+                                base_decl->get_firstNondefiningDeclaration())) {
+                      inst_decl->set_templateDeclaration(first_nondef);
+                      inst_decl->set_templateName(first_nondef->get_name());
                     }
                   }
-                 else
-                  {
-                    if (enum_sym != NULL)
-                       {
-                         // ROOT CAUSE FIX: Get enum declaration from the type instead of parent
-                         // The Clang frontend may not set parent pointers correctly for enum constants
-                         // But the type is always set correctly to an SgEnumType
-                         SgInitializedName* init_name = enum_sym->get_declaration();
-                         SgEnumDeclaration * enum_decl = NULL;
 
-                         if (init_name != NULL && init_name->get_type() != NULL) {
-                             SgEnumType* enum_type = isSgEnumType(init_name->get_type());
-                             if (enum_type != NULL) {
-                                 enum_decl = isSgEnumDeclaration(enum_type->get_declaration());
-                             }
-                         }
-
-                         // Fallback: try getting from parent if type method didn't work
-                         if (enum_decl == NULL && init_name != NULL) {
-                             enum_decl = isSgEnumDeclaration(init_name->get_parent());
-                         }
-
-                         ROSE_ASSERT(enum_decl != NULL);
-                         SgName name = enum_sym->get_name();
-                         *node = SageBuilder::buildEnumVal_nfi(0, enum_decl, name);
-                       }
-                      else
-                       {
-                         if (sym != NULL)
-                            {
-                              std::cerr << "Runtime error: Unknown type of symbol for a declaration reference." << std::endl;
-                              std::cerr << "    sym->class_name() = " << sym->class_name()  << std::endl;
-                              ROSE_ABORT();
-                            }
-                       }
+                  SgFunctionSymbol *inst_sym = isSgFunctionSymbol(
+                      inst_decl->get_symbol_from_symbol_table());
+                  if (inst_sym == NULL && func_scope != NULL &&
+                      func_type != NULL) {
+                    inst_sym = func_scope->lookup_function_symbol(
+                        func_sym->get_name(), func_type);
                   }
-             }
+                  if (inst_sym != NULL) {
+                    ref_func_sym = inst_sym;
+                  }
+                }
+              }
+
+              *node = SageBuilder::buildFunctionRefExp(ref_func_sym);
+
+              // ROOT CAUSE FIX: Set qualified name prefix (namespace) from
+              // Clang declaration This preserves namespace information (e.g.,
+              // std::) even when scope is global
+              SgFunctionRefExp *func_ref = isSgFunctionRefExp(*node);
+              if (func_ref != NULL) {
+                clang::FunctionDecl *func_decl =
+                    llvm::dyn_cast<clang::FunctionDecl>(
+                        decl_ref_expr->getDecl());
+                if (func_decl != NULL) {
+                  std::string qualified_name =
+                      func_decl->getQualifiedNameAsString();
+                  std::string simple_name = func_decl->getNameAsString();
+                  // Extract namespace prefix by removing simple name from
+                  // qualified name
+                  if (qualified_name.length() > simple_name.length() &&
+                      qualified_name.substr(qualified_name.length() -
+                                            simple_name.length()) ==
+                          simple_name) {
+                    // Remove the simple name and the trailing ::
+                    std::string namespace_prefix = qualified_name.substr(
+                        0, qualified_name.length() - simple_name.length());
+                    if (namespace_prefix.length() >= 2 &&
+                        namespace_prefix.substr(namespace_prefix.length() -
+                                                2) == "::") {
+                      namespace_prefix = namespace_prefix.substr(
+                          0, namespace_prefix.length() - 2);
+                    }
+                    if (!namespace_prefix.empty()) {
+                      // Add to global qualified name map so unparser can
+                      // retrieve it
+                      SgNode::get_globalQualifiedNameMapForNames()[func_ref] =
+                          namespace_prefix + "::";
+                    }
+                  }
+                }
+              }
+            } else {
+              if (enum_sym != NULL) {
+                // ROOT CAUSE FIX: Get enum declaration from the type instead of
+                // parent The Clang frontend may not set parent pointers
+                // correctly for enum constants But the type is always set
+                // correctly to an SgEnumType
+                SgInitializedName *init_name = enum_sym->get_declaration();
+                SgEnumDeclaration *enum_decl = NULL;
+
+                if (init_name != NULL && init_name->get_type() != NULL) {
+                  SgEnumType *enum_type = isSgEnumType(init_name->get_type());
+                  if (enum_type != NULL) {
+                    enum_decl =
+                        isSgEnumDeclaration(enum_type->get_declaration());
+                  }
+                }
+
+                // Fallback: try getting from parent if type method didn't work
+                if (enum_decl == NULL && init_name != NULL) {
+                  enum_decl = isSgEnumDeclaration(init_name->get_parent());
+                }
+
+                ROSE_ASSERT(enum_decl != NULL);
+                SgName name = enum_sym->get_name();
+                *node = SageBuilder::buildEnumVal_nfi(0, enum_decl, name);
+              } else {
+                if (sym != NULL) {
+                  std::cerr << "Runtime error: Unknown type of symbol for a "
+                               "declaration reference."
+                            << std::endl;
+                  std::cerr << "    sym->class_name() = " << sym->class_name()
+                            << std::endl;
+                  ROSE_ABORT();
+                }
+              }
+            }
+          }
         }
        else
         {

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -1326,109 +1326,113 @@ SgExpression* buildIntegralTemplateArgExpr(const llvm::APSInt& value, SgType* in
 }
 } // namespace
 
-SgTemplateArgumentPtrList
-ClangToSageTranslator::buildTemplateArguments(
-    const clang::TemplateSpecializationType* clang_type) {
+SgTemplateArgument *ClangToSageTranslator::translateTemplateArgument(
+    const clang::TemplateArgument &arg, bool explicitlySpecified) {
+  SgTemplateArgument *sg_arg = nullptr;
 
-    SgTemplateArgumentPtrList arg_list;
-
-    auto args = clang_type->template_arguments();
-    // std::cerr << "DEBUG: buildTemplateArguments called with " << args.size() << " arguments" << std::endl;
-    for (const clang::TemplateArgument& arg : args) {
-        // std::cerr << "DEBUG: Processing argument kind: " << arg.getKind() << std::endl;
-        SgTemplateArgument* sg_arg = nullptr;
-
-        switch (arg.getKind()) {
-            case clang::TemplateArgument::Type: {
-                // Type argument (e.g., double)
-                SgType* arg_type = buildTypeFromQualifiedType(arg.getAsType());
-                sg_arg = new SgTemplateArgument(arg_type, false);
-                break;
-            }
-
-            case clang::TemplateArgument::Integral: {
-                // Non-type argument (e.g., 1024)
-                llvm::APSInt value = arg.getAsIntegral();
-                SgType* int_type = buildTypeFromQualifiedType(arg.getIntegralType());
-
-                SgExpression* value_expr = buildIntegralTemplateArgExpr(value, int_type);
-
-                sg_arg = new SgTemplateArgument(
-                    SgTemplateArgument::nontype_argument,
-                    value_expr,
-                    int_type,
-                    nullptr, nullptr, false
-                );
-                
-                // DEBUG
-                // if (sg_arg) std::cerr << "DEBUG: Created SgTemplateArgument for integral" << std::endl;
-                break;
-            }
-
-            case clang::TemplateArgument::Template: {
-                // Template template argument
-                clang::TemplateName template_name = arg.getAsTemplate();
-                clang::TemplateDecl* template_decl = template_name.getAsTemplateDecl();
-                if (template_decl) {
-                    // We need to get the declaration of the template being passed as argument
-                    // For std::tuple, this should be the template declaration
-                    SgDeclarationStatement* sg_decl = (SgDeclarationStatement*)Traverse(template_decl);
-                    
-                    if (sg_decl) {
-                        if (SgTemplateClassDeclaration* class_tmpl = isSgTemplateClassDeclaration(sg_decl)) {
-                             // REX FIX: SgTemplateArgument crashes with SgTemplateClassDeclaration as template_template_argument.
-                             // Fallback to using type_argument with SgTemplateType.
-                             // SgClassType adds "class" keyword which is invalid for template template args.
-                             // SgTemplateType prints just the name.
-                             // Use qualified name to ensure "std::tuple" is printed, not just "tuple".
-                             SgName qual_name = class_tmpl->get_qualified_name();
-                             if (qual_name.getString().find("::") == std::string::npos && class_tmpl->get_scope()) {
-                                 // Fallback if get_qualified_name returns unqualified name (common in some ROSE versions)
-                                 // Manually construct qualified name if scope is namespace
-                                 if (SgNamespaceDefinitionStatement* ns_def = isSgNamespaceDefinitionStatement(class_tmpl->get_scope())) {
-                                     qual_name = ns_def->get_namespaceDeclaration()->get_name().getString() + "::" + class_tmpl->get_name().getString();
-                                 }
-                             }
-                             SgType* type = SageBuilder::buildTemplateType(qual_name);
-                             sg_arg = new SgTemplateArgument(type, false);
-                        } else {
-                             sg_arg = new SgTemplateArgument(SgTemplateArgument::template_template_argument, sg_decl);
-                        }
-                    } else {
-                        std::cerr << "Warning: Failed to translate template declaration for template argument\n";
-                    }
-                }
-                break;
-            }
-
-            case clang::TemplateArgument::Expression: {
-                // std::cerr << "DEBUG: Expression argument" << std::endl;
-                clang::Expr* clang_expr = arg.getAsExpr();
-                if (clang_expr) {
-                    SgNode* node = Traverse(clang_expr);
-                    SgExpression* sg_expr = isSgExpression(node);
-                    if (sg_expr) {
-                         // Use the simpler SgTemplateArgument constructor for expressions
-                         // The constructor signature is: SgTemplateArgument(SgExpression* parameter, bool explicitlySpecified)
-                         sg_arg = new SgTemplateArgument(sg_expr, false);
-                    }
-                }
-                break;
-            }
-
-            default:
-                std::cerr << "Warning: Unsupported template argument kind: " << arg.getKind() << "\n";
-                continue;
-        }
-
-        if (sg_arg) {
-            arg_list.push_back(sg_arg);
-        }
+  switch (arg.getKind()) {
+  case clang::TemplateArgument::Type: {
+    SgType *arg_type = buildTypeFromQualifiedType(arg.getAsType());
+    if (arg_type != NULL) {
+      sg_arg = new SgTemplateArgument(arg_type, explicitlySpecified);
     }
+    break;
+  }
 
-    return arg_list;
+  case clang::TemplateArgument::Integral: {
+    llvm::APSInt value = arg.getAsIntegral();
+    SgType *int_type = buildTypeFromQualifiedType(arg.getIntegralType());
+
+    SgExpression *value_expr = buildIntegralTemplateArgExpr(value, int_type);
+
+    sg_arg =
+        new SgTemplateArgument(SgTemplateArgument::nontype_argument, value_expr,
+                               int_type, nullptr, nullptr, explicitlySpecified);
+    break;
+  }
+
+  case clang::TemplateArgument::Template: {
+    clang::TemplateDecl *template_decl =
+        arg.getAsTemplate().getAsTemplateDecl();
+    if (template_decl != nullptr) {
+      SgDeclarationStatement *sg_decl =
+          (SgDeclarationStatement *)Traverse(template_decl);
+
+      if (sg_decl != nullptr) {
+        if (SgTemplateClassDeclaration *class_tmpl =
+                isSgTemplateClassDeclaration(sg_decl)) {
+          SgName qual_name = class_tmpl->get_qualified_name();
+          if (qual_name.getString().find("::") == std::string::npos &&
+              class_tmpl->get_scope()) {
+            if (SgNamespaceDefinitionStatement *ns_def =
+                    isSgNamespaceDefinitionStatement(class_tmpl->get_scope())) {
+              qual_name =
+                  ns_def->get_namespaceDeclaration()->get_name().getString() +
+                  "::" + class_tmpl->get_name().getString();
+            }
+          }
+          SgType *type = SageBuilder::buildTemplateType(qual_name);
+          sg_arg = new SgTemplateArgument(type, explicitlySpecified);
+        } else {
+          sg_arg = new SgTemplateArgument(
+              SgTemplateArgument::template_template_argument, sg_decl);
+        }
+      } else {
+        std::cerr << "Warning: Failed to translate template declaration "
+                     "for template argument\n";
+      }
+    }
+    break;
+  }
+
+  case clang::TemplateArgument::Expression: {
+    clang::Expr *clang_expr = arg.getAsExpr();
+    if (clang_expr != nullptr) {
+      SgNode *node = Traverse(clang_expr);
+      if (SgExpression *sg_expr = isSgExpression(node)) {
+        sg_arg = new SgTemplateArgument(sg_expr, explicitlySpecified);
+      }
+    }
+    break;
+  }
+
+  default:
+    std::cerr << "Warning: Unsupported template argument kind: "
+              << arg.getKind() << "\n";
+    break;
+  }
+
+  return sg_arg;
 }
 
+SgTemplateArgumentPtrList ClangToSageTranslator::buildTemplateArguments(
+    const clang::TemplateSpecializationType *clang_type) {
+
+  SgTemplateArgumentPtrList arg_list;
+
+  auto args = clang_type->template_arguments();
+  for (const clang::TemplateArgument &arg : args) {
+    if (SgTemplateArgument *sg_arg = translateTemplateArgument(arg, false)) {
+      arg_list.push_back(sg_arg);
+    }
+  }
+
+  return arg_list;
+}
+
+SgTemplateArgumentPtrList ClangToSageTranslator::buildTemplateArguments(
+    const clang::TemplateArgumentListInfo &arg_info, bool explicitlySpecified) {
+  SgTemplateArgumentPtrList arg_list;
+
+  for (const clang::TemplateArgumentLoc &arg_loc : arg_info.arguments()) {
+    if (SgTemplateArgument *sg_arg = translateTemplateArgument(
+            arg_loc.getArgument(), explicitlySpecified)) {
+      arg_list.push_back(sg_arg);
+    }
+  }
+
+  return arg_list;
+}
 
 SgTemplateInstantiationDecl*
 ClangToSageTranslator::getOrCreateTemplateInstantiation(

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -24,6 +24,18 @@ foreach(file_to_test ${CXX_TESTCODES_TO_RUN})
   compile_test(${file_to_test} "Cxx_tests")
 endforeach()
 
+# Verify explicit template arguments are preserved in calls
+add_test(
+  NAME Cxx_tests_rex_test2025_template_call_explicit_args
+  COMMAND sh -c "\"$@\" && grep \"foo<5>\" rose_rex_test2025_template_call.cpp | grep -v \"//\" && grep \"foo<10>\" rose_rex_test2025_template_call.cpp | grep -v \"//\" && ${CMAKE_CXX_COMPILER} -std=c++17 -c rose_rex_test2025_template_call.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_template_call.cpp
+)
+set_tests_properties(Cxx_tests_rex_test2025_template_call_explicit_args PROPERTIES LABELS Cxx_tests)
+
 # REX: This test intentionally fails (it contains a function-try-block which is currently
 # not fully supported and triggers an assertion failure or error). We want to ensure
 # it continues to fail (failure propagation) until properly supported.
@@ -35,4 +47,3 @@ add_test(
   NAME Cxx_tests_rex_test2025_issue99_failure_propagation
   COMMAND sh -c "\"$@\" && exit 1 || exit 0" dummy $<TARGET_FILE:${translator}> ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR} -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue99_failure_propagation.cpp
 )
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -9,6 +9,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   lexPhase2003_01.C
   lulesh.C
   luleshTALC.C
+  rex_test2025_template_call.cpp
   method-defn-in-tpldecl-0.C
   method-defn-in-tpldecl-1.C
   rose-1431-0.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_template_call.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_template_call.cpp
@@ -1,0 +1,9 @@
+// Template function call should preserve explicit template arguments
+
+template <int N> void foo() {}
+
+int main() {
+  foo<5>();
+  foo<10>();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- preserve explicit template arguments on Clang DeclRefExpr by translating TemplateArgumentListInfo and emitting template instantiation refs
- centralize template-argument translation helpers for TemplateArgumentListInfo/TemplateArgument with explicit flagging
- add regression test verifying foo<5>()/foo<10>() survives unparse and still compiles

## Testing
- ctest -j32 -R astInterface --output-on-failure
- ctest -j32 -R rex --output-on-failure
