### PR TITLE
Fix variadic template parameter pack handling

### DIFF
--- a/src/ROSETTA/Grammar/Support.code
+++ b/src/ROSETTA/Grammar/Support.code
@@ -21061,6 +21061,9 @@ void SgTemplateParameter::post_construction_initialization()
      p_templateDeclaration                 = NULL;
      p_defaultTemplateDeclarationParameter = NULL;
 #endif
+
+  // REX: template parameter packs default to false unless explicitly marked
+     p_is_parameter_pack = false;
    }
 
 // Different constructors for use in building the different types of parameters possible
@@ -21126,35 +21129,40 @@ SgTemplateParameter::SgTemplateParameter ( SgTemplateDeclaration* parameter, SgT
 bool
 SgTemplateParameter::is_matching_type    (const SgTemplateParameter & X, const SgTemplateParameter & Y)
    {
-     return (X.get_parameterType() == SgTemplateParameter::type_parameter) && (X.get_parameterType() == Y.get_parameterType());
+     return (X.get_parameterType() == SgTemplateParameter::type_parameter) &&
+            (X.get_parameterType() == Y.get_parameterType()) &&
+            (X.get_is_parameter_pack() == Y.get_is_parameter_pack());
    }
 
 bool
 SgTemplateParameter::is_matching_nontype (const SgTemplateParameter & X, const SgTemplateParameter & Y)
    {
-     return (X.get_parameterType() == SgTemplateParameter::nontype_parameter) && (X.get_parameterType() == Y.get_parameterType());
+     return (X.get_parameterType() == SgTemplateParameter::nontype_parameter) &&
+            (X.get_parameterType() == Y.get_parameterType()) &&
+            (X.get_is_parameter_pack() == Y.get_is_parameter_pack());
    }
 
 bool
 SgTemplateParameter::is_matching_template(const SgTemplateParameter & X, const SgTemplateParameter & Y)
    {
-     return (X.get_parameterType() == SgTemplateParameter::template_parameter) && (X.get_parameterType() == Y.get_parameterType());
+     return (X.get_parameterType() == SgTemplateParameter::template_parameter) &&
+            (X.get_parameterType() == Y.get_parameterType()) &&
+            (X.get_is_parameter_pack() == Y.get_is_parameter_pack());
    }
 
 // DQ (5/19/2014): This is added to symetry in the functions that are template on either SgTemplateArgument or SgTemplateParameter.
 bool
 SgTemplateParameter::is_matching_template_pack_expansion (const SgTemplateParameter & X, const SgTemplateParameter & Y)
    {
-  // There is not associated value for the SgTemplateParameter enums, so this function should always return SgTemplateParameter::is_matching_kind().
-  // return true;
-  // return (X.get_parameterType() == Y.get_parameterType());
-     return is_matching_kind(X,Y);
+  // Treat pack matching as both parameters being marked as packs and of the same base kind.
+     return X.get_is_parameter_pack() && Y.get_is_parameter_pack() && is_matching_kind(X,Y);
    }
 
 bool
 SgTemplateParameter::is_matching_kind (const SgTemplateParameter & X, const SgTemplateParameter & Y)
    {
-     return (X.get_parameterType() == Y.get_parameterType());
+     return (X.get_parameterType() == Y.get_parameterType()) &&
+            (X.get_is_parameter_pack() == Y.get_is_parameter_pack());
    }
 
 
@@ -21218,6 +21226,12 @@ SgTemplateParameter::get_mangled_name (void) const
 #endif
 
      string str_mangled_name (mangled_name.str());
+
+  // Encode parameter pack distinction so packs don't collide with non-pack manglings.
+     if (get_is_parameter_pack())
+        {
+          str_mangled_name += "__pack";
+        }
 
 #if 0
   // DQ (9/24/2012): Added test for template syntax in the generated mangled name (convert to std::string so we can simplify the test).

--- a/src/ROSETTA/src/support.C
+++ b/src/ROSETTA/src/support.C
@@ -2478,7 +2478,9 @@ Specifiers that can have only one value (implemented with a protected enum varia
   // DQ (11/21/2011): template parameters can be "int U = 42" in which case "U" needs to be an initialized name (see test2011_157.C).
      TemplateParameter.setDataPrototype     ( "SgInitializedName*", "initializedName", "= NULL",
                                                 CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, DEF_TRAVERSAL, NO_DELETE);
-
+     TemplateParameter.setDataPrototype(
+         "bool", "is_parameter_pack", "= false", NO_CONSTRUCTOR_PARAMETER,
+         BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE, COPY_DATA);
 
      TemplateArgument.setFunctionPrototype ( "HEADER_TEMPLATE_ARGUMENT", "../Grammar/Support.code");
      TemplateArgument.setDataPrototype     ( "SgTemplateArgument::template_argument_enum"   , "argumentType", "= argument_undefined",
@@ -2860,23 +2862,3 @@ Specifiers that can have only one value (implemented with a protected enum varia
     OpenclAccessModeModifier.setFunctionSource ( "SOURCE_OPENCL_ACCESS_MODE_MODIFIER", "../Grammar/Support.code" );
 
    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -1532,13 +1532,7 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                    type_name = type_name.substr(prefix.length());
                }
 
-               // REX FIX: Handle pack prefix "... " - extract it for separate handling
-               bool is_pack = false;
-               const std::string pack_prefix = "... ";
-               if (type_name.compare(0, pack_prefix.length(), pack_prefix) == 0) {
-                   is_pack = true;
-                   type_name = type_name.substr(pack_prefix.length());
-               }
+               bool is_pack = templateParameter->get_is_parameter_pack();
 
                // REX FIX: Check if this is an anonymous parameter (empty or placeholder name after pack prefix removed)
                // The frontend may generate __type_param_N for anonymous parameters
@@ -1554,14 +1548,25 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                  if (!stored_kw.empty()) {
                      kw = stored_kw + " ";
                  } else {
-                     // Default: prefer typename for anonymous parameters, class for named ones
-                     kw = type_name.empty() ? "typename " : "class ";
+                   // Default: prefer typename for anonymous parameters, class
+                   // for named ones
+                   kw = type_name.empty() ? "typename " : "class ";
                  }
                  curprint(kw);
                  
                  // Print pack ellipsis after keyword if this is a pack
                  if (is_pack) {
-                     curprint("... ");
+                   curprint("...");
+                   if (!type_name.empty()) {
+                     curprint(" ");
+                   }
+                 }
+               } else if (is_pack) {
+                 // Even outside of template headers, preserve the pack marker
+                 // before the name
+                 curprint("...");
+                 if (!type_name.empty()) {
+                   curprint(" ");
                  }
                }
                curprint(type_name);
@@ -1597,25 +1602,33 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                     printf ("unparseTemplateParameter(): case SgTemplateParameter::nontype_parameter: templateParameter->get_expression() = %p = %s \n",templateParameter->get_expression(),templateParameter->get_expression()->class_name().c_str());
 #endif
                     unp->u_exprStmt->unparseExpression(templateParameter->get_expression(),info);
-                  }
-                 else
-                  {
-                    ASSERT_not_null(templateParameter->get_initializedName());
+               } else {
+                 ASSERT_not_null(templateParameter->get_initializedName());
 
-                    SgType* type = templateParameter->get_initializedName()->get_type();
-                    ASSERT_not_null(type);
+                 SgType *type =
+                     templateParameter->get_initializedName()->get_type();
+                 ASSERT_not_null(type);
 #if 0
                     printf ("unparseTemplateParameter(): case SgTemplateParameter::nontype_parameter: templateParameter->get_initializedName()->get_type() = %p = %s \n",type,type->class_name().c_str());
 #endif
                  // DQ (9/10/2014): Note that this will unparse "int T" which we want in the template header, but not in the template parameter list.
                  // unp->u_type->outputType<SgInitializedName>(templateParameter->get_initializedName(),type,info);
-                    // TV (03/20/2018) only if it is a template header (not a specialization)
-                    if (is_template_header) {
-                      SgUnparse_Info ninfo(info);
-                      unp->u_type->unparseType(type,ninfo);
-                    }
-                    curprint(templateParameter->get_initializedName()->get_name());
-                  }
+                 // TV (03/20/2018) only if it is a template header (not a
+                 // specialization)
+                 if (is_template_header) {
+                   SgUnparse_Info ninfo(info);
+                   unp->u_type->unparseType(type, ninfo);
+                 }
+                 const SgName &param_name =
+                     templateParameter->get_initializedName()->get_name();
+                 if (templateParameter->get_is_parameter_pack()) {
+                   curprint("...");
+                   if (!param_name.getString().empty()) {
+                     curprint(" ");
+                   }
+                 }
+                 curprint(param_name);
+               }
 
                break;
              }
@@ -1648,6 +1661,12 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                std::string name_str = nrdecl->get_name().getString();
                if (name_str.size() > 2 && name_str.compare(0,2,"::") == 0) {
                    name_str = name_str.substr(2);
+               }
+               if (templateParameter->get_is_parameter_pack()) {
+                 curprint("...");
+                 if (!name_str.empty()) {
+                   curprint(" ");
+                 }
                }
                curprint(name_str);
 #if 0

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -4963,6 +4963,9 @@ Unparse_Type::unparseTemplateType(SgType* type, SgUnparse_Info& info)
        }
 
        curprint(type_name);
+       if (templateType->get_packed()) {
+         curprint(" ...");
+       }
        curprint(" ");
      }
    }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -480,13 +480,11 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         // Leave them empty so the unparser knows they're anonymous
         // The placeholder names like __type_param_0 are not needed
 
+        SgTemplateType *template_type =
+            SageBuilder::buildTemplateType(SgName(name_str));
         if (type_param->isParameterPack()) {
-             // REX FIX: ROSE unparser doesn't seem to check for pack flag on type parameters.
-             // Prepend "..." to the name so it prints "typename ... Args".
-             name_str = "... " + name_str;
+          template_type->set_packed(true);
         }
-
-        SgTemplateType* template_type = SageBuilder::buildTemplateType(SgName(name_str));
         sg_param = SageBuilder::buildTemplateParameter(SgTemplateParameter::type_parameter, template_type);
 
         // REX FIX: Set keyword (typename vs class) for type parameters
@@ -507,22 +505,7 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         }
         
         if (type_param->isParameterPack()) {
-             // REX FIX: Handle parameter packs
-             // Assuming SgTemplateParameter has set_is_parameter_pack based on grep
-             // If this fails to compile, we need to find the correct method/member.
-             // But usually ROSE follows this naming convention.
-             // Also, we need to make sure we don't need to wrap it in SgTemplateParameterPack?
-             // SgTemplateParameterPack is usually for arguments. For parameters, it's a flag.
-             // Let's try the flag.
-             // Wait, I need to verify if set_parameterType(template_parameter_pack) is the way.
-             // But grep showed set_is_parameter_pack.
-             // I'll try calling it.
-             // sg_param->set_parameterType(SgTemplateParameter::template_parameter_pack); 
-             // No, let's try the boolean setter.
-             // Actually, I can't call it if I don't know the name for sure.
-             // But I'll try.
-             // sg_param->set_is_parameter_pack(true); // This is risky without verification.
-             // Let's try to find the method name via grep again but with context.
+          sg_param->set_is_parameter_pack(true);
         }
     } else if (clang::NonTypeTemplateParmDecl* non_type_param = llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(param_decl)) {
         std::string name_str = non_type_param->getNameAsString();
@@ -544,9 +527,10 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         init_name->set_parent(param);
         param->set_type(type);
         sg_param = param;
-        
+
         if (non_type_param->isParameterPack()) {
-             // sg_param->set_is_parameter_pack(true);
+          param->set_is_parameter_pack(true);
+          init_name->set_is_parameter_pack(true);
         }
 
         // NOTE: Template parameters don't set declptr. SgTemplateParameter is an SgSupport node,
@@ -621,6 +605,9 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         // Create the template parameter with parameter_template kind
         // Use SgTemplateType with the parameter name
         SgTemplateType* param_type = SageBuilder::buildTemplateType(SgName(name_str));
+        if (template_template_param->isParameterPack()) {
+          param_type->set_packed(true);
+        }
         sg_param = SageBuilder::buildTemplateParameter(SgTemplateParameter::template_parameter, param_type);
         
         // Set the declaration parameter to the SgNonrealDecl
@@ -642,7 +629,7 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         SageInterface::setTemplateParameterKeyword(sg_param, outer_kw);
         
         if (template_template_param->isParameterPack()) {
-             // sg_param->set_is_parameter_pack(true);
+          sg_param->set_is_parameter_pack(true);
         }
     } else {
         std::cerr << "Warning: Unsupported template parameter kind: "
@@ -4494,6 +4481,13 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl * param_var_decl
     }
 
     SgInitializedName* param_init_name = SageBuilder::buildInitializedName(name, type, init);
+    if (param_var_decl->isParameterPack()) {
+      param_init_name->set_is_parameter_pack(true);
+      param_init_name->set_is_pack_element(true);
+      if (SgTemplateType *template_type = isSgTemplateType(type)) {
+        template_type->set_packed(true);
+      }
+    }
     // Set scope and parent to avoid unparser assertion - function declaration builder will adjust this later
     SgScopeStatement* scope = SageBuilder::topScopeStack();
     param_init_name->set_scope(scope);

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -877,6 +877,9 @@ bool ClangToSageTranslator::VisitPackExpansionType(clang::PackExpansionType * pa
     SgType* pattern_type = buildTypeFromQualifiedType(pattern);
 
     if (pattern_type != NULL) {
+      if (SgTemplateType *template_type = isSgTemplateType(pattern_type)) {
+        template_type->set_packed(true);
+      }
         // Use the pattern type directly - the pack expansion is handled at a higher level
         *node = pattern_type;
     } else {

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -36,6 +36,17 @@ add_test(
 )
 set_tests_properties(Cxx_tests_rex_test2025_template_call_explicit_args PROPERTIES LABELS Cxx_tests)
 
+add_test(
+  NAME Cxx_tests_rex_test2025_variadic_template_params_unparse
+  COMMAND sh -c "\"$@\" && grep -E \"template <typename[[:space:]]*\\\\.\\\\.\\\\.\" rose_rex_test2025_variadic_template_params.cpp | grep -v \"//\" && grep -E \"template <int[[:space:]]*\\\\.\\\\.\\\\.\" rose_rex_test2025_variadic_template_params.cpp | grep -v \"//\" && grep -E \"class[[:space:]]*\\\\.\\\\.\\\\.[[:space:]]*Templates\" rose_rex_test2025_variadic_template_params.cpp | grep -v \"//\" && ${CMAKE_CXX_COMPILER} -std=c++17 -c rose_rex_test2025_variadic_template_params.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_variadic_template_params.cpp
+)
+set_tests_properties(Cxx_tests_rex_test2025_variadic_template_params_unparse PROPERTIES LABELS Cxx_tests)
+
 # REX: This test intentionally fails (it contains a function-try-block which is currently
 # not fully supported and triggers an assertion failure or error). We want to ensure
 # it continues to fail (failure propagation) until properly supported.

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -10,6 +10,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   lulesh.C
   luleshTALC.C
   rex_test2025_template_call.cpp
+  rex_test2025_variadic_template_params.cpp
   method-defn-in-tpldecl-0.C
   method-defn-in-tpldecl-1.C
   rose-1431-0.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_variadic_template_params.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_variadic_template_params.cpp
@@ -1,0 +1,17 @@
+// Regression: template parameter packs must keep their ellipsis in the unparsed
+// output.
+
+template <typename... Args> void print(Args... args) {}
+
+template <int... Ns> struct IntPack {};
+
+template <typename... Ts> struct Simple {};
+
+template <template <typename...> class... Templates> struct TemplateHolder {};
+
+int main() {
+  print(1, 2.0, "hello");
+  IntPack<1, 2, 3> pack;
+  TemplateHolder<Simple, Simple> holder;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- mark template parameters as packs in the Clang translator instead of name hacks
- propagate pack metadata through SgTemplateType and unparser to emit ellipses for type/non-type/template template packs
- add regression test rex_test2025_variadic_template_params and wire into Cxx_tests

## Testing
- cmake --build build -j4
- ctest -R "Cxx_tests_rex_test2025_variadic_template_params|Cxx_tests_rex_test2025_variadic_template_params_unparse" --output-on-failure
