### PR TITLE
Fix variadic template parameter pack handling (issue 86)

### DIFF
--- a/src/ROSETTA/Grammar/Support.code
+++ b/src/ROSETTA/Grammar/Support.code
@@ -21061,6 +21061,9 @@ void SgTemplateParameter::post_construction_initialization()
      p_templateDeclaration                 = NULL;
      p_defaultTemplateDeclarationParameter = NULL;
 #endif
+
+  // Default to non-pack; the frontend sets this when encountering a parameter pack.
+     p_is_parameter_pack = false;
    }
 
 // Different constructors for use in building the different types of parameters possible

--- a/src/ROSETTA/src/support.C
+++ b/src/ROSETTA/src/support.C
@@ -2479,6 +2479,10 @@ Specifiers that can have only one value (implemented with a protected enum varia
      TemplateParameter.setDataPrototype     ( "SgInitializedName*", "initializedName", "= NULL",
                                                 CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, DEF_TRAVERSAL, NO_DELETE);
 
+     // Parameter pack flag for template parameters
+     TemplateParameter.setDataPrototype(
+         "bool", "is_parameter_pack", "= false", NO_CONSTRUCTOR_PARAMETER,
+         BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
 
      TemplateArgument.setFunctionPrototype ( "HEADER_TEMPLATE_ARGUMENT", "../Grammar/Support.code");
      TemplateArgument.setDataPrototype     ( "SgTemplateArgument::template_argument_enum"   , "argumentType", "= argument_undefined",
@@ -2860,23 +2864,3 @@ Specifiers that can have only one value (implemented with a protected enum varia
     OpenclAccessModeModifier.setFunctionSource ( "SOURCE_OPENCL_ACCESS_MODE_MODIFIER", "../Grammar/Support.code" );
 
    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -1532,13 +1532,7 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                    type_name = type_name.substr(prefix.length());
                }
 
-               // REX FIX: Handle pack prefix "... " - extract it for separate handling
-               bool is_pack = false;
-               const std::string pack_prefix = "... ";
-               if (type_name.compare(0, pack_prefix.length(), pack_prefix) == 0) {
-                   is_pack = true;
-                   type_name = type_name.substr(pack_prefix.length());
-               }
+               bool is_pack = templateParameter->get_is_parameter_pack();
 
                // REX FIX: Check if this is an anonymous parameter (empty or placeholder name after pack prefix removed)
                // The frontend may generate __type_param_N for anonymous parameters
@@ -1591,6 +1585,12 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
 
           case SgTemplateParameter::nontype_parameter:
              {
+            bool is_pack = templateParameter->get_is_parameter_pack();
+            if (!is_pack && templateParameter->get_initializedName() != NULL) {
+              is_pack = templateParameter->get_initializedName()
+                            ->get_is_parameter_pack();
+            }
+
                if (templateParameter->get_expression() != NULL)
                   {
 #if 0
@@ -1614,6 +1614,9 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                       SgUnparse_Info ninfo(info);
                       unp->u_type->unparseType(type,ninfo);
                     }
+                    if (is_pack) {
+                      curprint("... ");
+                    }
                     curprint(templateParameter->get_initializedName()->get_name());
                   }
 
@@ -1628,6 +1631,7 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
 #if 0
                printf ("unparseTemplateParameter(): case SgTemplateParameter::template_parameter: output name = %s \n",templateDeclaration->get_name().str());
 #endif
+               bool is_pack = templateParameter->get_is_parameter_pack();
                curprint("template ");
 
                SgTemplateParameterPtrList & templateParameterList = nrdecl->get_tpl_params();
@@ -1644,6 +1648,9 @@ Unparse_ExprStmt::unparseTemplateParameter(SgTemplateParameter* templateParamete
                    kw = stored_kw + " ";
                }
                curprint(kw);
+               if (is_pack) {
+                 curprint("... ");
+               }
 
                std::string name_str = nrdecl->get_name().getString();
                if (name_str.size() > 2 && name_str.compare(0,2,"::") == 0) {

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -480,12 +480,6 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         // Leave them empty so the unparser knows they're anonymous
         // The placeholder names like __type_param_0 are not needed
 
-        if (type_param->isParameterPack()) {
-             // REX FIX: ROSE unparser doesn't seem to check for pack flag on type parameters.
-             // Prepend "..." to the name so it prints "typename ... Args".
-             name_str = "... " + name_str;
-        }
-
         SgTemplateType* template_type = SageBuilder::buildTemplateType(SgName(name_str));
         sg_param = SageBuilder::buildTemplateParameter(SgTemplateParameter::type_parameter, template_type);
 
@@ -505,25 +499,7 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
                 }
             }
         }
-        
-        if (type_param->isParameterPack()) {
-             // REX FIX: Handle parameter packs
-             // Assuming SgTemplateParameter has set_is_parameter_pack based on grep
-             // If this fails to compile, we need to find the correct method/member.
-             // But usually ROSE follows this naming convention.
-             // Also, we need to make sure we don't need to wrap it in SgTemplateParameterPack?
-             // SgTemplateParameterPack is usually for arguments. For parameters, it's a flag.
-             // Let's try the flag.
-             // Wait, I need to verify if set_parameterType(template_parameter_pack) is the way.
-             // But grep showed set_is_parameter_pack.
-             // I'll try calling it.
-             // sg_param->set_parameterType(SgTemplateParameter::template_parameter_pack); 
-             // No, let's try the boolean setter.
-             // Actually, I can't call it if I don't know the name for sure.
-             // But I'll try.
-             // sg_param->set_is_parameter_pack(true); // This is risky without verification.
-             // Let's try to find the method name via grep again but with context.
-        }
+        sg_param->set_is_parameter_pack(type_param->isParameterPack());
     } else if (clang::NonTypeTemplateParmDecl* non_type_param = llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(param_decl)) {
         std::string name_str = non_type_param->getNameAsString();
         if (name_str.empty()) {
@@ -538,16 +514,15 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         // Build initialized name so the unparser keeps the parameter name/type when no default is present.
         SgInitializedName* init_name = SageBuilder::buildInitializedName(SgName(name_str), type);
         applySourceRange(init_name, non_type_param->getSourceRange());
+        init_name->set_is_parameter_pack(non_type_param->isParameterPack());
 
         SgTemplateParameter* param = SageBuilder::buildTemplateParameter(SgTemplateParameter::nontype_parameter, type);
         param->set_initializedName(init_name);
         init_name->set_parent(param);
         param->set_type(type);
         sg_param = param;
-        
-        if (non_type_param->isParameterPack()) {
-             // sg_param->set_is_parameter_pack(true);
-        }
+
+        sg_param->set_is_parameter_pack(non_type_param->isParameterPack());
 
         // NOTE: Template parameters don't set declptr. SgTemplateParameter is an SgSupport node,
         // not an SgDeclarationStatement, so it cannot be used with set_declptr().
@@ -640,10 +615,9 @@ SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang:
         // e.g., "template <typename ...> typename C" - the outer "typename" before C
         std::string outer_kw = template_template_param->wasDeclaredWithTypename() ? "typename" : "class";
         SageInterface::setTemplateParameterKeyword(sg_param, outer_kw);
-        
-        if (template_template_param->isParameterPack()) {
-             // sg_param->set_is_parameter_pack(true);
-        }
+
+        sg_param->set_is_parameter_pack(
+            template_template_param->isParameterPack());
     } else {
         std::cerr << "Warning: Unsupported template parameter kind: "
                   << param_decl->getDeclKindName() << std::endl;

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -47,3 +47,14 @@ add_test(
   NAME Cxx_tests_rex_test2025_issue99_failure_propagation
   COMMAND sh -c "\"$@\" && exit 1 || exit 0" dummy $<TARGET_FILE:${translator}> ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR} -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue99_failure_propagation.cpp
 )
+
+add_test(
+  NAME Cxx_tests_rex_test2025_variadic_template_packs
+  COMMAND sh -c "\"$@\" && grep -E \"template <typename\\s*\\.\\.\\.\" rose_rex_test2025_variadic_template_packs.cpp | grep -v \"//\" && grep -E \"template <int\\s*\\.\\.\\.\" rose_rex_test2025_variadic_template_packs.cpp | grep -v \"//\" && grep -E \"class\\s*\\.\\.\\s*Templates\" rose_rex_test2025_variadic_template_packs.cpp | grep -v \"//\" && ${CMAKE_CXX_COMPILER} -std=c++17 -c rose_rex_test2025_variadic_template_packs.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_variadic_template_packs.cpp
+)
+set_tests_properties(Cxx_tests_rex_test2025_variadic_template_packs PROPERTIES LABELS Cxx_tests)

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_variadic_template_packs.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_variadic_template_packs.cpp
@@ -1,0 +1,23 @@
+// Verify variadic template parameter packs (type, non-type, and
+// template-template) keep their ellipses.
+
+template <typename... Args> void print(Args... args) {}
+
+template <int... Ns> struct IntPack {};
+
+template <typename...> struct Variadic {};
+
+template <template <typename...> class... Templates> struct TemplatePack {
+  using first_template = Variadic<Templates<int>...>;
+};
+
+int main() {
+  print(1, 2.0, 3);
+  IntPack<1, 2, 3> int_pack{};
+  (void)int_pack;
+
+  TemplatePack<Variadic, Variadic> pack{};
+  (void)pack;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add native is_parameter_pack flag to SgTemplateParameter and initialize it
- set pack flag in Clang frontend for type/non-type/template-template params and use it in unparser
- add regression covering type, non-type, and template-template packs to ensure ellipses are preserved

## Testing
- not run (build/regeneration required for ROSETTA change)