### PR TITLE
Fix #90: preserve dependent array dimensions

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: 'HIGH'
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+ignore_patterns: []

--- a/scripts/install-pre-push-ci-tests-hook.sh
+++ b/scripts/install-pre-push-ci-tests-hook.sh
@@ -45,6 +45,10 @@ if [[ ! -f "$build_dir/CTestTestfile.cmake" ]]; then
 fi
 
 cd "$build_dir"
+cmake --build . -- -j"$(nproc)" || {
+  echo "Build failed; aborting push." >&2
+  exit 1
+}
 
 run_ctest_regex() {
   local regex=$1

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -9,46 +9,50 @@
 
 namespace {
 bool containsUnknownType(SgType *type) {
-    if (type == NULL) return true;
+  if (type == NULL)
+    return true;
 
-    if (isSgTypeUnknown(type)) return true;
-    if (auto *mod = isSgModifierType(type)) {
-        return containsUnknownType(mod->get_base_type());
+  if (isSgTypeUnknown(type))
+    return true;
+  if (auto *mod = isSgModifierType(type)) {
+    return containsUnknownType(mod->get_base_type());
+  }
+  if (auto *ptr = isSgPointerType(type)) {
+    return containsUnknownType(ptr->get_base_type());
+  }
+  if (auto *memPtr = isSgPointerMemberType(type)) {
+    return containsUnknownType(memPtr->get_base_type());
+  }
+  if (auto *ref = isSgReferenceType(type)) {
+    return containsUnknownType(ref->get_base_type());
+  }
+  if (auto *rref = isSgRvalueReferenceType(type)) {
+    return containsUnknownType(rref->get_base_type());
+  }
+  if (auto *arr = isSgArrayType(type)) {
+    return containsUnknownType(arr->get_base_type());
+  }
+  if (auto *td = isSgTypedefType(type)) {
+    return containsUnknownType(td->get_base_type());
+  }
+  if (auto *func = isSgFunctionType(type)) {
+    if (containsUnknownType(func->get_return_type()))
+      return true;
+    SgFunctionParameterTypeList *params = func->get_argument_list();
+    if (params != NULL) {
+      const SgTypePtrList &args = params->get_arguments();
+      for (SgType *arg : args) {
+        if (containsUnknownType(arg))
+          return true;
+      }
     }
-    if (auto *ptr = isSgPointerType(type)) {
-        return containsUnknownType(ptr->get_base_type());
-    }
-    if (auto *memPtr = isSgPointerMemberType(type)) {
-        return containsUnknownType(memPtr->get_base_type());
-    }
-    if (auto *ref = isSgReferenceType(type)) {
-        return containsUnknownType(ref->get_base_type());
-    }
-    if (auto *rref = isSgRvalueReferenceType(type)) {
-        return containsUnknownType(rref->get_base_type());
-    }
-    if (auto *arr = isSgArrayType(type)) {
-        return containsUnknownType(arr->get_base_type());
-    }
-    if (auto *td = isSgTypedefType(type)) {
-        return containsUnknownType(td->get_base_type());
-    }
-    if (auto *func = isSgFunctionType(type)) {
-        if (containsUnknownType(func->get_return_type())) return true;
-        SgFunctionParameterTypeList *params = func->get_argument_list();
-        if (params != NULL) {
-            const SgTypePtrList &args = params->get_arguments();
-            for (SgType *arg : args) {
-                if (containsUnknownType(arg)) return true;
-            }
-        }
-        return false;
-    }
-    if (auto *declType = isSgDeclType(type)) {
-        return containsUnknownType(declType->get_base_type());
-    }
-
     return false;
+  }
+  if (auto *declType = isSgDeclType(type)) {
+    return containsUnknownType(declType->get_base_type());
+  }
+
+  return false;
 }
 
 static std::string trimWhitespace(std::string s) {
@@ -89,357 +93,364 @@ buildTemplateInstantiationName(const std::string &base_name,
 }
 } // namespace
 
-SgSymbol * ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl * decl) {
-    if (decl == NULL) return NULL;
+SgSymbol *
+ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
+  if (decl == NULL)
+    return NULL;
 
-    // Recursion guard: If we're already looking up this declaration, return NULL
-    // to prevent infinite loops in template/member resolution
-    if (p_symbol_lookup_in_progress.find(decl) != p_symbol_lookup_in_progress.end()) {
+  // Recursion guard: If we're already looking up this declaration, return NULL
+  // to prevent infinite loops in template/member resolution
+  if (p_symbol_lookup_in_progress.find(decl) !=
+      p_symbol_lookup_in_progress.end()) {
 #if DEBUG_SYMBOL_TABLE_LOOKUP
-        std::cerr << "GetSymbolFromSymbolTable: Recursion detected for decl "
-                  << decl->getNameAsString() << ", returning NULL" << std::endl;
+    std::cerr << "GetSymbolFromSymbolTable: Recursion detected for decl "
+              << decl->getNameAsString() << ", returning NULL" << std::endl;
 #endif
-        return NULL;
-    }
+    return NULL;
+  }
 
-    // Add this decl to the in-progress set
-    p_symbol_lookup_in_progress.insert(decl);
+  // Add this decl to the in-progress set
+  p_symbol_lookup_in_progress.insert(decl);
 
-    // REX FIX: Check if the declaration has already been translated
-    // Only for Typedef/TypeAlias to avoid issues with Variables (see rex_template_instantiation.C)
-    if (llvm::isa<clang::TypedefNameDecl>(decl)) {
-        std::map<clang::Decl *, SgNode *>::iterator it_decl = p_decl_translation_map.find(decl);
-        if (it_decl != p_decl_translation_map.end()) {
-            SgNode * node = it_decl->second;
-            if (SgDeclarationStatement * decl_stmt = isSgDeclarationStatement(node)) {
-                 SgSymbol * symbol = decl_stmt->get_symbol_from_symbol_table();
-                 if (symbol != NULL) {
-                     p_symbol_lookup_in_progress.erase(decl);
-                     return symbol;
-                 }
-            }
+  // REX FIX: Check if the declaration has already been translated
+  // Only for Typedef/TypeAlias to avoid issues with Variables (see
+  // rex_template_instantiation.C)
+  if (llvm::isa<clang::TypedefNameDecl>(decl)) {
+    std::map<clang::Decl *, SgNode *>::iterator it_decl =
+        p_decl_translation_map.find(decl);
+    if (it_decl != p_decl_translation_map.end()) {
+      SgNode *node = it_decl->second;
+      if (SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(node)) {
+        SgSymbol *symbol = decl_stmt->get_symbol_from_symbol_table();
+        if (symbol != NULL) {
+          p_symbol_lookup_in_progress.erase(decl);
+          return symbol;
         }
+      }
     }
+  }
 
-    SgScopeStatement * scope = SageBuilder::topScopeStack();
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
 
+  /* Pei-Hung (08/29/2022) fieldDecl can be anonymous.
+   * Apply anonymous name to allow symbol lookup.
+   */
+  std::string declName = decl->getNameAsString();
 
-/* Pei-Hung (08/29/2022) fieldDecl can be anonymous.
- * Apply anonymous name to allow symbol lookup.
-*/
-    std::string declName = decl->getNameAsString();
-
-    if(llvm::isa<clang::FieldDecl>(decl) && ((clang::FieldDecl*)decl)->isAnonymousStructOrUnion())
-    {
-      declName = "__anonymous_" +  generate_source_position_string(decl->getBeginLoc());
+  if (llvm::isa<clang::FieldDecl>(decl) &&
+      ((clang::FieldDecl *)decl)->isAnonymousStructOrUnion()) {
+    declName =
+        "__anonymous_" + generate_source_position_string(decl->getBeginLoc());
 #if DEBUG_SYMBOL_TABLE_LOOKUP
     std::cerr << "Find anonymous fieldDecl: " << declName << std::endl;
 #endif
-    }
+  }
 
-    SgName name(declName);
+  SgName name(declName);
 
 #if DEBUG_SYMBOL_TABLE_LOOKUP
-    std::cerr << "Lookup symbol for: " << name << std::endl;
+  std::cerr << "Lookup symbol for: " << name << std::endl;
 #endif
 
-    if (name == "") {
-        // Remove from in-progress set before returning
-        p_symbol_lookup_in_progress.erase(decl);
-        return NULL;
-    }
-
-    std::list<SgScopeStatement *>::reverse_iterator it;
-    SgSymbol * sym = NULL;
-    switch (decl->getKind()) {
-        case clang::Decl::Typedef:
-        case clang::Decl::TypeAlias:
-        {
-            // TypeAlias (C++11 using declarations) are semantically equivalent to Typedef
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                 sym = (*it)->lookup_typedef_symbol(name);
-                 it++;
-            }
-            break;
-        }
-        case clang::Decl::Var:
-        case clang::Decl::ParmVar:
-        {
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_variable_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::CXXConstructor:
-        case clang::Decl::CXXDestructor:
-        case clang::Decl::CXXMethod:
-        case clang::Decl::Function:
-        {
-            SgType * tmp_type = buildTypeFromQualifiedType(((clang::FunctionDecl *)decl)->getType());
-            SgFunctionType * type = isSgFunctionType(tmp_type);
-            // ROOT CAUSE FIX: Some template/dependent function types may not convert to SgFunctionType
-            // Handle gracefully instead of asserting
-            if (type != NULL) {
-                it = SageBuilder::ScopeStack.rbegin();
-                while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                    sym = (*it)->lookup_function_symbol(name, type);
-                    it++;
-                }
-            }
-            // If type is NULL, return NULL (symbol not found)
-            break;
-        }
-        case clang::Decl::CXXConversion:
-        {
-            // ROOT CAUSE FIX: Conversion operators (operator T()) require special handling
-            // Try to get the function type, but allow it to fail gracefully
-            SgType * tmp_type = buildTypeFromQualifiedType(((clang::CXXConversionDecl *)decl)->getType());
-            SgFunctionType * type = isSgFunctionType(tmp_type);
-            if (type != NULL) {
-                // Normal case - type conversion succeeded
-                it = SageBuilder::ScopeStack.rbegin();
-                while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                    sym = (*it)->lookup_function_symbol(name, type);
-                    it++;
-                }
-            }
-            // If type is NULL or lookup failed, return NULL (not found)
-            // This is acceptable for conversion operators
-            break;
-        }
-        case clang::Decl::Field:
-        {
-            // field can be variable or ClassDefinition
-
-            // CLANG FRONTEND FIX: Skip template-dependent field lookups to avoid infinite loops
-            // Template-dependent fields (like fields in uninstantiated templates) cannot be
-            // properly resolved until template instantiation, so return NULL
-            clang::FieldDecl* field_decl = (clang::FieldDecl*)decl;
-            if (field_decl->getType()->isDependentType()) {
-#if DEBUG_SYMBOL_TABLE_LOOKUP
-                std::cerr << "GetSymbolFromSymbolTable: Skipping template-dependent field: "
-                          << field_decl->getNameAsString() << std::endl;
-#endif
-                // Remove from in-progress set before returning
-                p_symbol_lookup_in_progress.erase(decl);
-                return NULL;
-            }
-
-            clang::QualType fieldQualType = field_decl->getType();
-
-            const clang::Type* fieldType = fieldQualType.getTypePtr();
-
-            while((llvm::isa<clang::ElaboratedType>(fieldType)) || (llvm::isa<clang::ArrayType>(fieldType)))
-            {
-               if(llvm::isa<clang::ElaboratedType>(fieldType))
-               {
-                 fieldQualType = ((clang::ElaboratedType *)fieldType)->getNamedType();
-               }
-               else if(llvm::isa<clang::ArrayType>(fieldType))
-               {
-                 fieldQualType = ((clang::ArrayType *)fieldType)->getElementType();
-               }
-               fieldType = fieldQualType.getTypePtr();
-            }
-            bool isAnonymousStructOrUnion = false;
-            if(llvm::isa<clang::RecordType>(fieldType))
-            {
-                isAnonymousStructOrUnion = ((clang::FieldDecl *)decl)->isAnonymousStructOrUnion();
-            }
-
-            // CLANG FRONTEND FIX: Check if parent has been translated before calling Traverse
-            // to avoid infinite recursion during template instantiation
-            clang::Decl* parent_decl = ((clang::FieldDecl *)decl)->getParent();
-            SgNode* parent_node = NULL;
-
-            // First check if parent is already in translation map
-            std::map<clang::Decl *, SgNode *>::iterator it_decl = p_decl_translation_map.find(parent_decl);
-            if (it_decl != p_decl_translation_map.end()) {
-                parent_node = it_decl->second;
-            } else {
-                // Parent not yet translated - try to traverse it
-                // But only if we're not already looking up a symbol from this parent
-                // (avoids infinite recursion during template member resolution)
-                if (p_symbol_lookup_in_progress.find((clang::NamedDecl*)parent_decl) == p_symbol_lookup_in_progress.end()) {
-                    parent_node = Traverse(parent_decl);
-                }
-            }
-
-            SgClassDeclaration * sg_class_decl = isSgClassDeclaration(parent_node);
-            // CLANG FRONTEND FIX: sg_class_decl can be NULL if parent class was skipped (e.g., system header template)
-            if (sg_class_decl == NULL) {
-                // Parent class not translated (likely skipped system header template or recursion guard hit)
-                // Cannot find symbol without parent class
-                break;
-            }
-            if (sg_class_decl->get_definingDeclaration() == NULL) {
-                std::cerr << "Runtime Error: cannot find the definition of the class/struct associate to the field: " << name << std::endl;
-                // Cannot lookup symbol without class definition
-                break;
-            }
-
-            scope = isSgClassDeclaration(sg_class_decl->get_definingDeclaration())->get_definition();
-            if (scope == NULL) {
-                // No class definition available
-                break;
-            }
-
-            // CLANG FRONTEND FIX: Check if we're currently building this class (it's on the scope stack)
-            // If so, the AST is incomplete and symbol lookup might fail or loop
-            bool class_under_construction = false;
-            for (std::list<SgScopeStatement *>::iterator it_stack = SageBuilder::ScopeStack.begin();
-                 it_stack != SageBuilder::ScopeStack.end(); ++it_stack) {
-                if (*it_stack == scope) {
-                    class_under_construction = true;
-                    break;
-                }
-            }
-
-            if (class_under_construction) {
-                // We're currently building this class - symbol table may be incomplete
-                // Skip symbol lookup to avoid potential AST cycle issues
-#if DEBUG_SYMBOL_TABLE_LOOKUP
-                std::cerr << "GetSymbolFromSymbolTable: Skipping lookup for field '" << name
-                          << "' - parent class under construction" << std::endl;
-#endif
-                break;
-            }
-
-            // FIELD SYMBOL LOOKUP: Resolve field symbols by walking up scope chain
-            //
-            // ALGORITHM: Walk the full scope chain from innermost to outermost until
-            // we find the symbol or reach the top. Use a visited set to prevent infinite
-            // loops caused by cycles in the scope graph (which can occur during AST
-            // construction for complex template code).
-            //
-            // CORRECTNESS: Fields can be promoted through multiple levels of anonymous
-            // structs/unions, or be defined in deeply nested classes. A depth limit
-            // would incorrectly fail to resolve valid symbols in deep hierarchies.
-            //
-            std::set<SgScopeStatement*> visited;
-            while (scope != NULL && sym == NULL) {
-                // Prevent infinite loops by detecting cycles
-                if (visited.count(scope) > 0) {
-                    break;  // Cycle detected, bail out
-                }
-                visited.insert(scope);
-
-                // Look up symbol in current scope
-                if (isAnonymousStructOrUnion)
-                    sym = scope->lookup_class_symbol(name);
-                else
-                    sym = scope->lookup_variable_symbol(name);
-
-                // Move to parent scope
-                if (sym == NULL) {
-                    scope = scope->get_scope();
-                }
-            }
-            break;
-        }
-        case clang::Decl::ClassTemplatePartialSpecialization:
-        case clang::Decl::ClassTemplateSpecialization:
-        case clang::Decl::CXXRecord:
-        case clang::Decl::Record:
-        {
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_class_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::Label:
-        {
-            // Should not be reach as we use Traverse to retrieve Label (they are "terminal" statements) (it avoids the problem of forward use of label: goto before declaration)
-            name = SgName(((clang::LabelDecl *)decl)->getStmt()->getName());
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_label_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::EnumConstant:
-        {
-            name = SgName(((clang::EnumConstantDecl *)decl)->getName().str());
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_enum_field_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::Enum:
-        {
-            name = SgName(((clang::EnumDecl *)decl)->getName().str());
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_enum_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::NonTypeTemplateParm:
-        {
-            // Non-type template parameters are treated as variables
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_variable_symbol(name);
-                it++;
-            }
-            break;
-        }
-        case clang::Decl::VarTemplateSpecialization:
-        case clang::Decl::VarTemplatePartialSpecialization:
-        {
-            // Variable template specializations - treat as variables
-            it = SageBuilder::ScopeStack.rbegin();
-            while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
-                sym = (*it)->lookup_variable_symbol(name);
-                it++;
-            }
-            break;
-        }
-        default:
-            std::cerr << "Runtime Error: Unknown type of Decl. (" << decl->getDeclKindName() << ")" << std::endl;
-    }
-
+  if (name == "") {
     // Remove from in-progress set before returning
     p_symbol_lookup_in_progress.erase(decl);
+    return NULL;
+  }
 
-    return sym;
+  std::list<SgScopeStatement *>::reverse_iterator it;
+  SgSymbol *sym = NULL;
+  switch (decl->getKind()) {
+  case clang::Decl::Typedef:
+  case clang::Decl::TypeAlias: {
+    // TypeAlias (C++11 using declarations) are semantically equivalent to
+    // Typedef
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_typedef_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::Var:
+  case clang::Decl::ParmVar: {
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_variable_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::CXXConstructor:
+  case clang::Decl::CXXDestructor:
+  case clang::Decl::CXXMethod:
+  case clang::Decl::Function: {
+    SgType *tmp_type =
+        buildTypeFromQualifiedType(((clang::FunctionDecl *)decl)->getType());
+    SgFunctionType *type = isSgFunctionType(tmp_type);
+    // ROOT CAUSE FIX: Some template/dependent function types may not convert to
+    // SgFunctionType Handle gracefully instead of asserting
+    if (type != NULL) {
+      it = SageBuilder::ScopeStack.rbegin();
+      while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+        sym = (*it)->lookup_function_symbol(name, type);
+        it++;
+      }
+    }
+    // If type is NULL, return NULL (symbol not found)
+    break;
+  }
+  case clang::Decl::CXXConversion: {
+    // ROOT CAUSE FIX: Conversion operators (operator T()) require special
+    // handling Try to get the function type, but allow it to fail gracefully
+    SgType *tmp_type = buildTypeFromQualifiedType(
+        ((clang::CXXConversionDecl *)decl)->getType());
+    SgFunctionType *type = isSgFunctionType(tmp_type);
+    if (type != NULL) {
+      // Normal case - type conversion succeeded
+      it = SageBuilder::ScopeStack.rbegin();
+      while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+        sym = (*it)->lookup_function_symbol(name, type);
+        it++;
+      }
+    }
+    // If type is NULL or lookup failed, return NULL (not found)
+    // This is acceptable for conversion operators
+    break;
+  }
+  case clang::Decl::Field: {
+    // field can be variable or ClassDefinition
+
+    // CLANG FRONTEND FIX: Skip template-dependent field lookups to avoid
+    // infinite loops Template-dependent fields (like fields in uninstantiated
+    // templates) cannot be properly resolved until template instantiation, so
+    // return NULL
+    clang::FieldDecl *field_decl = (clang::FieldDecl *)decl;
+    if (field_decl->getType()->isDependentType()) {
+#if DEBUG_SYMBOL_TABLE_LOOKUP
+      std::cerr
+          << "GetSymbolFromSymbolTable: Skipping template-dependent field: "
+          << field_decl->getNameAsString() << std::endl;
+#endif
+      // Remove from in-progress set before returning
+      p_symbol_lookup_in_progress.erase(decl);
+      return NULL;
+    }
+
+    clang::QualType fieldQualType = field_decl->getType();
+
+    const clang::Type *fieldType = fieldQualType.getTypePtr();
+
+    while ((llvm::isa<clang::ElaboratedType>(fieldType)) ||
+           (llvm::isa<clang::ArrayType>(fieldType))) {
+      if (llvm::isa<clang::ElaboratedType>(fieldType)) {
+        fieldQualType = ((clang::ElaboratedType *)fieldType)->getNamedType();
+      } else if (llvm::isa<clang::ArrayType>(fieldType)) {
+        fieldQualType = ((clang::ArrayType *)fieldType)->getElementType();
+      }
+      fieldType = fieldQualType.getTypePtr();
+    }
+    bool isAnonymousStructOrUnion = false;
+    if (llvm::isa<clang::RecordType>(fieldType)) {
+      isAnonymousStructOrUnion =
+          ((clang::FieldDecl *)decl)->isAnonymousStructOrUnion();
+    }
+
+    // CLANG FRONTEND FIX: Check if parent has been translated before calling
+    // Traverse to avoid infinite recursion during template instantiation
+    clang::Decl *parent_decl = ((clang::FieldDecl *)decl)->getParent();
+    SgNode *parent_node = NULL;
+
+    // First check if parent is already in translation map
+    std::map<clang::Decl *, SgNode *>::iterator it_decl =
+        p_decl_translation_map.find(parent_decl);
+    if (it_decl != p_decl_translation_map.end()) {
+      parent_node = it_decl->second;
+    } else {
+      // Parent not yet translated - try to traverse it
+      // But only if we're not already looking up a symbol from this parent
+      // (avoids infinite recursion during template member resolution)
+      if (p_symbol_lookup_in_progress.find((clang::NamedDecl *)parent_decl) ==
+          p_symbol_lookup_in_progress.end()) {
+        parent_node = Traverse(parent_decl);
+      }
+    }
+
+    SgClassDeclaration *sg_class_decl = isSgClassDeclaration(parent_node);
+    // CLANG FRONTEND FIX: sg_class_decl can be NULL if parent class was skipped
+    // (e.g., system header template)
+    if (sg_class_decl == NULL) {
+      // Parent class not translated (likely skipped system header template or
+      // recursion guard hit) Cannot find symbol without parent class
+      break;
+    }
+    if (sg_class_decl->get_definingDeclaration() == NULL) {
+      std::cerr << "Runtime Error: cannot find the definition of the "
+                   "class/struct associate to the field: "
+                << name << std::endl;
+      // Cannot lookup symbol without class definition
+      break;
+    }
+
+    scope = isSgClassDeclaration(sg_class_decl->get_definingDeclaration())
+                ->get_definition();
+    if (scope == NULL) {
+      // No class definition available
+      break;
+    }
+
+    // CLANG FRONTEND FIX: Check if we're currently building this class (it's on
+    // the scope stack) If so, the AST is incomplete and symbol lookup might
+    // fail or loop
+    bool class_under_construction = false;
+    for (std::list<SgScopeStatement *>::iterator it_stack =
+             SageBuilder::ScopeStack.begin();
+         it_stack != SageBuilder::ScopeStack.end(); ++it_stack) {
+      if (*it_stack == scope) {
+        class_under_construction = true;
+        break;
+      }
+    }
+
+    if (class_under_construction) {
+      // We're currently building this class - symbol table may be incomplete
+      // Skip symbol lookup to avoid potential AST cycle issues
+#if DEBUG_SYMBOL_TABLE_LOOKUP
+      std::cerr << "GetSymbolFromSymbolTable: Skipping lookup for field '"
+                << name << "' - parent class under construction" << std::endl;
+#endif
+      break;
+    }
+
+    // FIELD SYMBOL LOOKUP: Resolve field symbols by walking up scope chain
+    //
+    // ALGORITHM: Walk the full scope chain from innermost to outermost until
+    // we find the symbol or reach the top. Use a visited set to prevent
+    // infinite loops caused by cycles in the scope graph (which can occur
+    // during AST construction for complex template code).
+    //
+    // CORRECTNESS: Fields can be promoted through multiple levels of anonymous
+    // structs/unions, or be defined in deeply nested classes. A depth limit
+    // would incorrectly fail to resolve valid symbols in deep hierarchies.
+    //
+    std::set<SgScopeStatement *> visited;
+    while (scope != NULL && sym == NULL) {
+      // Prevent infinite loops by detecting cycles
+      if (visited.count(scope) > 0) {
+        break; // Cycle detected, bail out
+      }
+      visited.insert(scope);
+
+      // Look up symbol in current scope
+      if (isAnonymousStructOrUnion)
+        sym = scope->lookup_class_symbol(name);
+      else
+        sym = scope->lookup_variable_symbol(name);
+
+      // Move to parent scope
+      if (sym == NULL) {
+        scope = scope->get_scope();
+      }
+    }
+    break;
+  }
+  case clang::Decl::ClassTemplatePartialSpecialization:
+  case clang::Decl::ClassTemplateSpecialization:
+  case clang::Decl::CXXRecord:
+  case clang::Decl::Record: {
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_class_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::Label: {
+    // Should not be reach as we use Traverse to retrieve Label (they are
+    // "terminal" statements) (it avoids the problem of forward use of label:
+    // goto before declaration)
+    name = SgName(((clang::LabelDecl *)decl)->getStmt()->getName());
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_label_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::EnumConstant: {
+    name = SgName(((clang::EnumConstantDecl *)decl)->getName().str());
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_enum_field_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::Enum: {
+    name = SgName(((clang::EnumDecl *)decl)->getName().str());
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_enum_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::NonTypeTemplateParm: {
+    // Non-type template parameters are treated as variables
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_variable_symbol(name);
+      it++;
+    }
+    break;
+  }
+  case clang::Decl::VarTemplateSpecialization:
+  case clang::Decl::VarTemplatePartialSpecialization: {
+    // Variable template specializations - treat as variables
+    it = SageBuilder::ScopeStack.rbegin();
+    while (it != SageBuilder::ScopeStack.rend() && sym == NULL) {
+      sym = (*it)->lookup_variable_symbol(name);
+      it++;
+    }
+    break;
+  }
+  default:
+    std::cerr << "Runtime Error: Unknown type of Decl. ("
+              << decl->getDeclKindName() << ")" << std::endl;
+  }
+
+  // Remove from in-progress set before returning
+  p_symbol_lookup_in_progress.erase(decl);
+
+  return sym;
 }
 
-
-
-SgTemplateParameterPtrList*
+SgTemplateParameterPtrList *
 ClangToSageTranslator::translateTemplateParameterList(
-    clang::TemplateParameterList* param_list,
-    SgDeclarationStatement* owning_template) {
-    SgTemplateParameterPtrList* sg_params = new SgTemplateParameterPtrList();
-    if (param_list == NULL) {
-        return sg_params;
-    }
-
-    unsigned index = 0;
-    for (clang::NamedDecl* param_decl : *param_list) {
-        SgTemplateParameter* sg_param = translateTemplateParameter(param_decl, owning_template, index);
-        if (sg_param != NULL) {
-            sg_params->push_back(sg_param);
-        }
-        ++index;
-    }
-
+    clang::TemplateParameterList *param_list,
+    SgDeclarationStatement *owning_template) {
+  SgTemplateParameterPtrList *sg_params = new SgTemplateParameterPtrList();
+  if (param_list == NULL) {
     return sg_params;
+  }
+
+  unsigned index = 0;
+  for (clang::NamedDecl *param_decl : *param_list) {
+    SgTemplateParameter *sg_param =
+        translateTemplateParameter(param_decl, owning_template, index);
+    if (sg_param != NULL) {
+      sg_params->push_back(sg_param);
+    }
+    ++index;
+  }
+
+  return sg_params;
 }
 
 namespace {
-// Ensure a declaration has parent and scope set using the current scope stack as fallback.
-// Logs a warning if the scope remains unset (will trip diagnostics later).
+// Ensure a declaration has parent and scope set using the current scope stack
+// as fallback. Logs a warning if the scope remains unset (will trip diagnostics
+// later).
 void diagnose_null_scope(SgDeclarationStatement *ds, const char *context) {
   if (ds == NULL || ds->get_scope() != NULL)
     return;
@@ -464,2060 +475,2256 @@ void ensure_parent_and_scope(SgDeclarationStatement *ds,
 }
 } // unnamed namespace
 
-void
-ClangToSageTranslator::populateClassDefinition(clang::RecordDecl* record_decl, SgClassDefinition* class_def) {
-    SageBuilder::pushScopeStack(class_def);
-    // REX FIX: Track access modifier state to suppress redundant keywords
-    SgAccessModifier::access_modifier_enum current_access =
-        SgAccessModifier::e_unknown;
-    if (record_decl->isClass()) {
-      current_access = SgAccessModifier::e_private;
-    } else if (record_decl->isStruct() || record_decl->isUnion()) {
-      current_access = SgAccessModifier::e_public;
+void ClangToSageTranslator::populateClassDefinition(
+    clang::RecordDecl *record_decl, SgClassDefinition *class_def) {
+  SageBuilder::pushScopeStack(class_def);
+  // REX FIX: Track access modifier state to suppress redundant keywords
+  SgAccessModifier::access_modifier_enum current_access =
+      SgAccessModifier::e_unknown;
+  if (record_decl->isClass()) {
+    current_access = SgAccessModifier::e_private;
+  } else if (record_decl->isStruct() || record_decl->isUnion()) {
+    current_access = SgAccessModifier::e_public;
+  }
+
+  // Reconstruct state from existing members (if any)
+  const SgDeclarationStatementPtrList &existing_members =
+      class_def->get_members();
+  for (auto mem : existing_members) {
+    SgAccessModifier::access_modifier_enum m =
+        mem->get_declarationModifier().get_accessModifier().get_modifier();
+    if (m != SgAccessModifier::e_unknown) {
+      current_access = m;
+    }
+  }
+
+  // REX FIX: We must detect if an access specifier was explicitly written.
+  bool explicit_access_context = false;
+
+  for (clang::Decl *inner_decl : record_decl->decls()) {
+    if (inner_decl == NULL) {
+      continue;
     }
 
-    // Reconstruct state from existing members (if any)
-    const SgDeclarationStatementPtrList &existing_members =
-        class_def->get_members();
-    for (auto mem : existing_members) {
-      SgAccessModifier::access_modifier_enum m =
-          mem->get_declarationModifier().get_accessModifier().get_modifier();
-      if (m != SgAccessModifier::e_unknown) {
-        current_access = m;
+    // Check for explicit access specifier (e.g. "private:")
+    if (llvm::isa<clang::AccessSpecDecl>(inner_decl)) {
+      explicit_access_context = true;
+      // We continue because AccessSpecDecl doesn't map to a ROSE node in
+      // Traverse But we need to update current_access to match what
+      // Traverse/Unparser expects
+      clang::AccessSpecDecl *asd =
+          llvm::cast<clang::AccessSpecDecl>(inner_decl);
+      clang::AccessSpecifier as = asd->getAccess();
+      if (as == clang::AS_public)
+        current_access = SgAccessModifier::e_public;
+      else if (as == clang::AS_protected)
+        current_access = SgAccessModifier::e_protected;
+      else if (as == clang::AS_private)
+        current_access = SgAccessModifier::e_private;
+      continue;
+    }
+
+    if (inner_decl->isImplicit()) {
+      continue;
+    }
+
+    SgNode *sg_child = Traverse(inner_decl);
+    if (SgDeclarationStatement *child_decl =
+            isSgDeclarationStatement(sg_child)) {
+      if (child_decl->get_parent() == NULL) {
+        child_decl->set_parent(class_def);
+      }
+      if (child_decl->get_scope() == NULL) {
+        child_decl->set_scope(class_def);
+      }
+      diagnose_null_scope(child_decl, "populateClassDefinition");
+
+      const SgDeclarationStatementPtrList &members = class_def->get_members();
+      if (std::find(members.begin(), members.end(), child_decl) ==
+          members.end()) {
+        class_def->append_member(child_decl);
+      }
+
+      // Redundancy Check
+      SgAccessModifier &mod =
+          child_decl->get_declarationModifier().get_accessModifier();
+      SgAccessModifier::access_modifier_enum access = mod.get_modifier();
+
+      if (access != SgAccessModifier::e_unknown) {
+        // REX ARCHITECTURE FIX:
+        // Instead of stripping redundant modifiers to e_unknown, we keep
+        // them but mark whether they are explicit or implicit. This
+        // preserves analysis safety (isPrivate() == true) while allowing
+        // the unparser to distinguish user intent.
+
+        mod.set_is_explicit(explicit_access_context);
+        if (explicit_access_context) {
+          explicit_access_context = false;
+        }
+
+        // Track current access for our own logic if needed, though with
+        // the new architecture we rely less on this state for stripping.
+        if (access != current_access) {
+          current_access = access;
+        }
+      }
+    }
+  }
+
+  SageBuilder::popScopeStack();
+}
+
+SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
+    clang::NamedDecl *param_decl, SgDeclarationStatement *owning_template,
+    unsigned position) {
+  std::map<clang::Decl *, SgNode *>::iterator it =
+      p_decl_translation_map.find(param_decl);
+  if (it != p_decl_translation_map.end()) {
+#if DEBUG_TRAVERSE_DECL
+    std::cerr << "Traverse Decl : " << param_decl << " ";
+    if (clang::NamedDecl::classof(param_decl)) {
+      std::cerr << ": " << ((clang::NamedDecl *)param_decl)->getNameAsString()
+                << ") ";
+    }
+    std::cerr << " already visited : node = " << it->second << std::endl;
+#endif
+    return isSgTemplateParameter(it->second);
+  }
+
+  SgTemplateParameter *sg_param = NULL;
+
+  if (clang::TemplateTypeParmDecl *type_param =
+          llvm::dyn_cast<clang::TemplateTypeParmDecl>(param_decl)) {
+    std::string name_str = type_param->getNameAsString();
+    // REX FIX: Don't generate placeholder names for anonymous parameters
+    // Leave them empty so the unparser knows they're anonymous
+    // The placeholder names like __type_param_0 are not needed
+
+    SgTemplateType *template_type =
+        SageBuilder::buildTemplateType(SgName(name_str));
+    if (type_param->isParameterPack()) {
+      template_type->set_packed(true);
+    }
+    sg_param = SageBuilder::buildTemplateParameter(
+        SgTemplateParameter::type_parameter, template_type);
+
+    // REX FIX: Set keyword (typename vs class) for type parameters
+    // This is needed for child parameters of template-template parameters
+    // which are not visited via VisitTemplateTypeParmDecl
+    std::string kw =
+        type_param->wasDeclaredWithTypename() ? "typename" : "class";
+    SageInterface::setTemplateParameterKeyword(sg_param, kw);
+
+    if (type_param->hasDefaultArgument()) {
+      const clang::TemplateArgumentLoc &default_loc =
+          type_param->getDefaultArgument();
+      const clang::TemplateArgument &default_arg = default_loc.getArgument();
+
+      if (default_arg.getKind() == clang::TemplateArgument::Type) {
+        SgType *default_type =
+            buildTypeFromQualifiedType(default_arg.getAsType());
+        if (default_type != NULL) {
+          sg_param->set_defaultTypeParameter(default_type);
+
+          // REX FIX: The ROSE unparser does not consistently print
+          // default template arguments for type parameters from the
+          // attribute alone in this context. To ensure "class T =
+          // void" is unparsed, we manually bake it into the template
+          // type name. This is a workaround for unparser limitations.
+          std::string type_str = default_type->unparseToString();
+          if (!type_str.empty()) {
+            // Create a new SgTemplateType just for this parameter's
+            // signature e.g. "T = void" Note: This type shouldn't be
+            // shared or used for body symbol lookup where "T" is
+            // expected, but since the primary template body doesn't
+            // use T (in the enable_if case), or T is shadowed/bound
+            // by the scope symbol, this visual hack handles the
+            // declaration requirement.
+            SgTemplateType *param_type_with_default =
+                SageBuilder::buildTemplateType(
+                    SgName(name_str + " = " + type_str));
+            if (type_param->isParameterPack()) {
+              param_type_with_default->set_packed(true);
+            }
+            sg_param->set_type(param_type_with_default);
+          }
+        }
       }
     }
 
-    // REX FIX: We must detect if an access specifier was explicitly written.
-    bool explicit_access_context = false;
-
-    for (clang::Decl* inner_decl : record_decl->decls()) {
-        if (inner_decl == NULL) {
-            continue;
-        }
-
-        // Check for explicit access specifier (e.g. "private:")
-        if (llvm::isa<clang::AccessSpecDecl>(inner_decl)) {
-          explicit_access_context = true;
-          // We continue because AccessSpecDecl doesn't map to a ROSE node in
-          // Traverse But we need to update current_access to match what
-          // Traverse/Unparser expects
-          clang::AccessSpecDecl *asd =
-              llvm::cast<clang::AccessSpecDecl>(inner_decl);
-          clang::AccessSpecifier as = asd->getAccess();
-          if (as == clang::AS_public)
-            current_access = SgAccessModifier::e_public;
-          else if (as == clang::AS_protected)
-            current_access = SgAccessModifier::e_protected;
-          else if (as == clang::AS_private)
-            current_access = SgAccessModifier::e_private;
-          continue;
-        }
-
-        if (inner_decl->isImplicit()) {
-            continue;
-        }
-
-        SgNode* sg_child = Traverse(inner_decl);
-        if (SgDeclarationStatement* child_decl = isSgDeclarationStatement(sg_child)) {
-            if (child_decl->get_parent() == NULL) {
-                child_decl->set_parent(class_def);
-            }
-            if (child_decl->get_scope() == NULL) {
-                child_decl->set_scope(class_def);
-            }
-            diagnose_null_scope(child_decl, "populateClassDefinition");
-
-            const SgDeclarationStatementPtrList &members =
-                class_def->get_members();
-            if (std::find(members.begin(), members.end(), child_decl) ==
-                members.end()) {
-              class_def->append_member(child_decl);
-            }
-
-            // Redundancy Check
-            SgAccessModifier &mod =
-                child_decl->get_declarationModifier().get_accessModifier();
-            SgAccessModifier::access_modifier_enum access = mod.get_modifier();
-
-            if (access != SgAccessModifier::e_unknown) {
-              // REX ARCHITECTURE FIX:
-              // Instead of stripping redundant modifiers to e_unknown, we keep
-              // them but mark whether they are explicit or implicit. This
-              // preserves analysis safety (isPrivate() == true) while allowing
-              // the unparser to distinguish user intent.
-
-              mod.set_is_explicit(explicit_access_context);
-              if (explicit_access_context) {
-                explicit_access_context = false;
-              }
-
-              // Track current access for our own logic if needed, though with
-              // the new architecture we rely less on this state for stripping.
-              if (access != current_access) {
-                current_access = access;
-              }
-            }
-        }
+    if (type_param->isParameterPack()) {
+      sg_param->set_is_parameter_pack(true);
+    }
+  } else if (clang::NonTypeTemplateParmDecl *non_type_param =
+                 llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(param_decl)) {
+    std::string name_str = non_type_param->getNameAsString();
+    if (name_str.empty()) {
+      name_str = "__non_type_param_" + std::to_string(position);
     }
 
-    SageBuilder::popScopeStack();
+    SgType *type = buildTypeFromQualifiedType(non_type_param->getType());
+    if (type == NULL) {
+      type = SageBuilder::buildIntType();
+    }
+
+    // Build initialized name so the unparser keeps the parameter name/type when
+    // no default is present.
+    SgInitializedName *init_name =
+        SageBuilder::buildInitializedName(SgName(name_str), type);
+    applySourceRange(init_name, non_type_param->getSourceRange());
+
+    SgTemplateParameter *param = SageBuilder::buildTemplateParameter(
+        SgTemplateParameter::nontype_parameter, type);
+    param->set_initializedName(init_name);
+    init_name->set_parent(param);
+    param->set_type(type);
+    sg_param = param;
+
+    if (non_type_param->isParameterPack()) {
+      param->set_is_parameter_pack(true);
+      init_name->set_is_parameter_pack(true);
+    }
+
+    // NOTE: Template parameters don't set declptr. SgTemplateParameter is an
+    // SgSupport node, not an SgDeclarationStatement, so it cannot be used with
+    // set_declptr(). The parent relationship (set above) is sufficient for
+    // template parameters.
+
+    if (non_type_param->hasDefaultArgument()) {
+      const clang::TemplateArgumentLoc &default_loc =
+          non_type_param->getDefaultArgument();
+      const clang::TemplateArgument &default_arg = default_loc.getArgument();
+      SgExpression *sg_default_expr = NULL;
+
+      switch (default_arg.getKind()) {
+      case clang::TemplateArgument::Expression: {
+        clang::Expr *expr = default_arg.getAsExpr();
+        if (expr != NULL) {
+          SgNode *sg_node = Traverse(expr);
+          sg_default_expr = isSgExpression(sg_node);
+        }
+        break;
+      }
+      case clang::TemplateArgument::Integral: {
+        const llvm::APSInt &value = default_arg.getAsIntegral();
+        bool is_signed = value.isSigned();
+        unsigned bitwidth = value.getBitWidth();
+        if (is_signed) {
+          long long v = (bitwidth <= 63) ? value.getSExtValue() : 0;
+          sg_default_expr = SageBuilder::buildLongLongIntVal(v);
+        } else {
+          unsigned long long v = (bitwidth <= 64) ? value.getZExtValue() : 0;
+          sg_default_expr = SageBuilder::buildUnsignedLongLongIntVal(v);
+        }
+        if (SgLongLongIntVal *ll = isSgLongLongIntVal(sg_default_expr)) {
+          llvm::SmallString<64> buf;
+          value.toString(buf, 10, value.isSigned());
+          ll->set_valueString(std::string(buf.begin(), buf.end()));
+        } else if (SgUnsignedLongLongIntVal *ull =
+                       isSgUnsignedLongLongIntVal(sg_default_expr)) {
+          llvm::SmallString<64> buf;
+          value.toString(buf, 10, value.isSigned());
+          ull->set_valueString(std::string(buf.begin(), buf.end()));
+        }
+        break;
+      }
+      default:
+        break;
+      }
+
+      if (sg_default_expr != NULL) {
+        sg_param->set_defaultExpressionParameter(sg_default_expr);
+      }
+    }
+  } else if (clang::TemplateTemplateParmDecl *template_template_param =
+                 llvm::dyn_cast<clang::TemplateTemplateParmDecl>(param_decl)) {
+    // Proper implementation for TemplateTemplateParmDecl using SgNonrealDecl
+    std::string name_str = template_template_param->getNameAsString();
+    if (name_str.empty()) {
+      name_str = "__template_template_param_" + std::to_string(position);
+    }
+
+    // Create SgNonrealDecl to represent the template template parameter
+    // using the current scope.
+    SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+    ROSE_ASSERT(current_scope != NULL);
+
+    SgDeclarationScope *decl_scope = isSgDeclarationScope(current_scope);
+    if (decl_scope == NULL) {
+      decl_scope = SageBuilder::buildDeclarationScope();
+      decl_scope->set_parent(current_scope);
+    }
+
+    SgNonrealDecl *nrdecl =
+        SageBuilder::buildNonrealDecl(SgName(name_str), decl_scope);
+    diagnose_null_scope(nrdecl, "TemplateTemplateParmDecl");
+
+    // Create the template parameter with parameter_template kind
+    // Use SgTemplateType with the parameter name
+    SgTemplateType *param_type =
+        SageBuilder::buildTemplateType(SgName(name_str));
+    if (template_template_param->isParameterPack()) {
+      param_type->set_packed(true);
+    }
+    sg_param = SageBuilder::buildTemplateParameter(
+        SgTemplateParameter::template_parameter, param_type);
+
+    // Set the declaration parameter to the SgNonrealDecl
+    // For template_parameter, get_templateDeclaration() is used to retrieve the
+    // nrdecl
+    sg_param->set_templateDeclaration(nrdecl);
+
+    // Translate and set the template parameters of the template template
+    // parameter
+    clang::TemplateParameterList *child_params =
+        template_template_param->getTemplateParameters();
+    if (child_params) {
+      // Pass nrdecl as the owning template for these parameters
+      SgTemplateParameterPtrList *sg_child_params =
+          translateTemplateParameterList(child_params, nrdecl);
+      // SgNonrealDecl::get_tpl_params() returns a reference to the list
+      nrdecl->get_tpl_params() = *sg_child_params;
+    }
+
+    // REX FIX: Set keyword (typename vs class) for the outer part of
+    // template-template parameter e.g., "template <typename ...> typename C" -
+    // the outer "typename" before C
+    std::string outer_kw = template_template_param->wasDeclaredWithTypename()
+                               ? "typename"
+                               : "class";
+    SageInterface::setTemplateParameterKeyword(sg_param, outer_kw);
+
+    if (template_template_param->isParameterPack()) {
+      sg_param->set_is_parameter_pack(true);
+    }
+  } else {
+    std::cerr << "Warning: Unsupported template parameter kind: "
+              << param_decl->getDeclKindName() << std::endl;
+    return NULL;
+  }
+
+  if (sg_param != NULL) {
+    applySourceRange(sg_param, param_decl->getSourceRange());
+
+    // Only set owning template if it's NOT a template_parameter,
+    // because template_parameter uses this field for the nrdecl.
+    if (owning_template != NULL &&
+        sg_param->get_parameterType() !=
+            SgTemplateParameter::template_parameter) {
+      sg_param->set_templateDeclaration(owning_template);
+    } else if (sg_param->get_parameterType() ==
+               SgTemplateParameter::template_parameter) {
+      // Verify that templateDeclaration is still the SgNonrealDecl
+      SgNode *decl = sg_param->get_templateDeclaration();
+
+      if (!isSgNonrealDecl(decl)) {
+        std::cerr << "ERROR: templateDeclaration is NOT SgNonrealDecl!"
+                  << std::endl;
+      }
+    }
+    p_decl_translation_map.insert(std::make_pair(param_decl, sg_param));
+  }
+
+  return sg_param;
 }
 
-SgTemplateParameter * ClangToSageTranslator::translateTemplateParameter ( clang::NamedDecl * param_decl, SgDeclarationStatement * owning_template, unsigned position ) {
-    std::map<clang::Decl *, SgNode *>::iterator it = p_decl_translation_map.find(param_decl);
-    if (it != p_decl_translation_map.end()) {
+SgNode *ClangToSageTranslator::Traverse(clang::Decl *decl) {
+  if (decl == NULL)
+    return NULL;
+
+  if (clang::NamedDecl *nd = llvm::dyn_cast<clang::NamedDecl>(decl)) {
+    std::string name = nd->getNameAsString();
+    if (name == "dep" || name == "pack" || name == "a" || name == "ms") {
+      // std::cerr << "DEBUG: Traverse(Decl) for " << name << " kind: " <<
+      // decl->getDeclKindName() << std::endl;
+    }
+  }
+
+  std::map<clang::Decl *, SgNode *>::iterator it =
+      p_decl_translation_map.find(decl);
+  if (it != p_decl_translation_map.end()) {
 #if DEBUG_TRAVERSE_DECL
-        std::cerr << "Traverse Decl : " << param_decl << " ";
-        if (clang::NamedDecl::classof(param_decl)) {
-            std::cerr << ": " << ((clang::NamedDecl *)param_decl)->getNameAsString() << ") ";
-        }
-        std::cerr << " already visited : node = " << it->second << std::endl;
-#endif
-        return isSgTemplateParameter(it->second);
-    }
-
-    SgTemplateParameter* sg_param = NULL;
-
-    if (clang::TemplateTypeParmDecl* type_param = llvm::dyn_cast<clang::TemplateTypeParmDecl>(param_decl)) {
-        std::string name_str = type_param->getNameAsString();
-        // REX FIX: Don't generate placeholder names for anonymous parameters
-        // Leave them empty so the unparser knows they're anonymous
-        // The placeholder names like __type_param_0 are not needed
-
-        SgTemplateType *template_type =
-            SageBuilder::buildTemplateType(SgName(name_str));
-        if (type_param->isParameterPack()) {
-          template_type->set_packed(true);
-        }
-        sg_param = SageBuilder::buildTemplateParameter(SgTemplateParameter::type_parameter, template_type);
-
-        // REX FIX: Set keyword (typename vs class) for type parameters
-        // This is needed for child parameters of template-template parameters
-        // which are not visited via VisitTemplateTypeParmDecl
-        std::string kw = type_param->wasDeclaredWithTypename() ? "typename" : "class";
-        SageInterface::setTemplateParameterKeyword(sg_param, kw);
-
-        if (type_param->hasDefaultArgument()) {
-            const clang::TemplateArgumentLoc& default_loc = type_param->getDefaultArgument();
-            const clang::TemplateArgument& default_arg = default_loc.getArgument();
-
-            if (default_arg.getKind() == clang::TemplateArgument::Type) {
-                SgType* default_type = buildTypeFromQualifiedType(default_arg.getAsType());
-                if (default_type != NULL) {
-                    sg_param->set_defaultTypeParameter(default_type);
-
-                    // REX FIX: The ROSE unparser does not consistently print
-                    // default template arguments for type parameters from the
-                    // attribute alone in this context. To ensure "class T =
-                    // void" is unparsed, we manually bake it into the template
-                    // type name. This is a workaround for unparser limitations.
-                    std::string type_str = default_type->unparseToString();
-                    if (!type_str.empty()) {
-                      // Create a new SgTemplateType just for this parameter's
-                      // signature e.g. "T = void" Note: This type shouldn't be
-                      // shared or used for body symbol lookup where "T" is
-                      // expected, but since the primary template body doesn't
-                      // use T (in the enable_if case), or T is shadowed/bound
-                      // by the scope symbol, this visual hack handles the
-                      // declaration requirement.
-                      SgTemplateType *param_type_with_default =
-                          SageBuilder::buildTemplateType(
-                              SgName(name_str + " = " + type_str));
-                      if (type_param->isParameterPack()) {
-                        param_type_with_default->set_packed(true);
-                      }
-                      sg_param->set_type(param_type_with_default);
-                    }
-                }
-            }
-        }
-        
-        if (type_param->isParameterPack()) {
-          sg_param->set_is_parameter_pack(true);
-        }
-    } else if (clang::NonTypeTemplateParmDecl* non_type_param = llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(param_decl)) {
-        std::string name_str = non_type_param->getNameAsString();
-        if (name_str.empty()) {
-            name_str = "__non_type_param_" + std::to_string(position);
-        }
-
-        SgType* type = buildTypeFromQualifiedType(non_type_param->getType());
-        if (type == NULL) {
-            type = SageBuilder::buildIntType();
-        }
-
-        // Build initialized name so the unparser keeps the parameter name/type when no default is present.
-        SgInitializedName* init_name = SageBuilder::buildInitializedName(SgName(name_str), type);
-        applySourceRange(init_name, non_type_param->getSourceRange());
-
-        SgTemplateParameter* param = SageBuilder::buildTemplateParameter(SgTemplateParameter::nontype_parameter, type);
-        param->set_initializedName(init_name);
-        init_name->set_parent(param);
-        param->set_type(type);
-        sg_param = param;
-
-        if (non_type_param->isParameterPack()) {
-          param->set_is_parameter_pack(true);
-          init_name->set_is_parameter_pack(true);
-        }
-
-        // NOTE: Template parameters don't set declptr. SgTemplateParameter is an SgSupport node,
-        // not an SgDeclarationStatement, so it cannot be used with set_declptr().
-        // The parent relationship (set above) is sufficient for template parameters.
-
-        if (non_type_param->hasDefaultArgument()) {
-            const clang::TemplateArgumentLoc& default_loc = non_type_param->getDefaultArgument();
-            const clang::TemplateArgument& default_arg = default_loc.getArgument();
-            SgExpression* sg_default_expr = NULL;
-
-            switch (default_arg.getKind()) {
-                case clang::TemplateArgument::Expression: {
-                    clang::Expr* expr = default_arg.getAsExpr();
-                    if (expr != NULL) {
-                        SgNode* sg_node = Traverse(expr);
-                        sg_default_expr = isSgExpression(sg_node);
-                    }
-                    break;
-                }
-                case clang::TemplateArgument::Integral: {
-                    const llvm::APSInt& value = default_arg.getAsIntegral();
-                    bool is_signed = value.isSigned();
-                    unsigned bitwidth = value.getBitWidth();
-                    if (is_signed) {
-                        long long v = (bitwidth <= 63) ? value.getSExtValue() : 0;
-                        sg_default_expr = SageBuilder::buildLongLongIntVal(v);
-                    } else {
-                        unsigned long long v = (bitwidth <= 64) ? value.getZExtValue() : 0;
-                        sg_default_expr = SageBuilder::buildUnsignedLongLongIntVal(v);
-                    }
-                    if (SgLongLongIntVal* ll = isSgLongLongIntVal(sg_default_expr)) {
-                        llvm::SmallString<64> buf;
-                        value.toString(buf, 10, value.isSigned());
-                        ll->set_valueString(std::string(buf.begin(), buf.end()));
-                    } else if (SgUnsignedLongLongIntVal* ull = isSgUnsignedLongLongIntVal(sg_default_expr)) {
-                        llvm::SmallString<64> buf;
-                        value.toString(buf, 10, value.isSigned());
-                        ull->set_valueString(std::string(buf.begin(), buf.end()));
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-
-            if (sg_default_expr != NULL) {
-                sg_param->set_defaultExpressionParameter(sg_default_expr);
-            }
-        }
-    } else if (clang::TemplateTemplateParmDecl* template_template_param = llvm::dyn_cast<clang::TemplateTemplateParmDecl>(param_decl)) {
-        // Proper implementation for TemplateTemplateParmDecl using SgNonrealDecl
-        std::string name_str = template_template_param->getNameAsString();
-        if (name_str.empty()) {
-            name_str = "__template_template_param_" + std::to_string(position);
-        }
-
-        // Create SgNonrealDecl to represent the template template parameter
-        // using the current scope.
-        SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-        ROSE_ASSERT(current_scope != NULL);
-
-        SgDeclarationScope *decl_scope = isSgDeclarationScope(current_scope);
-        if (decl_scope == NULL) {
-          decl_scope = SageBuilder::buildDeclarationScope();
-          decl_scope->set_parent(current_scope);
-        }
-
-        SgNonrealDecl* nrdecl = SageBuilder::buildNonrealDecl(SgName(name_str), decl_scope);
-        diagnose_null_scope(nrdecl, "TemplateTemplateParmDecl");
-
-        // Create the template parameter with parameter_template kind
-        // Use SgTemplateType with the parameter name
-        SgTemplateType* param_type = SageBuilder::buildTemplateType(SgName(name_str));
-        if (template_template_param->isParameterPack()) {
-          param_type->set_packed(true);
-        }
-        sg_param = SageBuilder::buildTemplateParameter(SgTemplateParameter::template_parameter, param_type);
-        
-        // Set the declaration parameter to the SgNonrealDecl
-        // For template_parameter, get_templateDeclaration() is used to retrieve the nrdecl
-        sg_param->set_templateDeclaration(nrdecl);
-        
-        // Translate and set the template parameters of the template template parameter
-        clang::TemplateParameterList* child_params = template_template_param->getTemplateParameters();
-        if (child_params) {
-             // Pass nrdecl as the owning template for these parameters
-             SgTemplateParameterPtrList* sg_child_params = translateTemplateParameterList(child_params, nrdecl);
-             // SgNonrealDecl::get_tpl_params() returns a reference to the list
-             nrdecl->get_tpl_params() = *sg_child_params;
-        }
-        
-        // REX FIX: Set keyword (typename vs class) for the outer part of template-template parameter
-        // e.g., "template <typename ...> typename C" - the outer "typename" before C
-        std::string outer_kw = template_template_param->wasDeclaredWithTypename() ? "typename" : "class";
-        SageInterface::setTemplateParameterKeyword(sg_param, outer_kw);
-        
-        if (template_template_param->isParameterPack()) {
-          sg_param->set_is_parameter_pack(true);
-        }
-    } else {
-        std::cerr << "Warning: Unsupported template parameter kind: "
-                  << param_decl->getDeclKindName() << std::endl;
-        return NULL;
-    }
-
-    if (sg_param != NULL) {
-        applySourceRange(sg_param, param_decl->getSourceRange());
-        
-        // Only set owning template if it's NOT a template_parameter, 
-        // because template_parameter uses this field for the nrdecl.
-        if (owning_template != NULL && sg_param->get_parameterType() != SgTemplateParameter::template_parameter) {
-            sg_param->set_templateDeclaration(owning_template);
-        } else if (sg_param->get_parameterType() == SgTemplateParameter::template_parameter) {
-             // Verify that templateDeclaration is still the SgNonrealDecl
-             SgNode* decl = sg_param->get_templateDeclaration();
-             
-             if (!isSgNonrealDecl(decl)) {
-                 std::cerr << "ERROR: templateDeclaration is NOT SgNonrealDecl!" << std::endl;
-             }
-        }
-        p_decl_translation_map.insert(std::make_pair(param_decl, sg_param));
-    }
-
-    return sg_param;
-}
-
-
-
-SgNode * ClangToSageTranslator::Traverse(clang::Decl * decl) {
-    if (decl == NULL)
-        return NULL;
-    
-    if (clang::NamedDecl* nd = llvm::dyn_cast<clang::NamedDecl>(decl)) {
-        std::string name = nd->getNameAsString();
-        if (name == "dep" || name == "pack" || name == "a" || name == "ms") {
-             // std::cerr << "DEBUG: Traverse(Decl) for " << name << " kind: " << decl->getDeclKindName() << std::endl;
-        }
-    }
-
-    std::map<clang::Decl *, SgNode *>::iterator it = p_decl_translation_map.find(decl);
-    if (it != p_decl_translation_map.end()) {
-#if DEBUG_TRAVERSE_DECL
-        std::cerr << "Traverse Decl : " << decl << " ";
-        if (clang::NamedDecl::classof(decl)) {
-            std::cerr << ": " << ((clang::NamedDecl *)decl)->getNameAsString() << ") ";
-        }
-        std::cerr << " already visited : node = " << it->second << std::endl;
-#endif
-        if (it->second == NULL && clang::NamedDecl::classof(decl)) {
-             std::string name = ((clang::NamedDecl *)decl)->getNameAsString();
-             if (name == "tuple") {
-                 std::cerr << "DEBUG: Traverse found 'tuple' in map but node is NULL!" << std::endl;
-             }
-        }
-        return it->second;
-    }
-
-    SgNode * result = NULL;
-    bool ret_status = false;
-
-    switch (decl->getKind()) {
-        case clang::Decl::AccessSpec:
-            ret_status = VisitAccessSpecDecl((clang::AccessSpecDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Block:
-            ret_status = VisitBlockDecl((clang::BlockDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Captured:
-            ret_status = VisitCapturedDecl((clang::CapturedDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Empty:
-            ret_status = VisitEmptyDecl((clang::EmptyDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Export:
-            ret_status = VisitExportDecl((clang::ExportDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ExternCContext:
-            ret_status = VisitExternCContextDecl((clang::ExternCContextDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::FileScopeAsm:
-            ret_status = VisitFileScopeAsmDecl((clang::FileScopeAsmDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Friend:
-            ret_status = VisitFriendDecl((clang::FriendDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::FriendTemplate:
-            ret_status = VisitFriendTemplateDecl((clang::FriendTemplateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Import:
-            ret_status = VisitImportDecl((clang::ImportDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Label:
-            ret_status = VisitLabelDecl((clang::LabelDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::NamespaceAlias:
-            ret_status = VisitNamespaceAliasDecl((clang::NamespaceAliasDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Namespace:
-            ret_status = VisitNamespaceDecl((clang::NamespaceDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::LinkageSpec:
-            ret_status = VisitLinkageSpecDecl((clang::LinkageSpecDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::BuiltinTemplate: {
-            ret_status = false;
-            result = NULL;
-            break;
-        }
-        case clang::Decl::Concept:
-            ret_status = VisitConceptDecl((clang::ConceptDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ClassTemplate:
-            ret_status = VisitClassTemplateDecl((clang::ClassTemplateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::FunctionTemplate:
-            ret_status = VisitFunctionTemplateDecl((clang::FunctionTemplateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::TypeAliasTemplate:
-            ret_status = VisitTypeAliasTemplateDecl((clang::TypeAliasTemplateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::VarTemplate:
-            ret_status = VisitVarTemplateDecl((clang::VarTemplateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::TemplateTemplateParm:
-            ret_status = VisitTemplateTemplateParmDecl((clang::TemplateTemplateParmDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Record:
-            ret_status = VisitRecordDecl((clang::RecordDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXRecord:
-            ret_status = VisitCXXRecordDecl((clang::CXXRecordDecl *)decl, &result);
-            if (result) {
-              SgDeclarationStatement *d = isSgDeclarationStatement(result);
-              if (d && d->get_firstNondefiningDeclaration() == NULL) {
-                fprintf(stderr,
-                        "DEBUG: Traverse VisitCXXRecordDecl returned decl %p "
-                        "with NULL firstNondef! name=%s. Fixing..\n",
-                        d,
-                        ((clang::NamedDecl *)decl)->getNameAsString().c_str());
-                d->set_firstNondefiningDeclaration(d);
-              }
-            }
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ClassTemplateSpecialization:
-            ret_status = VisitClassTemplateSpecializationDecl((clang::ClassTemplateSpecializationDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ClassTemplatePartialSpecialization:
-            ret_status = VisitClassTemplatePartialSpecializationDecl((clang::ClassTemplatePartialSpecializationDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Enum:
-            ret_status = VisitEnumDecl((clang::EnumDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::TemplateTypeParm:
-            ret_status = VisitTemplateTypeParmDecl((clang::TemplateTypeParmDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Typedef:
-            ret_status = VisitTypedefDecl((clang::TypedefDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::TypeAlias:
-            ret_status = VisitTypeAliasDecl((clang::TypeAliasDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::UnresolvedUsingTypename:
-            ret_status = VisitUnresolvedUsingTypenameDecl((clang::UnresolvedUsingTypenameDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Using:
-            ret_status = VisitUsingDecl((clang::UsingDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::UsingDirective:
-            ret_status = VisitUsingDirectiveDecl((clang::UsingDirectiveDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::UsingPack:
-            ret_status = VisitUsingPackDecl((clang::UsingPackDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::UsingShadow:
-            ret_status = VisitUsingShadowDecl((clang::UsingShadowDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ConstructorUsingShadow:
-            ret_status = VisitConstructorUsingShadowDecl((clang::ConstructorUsingShadowDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Binding:
-            ret_status = VisitBindingDecl((clang::BindingDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Field:
-            ret_status = VisitFieldDecl((clang::FieldDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Function:
-            ret_status = VisitFunctionDecl((clang::FunctionDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXDeductionGuide:
-            ret_status = VisitCXXDeductionGuideDecl((clang::CXXDeductionGuideDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXConstructor:
-            ret_status = VisitCXXConstructorDecl((clang::CXXConstructorDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXConversion:
-            ret_status = VisitCXXConversionDecl((clang::CXXConversionDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXDestructor:
-            ret_status = VisitCXXDestructorDecl((clang::CXXDestructorDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::CXXMethod:
-            ret_status = VisitCXXMethodDecl((clang::CXXMethodDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::MSProperty:
-            ret_status = VisitMSPropertyDecl((clang::MSPropertyDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::NonTypeTemplateParm:
-            ret_status = VisitNonTypeTemplateParmDecl((clang::NonTypeTemplateParmDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Decomposition:
-            ret_status = VisitDecompositionDecl((clang::DecompositionDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ImplicitParam:
-            ret_status = VisitImplicitParamDecl((clang::ImplicitParamDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPCapturedExpr:
-            ret_status = VisitOMPCaptureExprDecl((clang::OMPCapturedExprDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::ParmVar:
-            ret_status = VisitParmVarDecl((clang::ParmVarDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::VarTemplatePartialSpecialization:
-            ret_status = VisitVarTemplatePartialSpecializationDecl((clang::VarTemplatePartialSpecializationDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::VarTemplateSpecialization:
-            ret_status = VisitVarTemplateSpecializationDecl((clang::VarTemplateSpecializationDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::EnumConstant:
-            ret_status = VisitEnumConstantDecl((clang::EnumConstantDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::IndirectField:
-            ret_status = VisitIndirectFieldDecl((clang::IndirectFieldDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPDeclareMapper:
-            ret_status = VisitOMPDeclareMapperDecl((clang::OMPDeclareMapperDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPDeclareReduction:
-            ret_status = VisitOMPDeclareReductionDecl((clang::OMPDeclareReductionDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::UnresolvedUsingValue:
-            ret_status = VisitUnresolvedUsingValueDecl((clang::UnresolvedUsingValueDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPAllocate:
-            ret_status = VisitOMPAllocateDecl((clang::OMPAllocateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPRequires:
-            ret_status = VisitOMPRequiresDecl((clang::OMPRequiresDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::OMPThreadPrivate:
-            ret_status = VisitOMPThreadPrivateDecl((clang::OMPThreadPrivateDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::PragmaComment:
-            ret_status = VisitPragmaCommentDecl((clang::PragmaCommentDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::PragmaDetectMismatch:
-            ret_status = VisitPragmaDetectMismatchDecl((clang::PragmaDetectMismatchDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::StaticAssert:
-            ret_status = VisitStaticAssertDecl((clang::StaticAssertDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::TranslationUnit:
-            ret_status = VisitTranslationUnitDecl((clang::TranslationUnitDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-        case clang::Decl::Var:
-            ret_status = VisitVarDecl((clang::VarDecl *)decl, &result);
-            ROSE_ASSERT(ret_status == false || result != NULL);
-            break;
-
-        default:
-            std::cerr << "Unknown declacaration kind: " << decl->getDeclKindName() << " !" << std::endl;
-            ROSE_ABORT();
-    }
-
-    ROSE_ASSERT(ret_status == false || result != NULL);
-
-    if (ret_status && result != NULL) {
-        if (SgDeclarationStatement* ds = isSgDeclarationStatement(result)) {
-            ensure_parent_and_scope(ds);
-        }
-        p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(decl, result));
-    }
-
-#if DEBUG_TRAVERSE_DECL
-    std::cerr << "Traverse(clang::Decl : " << decl << " ";
+    std::cerr << "Traverse Decl : " << decl << " ";
     if (clang::NamedDecl::classof(decl)) {
-        std::cerr << ": " << ((clang::NamedDecl *)decl)->getNameAsString() << ") ";
+      std::cerr << ": " << ((clang::NamedDecl *)decl)->getNameAsString()
+                << ") ";
     }
-    std::cerr << " visit done : node = " << result << std::endl;
+    std::cerr << " already visited : node = " << it->second << std::endl;
+#endif
+    if (it->second == NULL && clang::NamedDecl::classof(decl)) {
+      std::string name = ((clang::NamedDecl *)decl)->getNameAsString();
+      if (name == "tuple") {
+        std::cerr << "DEBUG: Traverse found 'tuple' in map but node is NULL!"
+                  << std::endl;
+      }
+    }
+    return it->second;
+  }
+
+  SgNode *result = NULL;
+  bool ret_status = false;
+
+  switch (decl->getKind()) {
+  case clang::Decl::AccessSpec:
+    ret_status = VisitAccessSpecDecl((clang::AccessSpecDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Block:
+    ret_status = VisitBlockDecl((clang::BlockDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Captured:
+    ret_status = VisitCapturedDecl((clang::CapturedDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Empty:
+    ret_status = VisitEmptyDecl((clang::EmptyDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Export:
+    ret_status = VisitExportDecl((clang::ExportDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ExternCContext:
+    ret_status =
+        VisitExternCContextDecl((clang::ExternCContextDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::FileScopeAsm:
+    ret_status =
+        VisitFileScopeAsmDecl((clang::FileScopeAsmDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Friend:
+    ret_status = VisitFriendDecl((clang::FriendDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::FriendTemplate:
+    ret_status =
+        VisitFriendTemplateDecl((clang::FriendTemplateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Import:
+    ret_status = VisitImportDecl((clang::ImportDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Label:
+    ret_status = VisitLabelDecl((clang::LabelDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::NamespaceAlias:
+    ret_status =
+        VisitNamespaceAliasDecl((clang::NamespaceAliasDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Namespace:
+    ret_status = VisitNamespaceDecl((clang::NamespaceDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::LinkageSpec:
+    ret_status = VisitLinkageSpecDecl((clang::LinkageSpecDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::BuiltinTemplate: {
+    ret_status = false;
+    result = NULL;
+    break;
+  }
+  case clang::Decl::Concept:
+    ret_status = VisitConceptDecl((clang::ConceptDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ClassTemplate:
+    ret_status =
+        VisitClassTemplateDecl((clang::ClassTemplateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::FunctionTemplate:
+    ret_status =
+        VisitFunctionTemplateDecl((clang::FunctionTemplateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::TypeAliasTemplate:
+    ret_status = VisitTypeAliasTemplateDecl(
+        (clang::TypeAliasTemplateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::VarTemplate:
+    ret_status = VisitVarTemplateDecl((clang::VarTemplateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::TemplateTemplateParm:
+    ret_status = VisitTemplateTemplateParmDecl(
+        (clang::TemplateTemplateParmDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Record:
+    ret_status = VisitRecordDecl((clang::RecordDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXRecord:
+    ret_status = VisitCXXRecordDecl((clang::CXXRecordDecl *)decl, &result);
+    if (result) {
+      SgDeclarationStatement *d = isSgDeclarationStatement(result);
+      if (d && d->get_firstNondefiningDeclaration() == NULL) {
+        fprintf(stderr,
+                "DEBUG: Traverse VisitCXXRecordDecl returned decl %p "
+                "with NULL firstNondef! name=%s. Fixing..\n",
+                d, ((clang::NamedDecl *)decl)->getNameAsString().c_str());
+        d->set_firstNondefiningDeclaration(d);
+      }
+    }
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ClassTemplateSpecialization:
+    ret_status = VisitClassTemplateSpecializationDecl(
+        (clang::ClassTemplateSpecializationDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ClassTemplatePartialSpecialization:
+    ret_status = VisitClassTemplatePartialSpecializationDecl(
+        (clang::ClassTemplatePartialSpecializationDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Enum:
+    ret_status = VisitEnumDecl((clang::EnumDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::TemplateTypeParm:
+    ret_status =
+        VisitTemplateTypeParmDecl((clang::TemplateTypeParmDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Typedef:
+    ret_status = VisitTypedefDecl((clang::TypedefDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::TypeAlias:
+    ret_status = VisitTypeAliasDecl((clang::TypeAliasDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::UnresolvedUsingTypename:
+    ret_status = VisitUnresolvedUsingTypenameDecl(
+        (clang::UnresolvedUsingTypenameDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Using:
+    ret_status = VisitUsingDecl((clang::UsingDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::UsingDirective:
+    ret_status =
+        VisitUsingDirectiveDecl((clang::UsingDirectiveDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::UsingPack:
+    ret_status = VisitUsingPackDecl((clang::UsingPackDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::UsingShadow:
+    ret_status = VisitUsingShadowDecl((clang::UsingShadowDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ConstructorUsingShadow:
+    ret_status = VisitConstructorUsingShadowDecl(
+        (clang::ConstructorUsingShadowDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Binding:
+    ret_status = VisitBindingDecl((clang::BindingDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Field:
+    ret_status = VisitFieldDecl((clang::FieldDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Function:
+    ret_status = VisitFunctionDecl((clang::FunctionDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXDeductionGuide:
+    ret_status = VisitCXXDeductionGuideDecl(
+        (clang::CXXDeductionGuideDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXConstructor:
+    ret_status =
+        VisitCXXConstructorDecl((clang::CXXConstructorDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXConversion:
+    ret_status =
+        VisitCXXConversionDecl((clang::CXXConversionDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXDestructor:
+    ret_status =
+        VisitCXXDestructorDecl((clang::CXXDestructorDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::CXXMethod:
+    ret_status = VisitCXXMethodDecl((clang::CXXMethodDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::MSProperty:
+    ret_status = VisitMSPropertyDecl((clang::MSPropertyDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::NonTypeTemplateParm:
+    ret_status = VisitNonTypeTemplateParmDecl(
+        (clang::NonTypeTemplateParmDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Decomposition:
+    ret_status =
+        VisitDecompositionDecl((clang::DecompositionDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ImplicitParam:
+    ret_status =
+        VisitImplicitParamDecl((clang::ImplicitParamDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPCapturedExpr:
+    ret_status =
+        VisitOMPCaptureExprDecl((clang::OMPCapturedExprDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::ParmVar:
+    ret_status = VisitParmVarDecl((clang::ParmVarDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::VarTemplatePartialSpecialization:
+    ret_status = VisitVarTemplatePartialSpecializationDecl(
+        (clang::VarTemplatePartialSpecializationDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::VarTemplateSpecialization:
+    ret_status = VisitVarTemplateSpecializationDecl(
+        (clang::VarTemplateSpecializationDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::EnumConstant:
+    ret_status =
+        VisitEnumConstantDecl((clang::EnumConstantDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::IndirectField:
+    ret_status =
+        VisitIndirectFieldDecl((clang::IndirectFieldDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPDeclareMapper:
+    ret_status =
+        VisitOMPDeclareMapperDecl((clang::OMPDeclareMapperDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPDeclareReduction:
+    ret_status = VisitOMPDeclareReductionDecl(
+        (clang::OMPDeclareReductionDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::UnresolvedUsingValue:
+    ret_status = VisitUnresolvedUsingValueDecl(
+        (clang::UnresolvedUsingValueDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPAllocate:
+    ret_status = VisitOMPAllocateDecl((clang::OMPAllocateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPRequires:
+    ret_status = VisitOMPRequiresDecl((clang::OMPRequiresDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::OMPThreadPrivate:
+    ret_status =
+        VisitOMPThreadPrivateDecl((clang::OMPThreadPrivateDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::PragmaComment:
+    ret_status =
+        VisitPragmaCommentDecl((clang::PragmaCommentDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::PragmaDetectMismatch:
+    ret_status = VisitPragmaDetectMismatchDecl(
+        (clang::PragmaDetectMismatchDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::StaticAssert:
+    ret_status =
+        VisitStaticAssertDecl((clang::StaticAssertDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::TranslationUnit:
+    ret_status =
+        VisitTranslationUnitDecl((clang::TranslationUnitDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+  case clang::Decl::Var:
+    ret_status = VisitVarDecl((clang::VarDecl *)decl, &result);
+    ROSE_ASSERT(ret_status == false || result != NULL);
+    break;
+
+  default:
+    std::cerr << "Unknown declacaration kind: " << decl->getDeclKindName()
+              << " !" << std::endl;
+    ROSE_ABORT();
+  }
+
+  ROSE_ASSERT(ret_status == false || result != NULL);
+
+  if (ret_status && result != NULL) {
+    if (SgDeclarationStatement *ds = isSgDeclarationStatement(result)) {
+      ensure_parent_and_scope(ds);
+    }
+    p_decl_translation_map.insert(
+        std::pair<clang::Decl *, SgNode *>(decl, result));
+  }
+
+#if DEBUG_TRAVERSE_DECL
+  std::cerr << "Traverse(clang::Decl : " << decl << " ";
+  if (clang::NamedDecl::classof(decl)) {
+    std::cerr << ": " << ((clang::NamedDecl *)decl)->getNameAsString() << ") ";
+  }
+  std::cerr << " visit done : node = " << result << std::endl;
 #endif
 
-    return ret_status ? result : NULL;
+  return ret_status ? result : NULL;
 }
 
-SgNode * ClangToSageTranslator::TraverseForDeclContext(clang::DeclContext * decl_context) {
-    return Traverse((clang::Decl*)decl_context);
+SgNode *ClangToSageTranslator::TraverseForDeclContext(
+    clang::DeclContext *decl_context) {
+  return Traverse((clang::Decl *)decl_context);
 }
 
 /**********************/
 /* Visit Declarations */
 /**********************/
 
-bool ClangToSageTranslator::VisitDecl(clang::Decl * decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitDecl" << std::endl;
-#endif    
-    if (*node == NULL) {
-        const char* kind_name = decl ? decl->getDeclKindName() : "Unknown";
-        std::string loc_string;
-        if (decl) {
-            clang::SourceLocation loc = decl->getLocation();
-            if (loc.isValid()) {
-                clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-                clang::PresumedLoc ploc = sm.getPresumedLoc(loc);
-                if (ploc.isValid()) {
-                    loc_string = std::string(ploc.getFilename()) + ":" + std::to_string(ploc.getLine());
-                }
-            }
-        }
-        if (!loc_string.empty()) {
-            std::cerr << "Runtime error: No Sage node associated with the declaration (" << kind_name
-                      << " at " << loc_string << ")..." << std::endl;
-        } else {
-            std::cerr << "Runtime error: No Sage node associated with the declaration (" << kind_name << ")..." << std::endl;
-        }
-        if (const clang::NamedDecl *nd =
-                llvm::dyn_cast<clang::NamedDecl>(decl)) {
-          std::cerr << "Runtime error declaration name: "
-                    << nd->getNameAsString() << std::endl;
-        }
-        return false;
-    }
-
-    if (!isSgGlobal(*node))
-        applySourceRange(*node, decl->getSourceRange());
-
-    // TODO attributes
-/*
-    std::cerr << "Attribute list for " << decl->getDeclKindName() << " (" << decl << "): ";
-    clang::Decl::attr_iterator it;
-    for (it = decl->attr_begin(); it != decl->attr_end(); it++) {
-        std::cerr << (*it)->getKind() << ", ";
-    }
-    std::cerr << std::endl;
-
-    if (clang::VarDecl::classof(decl)) {
-        clang::VarDecl * var_decl = (clang::VarDecl *)decl;
-        std::cerr << "Stoprage class for " << decl->getDeclKindName() << " (" << decl << "): " << var_decl->getStorageClass() << std::endl;
-    }
-*/
-    return true;
-}
-
-bool ClangToSageTranslator::VisitAccessSpecDecl(clang::AccessSpecDecl * access_spec_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitAccessSpecDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDecl" << std::endl;
 #endif
-    // CLANG FRONTEND FIX: AccessSpecDecl (public:, private:, protected:) are not standalone
-    // declarations in ROSE - they're properties of member declarations. Set *node to NULL
-    // to indicate this declaration doesn't have a ROSE equivalent.
-    *node = NULL;
-
-    // Return false to indicate no ROSE node was created (this is expected behavior)
+  if (*node == NULL) {
+    const char *kind_name = decl ? decl->getDeclKindName() : "Unknown";
+    std::string loc_string;
+    if (decl) {
+      clang::SourceLocation loc = decl->getLocation();
+      if (loc.isValid()) {
+        clang::SourceManager &sm = p_compiler_instance->getSourceManager();
+        clang::PresumedLoc ploc = sm.getPresumedLoc(loc);
+        if (ploc.isValid()) {
+          loc_string = std::string(ploc.getFilename()) + ":" +
+                       std::to_string(ploc.getLine());
+        }
+      }
+    }
+    if (!loc_string.empty()) {
+      std::cerr
+          << "Runtime error: No Sage node associated with the declaration ("
+          << kind_name << " at " << loc_string << ")..." << std::endl;
+    } else {
+      std::cerr
+          << "Runtime error: No Sage node associated with the declaration ("
+          << kind_name << ")..." << std::endl;
+    }
+    if (const clang::NamedDecl *nd = llvm::dyn_cast<clang::NamedDecl>(decl)) {
+      std::cerr << "Runtime error declaration name: " << nd->getNameAsString()
+                << std::endl;
+    }
     return false;
+  }
+
+  if (!isSgGlobal(*node))
+    applySourceRange(*node, decl->getSourceRange());
+
+  // TODO attributes
+  /*
+      std::cerr << "Attribute list for " << decl->getDeclKindName() << " (" <<
+     decl << "): "; clang::Decl::attr_iterator it; for (it = decl->attr_begin();
+     it != decl->attr_end(); it++) { std::cerr << (*it)->getKind() << ", ";
+      }
+      std::cerr << std::endl;
+
+      if (clang::VarDecl::classof(decl)) {
+          clang::VarDecl * var_decl = (clang::VarDecl *)decl;
+          std::cerr << "Stoprage class for " << decl->getDeclKindName() << " ("
+     << decl << "): " << var_decl->getStorageClass() << std::endl;
+      }
+  */
+  return true;
 }
 
-bool ClangToSageTranslator::VisitBlockDecl(clang::BlockDecl * block_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitAccessSpecDecl(
+    clang::AccessSpecDecl *access_spec_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitBlockDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAccessSpecDecl" << std::endl;
 #endif
-    bool res = true;
+  // CLANG FRONTEND FIX: AccessSpecDecl (public:, private:, protected:) are not
+  // standalone declarations in ROSE - they're properties of member
+  // declarations. Set *node to NULL to indicate this declaration doesn't have a
+  // ROSE equivalent.
+  *node = NULL;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitDecl(block_decl, node) && res;
+  // Return false to indicate no ROSE node was created (this is expected
+  // behavior)
+  return false;
 }
 
-bool ClangToSageTranslator::VisitCapturedDecl(clang::CapturedDecl * captured_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitBlockDecl(clang::BlockDecl *block_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCapturedDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitBlockDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(captured_decl, node) && res;
+  return VisitDecl(block_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitEmptyDecl(clang::EmptyDecl * empty_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCapturedDecl(
+    clang::CapturedDecl *captured_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitEmptyDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCapturedDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // (3/29/2022) Pei-Hung it seems to be okay just skip processing EmptyDecl
-    // as SgBasicBlock allows no decl/stmt stored in it.
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(empty_decl, node) && res;
+  return VisitDecl(captured_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitExportDecl(clang::ExportDecl * export_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitEmptyDecl(clang::EmptyDecl *empty_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitExportDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitEmptyDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // (3/29/2022) Pei-Hung it seems to be okay just skip processing EmptyDecl
+  // as SgBasicBlock allows no decl/stmt stored in it.
 
-    return VisitDecl(export_decl, node) && res;
+  return VisitDecl(empty_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitExternCContextDecl(clang::ExternCContextDecl * ccontent_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitExportDecl(clang::ExportDecl *export_decl,
+                                            SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCContextDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitExportDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(ccontent_decl, node) && res;
+  return VisitDecl(export_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitFileScopeAsmDecl(clang::FileScopeAsmDecl * file_scope_asm_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitExternCContextDecl(
+    clang::ExternCContextDecl *ccontent_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFileScopeAsmDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCContextDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // LLVM 20 returns StringLiteral*, LLVM 21 returns std::string
-    std::string AsmString;
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+
+  return VisitDecl(ccontent_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitFileScopeAsmDecl(
+    clang::FileScopeAsmDecl *file_scope_asm_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitFileScopeAsmDecl" << std::endl;
+#endif
+  bool res = true;
+
+  // LLVM 20 returns StringLiteral*, LLVM 21 returns std::string
+  std::string AsmString;
 #if LLVM_VERSION_MAJOR >= 21
-    AsmString = file_scope_asm_decl->getAsmString();
+  AsmString = file_scope_asm_decl->getAsmString();
 #else
-    if (auto* str_lit = file_scope_asm_decl->getAsmString()) {
-        AsmString = str_lit->getString().str();
-    }
+  if (auto *str_lit = file_scope_asm_decl->getAsmString()) {
+    AsmString = str_lit->getString().str();
+  }
 #endif
 
 #if DEBUG_VISIT_DECL
-    std::cerr << "AsmString:" << AsmString << std::endl;
+  std::cerr << "AsmString:" << AsmString << std::endl;
 #endif
-    SgAsmStmt* asmStmt = SageBuilder::buildAsmStatement(AsmString); 
-    asmStmt->set_firstNondefiningDeclaration(asmStmt);
-    asmStmt->set_definingDeclaration(asmStmt);
-    asmStmt->set_parent(SageBuilder::topScopeStack());
-    *node = asmStmt;
+  SgAsmStmt *asmStmt = SageBuilder::buildAsmStatement(AsmString);
+  asmStmt->set_firstNondefiningDeclaration(asmStmt);
+  asmStmt->set_definingDeclaration(asmStmt);
+  asmStmt->set_parent(SageBuilder::topScopeStack());
+  *node = asmStmt;
 
-    return VisitDecl(file_scope_asm_decl, node) && res;
+  return VisitDecl(file_scope_asm_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl * friend_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
+                                            SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFriendDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFriendDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Translate the underlying entity being declared as a friend.
-    SgDeclarationStatement* sg_decl = NULL;
-    if (clang::NamedDecl* named_decl = friend_decl->getFriendDecl()) {
-        SgNode* tmp = Traverse(named_decl);
-        sg_decl = isSgDeclarationStatement(tmp);
-        if (sg_decl == NULL) {
-            if (SgInitializedName* init = isSgInitializedName(tmp)) {
-                sg_decl = isSgDeclarationStatement(init->get_parent());
-            }
-        }
-    } else if (clang::TypeSourceInfo* type_info = friend_decl->getFriendType()) {
-        const clang::Type* friend_type = type_info->getType().getTypePtr();
-        if (const clang::RecordType* record_type = llvm::dyn_cast<clang::RecordType>(friend_type)) {
-            sg_decl = isSgDeclarationStatement(Traverse(record_type->getDecl()));
-        }
-    }
-
-    // If we still cannot build a declaration, keep the AST structurally valid
-    // with a placeholder node rather than failing the traversal.
+  // Translate the underlying entity being declared as a friend.
+  SgDeclarationStatement *sg_decl = NULL;
+  if (clang::NamedDecl *named_decl = friend_decl->getFriendDecl()) {
+    SgNode *tmp = Traverse(named_decl);
+    sg_decl = isSgDeclarationStatement(tmp);
     if (sg_decl == NULL) {
-        *node = new SgNullStatement();
-        return VisitDecl(friend_decl, node) && res;
+      if (SgInitializedName *init = isSgInitializedName(tmp)) {
+        sg_decl = isSgDeclarationStatement(init->get_parent());
+      }
     }
+  } else if (clang::TypeSourceInfo *type_info = friend_decl->getFriendType()) {
+    const clang::Type *friend_type = type_info->getType().getTypePtr();
+    if (const clang::RecordType *record_type =
+            llvm::dyn_cast<clang::RecordType>(friend_type)) {
+      sg_decl = isSgDeclarationStatement(Traverse(record_type->getDecl()));
+    }
+  }
 
-    auto mark_friend = [](SgDeclarationStatement* decl) {
-        if (decl != NULL) {
-            decl->get_declarationModifier().setFriend();
-        }
-    };
-
-    mark_friend(sg_decl);
-    mark_friend(sg_decl->get_firstNondefiningDeclaration());
-    mark_friend(sg_decl->get_definingDeclaration());
-
-    auto ensure_scope_and_parent = [](SgDeclarationStatement* decl, SgScopeStatement* current_scope) {
-        if (decl == NULL || current_scope == NULL) return;
-        if (decl->get_scope() == NULL) {
-            decl->set_scope(current_scope);
-        }
-        if (decl->get_parent() == NULL) {
-            decl->set_parent(current_scope);
-        }
-    };
-
-    SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-    ensure_scope_and_parent(sg_decl, current_scope);
-    ensure_scope_and_parent(sg_decl->get_firstNondefiningDeclaration(), current_scope);
-    ensure_scope_and_parent(sg_decl->get_definingDeclaration(), current_scope);
-    diagnose_null_scope(sg_decl, "FriendDecl");
-
-    // REX FIX: Issue 99
-    // Ensure that the body of the friend function definition points back to the
-    // definition. This is required for VirtualCFG and other analyses.
-
-    if (sg_decl->get_firstNondefiningDeclaration() == NULL)
-         sg_decl->set_firstNondefiningDeclaration(sg_decl);
-    if (sg_decl->get_definingDeclaration() == NULL)
-         sg_decl->set_definingDeclaration(sg_decl);
-
-    *node = sg_decl;
+  // If we still cannot build a declaration, keep the AST structurally valid
+  // with a placeholder node rather than failing the traversal.
+  if (sg_decl == NULL) {
+    *node = new SgNullStatement();
     return VisitDecl(friend_decl, node) && res;
+  }
+
+  auto mark_friend = [](SgDeclarationStatement *decl) {
+    if (decl != NULL) {
+      decl->get_declarationModifier().setFriend();
+    }
+  };
+
+  mark_friend(sg_decl);
+  mark_friend(sg_decl->get_firstNondefiningDeclaration());
+  mark_friend(sg_decl->get_definingDeclaration());
+
+  auto ensure_scope_and_parent = [](SgDeclarationStatement *decl,
+                                    SgScopeStatement *current_scope) {
+    if (decl == NULL || current_scope == NULL)
+      return;
+    if (decl->get_scope() == NULL) {
+      decl->set_scope(current_scope);
+    }
+    if (decl->get_parent() == NULL) {
+      decl->set_parent(current_scope);
+    }
+  };
+
+  SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+  ensure_scope_and_parent(sg_decl, current_scope);
+  ensure_scope_and_parent(sg_decl->get_firstNondefiningDeclaration(),
+                          current_scope);
+  ensure_scope_and_parent(sg_decl->get_definingDeclaration(), current_scope);
+  diagnose_null_scope(sg_decl, "FriendDecl");
+
+  // REX FIX: Issue 99
+  // Ensure that the body of the friend function definition points back to the
+  // definition. This is required for VirtualCFG and other analyses.
+
+  if (sg_decl->get_firstNondefiningDeclaration() == NULL)
+    sg_decl->set_firstNondefiningDeclaration(sg_decl);
+  if (sg_decl->get_definingDeclaration() == NULL)
+    sg_decl->set_definingDeclaration(sg_decl);
+
+  *node = sg_decl;
+  return VisitDecl(friend_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitFriendTemplateDecl(clang::FriendTemplateDecl * friend_template_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitFriendTemplateDecl(
+    clang::FriendTemplateDecl *friend_template_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFriendTemplateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFriendTemplateDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    SgDeclarationStatement* sg_decl = NULL;
-    if (clang::NamedDecl* named_decl = friend_template_decl->getFriendDecl()) {
-        SgNode* tmp = Traverse(named_decl);
-        sg_decl = isSgDeclarationStatement(tmp);
-    }
+  SgDeclarationStatement *sg_decl = NULL;
+  if (clang::NamedDecl *named_decl = friend_template_decl->getFriendDecl()) {
+    SgNode *tmp = Traverse(named_decl);
+    sg_decl = isSgDeclarationStatement(tmp);
+  }
 
-    if (sg_decl == NULL) {
-        *node = new SgNullStatement();
-        return VisitDecl(friend_template_decl, node) && res;
-    }
-
-    auto mark_friend = [](SgDeclarationStatement* decl) {
-        if (decl != NULL) {
-            decl->get_declarationModifier().setFriend();
-        }
-    };
-
-    mark_friend(sg_decl);
-    mark_friend(sg_decl->get_firstNondefiningDeclaration());
-    mark_friend(sg_decl->get_definingDeclaration());
-
-    auto ensure_scope_and_parent = [](SgDeclarationStatement* decl, SgScopeStatement* current_scope) {
-        if (decl == NULL || current_scope == NULL) return;
-        if (decl->get_scope() == NULL) {
-            decl->set_scope(current_scope);
-        }
-        if (decl->get_parent() == NULL) {
-            decl->set_parent(current_scope);
-        }
-    };
-
-    SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-    ensure_scope_and_parent(sg_decl, current_scope);
-    ensure_scope_and_parent(sg_decl->get_firstNondefiningDeclaration(), current_scope);
-    ensure_scope_and_parent(sg_decl->get_definingDeclaration(), current_scope);
-
-    if (sg_decl->get_firstNondefiningDeclaration() == NULL)
-         sg_decl->set_firstNondefiningDeclaration(sg_decl);
-    if (sg_decl->get_definingDeclaration() == NULL)
-         sg_decl->set_definingDeclaration(sg_decl);
-
-    // REX FIX: Issue 99
-    // Ensure that the body of the friend function definition points back to the
-    // definition. This is required for VirtualCFG and other analyses.
-    if (SgFunctionDeclaration *func_decl =
-            isSgFunctionDeclaration(sg_decl->get_definingDeclaration())) {
-      if (SgFunctionDefinition *def = func_decl->get_definition()) {
-        if (SgBasicBlock *body = def->get_body()) {
-          if (body->get_parent() != def) {
-            body->set_parent(def);
-          }
-        }
-      }
-    }
-
-    *node = sg_decl;
+  if (sg_decl == NULL) {
+    *node = new SgNullStatement();
     return VisitDecl(friend_template_decl, node) && res;
-}
+  }
 
-bool ClangToSageTranslator::VisitImportDecl(clang::ImportDecl * import_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitImportDecl" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitDecl(import_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitNamedDecl(clang::NamedDecl * named_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitNamedDecl" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitDecl(named_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitLabelDecl(clang::LabelDecl * label_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitLabelDecl" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitNamedDecl(label_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitNamespaceAliasDecl(clang::NamespaceAliasDecl * namespace_alias_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitNamespaceAliasDecl" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitNamedDecl(namespace_alias_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitNamespaceDecl(clang::NamespaceDecl * namespace_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitNamespaceDecl" << std::endl;
-#endif
-
-    // Get the namespace name (handle anonymous namespaces)
-    bool isAnonymous = namespace_decl->isAnonymousNamespace();
-    std::string namespaceName = namespace_decl->getNameAsString();
-    if (isAnonymous || namespaceName.empty()) {
-        namespaceName = "__anonymous_namespace_" + generate_source_position_string(namespace_decl->getBeginLoc());
+  auto mark_friend = [](SgDeclarationStatement *decl) {
+    if (decl != NULL) {
+      decl->get_declarationModifier().setFriend();
     }
-    SgName name(namespaceName);
+  };
 
-    // Get current scope
-    SgScopeStatement *scope = SageBuilder::topScopeStack();
-    if (scope == nullptr) {
-        scope = p_global_scope;
+  mark_friend(sg_decl);
+  mark_friend(sg_decl->get_firstNondefiningDeclaration());
+  mark_friend(sg_decl->get_definingDeclaration());
+
+  auto ensure_scope_and_parent = [](SgDeclarationStatement *decl,
+                                    SgScopeStatement *current_scope) {
+    if (decl == NULL || current_scope == NULL)
+      return;
+    if (decl->get_scope() == NULL) {
+      decl->set_scope(current_scope);
     }
-
-    // Build namespace declaration using SageBuilder
-    // This function handles:
-    // - Creating the declaration and definition
-    // - Looking up existing namespace symbols for reopening
-    // - Setting up global_definition to link all instances
-    // - Inserting the symbol (only for first declaration)
-    // We don't need to manually duplicate any of this logic
-    SgNamespaceDeclarationStatement *sg_namespace_decl =
-        SageBuilder::buildNamespaceDeclaration_nfi(name, isAnonymous, scope);
-
-    // Get the definition that was already created by the builder
-    SgNamespaceDefinitionStatement *sg_namespace_def = sg_namespace_decl->get_definition();
-    ROSE_ASSERT(sg_namespace_def != nullptr);
-
-    // ROOT CAUSE FIX: Do NOT manually append - SageBuilder::buildNamespaceDeclaration_nfi() already
-    // inserted the declaration into the scope. Manually appending it again causes duplicate
-    // statement errors in AST consistency checks.
-    // The _nfi suffix means "no file info" not "no insertion"
-    // REMOVED: SageInterface::appendStatement(sg_namespace_decl, scope);
-
-    applySourceRange(sg_namespace_decl, namespace_decl->getSourceRange());
-
-    // Traverse children within the namespace definition scope
-    ROSE_ASSERT(sg_namespace_def != nullptr);
-    SageBuilder::pushScopeStack(sg_namespace_def);
-
-    for (auto it = namespace_decl->decls_begin(); it != namespace_decl->decls_end(); ++it) {
-        clang::Decl *inner_decl = *it;
-        if (inner_decl == nullptr)
-            continue;
-
-        SgNode *child = Traverse(inner_decl);
-        if (SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(child)) {
-            bool is_parent_unset = (decl_stmt->get_parent() == nullptr);
-            bool is_parent_this = (decl_stmt->get_parent() == sg_namespace_def);
-
-            if (is_parent_unset || is_parent_this) {
-                // Check if already in list to avoid duplicates
-                const SgDeclarationStatementPtrList& decls = sg_namespace_def->get_declarations();
-                bool found = false;
-                for (SgDeclarationStatement* d : decls) {
-                    if (d == decl_stmt) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found) {
-                    sg_namespace_def->append_declaration(decl_stmt);
-                    if (is_parent_unset) {
-                        decl_stmt->set_parent(sg_namespace_def);
-                    }
-                }
-            }
-        }
+    if (decl->get_parent() == NULL) {
+      decl->set_parent(current_scope);
     }
+  };
 
-    SageBuilder::popScopeStack();
+  SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+  ensure_scope_and_parent(sg_decl, current_scope);
+  ensure_scope_and_parent(sg_decl->get_firstNondefiningDeclaration(),
+                          current_scope);
+  ensure_scope_and_parent(sg_decl->get_definingDeclaration(), current_scope);
 
-    *node = sg_namespace_decl;
-    return true;
-}
+  if (sg_decl->get_firstNondefiningDeclaration() == NULL)
+    sg_decl->set_firstNondefiningDeclaration(sg_decl);
+  if (sg_decl->get_definingDeclaration() == NULL)
+    sg_decl->set_definingDeclaration(sg_decl);
 
-bool ClangToSageTranslator::VisitLinkageSpecDecl(clang::LinkageSpecDecl * linkage_spec_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitLinkageSpecDecl" << std::endl;
-#endif
-
-    SgScopeStatement *current_scope = SageBuilder::topScopeStack();
-    for (auto it = linkage_spec_decl->decls_begin(); it != linkage_spec_decl->decls_end(); ++it) {
-        clang::Decl *inner_decl = *it;
-        if (inner_decl == nullptr)
-            continue;
-
-        SgNode *child = Traverse(inner_decl);
-        if (SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(child)) {
-            if (decl_stmt->get_parent() == nullptr && current_scope != nullptr) {
-                SageInterface::appendStatement(decl_stmt, current_scope);
-            }
-        }
-    }
-
-    *node = nullptr;
-    return false;
-}
-
-bool ClangToSageTranslator::VisitTemplateDecl(clang::TemplateDecl * template_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTemplateDecl" << std::endl;
-#endif
-    if (template_decl != nullptr && template_decl->getTemplatedDecl() != nullptr) {
-        Traverse(template_decl->getTemplatedDecl());
-    }
-    // TODO(roadmap): Emit proper template decl nodes once namespace/template scaffolding lands
-    // (see docs/axpy_clang_frontend.md roadmap section).
-    *node = NULL;
-    return false;
-}
-
-bool ClangToSageTranslator::VisitBuiltinTemplateDecl(clang::BuiltinTemplateDecl * builtin_template_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitBuiltinTemplateDecl" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitTemplateDecl(builtin_template_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitConceptDecl(clang::ConceptDecl * concept_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitConceptDecl" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitTemplateDecl(concept_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitRedeclarableTemplateDecl(clang::RedeclarableTemplateDecl * redeclarable_template_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitRedeclarableTemplateDecl" << std::endl;
-#endif
-    return VisitTemplateDecl(redeclarable_template_decl, node);
-}
-
-bool ClangToSageTranslator::VisitClassTemplateDecl(clang::ClassTemplateDecl * class_template_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitClassTemplateDecl" << std::endl;
-#endif
-    bool res = true;
-    if (class_template_decl == NULL) {
-        *node = NULL;
-        return false;
-    }
-
-    // CLANG FRONTEND FIX: Skip system header template classes to avoid performance issues
-    // System headers contain massive template hierarchies that cause extremely slow processing
-    // clang::SourceManager &SM = p_compiler_instance->getSourceManager();
-    // if (SM.isInSystemHeader(class_template_decl->getLocation())) {
-    //     // Skip this template class - let VisitRecordDecl handle it as a regular class
-    //     *node = NULL;
-    //     return false;
-    // }
-
-    clang::CXXRecordDecl* templated_decl = class_template_decl->getTemplatedDecl();
-    if (templated_decl == NULL) {
-        *node = NULL;
-        return false;
-    }
-
-    // Determine the template name, generate a fallback if necessary
-    std::string template_name_str = templated_decl->getNameAsString();
-    if (template_name_str.empty()) {
-        template_name_str = "__anon_template_" + generate_source_position_string(class_template_decl->getBeginLoc());
-    }
-    SgName template_name(template_name_str);
-
-    // Resolve class kind
-    SgClassDeclaration::class_types class_kind = SgClassDeclaration::e_class;
-    switch (templated_decl->getTagKind()) {
-        case clang::TagTypeKind::Struct:
-            class_kind = SgClassDeclaration::e_struct;
-            break;
-        case clang::TagTypeKind::Class:
-            class_kind = SgClassDeclaration::e_class;
-            break;
-        case clang::TagTypeKind::Union:
-            class_kind = SgClassDeclaration::e_union;
-            break;
-        default:
-            std::cerr << "Warning: Unsupported tag kind for class template: "
-                      << static_cast<int>(templated_decl->getTagKind()) << std::endl;
-            break;
-    }
-
-    clang::DeclContext* decl_context = class_template_decl->getDeclContext();
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-
-    // Check if we can get a better scope from the DeclContext
-    if (decl_context && !decl_context->isTranslationUnit()) {
-        clang::Decl* context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
-        if (context_decl) {
-            SgNode* context_node = NULL;
-            std::map<clang::Decl*, SgNode*>::iterator it = p_decl_translation_map.find(context_decl);
-            if (it != p_decl_translation_map.end()) {
-                context_node = it->second;
-                SgNamespaceDefinitionStatement* ns_def = isSgNamespaceDefinitionStatement(context_node);
-                SgClassDefinition* class_def = isSgClassDefinition(context_node);
-                if (ns_def != NULL) {
-                    scope = ns_def;
-                } else if (class_def != NULL) {
-                    scope = class_def;
-                }
-            } else if (clang::NamespaceDecl *ns_decl =
-                           llvm::dyn_cast<clang::NamespaceDecl>(context_decl)) {
-              // REX FIX: Ensure namespace if potential parent scope is a
-              // namespace but not logged yet
-              SgNamespaceDeclarationStatement *ns_stmt =
-                  ensureNamespaceDeclaration(ns_decl);
-              if (ns_stmt) {
-                scope = ns_stmt->get_definition();
-              }
-            }
-        }
-    }
-
-    if (scope == NULL) {
-        scope = getGlobalScope();
-    }
-
-    // Build template parameters and template declaration
-    SgTemplateArgumentPtrList* empty_args = new SgTemplateArgumentPtrList();
-    SgTemplateParameterPtrList *params = translateTemplateParameterList(
-        class_template_decl->getTemplateParameters(), NULL);
-
-    SgTemplateClassDeclaration* template_decl =
-        SageBuilder::buildTemplateClassDeclaration_nfi(
-            template_name,
-            class_kind,
-            scope,
-            NULL,
-            params,
-            empty_args);
-
-    // REX FIX: Handle AS_none for ClassTemplateDecl
-    clang::AccessSpecifier access = class_template_decl->getAccess();
-    if (access == clang::AS_public) {
-      template_decl->get_declarationModifier().get_accessModifier().setPublic();
-    } else if (access == clang::AS_private) {
-      template_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setPrivate();
-    } else if (access == clang::AS_protected) {
-      template_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setProtected();
-    } else if (access == clang::AS_none) {
-      if (isSgClassDefinition(scope)) {
-        SgClassDefinition *class_def = isSgClassDefinition(scope);
-        if (class_def->get_declaration()->get_class_type() ==
-            SgClassDeclaration::e_class) {
-          template_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPrivate();
-        } else {
-          template_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPublic();
+  // REX FIX: Issue 99
+  // Ensure that the body of the friend function definition points back to the
+  // definition. This is required for VirtualCFG and other analyses.
+  if (SgFunctionDeclaration *func_decl =
+          isSgFunctionDeclaration(sg_decl->get_definingDeclaration())) {
+    if (SgFunctionDefinition *def = func_decl->get_definition()) {
+      if (SgBasicBlock *body = def->get_body()) {
+        if (body->get_parent() != def) {
+          body->set_parent(def);
         }
       }
     }
+  }
 
-    delete params;
-    delete empty_args;
-
-    if (template_decl == NULL) {
-      *node = NULL;
-      return false;
-    }
-
-    // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
-    // crash (ua test).
-    SgDeclarationStatement *firstNondef =
-        template_decl->get_firstNondefiningDeclaration();
-    if (firstNondef == NULL) {
-      template_decl->set_firstNondefiningDeclaration(template_decl);
-    } else {
-      if (firstNondef->get_firstNondefiningDeclaration() == NULL) {
-        // std::cerr << "DEBUG: VisitClassTemplateDecl fixing transitive
-        // firstNondef for " << template_decl->get_name().getString() <<
-        // std::endl;
-        firstNondef->set_firstNondefiningDeclaration(firstNondef);
-      }
-    }
-
-    // Attach template parameter back-links
-    SgTemplateParameterPtrList& decl_params = template_decl->get_templateParameters();
-    for (SgTemplateParameter* param : decl_params) {
-        if (param != NULL) {
-            // Only set owning template if it's NOT a template_parameter,
-            // because template_parameter uses this field for the nrdecl.
-            if (param->get_parameterType() != SgTemplateParameter::template_parameter) {
-                param->set_templateDeclaration(template_decl);
-            }
-        }
-    }
-
-    applySourceRange(template_decl, class_template_decl->getSourceRange());
-
-    // ROOT CAUSE FIX: Cache before appending to prevent double visitation
-    p_decl_translation_map.insert(std::make_pair(class_template_decl, template_decl));
-    p_decl_translation_map.insert(std::make_pair(templated_decl, template_decl));
-
-    // REX FIX: Do not append here. The caller (Traverse) will return this node and the caller of Traverse (e.g. VisitTranslationUnitDecl) will append it.
-    // Appending here causes duplicates in the global scope.
-    // if (template_decl->get_parent() == NULL && scope != NULL) {
-    //    SageInterface::appendStatement(template_decl, scope);
-    // }
-
-    // Populate the class definition for definitions
-    if (templated_decl->isThisDeclarationADefinition()) {
-        if (SgTemplateClassDefinition* class_def = isSgTemplateClassDefinition(template_decl->get_definition())) {
-            applySourceRange(class_def, templated_decl->getSourceRange());
-            populateClassDefinition(templated_decl, class_def);
-        }
-    } else {
-        template_decl->setForward();
-    }
-
-    for (auto it = class_template_decl->spec_begin(); it != class_template_decl->spec_end(); ++it) {
-        Traverse(*it);
-    }
-
-    *node = template_decl;
-
-    return true;
+  *node = sg_decl;
+  return VisitDecl(friend_template_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitFunctionTemplateDecl(clang::FunctionTemplateDecl * function_template_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitImportDecl(clang::ImportDecl *import_decl,
+                                            SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFunctionTemplateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitImportDecl" << std::endl;
 #endif
-    if (function_template_decl == NULL) {
-      *node = NULL;
-      return false;
-    }
+  bool res = true;
 
-    clang::FunctionDecl *templated_decl =
-        function_template_decl->getTemplatedDecl();
-    if (templated_decl == NULL) {
-      *node = NULL;
-      return false;
-    }
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    bool res = translateFunctionDeclCommon(templated_decl,
-                                           function_template_decl, node);
-
-    if (res && *node != NULL) {
-      p_decl_translation_map.insert(std::make_pair(templated_decl, *node));
-    }
-
-    return res;
+  return VisitDecl(import_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeAliasTemplateDecl(clang::TypeAliasTemplateDecl * type_alias_template_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitNamedDecl(clang::NamedDecl *named_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTypeAliasTemplateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitNamedDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Get the underlying TypeAliasDecl
-    clang::TypeAliasDecl* type_alias_decl = type_alias_template_decl->getTemplatedDecl();
-    ROSE_ASSERT(type_alias_decl != NULL);
-    
-    // REX FIX: Do NOT traverse the TypeAliasDecl directly, as it creates a SgTypedefDeclaration
-    // that conflicts with the SgTemplateTypedefDeclaration we want to build.
-    // Instead, extract the necessary info and build SgTemplateTypedefDeclaration directly.
-    
-    SgName name(type_alias_template_decl->getNameAsString());
-    clang::QualType underlyingQualType = type_alias_decl->getUnderlyingType();
-    SgType * base_type = buildTypeFromQualifiedType(underlyingQualType);
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-
-
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-    
-    // Get the symbol for the parent scope (mimic buildTemplateTypedefDeclaration_nfi logic but be lenient)
-    SgSymbol* scopeSymbol = NULL;
-    if (SgClassDefinition* def = isSgClassDefinition(scope)) {
-        scopeSymbol = def->get_declaration()->get_symbol_from_symbol_table();
-    } else if (SgNamespaceDefinitionStatement* def = isSgNamespaceDefinitionStatement(scope)) {
-        scopeSymbol = def->get_namespaceDeclaration()->get_symbol_from_symbol_table();
-    }
-    
-    // Create SgTemplateTypedefDeclaration manually
-    SgTemplateTypedefDeclaration* template_typedef = new SgTemplateTypedefDeclaration(
-        name, 
-        base_type, 
-        NULL, // Type will be set later
-        NULL, // Base declaration (optional)
-        scopeSymbol
-    );
-    
-    template_typedef->set_scope(scope);
-    template_typedef->set_parent(scope);
-    
-    // REX FIX: Set source position to avoid AST post-processing assertion failure
-    applySourceRange(template_typedef, type_alias_template_decl->getSourceRange());
-    
-    // Set firstNondefiningDeclaration (required for unparsing)
-    template_typedef->set_firstNondefiningDeclaration(template_typedef);
-    template_typedef->set_definingDeclaration(NULL);
-
-    // Create SgTypedefType
-    SgTypedefType* typedefType = SgTypedefType::createType(template_typedef);
-    template_typedef->set_type(typedefType);
-    
-    // Create and insert symbol
-    SgTemplateTypedefSymbol* typedef_symbol = new SgTemplateTypedefSymbol(template_typedef);
-    scope->insert_symbol(name, typedef_symbol);
-
-    // Handle template parameters
-    clang::TemplateParameterList* param_list = type_alias_template_decl->getTemplateParameters();
-    SgTemplateParameterPtrList* template_params = NULL;
-    if (param_list != NULL) {
-        // REX FIX: Pass template_typedef as owning template
-        template_params = translateTemplateParameterList(type_alias_template_decl->getTemplateParameters(), template_typedef);
-    } else {
-        template_params = new SgTemplateParameterPtrList(); // Empty list if no parameters
-    }
-    
-    // REX FIX: Set template parameters on the declaration!
-    template_typedef->get_templateParameters() = *template_params;
-
-    // REX FIX: Do not append to scope here. VisitTranslationUnitDecl handles it.
-    // if (scope) {
-    //     scope->append_statement(template_typedef);
-    // }
-
-    // Add to map
-    p_decl_translation_map.insert(std::make_pair(type_alias_template_decl, template_typedef));
-    
-    *node = template_typedef;
-    // REX FIX: Do not call VisitRedeclarableTemplateDecl -> VisitTemplateDecl as it clears *node to NULL
-    return true;
+  return VisitDecl(named_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitVarTemplateDecl(clang::VarTemplateDecl * var_template_decl, SgNode ** node) {
-
+bool ClangToSageTranslator::VisitLabelDecl(clang::LabelDecl *label_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitVarTemplateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitLabelDecl" << std::endl;
 #endif
-    if (var_template_decl != nullptr) {
-        Traverse(var_template_decl->getTemplatedDecl());
-    }
-    *node = NULL;
-    return false;
+  bool res = true;
+
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+
+  return VisitNamedDecl(label_decl, node) && res;
 }
 
-
-bool ClangToSageTranslator::VisitTemplateTemplateParmDecl(clang::TemplateTemplateParmDecl * template_template_parm_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitNamespaceAliasDecl(
+    clang::NamespaceAliasDecl *namespace_alias_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTemplateTemplateParmDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitNamespaceAliasDecl" << std::endl;
 #endif
-    SgDeclarationStatement* owning_template = NULL;
-    if (clang::DeclContext* ctx = template_template_parm_decl->getDeclContext()) {
-        if (clang::TemplateDecl* template_ctx = llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
-            auto it = p_decl_translation_map.find(template_ctx);
-            if (it != p_decl_translation_map.end()) {
-                owning_template = isSgDeclarationStatement(it->second);
-            }
-        }
-    }
+  bool res = true;
 
-    unsigned position = template_template_parm_decl->getIndex();
-    SgTemplateParameter* sg_param =
-        translateTemplateParameter(template_template_parm_decl, owning_template, position);
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    *node = sg_param;
-    return sg_param != NULL;
+  return VisitNamedDecl(namespace_alias_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeDecl(clang::TypeDecl * type_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitNamespaceDecl(
+    clang::NamespaceDecl *namespace_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTypeDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitNamespaceDecl" << std::endl;
 #endif
 
-    bool res = true;
+  // Get the namespace name (handle anonymous namespaces)
+  bool isAnonymous = namespace_decl->isAnonymousNamespace();
+  std::string namespaceName = namespace_decl->getNameAsString();
+  if (isAnonymous || namespaceName.empty()) {
+    namespaceName =
+        "__anonymous_namespace_" +
+        generate_source_position_string(namespace_decl->getBeginLoc());
+  }
+  SgName name(namespaceName);
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  // Get current scope
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+  if (scope == nullptr) {
+    scope = p_global_scope;
+  }
 
-    return VisitNamedDecl(type_decl, node) && res;
-}
+  // Build namespace declaration using SageBuilder
+  // This function handles:
+  // - Creating the declaration and definition
+  // - Looking up existing namespace symbols for reopening
+  // - Setting up global_definition to link all instances
+  // - Inserting the symbol (only for first declaration)
+  // We don't need to manually duplicate any of this logic
+  SgNamespaceDeclarationStatement *sg_namespace_decl =
+      SageBuilder::buildNamespaceDeclaration_nfi(name, isAnonymous, scope);
 
-bool ClangToSageTranslator::VisitTagDecl(clang::TagDecl * tag_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTagDecl" << std::endl;
-#endif
+  // Get the definition that was already created by the builder
+  SgNamespaceDefinitionStatement *sg_namespace_def =
+      sg_namespace_decl->get_definition();
+  ROSE_ASSERT(sg_namespace_def != nullptr);
 
-    bool res = true;
+  // ROOT CAUSE FIX: Do NOT manually append -
+  // SageBuilder::buildNamespaceDeclaration_nfi() already inserted the
+  // declaration into the scope. Manually appending it again causes duplicate
+  // statement errors in AST consistency checks.
+  // The _nfi suffix means "no file info" not "no insertion"
+  // REMOVED: SageInterface::appendStatement(sg_namespace_decl, scope);
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  applySourceRange(sg_namespace_decl, namespace_decl->getSourceRange());
 
-    return VisitTypeDecl(tag_decl, node) && res;
-}
+  // Traverse children within the namespace definition scope
+  ROSE_ASSERT(sg_namespace_def != nullptr);
+  SageBuilder::pushScopeStack(sg_namespace_def);
 
-bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl * record_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitRecordDecl" << std::endl;
-#endif
+  for (auto it = namespace_decl->decls_begin();
+       it != namespace_decl->decls_end(); ++it) {
+    clang::Decl *inner_decl = *it;
+    if (inner_decl == nullptr)
+      continue;
 
-    // FIXME May have to check the symbol table first, because of out-of-order traversal of C++ classes (Could be done in CxxRecord class...)
+    SgNode *child = Traverse(inner_decl);
+    if (SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(child)) {
+      bool is_parent_unset = (decl_stmt->get_parent() == nullptr);
+      bool is_parent_this = (decl_stmt->get_parent() == sg_namespace_def);
 
-    // FIXME May have to check the symbol table first, because of out-of-order
-    // traversal of C++ classes (Could be done in CxxRecord class...)
-
-    bool res = true;
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitRecordDecl name:" <<record_decl->getNameAsString() <<  "\n";
-    std:: cerr << "isAnonymousStructOrUnion() " << record_decl->isAnonymousStructOrUnion() << "\n";
-    std:: cerr << "isThisDeclarationADefinition() " << record_decl->isThisDeclarationADefinition() << "\n";
-    std:: cerr << "isCompleteDefinition() " << record_decl->isCompleteDefinition() << "\n";
-    std:: cerr << "isCompleteDefinitionRequired() " << record_decl->isCompleteDefinitionRequired() << "\n";
-    std:: cerr << "isBeingDefined() " << record_decl->isBeingDefined() << "\n";
-    std:: cerr << "isEmbeddedInDeclarator() " << record_decl->isEmbeddedInDeclarator() << "\n";
-    std:: cerr << "isFreeStanding() " << record_decl->isFreeStanding() << "\n";
-    std:: cerr << "mayHaveOutOfDateDef() " << record_decl->mayHaveOutOfDateDef() << "\n";
-    std:: cerr << "isDependentType() " << record_decl->isDependentType() << "\n";
-    std:: cerr << "hasNameForLinkage () " << record_decl->hasNameForLinkage () << "\n";
-    std:: cerr << "hasLinkage() " << record_decl->hasLinkage() << "\n";
-    std:: cerr << "hasExternalFormalLinkage() " << record_decl->hasExternalFormalLinkage() << "\n";
-    std:: cerr << "isExternallyVisible () " << record_decl->isExternallyVisible () << "\n";
-    std:: cerr << "isExternallyDeclarable () " << record_decl->isExternallyDeclarable () << "\n";
-    std:: cerr << "isLinkageValid () " << record_decl->isLinkageValid () << "\n";
-    std:: cerr << "hasLinkageBeenComputed() " << record_decl->hasLinkageBeenComputed() << "\n";
-    std:: cerr << "isModulePrivate() " << record_decl->isModulePrivate() << "\n";
-#endif
-
-    // CLANG FRONTEND FIX: Check if this decl was already translated (e.g., by template visitors)
-    // This prevents creating duplicate SgClassDeclaration for nodes already handled as templates
-    std::map<clang::Decl*, SgNode*>::iterator it = p_decl_translation_map.find(record_decl);
-    if (it != p_decl_translation_map.end()) {
-#if DEBUG_VISIT_DECL
-        std::cerr << "VisitRecordDecl: Already translated, skipping: " << record_decl->getNameAsString() << std::endl;
-#endif
-        *node = it->second;
-        if (SgClassDeclaration *cd = isSgClassDeclaration(*node)) {
-          if (cd->get_firstNondefiningDeclaration() == NULL) {
-            cd->set_firstNondefiningDeclaration(cd);
+      if (is_parent_unset || is_parent_this) {
+        // Check if already in list to avoid duplicates
+        const SgDeclarationStatementPtrList &decls =
+            sg_namespace_def->get_declarations();
+        bool found = false;
+        for (SgDeclarationStatement *d : decls) {
+          if (d == decl_stmt) {
+            found = true;
+            break;
           }
         }
-        return true;  // Already processed
-    }
 
-    SgClassDeclaration * sg_class_decl = NULL;
+        if (!found) {
+          sg_namespace_def->append_declaration(decl_stmt);
+          if (is_parent_unset) {
+            decl_stmt->set_parent(sg_namespace_def);
+          }
+        }
+      }
+    }
+  }
+
+  SageBuilder::popScopeStack();
+
+  *node = sg_namespace_decl;
+  return true;
+}
+
+bool ClangToSageTranslator::VisitLinkageSpecDecl(
+    clang::LinkageSpecDecl *linkage_spec_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitLinkageSpecDecl" << std::endl;
+#endif
+
+  SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+  for (auto it = linkage_spec_decl->decls_begin();
+       it != linkage_spec_decl->decls_end(); ++it) {
+    clang::Decl *inner_decl = *it;
+    if (inner_decl == nullptr)
+      continue;
+
+    SgNode *child = Traverse(inner_decl);
+    if (SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(child)) {
+      if (decl_stmt->get_parent() == nullptr && current_scope != nullptr) {
+        SageInterface::appendStatement(decl_stmt, current_scope);
+      }
+    }
+  }
+
+  *node = nullptr;
+  return false;
+}
+
+bool ClangToSageTranslator::VisitTemplateDecl(
+    clang::TemplateDecl *template_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitTemplateDecl" << std::endl;
+#endif
+  if (template_decl != nullptr &&
+      template_decl->getTemplatedDecl() != nullptr) {
+    Traverse(template_decl->getTemplatedDecl());
+  }
+  // TODO(roadmap): Emit proper template decl nodes once namespace/template
+  // scaffolding lands (see docs/axpy_clang_frontend.md roadmap section).
+  *node = NULL;
+  return false;
+}
+
+bool ClangToSageTranslator::VisitBuiltinTemplateDecl(
+    clang::BuiltinTemplateDecl *builtin_template_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitBuiltinTemplateDecl" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitTemplateDecl(builtin_template_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitConceptDecl(clang::ConceptDecl *concept_decl,
+                                             SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitConceptDecl" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitTemplateDecl(concept_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitRedeclarableTemplateDecl(
+    clang::RedeclarableTemplateDecl *redeclarable_template_decl,
+    SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitRedeclarableTemplateDecl"
+            << std::endl;
+#endif
+  return VisitTemplateDecl(redeclarable_template_decl, node);
+}
+
+bool ClangToSageTranslator::VisitClassTemplateDecl(
+    clang::ClassTemplateDecl *class_template_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitClassTemplateDecl" << std::endl;
+#endif
+  bool res = true;
+  if (class_template_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
+
+  // CLANG FRONTEND FIX: Skip system header template classes to avoid
+  // performance issues System headers contain massive template hierarchies that
+  // cause extremely slow processing clang::SourceManager &SM =
+  // p_compiler_instance->getSourceManager(); if
+  // (SM.isInSystemHeader(class_template_decl->getLocation())) {
+  //     // Skip this template class - let VisitRecordDecl handle it as a
+  //     regular class *node = NULL; return false;
+  // }
+
+  clang::CXXRecordDecl *templated_decl =
+      class_template_decl->getTemplatedDecl();
+  if (templated_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
+
+  // Determine the template name, generate a fallback if necessary
+  std::string template_name_str = templated_decl->getNameAsString();
+  if (template_name_str.empty()) {
+    template_name_str =
+        "__anon_template_" +
+        generate_source_position_string(class_template_decl->getBeginLoc());
+  }
+  SgName template_name(template_name_str);
+
+  // Resolve class kind
+  SgClassDeclaration::class_types class_kind = SgClassDeclaration::e_class;
+  switch (templated_decl->getTagKind()) {
+  case clang::TagTypeKind::Struct:
+    class_kind = SgClassDeclaration::e_struct;
+    break;
+  case clang::TagTypeKind::Class:
+    class_kind = SgClassDeclaration::e_class;
+    break;
+  case clang::TagTypeKind::Union:
+    class_kind = SgClassDeclaration::e_union;
+    break;
+  default:
+    std::cerr << "Warning: Unsupported tag kind for class template: "
+              << static_cast<int>(templated_decl->getTagKind()) << std::endl;
+    break;
+  }
+
+  clang::DeclContext *decl_context = class_template_decl->getDeclContext();
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+
+  // Check if we can get a better scope from the DeclContext
+  if (decl_context && !decl_context->isTranslationUnit()) {
+    clang::Decl *context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
+    if (context_decl) {
+      SgNode *context_node = NULL;
+      std::map<clang::Decl *, SgNode *>::iterator it =
+          p_decl_translation_map.find(context_decl);
+      if (it != p_decl_translation_map.end()) {
+        context_node = it->second;
+        SgNamespaceDefinitionStatement *ns_def =
+            isSgNamespaceDefinitionStatement(context_node);
+        SgClassDefinition *class_def = isSgClassDefinition(context_node);
+        if (ns_def != NULL) {
+          scope = ns_def;
+        } else if (class_def != NULL) {
+          scope = class_def;
+        }
+      } else if (clang::NamespaceDecl *ns_decl =
+                     llvm::dyn_cast<clang::NamespaceDecl>(context_decl)) {
+        // REX FIX: Ensure namespace if potential parent scope is a
+        // namespace but not logged yet
+        SgNamespaceDeclarationStatement *ns_stmt =
+            ensureNamespaceDeclaration(ns_decl);
+        if (ns_stmt) {
+          scope = ns_stmt->get_definition();
+        }
+      }
+    }
+  }
+
+  if (scope == NULL) {
+    scope = getGlobalScope();
+  }
+
+  // Build template parameters and template declaration
+  SgTemplateArgumentPtrList *empty_args = new SgTemplateArgumentPtrList();
+  SgTemplateParameterPtrList *params = translateTemplateParameterList(
+      class_template_decl->getTemplateParameters(), NULL);
+
+  SgTemplateClassDeclaration *template_decl =
+      SageBuilder::buildTemplateClassDeclaration_nfi(
+          template_name, class_kind, scope, NULL, params, empty_args);
+
+  // REX FIX: Handle AS_none for ClassTemplateDecl
+  clang::AccessSpecifier access = class_template_decl->getAccess();
+  if (access == clang::AS_public) {
+    template_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    template_decl->get_declarationModifier().get_accessModifier().setPrivate();
+  } else if (access == clang::AS_protected) {
+    template_decl->get_declarationModifier()
+        .get_accessModifier()
+        .setProtected();
+  } else if (access == clang::AS_none) {
+    if (isSgClassDefinition(scope)) {
+      SgClassDefinition *class_def = isSgClassDefinition(scope);
+      if (class_def->get_declaration()->get_class_type() ==
+          SgClassDeclaration::e_class) {
+        template_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPrivate();
+      } else {
+        template_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPublic();
+      }
+    }
+  }
+
+  delete params;
+  delete empty_args;
+
+  if (template_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
+
+  // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
+  // crash (ua test).
+  SgDeclarationStatement *firstNondef =
+      template_decl->get_firstNondefiningDeclaration();
+  if (firstNondef == NULL) {
+    template_decl->set_firstNondefiningDeclaration(template_decl);
+  } else {
+    if (firstNondef->get_firstNondefiningDeclaration() == NULL) {
+      // std::cerr << "DEBUG: VisitClassTemplateDecl fixing transitive
+      // firstNondef for " << template_decl->get_name().getString() <<
+      // std::endl;
+      firstNondef->set_firstNondefiningDeclaration(firstNondef);
+    }
+  }
+
+  // Attach template parameter back-links
+  SgTemplateParameterPtrList &decl_params =
+      template_decl->get_templateParameters();
+  for (SgTemplateParameter *param : decl_params) {
+    if (param != NULL) {
+      // Only set owning template if it's NOT a template_parameter,
+      // because template_parameter uses this field for the nrdecl.
+      if (param->get_parameterType() !=
+          SgTemplateParameter::template_parameter) {
+        param->set_templateDeclaration(template_decl);
+      }
+    }
+  }
+
+  applySourceRange(template_decl, class_template_decl->getSourceRange());
+
+  // ROOT CAUSE FIX: Cache before appending to prevent double visitation
+  p_decl_translation_map.insert(
+      std::make_pair(class_template_decl, template_decl));
+  p_decl_translation_map.insert(std::make_pair(templated_decl, template_decl));
+
+  // REX FIX: Do not append here. The caller (Traverse) will return this node
+  // and the caller of Traverse (e.g. VisitTranslationUnitDecl) will append it.
+  // Appending here causes duplicates in the global scope.
+  // if (template_decl->get_parent() == NULL && scope != NULL) {
+  //    SageInterface::appendStatement(template_decl, scope);
+  // }
+
+  // Populate the class definition for definitions
+  if (templated_decl->isThisDeclarationADefinition()) {
+    if (SgTemplateClassDefinition *class_def =
+            isSgTemplateClassDefinition(template_decl->get_definition())) {
+      applySourceRange(class_def, templated_decl->getSourceRange());
+      populateClassDefinition(templated_decl, class_def);
+    }
+  } else {
+    template_decl->setForward();
+  }
+
+  for (auto it = class_template_decl->spec_begin();
+       it != class_template_decl->spec_end(); ++it) {
+    Traverse(*it);
+  }
+
+  *node = template_decl;
+
+  return true;
+}
+
+bool ClangToSageTranslator::VisitFunctionTemplateDecl(
+    clang::FunctionTemplateDecl *function_template_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitFunctionTemplateDecl" << std::endl;
+#endif
+  if (function_template_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
+
+  clang::FunctionDecl *templated_decl =
+      function_template_decl->getTemplatedDecl();
+  if (templated_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
+
+  bool res =
+      translateFunctionDeclCommon(templated_decl, function_template_decl, node);
+
+  if (res && *node != NULL) {
+    p_decl_translation_map.insert(std::make_pair(templated_decl, *node));
+  }
+
+  return res;
+}
+
+bool ClangToSageTranslator::VisitTypeAliasTemplateDecl(
+    clang::TypeAliasTemplateDecl *type_alias_template_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitTypeAliasTemplateDecl" << std::endl;
+#endif
+  bool res = true;
+
+  // Get the underlying TypeAliasDecl
+  clang::TypeAliasDecl *type_alias_decl =
+      type_alias_template_decl->getTemplatedDecl();
+  ROSE_ASSERT(type_alias_decl != NULL);
+
+  // REX FIX: Do NOT traverse the TypeAliasDecl directly, as it creates a
+  // SgTypedefDeclaration that conflicts with the SgTemplateTypedefDeclaration
+  // we want to build. Instead, extract the necessary info and build
+  // SgTemplateTypedefDeclaration directly.
+
+  SgName name(type_alias_template_decl->getNameAsString());
+  clang::QualType underlyingQualType = type_alias_decl->getUnderlyingType();
+  SgType *base_type = buildTypeFromQualifiedType(underlyingQualType);
+
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+
+  // Get the symbol for the parent scope (mimic
+  // buildTemplateTypedefDeclaration_nfi logic but be lenient)
+  SgSymbol *scopeSymbol = NULL;
+  if (SgClassDefinition *def = isSgClassDefinition(scope)) {
+    scopeSymbol = def->get_declaration()->get_symbol_from_symbol_table();
+  } else if (SgNamespaceDefinitionStatement *def =
+                 isSgNamespaceDefinitionStatement(scope)) {
+    scopeSymbol =
+        def->get_namespaceDeclaration()->get_symbol_from_symbol_table();
+  }
+
+  // Create SgTemplateTypedefDeclaration manually
+  SgTemplateTypedefDeclaration *template_typedef =
+      new SgTemplateTypedefDeclaration(name, base_type,
+                                       NULL, // Type will be set later
+                                       NULL, // Base declaration (optional)
+                                       scopeSymbol);
+
+  template_typedef->set_scope(scope);
+  template_typedef->set_parent(scope);
+
+  // REX FIX: Set source position to avoid AST post-processing assertion failure
+  applySourceRange(template_typedef,
+                   type_alias_template_decl->getSourceRange());
+
+  // Set firstNondefiningDeclaration (required for unparsing)
+  template_typedef->set_firstNondefiningDeclaration(template_typedef);
+  template_typedef->set_definingDeclaration(NULL);
+
+  // Create SgTypedefType
+  SgTypedefType *typedefType = SgTypedefType::createType(template_typedef);
+  template_typedef->set_type(typedefType);
+
+  // Create and insert symbol
+  SgTemplateTypedefSymbol *typedef_symbol =
+      new SgTemplateTypedefSymbol(template_typedef);
+  scope->insert_symbol(name, typedef_symbol);
+
+  // Handle template parameters
+  clang::TemplateParameterList *param_list =
+      type_alias_template_decl->getTemplateParameters();
+  SgTemplateParameterPtrList *template_params = NULL;
+  if (param_list != NULL) {
+    // REX FIX: Pass template_typedef as owning template
+    template_params = translateTemplateParameterList(
+        type_alias_template_decl->getTemplateParameters(), template_typedef);
+  } else {
+    template_params =
+        new SgTemplateParameterPtrList(); // Empty list if no parameters
+  }
+
+  // REX FIX: Set template parameters on the declaration!
+  template_typedef->get_templateParameters() = *template_params;
+
+  // REX FIX: Do not append to scope here. VisitTranslationUnitDecl handles it.
+  // if (scope) {
+  //     scope->append_statement(template_typedef);
+  // }
+
+  // Add to map
+  p_decl_translation_map.insert(
+      std::make_pair(type_alias_template_decl, template_typedef));
+
+  *node = template_typedef;
+  // REX FIX: Do not call VisitRedeclarableTemplateDecl -> VisitTemplateDecl as
+  // it clears *node to NULL
+  return true;
+}
+
+bool ClangToSageTranslator::VisitVarTemplateDecl(
+    clang::VarTemplateDecl *var_template_decl, SgNode **node) {
+
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitVarTemplateDecl" << std::endl;
+#endif
+  if (var_template_decl != nullptr) {
+    Traverse(var_template_decl->getTemplatedDecl());
+  }
+  *node = NULL;
+  return false;
+}
+
+bool ClangToSageTranslator::VisitTemplateTemplateParmDecl(
+    clang::TemplateTemplateParmDecl *template_template_parm_decl,
+    SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitTemplateTemplateParmDecl"
+            << std::endl;
+#endif
+  SgDeclarationStatement *owning_template = NULL;
+  if (clang::DeclContext *ctx = template_template_parm_decl->getDeclContext()) {
+    if (clang::TemplateDecl *template_ctx =
+            llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
+      auto it = p_decl_translation_map.find(template_ctx);
+      if (it != p_decl_translation_map.end()) {
+        owning_template = isSgDeclarationStatement(it->second);
+      }
+    }
+  }
+
+  unsigned position = template_template_parm_decl->getIndex();
+  SgTemplateParameter *sg_param = translateTemplateParameter(
+      template_template_parm_decl, owning_template, position);
+
+  *node = sg_param;
+  return sg_param != NULL;
+}
+
+bool ClangToSageTranslator::VisitTypeDecl(clang::TypeDecl *type_decl,
+                                          SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitTypeDecl" << std::endl;
+#endif
+
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitNamedDecl(type_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitTagDecl(clang::TagDecl *tag_decl,
+                                         SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitTagDecl" << std::endl;
+#endif
+
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitTypeDecl(tag_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
+                                            SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitRecordDecl" << std::endl;
+#endif
+
+  // FIXME May have to check the symbol table first, because of out-of-order
+  // traversal of C++ classes (Could be done in CxxRecord class...)
+
+  // FIXME May have to check the symbol table first, because of out-of-order
+  // traversal of C++ classes (Could be done in CxxRecord class...)
+
+  bool res = true;
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitRecordDecl name:"
+            << record_decl->getNameAsString() << "\n";
+  std::cerr << "isAnonymousStructOrUnion() "
+            << record_decl->isAnonymousStructOrUnion() << "\n";
+  std::cerr << "isThisDeclarationADefinition() "
+            << record_decl->isThisDeclarationADefinition() << "\n";
+  std::cerr << "isCompleteDefinition() " << record_decl->isCompleteDefinition()
+            << "\n";
+  std::cerr << "isCompleteDefinitionRequired() "
+            << record_decl->isCompleteDefinitionRequired() << "\n";
+  std::cerr << "isBeingDefined() " << record_decl->isBeingDefined() << "\n";
+  std::cerr << "isEmbeddedInDeclarator() "
+            << record_decl->isEmbeddedInDeclarator() << "\n";
+  std::cerr << "isFreeStanding() " << record_decl->isFreeStanding() << "\n";
+  std::cerr << "mayHaveOutOfDateDef() " << record_decl->mayHaveOutOfDateDef()
+            << "\n";
+  std::cerr << "isDependentType() " << record_decl->isDependentType() << "\n";
+  std::cerr << "hasNameForLinkage () " << record_decl->hasNameForLinkage()
+            << "\n";
+  std::cerr << "hasLinkage() " << record_decl->hasLinkage() << "\n";
+  std::cerr << "hasExternalFormalLinkage() "
+            << record_decl->hasExternalFormalLinkage() << "\n";
+  std::cerr << "isExternallyVisible () " << record_decl->isExternallyVisible()
+            << "\n";
+  std::cerr << "isExternallyDeclarable () "
+            << record_decl->isExternallyDeclarable() << "\n";
+  std::cerr << "isLinkageValid () " << record_decl->isLinkageValid() << "\n";
+  std::cerr << "hasLinkageBeenComputed() "
+            << record_decl->hasLinkageBeenComputed() << "\n";
+  std::cerr << "isModulePrivate() " << record_decl->isModulePrivate() << "\n";
+#endif
+
+  // CLANG FRONTEND FIX: Check if this decl was already translated (e.g., by
+  // template visitors) This prevents creating duplicate SgClassDeclaration for
+  // nodes already handled as templates
+  std::map<clang::Decl *, SgNode *>::iterator it =
+      p_decl_translation_map.find(record_decl);
+  if (it != p_decl_translation_map.end()) {
+#if DEBUG_VISIT_DECL
+    std::cerr << "VisitRecordDecl: Already translated, skipping: "
+              << record_decl->getNameAsString() << std::endl;
+#endif
+    *node = it->second;
+    if (SgClassDeclaration *cd = isSgClassDeclaration(*node)) {
+      if (cd->get_firstNondefiningDeclaration() == NULL) {
+        cd->set_firstNondefiningDeclaration(cd);
+      }
+    }
+    return true; // Already processed
+  }
+
+  SgClassDeclaration *sg_class_decl = NULL;
 
   // Find previous declaration
 
-    clang::RecordDecl * prev_record_decl = record_decl->getPreviousDecl();
-    clang::RecordDecl * record_Definition = record_decl->getDefinition();
-    bool isDefined = record_decl->isThisDeclarationADefinition();
-    bool isAnonymousStructOrUnion = record_decl->isAnonymousStructOrUnion();
+  clang::RecordDecl *prev_record_decl = record_decl->getPreviousDecl();
+  clang::RecordDecl *record_Definition = record_decl->getDefinition();
+  bool isDefined = record_decl->isThisDeclarationADefinition();
+  bool isAnonymousStructOrUnion = record_decl->isAnonymousStructOrUnion();
 
-    SgClassSymbol * sg_prev_class_sym = isSgClassSymbol(GetSymbolFromSymbolTable(prev_record_decl));
-    SgClassDeclaration * sg_prev_class_decl = NULL;
-    if (sg_prev_class_sym != NULL) {
-        // CLANG FRONTEND FIX: Accept both SgClassDeclaration and SgTemplateClassDeclaration
-        // For templates, the symbol table may contain SgTemplateClassDeclaration from VisitClassTemplateDecl
-        sg_prev_class_decl = isSgClassDeclaration(sg_prev_class_sym->get_declaration());
+  SgClassSymbol *sg_prev_class_sym =
+      isSgClassSymbol(GetSymbolFromSymbolTable(prev_record_decl));
+  SgClassDeclaration *sg_prev_class_decl = NULL;
+  if (sg_prev_class_sym != NULL) {
+    // CLANG FRONTEND FIX: Accept both SgClassDeclaration and
+    // SgTemplateClassDeclaration For templates, the symbol table may contain
+    // SgTemplateClassDeclaration from VisitClassTemplateDecl
+    sg_prev_class_decl =
+        isSgClassDeclaration(sg_prev_class_sym->get_declaration());
 
-        if (sg_prev_class_decl != NULL &&
-            sg_prev_class_decl->get_firstNondefiningDeclaration() == NULL) {
-          // Fix it by assuming it is its own first non-defining declaration
-          sg_prev_class_decl->set_firstNondefiningDeclaration(
-              sg_prev_class_decl);
-        }
+    if (sg_prev_class_decl != NULL &&
+        sg_prev_class_decl->get_firstNondefiningDeclaration() == NULL) {
+      // Fix it by assuming it is its own first non-defining declaration
+      sg_prev_class_decl->set_firstNondefiningDeclaration(sg_prev_class_decl);
     }
+  }
 
-    SgClassDeclaration * sg_first_class_decl = sg_prev_class_decl == NULL ? NULL : isSgClassDeclaration(sg_prev_class_decl->get_firstNondefiningDeclaration());
+  SgClassDeclaration *sg_first_class_decl =
+      sg_prev_class_decl == NULL
+          ? NULL
+          : isSgClassDeclaration(
+                sg_prev_class_decl->get_firstNondefiningDeclaration());
 
-    //SgClassDeclaration * sg_def_class_decl = sg_prev_class_decl == NULL ? NULL : isSgClassDeclaration(sg_prev_class_decl->get_definingDeclaration());
-    SgClassSymbol * sg_defining_sym = isSgClassSymbol(GetSymbolFromSymbolTable(record_Definition));
-    SgClassDeclaration * sg_def_class_decl = NULL;
-    if (sg_defining_sym != NULL && sg_defining_sym->get_declaration() != NULL) {
-        // CLANG FRONTEND FIX: Accept both SgClassDeclaration and SgTemplateClassDeclaration
-        SgDeclarationStatement* decl_stmt = sg_defining_sym->get_declaration();
-        sg_def_class_decl = isSgClassDeclaration(decl_stmt->get_definingDeclaration());
+  // SgClassDeclaration * sg_def_class_decl = sg_prev_class_decl == NULL ? NULL
+  // : isSgClassDeclaration(sg_prev_class_decl->get_definingDeclaration());
+  SgClassSymbol *sg_defining_sym =
+      isSgClassSymbol(GetSymbolFromSymbolTable(record_Definition));
+  SgClassDeclaration *sg_def_class_decl = NULL;
+  if (sg_defining_sym != NULL && sg_defining_sym->get_declaration() != NULL) {
+    // CLANG FRONTEND FIX: Accept both SgClassDeclaration and
+    // SgTemplateClassDeclaration
+    SgDeclarationStatement *decl_stmt = sg_defining_sym->get_declaration();
+    sg_def_class_decl =
+        isSgClassDeclaration(decl_stmt->get_definingDeclaration());
+  }
+
+  // For template specializations, the first declaration may also be the
+  // definition In that case, sg_first_class_decl and sg_def_class_decl may
+  // refer to the same node
+  if (sg_first_class_decl == NULL && sg_def_class_decl != NULL) {
+    // This can happen for template specializations that are instantiated on
+    // first use Use the defining declaration as the first declaration
+    sg_first_class_decl = isSgClassDeclaration(
+        sg_def_class_decl->get_firstNondefiningDeclaration());
+    if (sg_first_class_decl == NULL) {
+      // Still NULL - this means the defining decl doesn't have firstNondefining
+      // set For template specializations, this is acceptable (they may not have
+      // separate declarations) Just use the definition as the first declaration
+      std::cerr << "Warning: Class definition without first non-defining "
+                   "declaration: "
+                << record_decl->getNameAsString()
+                << " (using definition as first declaration)" << std::endl;
+      sg_first_class_decl = sg_def_class_decl;
     }
+  }
 
-    // For template specializations, the first declaration may also be the definition
-    // In that case, sg_first_class_decl and sg_def_class_decl may refer to the same node
-    if (sg_first_class_decl == NULL && sg_def_class_decl != NULL) {
-        // This can happen for template specializations that are instantiated on first use
-        // Use the defining declaration as the first declaration
-        sg_first_class_decl = isSgClassDeclaration(sg_def_class_decl->get_firstNondefiningDeclaration());
-        if (sg_first_class_decl == NULL) {
-            // Still NULL - this means the defining decl doesn't have firstNondefining set
-            // For template specializations, this is acceptable (they may not have separate declarations)
-            // Just use the definition as the first declaration
-            std::cerr << "Warning: Class definition without first non-defining declaration: "
-                      << record_decl->getNameAsString() << " (using definition as first declaration)" << std::endl;
-            sg_first_class_decl = sg_def_class_decl;
-        }
-    }
+  // ROSE_ASSERT(sg_first_class_decl != NULL || sg_def_class_decl == NULL);
+  // Assertion relaxed for template specializations which may not have separate
+  // forward declarations
 
-    // ROSE_ASSERT(sg_first_class_decl != NULL || sg_def_class_decl == NULL);
-    // Assertion relaxed for template specializations which may not have separate forward declarations
-
-    bool had_prev_decl = sg_first_class_decl != NULL;
+  bool had_prev_decl = sg_first_class_decl != NULL;
 
   // Name
 
+  /* Pei-Hung (08/29/2022) RecordDecl can be anonymous.
+   * Apply anonymous name to allow symbol lookup.
+   * Need to check later if isAnonymousStructOrUnion is equivalent to Decl with
+   * empty name.
+   */
+  std::string recordDeclName = record_decl->getNameAsString();
+  if (isAnonymousStructOrUnion) {
+    recordDeclName = "__anonymous_" + generate_source_position_string(
+                                          record_decl->getBeginLoc());
+  }
 
-/* Pei-Hung (08/29/2022) RecordDecl can be anonymous.
- * Apply anonymous name to allow symbol lookup.
- * Need to check later if isAnonymousStructOrUnion is equivalent to Decl with empty name.
-*/
-    std::string recordDeclName = record_decl->getNameAsString();
-    if(isAnonymousStructOrUnion)
-    {
-      recordDeclName = "__anonymous_" +  generate_source_position_string(record_decl->getBeginLoc());
-    }
-
-    SgName name(recordDeclName);
-
+  SgName name(recordDeclName);
 
   // Type of class
 
-    SgClassDeclaration::class_types type_of_class;
-    switch (record_decl->getTagKind()) {
-        case clang::TagTypeKind::Struct:
-            type_of_class = SgClassDeclaration::e_struct;
-            break;
-        case clang::TagTypeKind::Class:
-            type_of_class = SgClassDeclaration::e_class;
-            break;
-        case clang::TagTypeKind::Union:
-            type_of_class = SgClassDeclaration::e_union;
-            break;
-        default:
-            std::cerr << "Runtime error: RecordDecl can only be a struct/class/union." << std::endl;
-            res = false;
-    }
+  SgClassDeclaration::class_types type_of_class;
+  switch (record_decl->getTagKind()) {
+  case clang::TagTypeKind::Struct:
+    type_of_class = SgClassDeclaration::e_struct;
+    break;
+  case clang::TagTypeKind::Class:
+    type_of_class = SgClassDeclaration::e_class;
+    break;
+  case clang::TagTypeKind::Union:
+    type_of_class = SgClassDeclaration::e_union;
+    break;
+  default:
+    std::cerr << "Runtime error: RecordDecl can only be a struct/class/union."
+              << std::endl;
+    res = false;
+  }
 
   // Build declaration(s)
 
-    sg_class_decl = new SgClassDeclaration(name, type_of_class, NULL, NULL);
+  sg_class_decl = new SgClassDeclaration(name, type_of_class, NULL, NULL);
 
-    // ROOT CAUSE FIX: Use the correct scope from Clang, not just topScopeStack()
-    // For template instantiations in namespaces, we need to use their actual lexical scope
-    clang::DeclContext* decl_context = record_decl->getDeclContext();
-    SgScopeStatement* correct_scope = SageBuilder::topScopeStack();
+  // ROOT CAUSE FIX: Use the correct scope from Clang, not just topScopeStack()
+  // For template instantiations in namespaces, we need to use their actual
+  // lexical scope
+  clang::DeclContext *decl_context = record_decl->getDeclContext();
+  SgScopeStatement *correct_scope = SageBuilder::topScopeStack();
 
-    // Check if we can get a better scope from the DeclContext
-    if (decl_context && !decl_context->isTranslationUnit()) {
-        clang::Decl* context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
-        if (context_decl) {
-            SgNode* context_node = NULL;
-            std::map<clang::Decl*, SgNode*>::iterator it = p_decl_translation_map.find(context_decl);
-            if (it != p_decl_translation_map.end()) {
-                context_node = it->second;
-                SgNamespaceDefinitionStatement* ns_def = isSgNamespaceDefinitionStatement(context_node);
-                SgClassDefinition* class_def = isSgClassDefinition(context_node);
-                if (ns_def != NULL) {
-                    correct_scope = ns_def;
-                } else if (class_def != NULL) {
-                    correct_scope = class_def;
-                }
-            }
+  // Check if we can get a better scope from the DeclContext
+  if (decl_context && !decl_context->isTranslationUnit()) {
+    clang::Decl *context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
+    if (context_decl) {
+      SgNode *context_node = NULL;
+      std::map<clang::Decl *, SgNode *>::iterator it =
+          p_decl_translation_map.find(context_decl);
+      if (it != p_decl_translation_map.end()) {
+        context_node = it->second;
+        SgNamespaceDefinitionStatement *ns_def =
+            isSgNamespaceDefinitionStatement(context_node);
+        SgClassDefinition *class_def = isSgClassDefinition(context_node);
+        if (ns_def != NULL) {
+          correct_scope = ns_def;
+        } else if (class_def != NULL) {
+          correct_scope = class_def;
         }
+      }
     }
+  }
 
-    sg_class_decl->set_scope(correct_scope);
-    sg_class_decl->set_parent(correct_scope);
+  sg_class_decl->set_scope(correct_scope);
+  sg_class_decl->set_parent(correct_scope);
 
- // DQ (11/28/2020): Adding asertion.
-    ROSE_ASSERT(sg_class_decl->get_parent() != NULL);
+  // DQ (11/28/2020): Adding asertion.
+  ROSE_ASSERT(sg_class_decl->get_parent() != NULL);
 
-    // std::cerr << "DEBUG: VisitCXXRecordDecl for " << record_decl->getNameAsString() << std::endl;
+  // std::cerr << "DEBUG: VisitCXXRecordDecl for " <<
+  // record_decl->getNameAsString() << std::endl;
 
-    // CRITICAL: Set firstNondefiningDeclaration BEFORE calling createType()
-    // createType() internally asserts that this pointer is not null
-    // This will be corrected later if this is not actually the first declaration
-    if (sg_first_class_decl != NULL) {
-        // CLANG FRONTEND FIX: Only set if variant types match
-        if (sg_first_class_decl->variantT() == sg_class_decl->variantT()) {
-            sg_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
-        } else {
-            // Variant mismatch - set to self to avoid assertion
-            sg_class_decl->set_firstNondefiningDeclaration(sg_class_decl);
-        }
+  // CRITICAL: Set firstNondefiningDeclaration BEFORE calling createType()
+  // createType() internally asserts that this pointer is not null
+  // This will be corrected later if this is not actually the first declaration
+  if (sg_first_class_decl != NULL) {
+    // CLANG FRONTEND FIX: Only set if variant types match
+    if (sg_first_class_decl->variantT() == sg_class_decl->variantT()) {
+      sg_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
     } else {
-        sg_class_decl->set_firstNondefiningDeclaration(sg_class_decl);
+      // Variant mismatch - set to self to avoid assertion
+      sg_class_decl->set_firstNondefiningDeclaration(sg_class_decl);
+    }
+  } else {
+    sg_class_decl->set_firstNondefiningDeclaration(sg_class_decl);
+  }
+
+  SgClassType *type = NULL;
+  if (sg_first_class_decl != NULL) {
+    type = sg_first_class_decl->get_type();
+  } else {
+    type = SgClassType::createType(sg_class_decl);
+  }
+  ROSE_ASSERT(type != NULL);
+  sg_class_decl->set_type(type);
+
+  if (isAnonymousStructOrUnion)
+    sg_class_decl->set_isUnNamed(true);
+
+  if (!had_prev_decl) {
+    sg_first_class_decl = sg_class_decl;
+    sg_first_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
+    sg_first_class_decl->set_definingDeclaration(NULL);
+    sg_first_class_decl->set_definition(NULL);
+    sg_first_class_decl->setForward();
+    // ROOT CAUSE FIX: Use correct_scope consistently for symbol insertion
+    SgClassSymbol *class_symbol = new SgClassSymbol(sg_first_class_decl);
+    correct_scope->insert_symbol(name, class_symbol);
+  } else if (!isDefined) {
+    // OPENMP LOWERING FIX: Even though we're skipping this non-defining
+    // redeclaration, sg_class_decl may still be referenced (e.g., through
+    // SgClassType), so set its file info
+    applySourceRange(sg_class_decl, record_decl->getSourceRange());
+
+    // Only apply source range to sg_first_class_decl if it's missing file info
+    // Use the real source location to preserve user-written declaration
+    // information
+    if (sg_first_class_decl != NULL &&
+        sg_first_class_decl->get_startOfConstruct() == NULL) {
+      applySourceRange(sg_first_class_decl, record_decl->getSourceRange());
     }
 
-    SgClassType * type = NULL;
-    if (sg_first_class_decl != NULL) {
-        type = sg_first_class_decl->get_type();
-    }
-    else {
-        type = SgClassType::createType(sg_class_decl);
-    }
-    ROSE_ASSERT(type != NULL);
-    sg_class_decl->set_type(type);
+    // CRITICAL: Set *node before returning, otherwise it contains garbage
+    // Return the first declaration since we're skipping this redeclaration
+    *node = sg_first_class_decl;
 
-    if (isAnonymousStructOrUnion) sg_class_decl->set_isUnNamed(true);
+    return false; // FIXME ROSE need only one non-defining declaration
+                  // (SageBuilder don't let me build another one....)
+  }
 
-    if (!had_prev_decl) {
-        sg_first_class_decl = sg_class_decl;
-        sg_first_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
-        sg_first_class_decl->set_definingDeclaration(NULL);
-        sg_first_class_decl->set_definition(NULL);
-        sg_first_class_decl->setForward();
-        // ROOT CAUSE FIX: Use correct_scope consistently for symbol insertion
-        SgClassSymbol * class_symbol = new SgClassSymbol(sg_first_class_decl);
-        correct_scope->insert_symbol(name, class_symbol);
-    }
-    else if (!isDefined) {
-        // OPENMP LOWERING FIX: Even though we're skipping this non-defining redeclaration,
-        // sg_class_decl may still be referenced (e.g., through SgClassType), so set its file info
-        applySourceRange(sg_class_decl, record_decl->getSourceRange());
+  if (isDefined) {
+    sg_def_class_decl = new SgClassDeclaration(name, type_of_class, type, NULL);
+    // ROOT CAUSE FIX: Use correct_scope consistently for defining declaration
+    // too
+    sg_def_class_decl->set_scope(correct_scope);
+    if (isAnonymousStructOrUnion)
+      sg_def_class_decl->set_isUnNamed(true);
+    sg_def_class_decl->set_parent(correct_scope);
 
-        // Only apply source range to sg_first_class_decl if it's missing file info
-        // Use the real source location to preserve user-written declaration information
-        if (sg_first_class_decl != NULL && sg_first_class_decl->get_startOfConstruct() == NULL) {
-            applySourceRange(sg_first_class_decl, record_decl->getSourceRange());
-        }
-
-        // CRITICAL: Set *node before returning, otherwise it contains garbage
-        // Return the first declaration since we're skipping this redeclaration
-        *node = sg_first_class_decl;
-
-        return false; // FIXME ROSE need only one non-defining declaration (SageBuilder don't let me build another one....)
+    // OPENMP LOWERING FIX: The sg_class_decl created at line 1350 will be
+    // orphaned when we reassign below, but it may still be referenced through
+    // SgClassType. Set its file info before orphaning.
+    if (had_prev_decl && sg_class_decl->get_startOfConstruct() == NULL) {
+      applySourceRange(sg_class_decl, record_decl->getSourceRange());
     }
 
-    if (isDefined) {
-        sg_def_class_decl = new SgClassDeclaration(name, type_of_class, type, NULL);
-        // ROOT CAUSE FIX: Use correct_scope consistently for defining declaration too
-        sg_def_class_decl->set_scope(correct_scope);
-        if (isAnonymousStructOrUnion) sg_def_class_decl->set_isUnNamed(true);
-        sg_def_class_decl->set_parent(correct_scope);
+    sg_class_decl = sg_def_class_decl; // we return the defining decl
 
-        // OPENMP LOWERING FIX: The sg_class_decl created at line 1350 will be orphaned when we reassign below,
-        // but it may still be referenced through SgClassType. Set its file info before orphaning.
-        if (had_prev_decl && sg_class_decl->get_startOfConstruct() == NULL) {
-            applySourceRange(sg_class_decl, record_decl->getSourceRange());
+    // CLANG FRONTEND FIX: Only set if variant types match
+    if (sg_first_class_decl != NULL &&
+        sg_first_class_decl->variantT() == sg_def_class_decl->variantT()) {
+      sg_def_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
+    } else {
+      sg_def_class_decl->set_firstNondefiningDeclaration(sg_def_class_decl);
+    }
+    if (sg_def_class_decl->get_firstNondefiningDeclaration() == NULL) {
+      fprintf(stderr,
+              "DEBUG: VisitRecordDecl ERROR: firstNondef is NULL after set "
+              "for %p %s! Fixing...\n",
+              sg_def_class_decl, name.getString().c_str());
+      sg_def_class_decl->set_firstNondefiningDeclaration(sg_def_class_decl);
+    }
+    sg_def_class_decl->set_definingDeclaration(sg_def_class_decl);
+
+    // CLANG FRONTEND FIX: Only set definingDeclaration if variant types match
+    if (sg_first_class_decl != NULL &&
+        sg_first_class_decl->variantT() == sg_def_class_decl->variantT()) {
+      sg_first_class_decl->set_definingDeclaration(sg_def_class_decl);
+    }
+    setCompilerGeneratedFileInfo(sg_first_class_decl);
+
+    // Build ClassDefinition
+    SgClassDefinition *sg_class_def =
+        isSgClassDefinition(sg_def_class_decl->get_definition());
+    if (sg_class_def == NULL) {
+      sg_class_def = SageBuilder::buildClassDefinition_nfi(sg_def_class_decl);
+    }
+    sg_def_class_decl->set_definition(sg_class_def);
+
+    ROSE_ASSERT(sg_class_def->get_symbol_table() != NULL);
+
+    applySourceRange(sg_class_def, record_decl->getSourceRange());
+
+    SageBuilder::pushScopeStack(sg_class_def);
+
+    // CRITICAL FIX: Add to translation map BEFORE processing members!
+    // This prevents infinite recursion if member processing triggers a lookup
+    // of this class type. The Traverse() function normally adds to the map
+    // after Visit returns, but that's too late - by then we've already
+    // processed members which may trigger recursive visits.
+    p_decl_translation_map.insert(std::make_pair(record_decl, sg_class_decl));
+
+    // CLANG FRONTEND FIX: Skip processing members of system header template
+    // classes to avoid performance issues System headers contain massive
+    // template hierarchies that cause extremely slow processing
+    bool skip_members = false;
+    clang::SourceManager &SM = p_compiler_instance->getSourceManager();
+    if (SM.isInSystemHeader(record_decl->getLocation())) {
+      if (clang::CXXRecordDecl *cxx_rec =
+              llvm::dyn_cast<clang::CXXRecordDecl>(record_decl)) {
+        if (cxx_rec->getDescribedClassTemplate() != NULL ||
+            cxx_rec->getTemplateInstantiationPattern() != NULL) {
+          skip_members = true;
         }
+      }
+    }
 
-        sg_class_decl = sg_def_class_decl; // we return the defining decl
+    if (!skip_members) {
+      // REX FIX: Track access modifier state to suppress redundant keywords
+      SgAccessModifier::access_modifier_enum current_access =
+          SgAccessModifier::e_unknown;
+      if (record_decl->isClass()) {
+        current_access = SgAccessModifier::e_private;
+      } else if (record_decl->isStruct() || record_decl->isUnion()) {
+        current_access = SgAccessModifier::e_public;
+      }
 
-        // CLANG FRONTEND FIX: Only set if variant types match
-        if (sg_first_class_decl != NULL && sg_first_class_decl->variantT() == sg_def_class_decl->variantT()) {
-            sg_def_class_decl->set_firstNondefiningDeclaration(sg_first_class_decl);
-        } else {
-            sg_def_class_decl->set_firstNondefiningDeclaration(sg_def_class_decl);
+      clang::RecordDecl::field_iterator it;
+      for (it = record_decl->field_begin(); it != record_decl->field_end();
+           it++) {
+        SgNode *tmp_field = Traverse(*it);
+        SgDeclarationStatement *field_decl =
+            isSgDeclarationStatement(tmp_field);
+        ROSE_ASSERT(field_decl != NULL);
+        sg_class_def->append_member(field_decl);
+        field_decl->set_parent(sg_class_def);
+        // Reverted Redundancy Check
+        SgAccessModifier &mod =
+            field_decl->get_declarationModifier().get_accessModifier();
+        SgAccessModifier::access_modifier_enum access = mod.get_modifier();
+
+        if (access != SgAccessModifier::e_unknown) {
+          if (access == current_access) {
+            mod.set_modifier(SgAccessModifier::e_unknown);
+          } else {
+            current_access = access;
+          }
         }
-        if (sg_def_class_decl->get_firstNondefiningDeclaration() == NULL) {
-          fprintf(stderr,
-                  "DEBUG: VisitRecordDecl ERROR: firstNondef is NULL after set "
-                  "for %p %s! Fixing...\n",
-                  sg_def_class_decl, name.getString().c_str());
-          sg_def_class_decl->set_firstNondefiningDeclaration(sg_def_class_decl);
-        }
-        sg_def_class_decl->set_definingDeclaration(sg_def_class_decl);
+      }
+    }
 
-        // CLANG FRONTEND FIX: Only set definingDeclaration if variant types match
-        if (sg_first_class_decl != NULL && sg_first_class_decl->variantT() == sg_def_class_decl->variantT()) {
-            sg_first_class_decl->set_definingDeclaration(sg_def_class_decl);
-        }
-        setCompilerGeneratedFileInfo(sg_first_class_decl);
+    SageBuilder::popScopeStack();
+  }
 
-  // Build ClassDefinition
-        SgClassDefinition * sg_class_def = isSgClassDefinition(sg_def_class_decl->get_definition());
-        if (sg_class_def == NULL) {
-            sg_class_def = SageBuilder::buildClassDefinition_nfi(sg_def_class_decl);
-        }
-        sg_def_class_decl->set_definition(sg_class_def);
+  ROSE_ASSERT(sg_class_decl->get_definingDeclaration() == NULL ||
+              isSgClassDeclaration(sg_class_decl->get_definingDeclaration())
+                      ->get_definition() != NULL);
+  ROSE_ASSERT(sg_first_class_decl->get_definition() == NULL);
+  ROSE_ASSERT(sg_def_class_decl == NULL ||
+              sg_def_class_decl->get_definition() != NULL);
 
-        ROSE_ASSERT(sg_class_def->get_symbol_table() != NULL);
+  *node = sg_class_decl;
 
-        applySourceRange(sg_class_def, record_decl->getSourceRange());
+  return VisitTagDecl(record_decl, node) && res;
+}
 
-        SageBuilder::pushScopeStack(sg_class_def);
+bool ClangToSageTranslator::VisitCXXRecordDecl(
+    clang::CXXRecordDecl *cxx_record_decl, SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitCXXRecordDecl" << std::endl;
+#endif
+  bool res = VisitRecordDecl(cxx_record_decl, node);
 
-        // CRITICAL FIX: Add to translation map BEFORE processing members!
-        // This prevents infinite recursion if member processing triggers a lookup of this class type.
-        // The Traverse() function normally adds to the map after Visit returns, but that's too late -
-        // by then we've already processed members which may trigger recursive visits.
-        p_decl_translation_map.insert(std::make_pair(record_decl, sg_class_decl));
-
-        // CLANG FRONTEND FIX: Skip processing members of system header template classes to avoid performance issues
-        // System headers contain massive template hierarchies that cause extremely slow processing
-        bool skip_members = false;
-        clang::SourceManager &SM = p_compiler_instance->getSourceManager();
-        if (SM.isInSystemHeader(record_decl->getLocation())) {
-            if (clang::CXXRecordDecl* cxx_rec = llvm::dyn_cast<clang::CXXRecordDecl>(record_decl)) {
-                if (cxx_rec->getDescribedClassTemplate() != NULL ||
-                    cxx_rec->getTemplateInstantiationPattern() != NULL) {
-                    skip_members = true;
-                }
-            }
-        }
-
-        if (!skip_members) {
-          // REX FIX: Track access modifier state to suppress redundant keywords
-          SgAccessModifier::access_modifier_enum current_access =
-              SgAccessModifier::e_unknown;
-          if (record_decl->isClass()) {
-            current_access = SgAccessModifier::e_private;
-          } else if (record_decl->isStruct() || record_decl->isUnion()) {
-            current_access = SgAccessModifier::e_public;
+  // CLANG FRONTEND FIX: Process C++ specific members (methods, constructors,
+  // etc.) Only do this if this is the DEFINING declaration (not forward
+  // declaration or redeclaration)
+  if (cxx_record_decl->isThisDeclarationADefinition() &&
+      cxx_record_decl->hasDefinition()) {
+    SgClassDeclaration *sg_class_decl = isSgClassDeclaration(*node);
+    if (sg_class_decl != NULL) {
+      SgClassDeclaration *def_decl =
+          isSgClassDeclaration(sg_class_decl->get_definingDeclaration());
+      if (def_decl != NULL &&
+          def_decl == sg_class_decl) { // Make sure this IS the defining decl
+        SgClassDefinition *sg_class_def = def_decl->get_definition();
+        if (sg_class_def != NULL) {
+          // Skip ALL system header classes to avoid namespace qualification
+          // corruption Processing system header members causes issues with name
+          // qualification traversal
+          bool skip_members = false;
+          clang::SourceManager &SM = p_compiler_instance->getSourceManager();
+          if (SM.isInSystemHeader(cxx_record_decl->getLocation())) {
+            skip_members = true; // Skip ALL system headers, not just templates
           }
 
-            clang::RecordDecl::field_iterator it;
-            for (it = record_decl->field_begin(); it != record_decl->field_end(); it++) {
-                SgNode * tmp_field = Traverse(*it);
-                SgDeclarationStatement * field_decl = isSgDeclarationStatement(tmp_field);
-                ROSE_ASSERT(field_decl != NULL);
-                sg_class_def->append_member(field_decl);
-                field_decl->set_parent(sg_class_def);
-                // Reverted Redundancy Check
+          if (!skip_members) {
+            // Check if scope stack is in correct state
+            SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+
+            // Only push scope if not already at this class definition
+            bool need_scope_push = (current_scope != sg_class_def);
+            if (need_scope_push) {
+              SageBuilder::pushScopeStack(sg_class_def);
+            }
+
+            // Implement access tracking state machine
+            SgAccessModifier::access_modifier_enum current_access =
+                SgAccessModifier::e_unknown;
+            // Initialize state based on container default
+            bool is_class = cxx_record_decl->isClass(); // Default private
+            bool is_struct_or_union =
+                cxx_record_decl->isStruct() ||
+                cxx_record_decl->isUnion(); // Default public
+
+            // Default state
+            if (is_class)
+              current_access = SgAccessModifier::e_private;
+            else if (is_struct_or_union)
+              current_access = SgAccessModifier::e_public;
+
+            // Reconstruct state from existing members (added in
+            // VisitRecordDecl)
+            SgDeclarationStatementPtrList &members =
+                sg_class_def->get_members();
+            for (auto mem : members) {
+              SgAccessModifier::access_modifier_enum m =
+                  mem->get_declarationModifier()
+                      .get_accessModifier()
+                      .get_modifier();
+              if (m != SgAccessModifier::e_unknown) {
+                current_access = m;
+              }
+            }
+
+            // Process member functions (includes methods, constructors,
+            // destructors, operators)
+            clang::CXXRecordDecl::method_iterator it_method;
+            for (it_method = cxx_record_decl->method_begin();
+                 it_method != cxx_record_decl->method_end(); it_method++) {
+              clang::CXXMethodDecl *method = *it_method;
+
+              // Skip implicit methods to avoid processing compiler-generated
+              // functions
+              if (method->isImplicit()) {
+                continue;
+              }
+
+              SgNode *tmp_method = Traverse(method);
+              SgDeclarationStatement *method_decl =
+                  isSgDeclarationStatement(tmp_method);
+              if (method_decl != NULL) {
+                sg_class_def->append_member(method_decl);
+                method_decl->set_parent(sg_class_def);
+
+                // Redundancy Check - REMOVED for REX FIX
+                // The unparser requires valid access modifiers
+                // on each node to update its state. Removing
+                // them causes "isUnsetAccess()" assertions.
                 SgAccessModifier &mod =
-                    field_decl->get_declarationModifier().get_accessModifier();
+                    method_decl->get_declarationModifier().get_accessModifier();
+                SgAccessModifier::access_modifier_enum access =
+                    mod.get_modifier();
+                if (access != SgAccessModifier::e_unknown) {
+                  current_access = access;
+                }
+              }
+            }
+
+            // Process other declarations (typedefs, enums, templates, nested
+            // classes, etc.) Skip fields and methods as they are handled above
+            // or in VisitRecordDecl
+            for (clang::DeclContext::decl_iterator it =
+                     cxx_record_decl->decls_begin();
+                 it != cxx_record_decl->decls_end(); ++it) {
+              clang::Decl *decl = *it;
+              // std::cerr << "DEBUG: VisitCXXRecordDecl iterating decl: " <<
+              // decl->getDeclKindName() << std::endl;
+              if (llvm::isa<clang::FieldDecl>(decl) ||
+                  llvm::isa<clang::CXXMethodDecl>(decl) ||
+                  llvm::isa<clang::AccessSpecDecl>(decl) ||
+                  llvm::isa<clang::IndirectFieldDecl>(decl)) {
+                continue;
+              }
+
+              // Skip implicit declarations
+              if (decl->isImplicit())
+                continue;
+
+              SgNode *tmp_decl = Traverse(decl);
+              SgDeclarationStatement *child_decl =
+                  isSgDeclarationStatement(tmp_decl);
+              if (child_decl != NULL) {
+                sg_class_def->append_member(child_decl);
+                child_decl->set_parent(sg_class_def);
+
+                // Redundancy Check
+                SgAccessModifier &mod =
+                    child_decl->get_declarationModifier().get_accessModifier();
                 SgAccessModifier::access_modifier_enum access =
                     mod.get_modifier();
 
                 if (access != SgAccessModifier::e_unknown) {
-                  if (access == current_access) {
-                    mod.set_modifier(SgAccessModifier::e_unknown);
-                  } else {
-                    current_access = access;
-                  }
+                  current_access = access;
                 }
-            }
-        }
-
-        SageBuilder::popScopeStack();
-    }
-
-    ROSE_ASSERT(sg_class_decl->get_definingDeclaration() == NULL || isSgClassDeclaration(sg_class_decl->get_definingDeclaration())->get_definition() != NULL);
-    ROSE_ASSERT(sg_first_class_decl->get_definition() == NULL);
-    ROSE_ASSERT(sg_def_class_decl == NULL || sg_def_class_decl->get_definition() != NULL);
-
-    *node = sg_class_decl;
-
-    return VisitTagDecl(record_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXRecordDecl(clang::CXXRecordDecl * cxx_record_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXRecordDecl" << std::endl;
-#endif
-    bool res = VisitRecordDecl(cxx_record_decl, node);
-
-    // CLANG FRONTEND FIX: Process C++ specific members (methods, constructors, etc.)
-    // Only do this if this is the DEFINING declaration (not forward declaration or redeclaration)
-    if (cxx_record_decl->isThisDeclarationADefinition() && cxx_record_decl->hasDefinition()) {
-        SgClassDeclaration* sg_class_decl = isSgClassDeclaration(*node);
-        if (sg_class_decl != NULL) {
-            SgClassDeclaration* def_decl = isSgClassDeclaration(sg_class_decl->get_definingDeclaration());
-            if (def_decl != NULL && def_decl == sg_class_decl) {  // Make sure this IS the defining decl
-                SgClassDefinition* sg_class_def = def_decl->get_definition();
-                if (sg_class_def != NULL) {
-                    // Skip ALL system header classes to avoid namespace qualification corruption
-                    // Processing system header members causes issues with name qualification traversal
-                    bool skip_members = false;
-                    clang::SourceManager &SM = p_compiler_instance->getSourceManager();
-                    if (SM.isInSystemHeader(cxx_record_decl->getLocation())) {
-                        skip_members = true;  // Skip ALL system headers, not just templates
-                    }
-
-                    if (!skip_members) {
-                        // Check if scope stack is in correct state
-                        SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-
-                        // Only push scope if not already at this class definition
-                        bool need_scope_push = (current_scope != sg_class_def);
-                        if (need_scope_push) {
-                            SageBuilder::pushScopeStack(sg_class_def);
-                        }
-
-                        // Implement access tracking state machine
-                        SgAccessModifier::access_modifier_enum current_access =
-                            SgAccessModifier::e_unknown;
-                        // Initialize state based on container default
-                        bool is_class =
-                            cxx_record_decl->isClass(); // Default private
-                        bool is_struct_or_union =
-                            cxx_record_decl->isStruct() ||
-                            cxx_record_decl->isUnion(); // Default public
-
-                        // Default state
-                        if (is_class)
-                          current_access = SgAccessModifier::e_private;
-                        else if (is_struct_or_union)
-                          current_access = SgAccessModifier::e_public;
-
-                        // Reconstruct state from existing members (added in
-                        // VisitRecordDecl)
-                        SgDeclarationStatementPtrList &members =
-                            sg_class_def->get_members();
-                        for (auto mem : members) {
-                          SgAccessModifier::access_modifier_enum m =
-                              mem->get_declarationModifier()
-                                  .get_accessModifier()
-                                  .get_modifier();
-                          if (m != SgAccessModifier::e_unknown) {
-                            current_access = m;
-                          }
-                        }
-
-                        // Process member functions (includes methods, constructors, destructors, operators)
-                        clang::CXXRecordDecl::method_iterator it_method;
-                        for (it_method = cxx_record_decl->method_begin(); it_method !=  cxx_record_decl->method_end(); it_method++) {
-                            clang::CXXMethodDecl* method = *it_method;
-
-                            // Skip implicit methods to avoid processing compiler-generated functions
-                            if (method->isImplicit()) {
-                                continue;
-                            }
-
-                            SgNode* tmp_method = Traverse(method);
-                            SgDeclarationStatement* method_decl = isSgDeclarationStatement(tmp_method);
-                            if (method_decl != NULL) {
-                                sg_class_def->append_member(method_decl);
-                                method_decl->set_parent(sg_class_def);
-
-                                // Redundancy Check - REMOVED for REX FIX
-                                // The unparser requires valid access modifiers
-                                // on each node to update its state. Removing
-                                // them causes "isUnsetAccess()" assertions.
-                                SgAccessModifier &mod =
-                                    method_decl->get_declarationModifier()
-                                        .get_accessModifier();
-                                SgAccessModifier::access_modifier_enum access =
-                                    mod.get_modifier();
-                                if (access != SgAccessModifier::e_unknown) {
-                                  current_access = access;
-                                }
-                            }
-                        }
-
-                        // Process other declarations (typedefs, enums, templates, nested classes, etc.)
-                        // Skip fields and methods as they are handled above or in VisitRecordDecl
-                        for (clang::DeclContext::decl_iterator it = cxx_record_decl->decls_begin(); it != cxx_record_decl->decls_end(); ++it) {
-                            clang::Decl* decl = *it;
-                            // std::cerr << "DEBUG: VisitCXXRecordDecl iterating decl: " << decl->getDeclKindName() << std::endl;
-                            if (llvm::isa<clang::FieldDecl>(decl) || 
-                                llvm::isa<clang::CXXMethodDecl>(decl) ||
-                                llvm::isa<clang::AccessSpecDecl>(decl) ||
-                                llvm::isa<clang::IndirectFieldDecl>(decl)) {
-                                continue;
-                            }
-
-                            // Skip implicit declarations
-                            if (decl->isImplicit()) continue;
-
-                            SgNode* tmp_decl = Traverse(decl);
-                            SgDeclarationStatement* child_decl = isSgDeclarationStatement(tmp_decl);
-                            if (child_decl != NULL) {
-                                sg_class_def->append_member(child_decl);
-                                child_decl->set_parent(sg_class_def);
-
-                                // Redundancy Check
-                                SgAccessModifier &mod =
-                                    child_decl->get_declarationModifier()
-                                        .get_accessModifier();
-                                SgAccessModifier::access_modifier_enum access =
-                                    mod.get_modifier();
-
-                                if (access != SgAccessModifier::e_unknown) {
-                                  current_access = access;
-                                }
-                            }
-                        }
-
-                        if (need_scope_push) {
-                            SageBuilder::popScopeStack();
-                        }
-                    }
-
-                    // Base classes and friends are TODO for future implementation
-                }
-            }
-        }
-    }
-
-    if (res && node && *node) {
-      if (SgClassDeclaration *decl = isSgClassDeclaration(*node)) {
-        // REX FIX: Issue 107 Root Cause.
-        // Check if firstNondefiningDeclaration is NULL OR points to self (for
-        // defining decls). This catches cases where VisitRecordDecl setup was
-        // insufficient.
-        SgDeclarationStatement *firstNonDef =
-            decl->get_firstNondefiningDeclaration();
-        if (firstNonDef == NULL ||
-            (decl->get_definition() && firstNonDef == decl)) {
-
-          // Create non-defining declaration.
-          // Must handle SgTemplateInstantiationDecl vs SgClassDeclaration vs
-          // SgTemplateClassDeclaration.
-          SgClassDeclaration *nonDef = NULL;
-
-          if (SgTemplateInstantiationDecl *tplInst =
-                  isSgTemplateInstantiationDecl(decl)) {
-            // Need buildNondefiningTemplateInstantiationDecl? Or generic
-            // buildNondefiningClassDeclaration works?
-            // buildNondefiningClassDeclaration_nfi should handle it? NO, it
-            // creates SgClassDeclaration. SgTemplateInstantiationDecl is a
-            // subclass. Use buildNondefiningClassDeclaration_nfi might return
-            // SgClassDeclaration (sliced?). Let's use deepCopy approach here
-            // too as fallback, or simpler: Manually create one?
-            // SageBuilder::buildNondefiningClassDeclaration_nfi signature takes
-            // class_types. It might create SgClassDeclaration. If we need
-            // SgTemplateInstantiationDecl, we must ensure type is correct.
-
-            // Try SageBuilder::buildNondefiningClassDeclaration_nfi first.
-            nonDef = SageBuilder::buildNondefiningClassDeclaration_nfi(
-                decl->get_name(), decl->get_class_type(), decl->get_scope(),
-                false, NULL);
-
-            // What if we need SgTemplateInstantiationDecl?
-            // If nonDef is SgClassDeclaration, unparser might be confused if it
-            // expects TemplateInstantiation. But unparser looks at defining
-            // decl mostly. For mangled name, SgClassDeclaration of same name
-            // might be OK? But SgTemplateInstantiationDecl has template args.
-            // SgClassDeclaration doesn't. We MUST preserve node type.
-
-            if (!isSgTemplateInstantiationDecl(nonDef)) {
-              // If builder gave us SgClassDeclaration, it's insufficient for
-              // template instantiated decls. Clone logic:
-              nonDef = (SgClassDeclaration *)SageInterface::deepCopy(decl);
-              nonDef->set_definition(NULL);
-              nonDef->set_firstNondefiningDeclaration(nonDef);
-              nonDef->set_definingDeclaration(decl);
-              // Unset parent to be safe (will serve as non-def).
-              // Actually it needs same scope parent.
-              nonDef->set_parent(decl->get_parent());
-              nonDef->set_scope(decl->get_scope());
+              }
             }
 
-          } else {
-            nonDef = SageBuilder::buildNondefiningClassDeclaration_nfi(
-                decl->get_name(), decl->get_class_type(), decl->get_scope(),
-                false, NULL);
+            if (need_scope_push) {
+              SageBuilder::popScopeStack();
+            }
           }
 
-          if (nonDef) {
-            nonDef->set_parent(decl->get_parent());
-
-            nonDef->set_firstNondefiningDeclaration(nonDef);
-            nonDef->set_definingDeclaration(decl);
-
-            decl->set_firstNondefiningDeclaration(nonDef);
-            decl->set_definingDeclaration(decl);
-          }
+          // Base classes and friends are TODO for future implementation
         }
       }
     }
+  }
 
-    return res;
+  if (res && node && *node) {
+    if (SgClassDeclaration *decl = isSgClassDeclaration(*node)) {
+      // REX FIX: Issue 107 Root Cause.
+      // Check if firstNondefiningDeclaration is NULL OR points to self (for
+      // defining decls). This catches cases where VisitRecordDecl setup was
+      // insufficient.
+      SgDeclarationStatement *firstNonDef =
+          decl->get_firstNondefiningDeclaration();
+      if (firstNonDef == NULL ||
+          (decl->get_definition() && firstNonDef == decl)) {
+
+        // Create non-defining declaration.
+        // Must handle SgTemplateInstantiationDecl vs SgClassDeclaration vs
+        // SgTemplateClassDeclaration.
+        SgClassDeclaration *nonDef = NULL;
+
+        if (SgTemplateInstantiationDecl *tplInst =
+                isSgTemplateInstantiationDecl(decl)) {
+          // Need buildNondefiningTemplateInstantiationDecl? Or generic
+          // buildNondefiningClassDeclaration works?
+          // buildNondefiningClassDeclaration_nfi should handle it? NO, it
+          // creates SgClassDeclaration. SgTemplateInstantiationDecl is a
+          // subclass. Use buildNondefiningClassDeclaration_nfi might return
+          // SgClassDeclaration (sliced?). Let's use deepCopy approach here
+          // too as fallback, or simpler: Manually create one?
+          // SageBuilder::buildNondefiningClassDeclaration_nfi signature takes
+          // class_types. It might create SgClassDeclaration. If we need
+          // SgTemplateInstantiationDecl, we must ensure type is correct.
+
+          // Try SageBuilder::buildNondefiningClassDeclaration_nfi first.
+          nonDef = SageBuilder::buildNondefiningClassDeclaration_nfi(
+              decl->get_name(), decl->get_class_type(), decl->get_scope(),
+              false, NULL);
+
+          // What if we need SgTemplateInstantiationDecl?
+          // If nonDef is SgClassDeclaration, unparser might be confused if it
+          // expects TemplateInstantiation. But unparser looks at defining
+          // decl mostly. For mangled name, SgClassDeclaration of same name
+          // might be OK? But SgTemplateInstantiationDecl has template args.
+          // SgClassDeclaration doesn't. We MUST preserve node type.
+
+          if (!isSgTemplateInstantiationDecl(nonDef)) {
+            // If builder gave us SgClassDeclaration, it's insufficient for
+            // template instantiated decls. Clone logic:
+            nonDef = (SgClassDeclaration *)SageInterface::deepCopy(decl);
+            nonDef->set_definition(NULL);
+            nonDef->set_firstNondefiningDeclaration(nonDef);
+            nonDef->set_definingDeclaration(decl);
+            // Unset parent to be safe (will serve as non-def).
+            // Actually it needs same scope parent.
+            nonDef->set_parent(decl->get_parent());
+            nonDef->set_scope(decl->get_scope());
+          }
+
+        } else {
+          nonDef = SageBuilder::buildNondefiningClassDeclaration_nfi(
+              decl->get_name(), decl->get_class_type(), decl->get_scope(),
+              false, NULL);
+        }
+
+        if (nonDef) {
+          nonDef->set_parent(decl->get_parent());
+
+          nonDef->set_firstNondefiningDeclaration(nonDef);
+          nonDef->set_definingDeclaration(decl);
+
+          decl->set_firstNondefiningDeclaration(nonDef);
+          decl->set_definingDeclaration(decl);
+        }
+      }
+    }
+  }
+
+  return res;
 }
 
 // Helper from clang-frontend-type.cpp
@@ -2553,7 +2760,9 @@ static SgExpression *buildIntegralTemplateArgExpr(const llvm::APSInt &value,
   return expr;
 }
 
-bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(clang::ClassTemplateSpecializationDecl * class_tpl_spec_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
+    clang::ClassTemplateSpecializationDecl *class_tpl_spec_decl,
+    SgNode **node) {
 
   // Ensure we handle Partial Specializations separately (fallback to
   // CXXRecordDecl for now to avoid regression)
@@ -2569,388 +2778,386 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(clang::ClassTem
     return VisitCXXRecordDecl(class_tpl_spec_decl, node);
   }
 
-    bool res = true;
+  bool res = true;
 
-    if (class_tpl_spec_decl == NULL) {
-      *node = NULL;
-      return false;
-    }
+  if (class_tpl_spec_decl == NULL) {
+    *node = NULL;
+    return false;
+  }
 
-    // Determine the template name from the specialized template
-    std::string template_name_str;
-    clang::TemplateDecl *specialized_template =
-        class_tpl_spec_decl->getSpecializedTemplate();
-    if (specialized_template) {
-      template_name_str = specialized_template->getNameAsString();
-    } else {
-      template_name_str =
-          "__anon_template_spec_" +
-          generate_source_position_string(class_tpl_spec_decl->getBeginLoc());
-    }
-    SgName name(template_name_str);
+  // Determine the template name from the specialized template
+  std::string template_name_str;
+  clang::TemplateDecl *specialized_template =
+      class_tpl_spec_decl->getSpecializedTemplate();
+  if (specialized_template) {
+    template_name_str = specialized_template->getNameAsString();
+  } else {
+    template_name_str =
+        "__anon_template_spec_" +
+        generate_source_position_string(class_tpl_spec_decl->getBeginLoc());
+  }
+  SgName name(template_name_str);
 
-    // Resolve class kind
-    SgClassDeclaration::class_types class_kind = SgClassDeclaration::e_class;
-    switch (class_tpl_spec_decl->getTagKind()) {
-    case clang::TagTypeKind::Struct:
-      class_kind = SgClassDeclaration::e_struct;
-      break;
-    case clang::TagTypeKind::Class:
-      class_kind = SgClassDeclaration::e_class;
-      break;
-    case clang::TagTypeKind::Union:
-      class_kind = SgClassDeclaration::e_union;
-      break;
-    default:
-      std::cerr
-          << "Warning: Unsupported tag kind for class template specialization: "
-          << static_cast<int>(class_tpl_spec_decl->getTagKind()) << std::endl;
-      break;
-    }
+  // Resolve class kind
+  SgClassDeclaration::class_types class_kind = SgClassDeclaration::e_class;
+  switch (class_tpl_spec_decl->getTagKind()) {
+  case clang::TagTypeKind::Struct:
+    class_kind = SgClassDeclaration::e_struct;
+    break;
+  case clang::TagTypeKind::Class:
+    class_kind = SgClassDeclaration::e_class;
+    break;
+  case clang::TagTypeKind::Union:
+    class_kind = SgClassDeclaration::e_union;
+    break;
+  default:
+    std::cerr
+        << "Warning: Unsupported tag kind for class template specialization: "
+        << static_cast<int>(class_tpl_spec_decl->getTagKind()) << std::endl;
+    break;
+  }
 
-    clang::DeclContext *decl_context = class_tpl_spec_decl->getDeclContext();
-    SgScopeStatement *scope = SageBuilder::topScopeStack();
+  clang::DeclContext *decl_context = class_tpl_spec_decl->getDeclContext();
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
 
-    // Check if we can get a better scope from the DeclContext
-    if (decl_context && !decl_context->isTranslationUnit()) {
-      clang::Decl *context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
-      if (context_decl) {
-        SgNode *context_node = NULL;
-        std::map<clang::Decl *, SgNode *>::iterator it =
-            p_decl_translation_map.find(context_decl);
-        if (it != p_decl_translation_map.end()) {
-          context_node = it->second;
-          SgNamespaceDefinitionStatement *ns_def =
-              isSgNamespaceDefinitionStatement(context_node);
-          SgClassDefinition *class_def = isSgClassDefinition(context_node);
-          if (ns_def != NULL) {
-            scope = ns_def;
-          } else if (class_def != NULL) {
-            scope = class_def;
-          }
+  // Check if we can get a better scope from the DeclContext
+  if (decl_context && !decl_context->isTranslationUnit()) {
+    clang::Decl *context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
+    if (context_decl) {
+      SgNode *context_node = NULL;
+      std::map<clang::Decl *, SgNode *>::iterator it =
+          p_decl_translation_map.find(context_decl);
+      if (it != p_decl_translation_map.end()) {
+        context_node = it->second;
+        SgNamespaceDefinitionStatement *ns_def =
+            isSgNamespaceDefinitionStatement(context_node);
+        SgClassDefinition *class_def = isSgClassDefinition(context_node);
+        if (ns_def != NULL) {
+          scope = ns_def;
+        } else if (class_def != NULL) {
+          scope = class_def;
         }
       }
     }
+  }
 
-    if (scope == NULL) {
-      scope = getGlobalScope();
-    }
+  if (scope == NULL) {
+    scope = getGlobalScope();
+  }
 
-    // Build template arguments
-    SgTemplateArgumentPtrList template_args;
-    const clang::TemplateArgumentList &args =
-        class_tpl_spec_decl->getTemplateArgs();
-    SgName name_with_template_args(
-        buildTemplateInstantiationName(name.getString(), args));
+  // Build template arguments
+  SgTemplateArgumentPtrList template_args;
+  const clang::TemplateArgumentList &args =
+      class_tpl_spec_decl->getTemplateArgs();
+  SgName name_with_template_args(
+      buildTemplateInstantiationName(name.getString(), args));
 
-    // Helper lambda to build args (to avoid code duplication)
-    auto build_args = [&](SgTemplateArgumentPtrList &target_list) {
-      for (unsigned i = 0; i < args.size(); ++i) {
-        const clang::TemplateArgument &arg = args[i];
-        SgTemplateArgument *sg_arg = NULL;
-        switch (arg.getKind()) {
-        case clang::TemplateArgument::Type: {
-          SgType *arg_type = buildTypeFromQualifiedType(arg.getAsType());
-          sg_arg = new SgTemplateArgument(arg_type, false);
-          break;
+  // Helper lambda to build args (to avoid code duplication)
+  auto build_args = [&](SgTemplateArgumentPtrList &target_list) {
+    for (unsigned i = 0; i < args.size(); ++i) {
+      const clang::TemplateArgument &arg = args[i];
+      SgTemplateArgument *sg_arg = NULL;
+      switch (arg.getKind()) {
+      case clang::TemplateArgument::Type: {
+        SgType *arg_type = buildTypeFromQualifiedType(arg.getAsType());
+        sg_arg = new SgTemplateArgument(arg_type, false);
+        break;
+      }
+      case clang::TemplateArgument::Integral: {
+        llvm::APSInt value = arg.getAsIntegral();
+        SgType *int_type = buildTypeFromQualifiedType(arg.getIntegralType());
+        SgExpression *value_expr =
+            buildIntegralTemplateArgExpr(value, int_type);
+        sg_arg = new SgTemplateArgument(SgTemplateArgument::nontype_argument,
+                                        false /*isArrayBoundUnknownType*/,
+                                        int_type, value_expr, nullptr, false);
+        if (value_expr != nullptr) {
+          value_expr->set_parent(sg_arg);
         }
-        case clang::TemplateArgument::Integral: {
-          llvm::APSInt value = arg.getAsIntegral();
-          SgType *int_type = buildTypeFromQualifiedType(arg.getIntegralType());
-          SgExpression *value_expr =
-              buildIntegralTemplateArgExpr(value, int_type);
-          sg_arg =
-              new SgTemplateArgument(SgTemplateArgument::nontype_argument,
-                                     value_expr, int_type, NULL, NULL, false);
-          break;
-        }
-        case clang::TemplateArgument::Template: {
-          clang::TemplateName template_name_arg = arg.getAsTemplate();
-          clang::TemplateDecl *template_decl_arg =
-              template_name_arg.getAsTemplateDecl();
-          if (template_decl_arg) {
-            SgNode *traverse_result = Traverse(template_decl_arg);
-            SgDeclarationStatement *sg_decl =
-                isSgDeclarationStatement(traverse_result);
+        break;
+      }
+      case clang::TemplateArgument::Template: {
+        clang::TemplateName template_name_arg = arg.getAsTemplate();
+        clang::TemplateDecl *template_decl_arg =
+            template_name_arg.getAsTemplateDecl();
+        if (template_decl_arg) {
+          SgNode *traverse_result = Traverse(template_decl_arg);
+          SgDeclarationStatement *sg_decl =
+              isSgDeclarationStatement(traverse_result);
 
-            // REX FIX: Traverse returns SgTemplateParameter for
-            // TemplateTemplateParmDecl via VisitTemplateTemplateParmDecl.
-            // SgTemplateParameter is NOT an SgDeclarationStatement, but it
-            // holds the SgNonrealDecl we need.
-            if (SgTemplateParameter *param =
-                    isSgTemplateParameter(traverse_result)) {
-              if (SgDeclarationStatement *inner_decl =
-                      param->get_templateDeclaration()) {
-                if (isSgNonrealDecl(inner_decl)) {
-                  sg_decl = inner_decl;
-                }
-              }
-            }
-
-            if (sg_decl) {
-              if (SgTemplateClassDeclaration *class_tmpl =
-                      isSgTemplateClassDeclaration(sg_decl)) {
-                SgName qual_name = class_tmpl->get_qualified_name();
-                if (qual_name.getString().find("::") == std::string::npos &&
-                    class_tmpl->get_scope()) {
-                  if (SgNamespaceDefinitionStatement *ns_def =
-                          isSgNamespaceDefinitionStatement(
-                              class_tmpl->get_scope())) {
-                    qual_name = ns_def->get_namespaceDeclaration()
-                                    ->get_name()
-                                    .getString() +
-                                "::" + class_tmpl->get_name().getString();
-                  }
-                }
-                SgType *type = SageBuilder::buildTemplateType(qual_name);
-                sg_arg = new SgTemplateArgument(type, false);
-              } else {
-                sg_arg = new SgTemplateArgument(
-                    SgTemplateArgument::template_template_argument, sg_decl);
-                sg_arg->set_templateDeclaration(sg_decl);
+          // REX FIX: Traverse returns SgTemplateParameter for
+          // TemplateTemplateParmDecl via VisitTemplateTemplateParmDecl.
+          // SgTemplateParameter is NOT an SgDeclarationStatement, but it
+          // holds the SgNonrealDecl we need.
+          if (SgTemplateParameter *param =
+                  isSgTemplateParameter(traverse_result)) {
+            if (SgDeclarationStatement *inner_decl =
+                    param->get_templateDeclaration()) {
+              if (isSgNonrealDecl(inner_decl)) {
+                sg_decl = inner_decl;
               }
             }
           }
-          break;
-        }
-        case clang::TemplateArgument::Expression: {
-          clang::Expr *clang_expr = arg.getAsExpr();
-          if (clang_expr) {
-            SgNode *node = Traverse(clang_expr);
-            SgExpression *sg_expr = isSgExpression(node);
-            if (sg_expr) {
-              sg_arg = new SgTemplateArgument(sg_expr, false);
+
+          if (sg_decl) {
+            if (SgTemplateClassDeclaration *class_tmpl =
+                    isSgTemplateClassDeclaration(sg_decl)) {
+              SgName qual_name = class_tmpl->get_qualified_name();
+              if (qual_name.getString().find("::") == std::string::npos &&
+                  class_tmpl->get_scope()) {
+                if (SgNamespaceDefinitionStatement *ns_def =
+                        isSgNamespaceDefinitionStatement(
+                            class_tmpl->get_scope())) {
+                  qual_name = ns_def->get_namespaceDeclaration()
+                                  ->get_name()
+                                  .getString() +
+                              "::" + class_tmpl->get_name().getString();
+                }
+              }
+              SgType *type = SageBuilder::buildTemplateType(qual_name);
+              sg_arg = new SgTemplateArgument(type, false);
+            } else {
+              sg_arg = new SgTemplateArgument(
+                  SgTemplateArgument::template_template_argument, sg_decl);
+              sg_arg->set_templateDeclaration(sg_decl);
             }
           }
-          break;
         }
-        default:
-          break;
+        break;
+      }
+      case clang::TemplateArgument::Expression: {
+        clang::Expr *clang_expr = arg.getAsExpr();
+        if (clang_expr) {
+          SgNode *node = Traverse(clang_expr);
+          SgExpression *sg_expr = isSgExpression(node);
+          if (sg_expr) {
+            sg_arg = new SgTemplateArgument(sg_expr, false);
+          }
         }
-        if (sg_arg)
-          target_list.push_back(sg_arg);
+        break;
       }
-    };
-
-    // Implement Two-Declaration Pattern for consistency
-    // Always create a non-defining declaration (forward decl) and a defining
-    // declaration if this is a definition.
-
-    SgTemplateInstantiationDecl *instantiationDecl = NULL;
-    SgTemplateInstantiationDecl *firstNondefiningDeclaration = NULL;
-
-    // Traverse the specialized template to ensure it exists in the AST and we
-    // have the ROSE node
-    SgTemplateClassDeclaration *primary_template_decl = NULL;
-    if (specialized_template) {
-      SgNode *primary_node = Traverse(specialized_template);
-      primary_template_decl = isSgTemplateClassDeclaration(primary_node);
-    }
-
-    // ROOT CAUSE FIX: Check instantiation cache first
-    // This connects explicit specializations to the same nodes used by implicit
-    // instantiations
-    std::string inst_name_full;
-    if (primary_template_decl) {
-      std::string template_qualified_name =
-          getTemplateQualifiedName(primary_template_decl);
-      inst_name_full = mangleTemplateInstantiation(
-          template_qualified_name, class_tpl_spec_decl->getTemplateArgs());
-
-      auto cache_it = p_template_inst_cache.find(inst_name_full);
-      if (cache_it != p_template_inst_cache.end()) {
-        firstNondefiningDeclaration = cache_it->second;
+      default:
+        break;
       }
+      if (sg_arg)
+        target_list.push_back(sg_arg);
     }
+  };
 
-    // Check for existing symbol in the scope if not found in cache
-    if (firstNondefiningDeclaration == NULL) {
-      SgSymbol *existing_symbol = scope->lookup_symbol(name);
-      if (existing_symbol) {
-        SgClassSymbol *class_symbol = isSgClassSymbol(existing_symbol);
-        if (class_symbol) {
-          SgClassDeclaration *existing_decl = class_symbol->get_declaration();
-          firstNondefiningDeclaration =
-              isSgTemplateInstantiationDecl(existing_decl);
+  // Implement Two-Declaration Pattern for consistency
+  // Always create a non-defining declaration (forward decl) and a defining
+  // declaration if this is a definition.
+
+  SgTemplateInstantiationDecl *instantiationDecl = NULL;
+  SgTemplateInstantiationDecl *firstNondefiningDeclaration = NULL;
+
+  // Traverse the specialized template to ensure it exists in the AST and we
+  // have the ROSE node
+  SgTemplateClassDeclaration *primary_template_decl = NULL;
+  if (specialized_template) {
+    SgNode *primary_node = Traverse(specialized_template);
+    primary_template_decl = isSgTemplateClassDeclaration(primary_node);
+  }
+
+  // ROOT CAUSE FIX: Check instantiation cache first
+  // This connects explicit specializations to the same nodes used by implicit
+  // instantiations
+  std::string inst_name_full;
+  if (primary_template_decl) {
+    std::string template_qualified_name =
+        getTemplateQualifiedName(primary_template_decl);
+    inst_name_full = mangleTemplateInstantiation(
+        template_qualified_name, class_tpl_spec_decl->getTemplateArgs());
+
+    auto cache_it = p_template_inst_cache.find(inst_name_full);
+    if (cache_it != p_template_inst_cache.end()) {
+      firstNondefiningDeclaration = cache_it->second;
+    }
+  }
+
+  // Check for existing symbol in the scope if not found in cache
+  if (firstNondefiningDeclaration == NULL) {
+    SgSymbol *existing_symbol = scope->lookup_symbol(name);
+    if (existing_symbol) {
+      SgClassSymbol *class_symbol = isSgClassSymbol(existing_symbol);
+      if (class_symbol) {
+        SgClassDeclaration *existing_decl = class_symbol->get_declaration();
+        firstNondefiningDeclaration =
+            isSgTemplateInstantiationDecl(existing_decl);
 #if 0
                 if (firstNondefiningDeclaration) {
                     std::cout << "Reuse existing SgTemplateInstantiationDecl: " << firstNondefiningDeclaration << " name: " << firstNondefiningDeclaration->get_name().getString() << std::endl;
                 }
 #endif
-        }
       }
     }
+  }
 
-    if (firstNondefiningDeclaration == NULL) {
-      SgTemplateArgumentPtrList forward_args;
-      build_args(forward_args);
+  if (firstNondefiningDeclaration == NULL) {
+    SgTemplateArgumentPtrList forward_args;
+    build_args(forward_args);
 
-      instantiationDecl = new SgTemplateInstantiationDecl(
-          name_with_template_args, class_kind, NULL, NULL, NULL, forward_args);
-      instantiationDecl->get_templateArguments() = forward_args;
+    instantiationDecl = new SgTemplateInstantiationDecl(
+        name_with_template_args, class_kind, NULL, NULL, NULL, forward_args);
+    instantiationDecl->get_templateArguments() = forward_args;
 
-      // Register in cache immediately
-      p_template_inst_cache[inst_name_full] = instantiationDecl;
+    // Register in cache immediately
+    p_template_inst_cache[inst_name_full] = instantiationDecl;
 
-      firstNondefiningDeclaration = instantiationDecl;
-      instantiationDecl->set_firstNondefiningDeclaration(
-          firstNondefiningDeclaration);
-      instantiationDecl->set_definingDeclaration(NULL);
-      instantiationDecl->set_forward(true);
-      instantiationDecl->set_templateName(name);
+    firstNondefiningDeclaration = instantiationDecl;
+    instantiationDecl->set_firstNondefiningDeclaration(
+        firstNondefiningDeclaration);
+    instantiationDecl->set_definingDeclaration(NULL);
+    instantiationDecl->set_forward(true);
+    instantiationDecl->set_templateName(name);
 
-      if (name.getString() == "__conditional" ||
-          name.getString() == "conditional") {
-        std::cerr << "DEBUG: VisitClassTemplateSpecializationDecl created "
-                     "NON-DEFINING: "
-                  << name.getString() << " at " << instantiationDecl
-                  << " firstNondef: "
-                  << instantiationDecl->get_firstNondefiningDeclaration()
-                  << std::endl;
-      }
+    if (name.getString() == "__conditional" ||
+        name.getString() == "conditional") {
+      std::cerr << "DEBUG: VisitClassTemplateSpecializationDecl created "
+                   "NON-DEFINING: "
+                << name.getString() << " at " << instantiationDecl
+                << " firstNondef: "
+                << instantiationDecl->get_firstNondefiningDeclaration()
+                << std::endl;
+    }
 
-      SgClassType *type = SgClassType::createType(instantiationDecl);
-      instantiationDecl->set_type(type);
+    SgClassType *type = SgClassType::createType(instantiationDecl);
+    instantiationDecl->set_type(type);
 
-      // setStatementSourcePosition(instantiationDecl, class_tpl_spec_decl);
-      applySourceRange(instantiationDecl,
-                       class_tpl_spec_decl->getSourceRange());
-      instantiationDecl->set_scope(scope);
-      instantiationDecl->set_parent(scope);
+    // setStatementSourcePosition(instantiationDecl, class_tpl_spec_decl);
+    applySourceRange(instantiationDecl, class_tpl_spec_decl->getSourceRange());
+    instantiationDecl->set_scope(scope);
+    instantiationDecl->set_parent(scope);
 
-      for (SgTemplateArgument *arg :
-           instantiationDecl->get_templateArguments()) {
+    for (SgTemplateArgument *arg : instantiationDecl->get_templateArguments()) {
+      arg->set_parent(instantiationDecl);
+    }
+
+    // Insert symbol (for the forward decl/type)
+    // ROOT CAUSE FIX: Use full mangled name for symbol table to avoid
+    // conflicts between specializations (e.g. MyTemplate_int vs
+    // MyTemplate_double)
+    SgName symbol_name = inst_name_full.empty() ? name : SgName(inst_name_full);
+
+    if (!scope->symbol_exists(symbol_name)) {
+      SgClassSymbol *class_symbol = new SgClassSymbol(instantiationDecl);
+      scope->insert_symbol(symbol_name, class_symbol);
+    }
+  } else {
+    // We found an existing declaration, so we don't create a new non-defining
+    // one.
+    instantiationDecl = firstNondefiningDeclaration;
+    if (instantiationDecl != NULL &&
+        instantiationDecl->get_name() != name_with_template_args) {
+      instantiationDecl->set_name(name_with_template_args);
+    }
+    if (instantiationDecl->get_templateArguments().empty()) {
+      SgTemplateArgumentPtrList recovered_args;
+      build_args(recovered_args);
+      instantiationDecl->get_templateArguments() = recovered_args;
+    }
+    for (SgTemplateArgument *arg : instantiationDecl->get_templateArguments()) {
+      if (arg != NULL) {
         arg->set_parent(instantiationDecl);
       }
+    }
+    // setStatementSourcePosition(instantiationDecl, class_tpl_spec_decl); //
+    // Don't reset position of reused decl
+  }
 
-      // Insert symbol (for the forward decl/type)
-      // ROOT CAUSE FIX: Use full mangled name for symbol table to avoid
-      // conflicts between specializations (e.g. MyTemplate_int vs
-      // MyTemplate_double)
-      SgName symbol_name =
-          inst_name_full.empty() ? name : SgName(inst_name_full);
+  // Set specialized template for the non-defining declaration (if new) or
+  // check it
+  if (instantiationDecl->get_templateDeclaration() == NULL) {
+    // Link to the primary template declaration
+    if (primary_template_decl) {
+      instantiationDecl->set_templateDeclaration(primary_template_decl);
+    }
+  }
 
-      if (!scope->symbol_exists(symbol_name)) {
-        SgClassSymbol *class_symbol = new SgClassSymbol(instantiationDecl);
-        scope->insert_symbol(symbol_name, class_symbol);
-      }
-    } else {
-      // We found an existing declaration, so we don't create a new non-defining
-      // one.
-      instantiationDecl = firstNondefiningDeclaration;
-      if (instantiationDecl != NULL &&
-          instantiationDecl->get_name() != name_with_template_args) {
-        instantiationDecl->set_name(name_with_template_args);
-      }
-      if (instantiationDecl->get_templateArguments().empty()) {
-        SgTemplateArgumentPtrList recovered_args;
-        build_args(recovered_args);
-        instantiationDecl->get_templateArguments() = recovered_args;
-      }
-      for (SgTemplateArgument *arg :
-           instantiationDecl->get_templateArguments()) {
-        if (arg != NULL) {
-          arg->set_parent(instantiationDecl);
-        }
-      }
-      // setStatementSourcePosition(instantiationDecl, class_tpl_spec_decl); //
-      // Don't reset position of reused decl
+  bool isDef = class_tpl_spec_decl->isThisDeclarationADefinition();
+  if (isDef) {
+    SgTemplateArgumentPtrList defining_args;
+    build_args(defining_args);
+
+    // Create defining declaration
+    SgTemplateInstantiationDecl *definingDecl = new SgTemplateInstantiationDecl(
+        name_with_template_args, class_kind, NULL, NULL, NULL, defining_args);
+    definingDecl->get_templateArguments() = defining_args;
+
+    // Link defining and non-defining declarations
+    definingDecl->set_firstNondefiningDeclaration(firstNondefiningDeclaration);
+    firstNondefiningDeclaration->set_definingDeclaration(definingDecl);
+    definingDecl->set_definingDeclaration(definingDecl);
+
+    if (name.getString() == "__conditional" ||
+        name.getString() == "conditional") {
+      std::cerr
+          << "DEBUG: VisitClassTemplateSpecializationDecl created DEFINING: "
+          << name.getString() << " at " << definingDecl
+          << " firstNondef: " << definingDecl->get_firstNondefiningDeclaration()
+          << std::endl;
     }
 
-    // Set specialized template for the non-defining declaration (if new) or
-    // check it
-    if (instantiationDecl->get_templateDeclaration() == NULL) {
-      // Link to the primary template declaration
-      if (primary_template_decl) {
-        instantiationDecl->set_templateDeclaration(primary_template_decl);
-      }
+    // This is a definition
+    definingDecl->set_forward(false);
+    definingDecl->set_templateName(name);
+    definingDecl->set_type(firstNondefiningDeclaration->get_type());
+
+    // setStatementSourcePosition(definingDecl, class_tpl_spec_decl);
+    applySourceRange(definingDecl, class_tpl_spec_decl->getSourceRange());
+    definingDecl->set_scope(scope);
+    definingDecl->set_parent(scope);
+
+    for (SgTemplateArgument *arg : definingDecl->get_templateArguments()) {
+      arg->set_parent(definingDecl);
     }
 
-    bool isDef = class_tpl_spec_decl->isThisDeclarationADefinition();
-    if (isDef) {
-      SgTemplateArgumentPtrList defining_args;
-      build_args(defining_args);
+    // Copy primary template link
+    definingDecl->set_templateDeclaration(
+        firstNondefiningDeclaration->get_templateDeclaration());
 
-      // Create defining declaration
-      SgTemplateInstantiationDecl *definingDecl =
-          new SgTemplateInstantiationDecl(name_with_template_args, class_kind,
-                                          NULL, NULL, NULL, defining_args);
-      definingDecl->get_templateArguments() = defining_args;
+    // Build definition body
+    SgTemplateInstantiationDefn *class_def =
+        new SgTemplateInstantiationDefn(definingDecl);
+    definingDecl->set_definition(class_def);
+    class_def->set_parent(definingDecl);
+    // setStatementSourcePosition(class_def, class_tpl_spec_decl);
+    applySourceRange(class_def, class_tpl_spec_decl->getSourceRange());
 
-      // Link defining and non-defining declarations
-      definingDecl->set_firstNondefiningDeclaration(
-          firstNondefiningDeclaration);
-      firstNondefiningDeclaration->set_definingDeclaration(definingDecl);
-      definingDecl->set_definingDeclaration(definingDecl);
+    instantiationDecl = definingDecl; // Return the defining declaration
+  }
 
-      if (name.getString() == "__conditional" ||
-          name.getString() == "conditional") {
-        std::cerr
-            << "DEBUG: VisitClassTemplateSpecializationDecl created DEFINING: "
-            << name.getString() << " at " << definingDecl << " firstNondef: "
-            << definingDecl->get_firstNondefiningDeclaration() << std::endl;
-      }
+  // Ensure we return the correct node
+  *node = instantiationDecl;
+  SgTemplateInstantiationDecl *instantiationDeclChecked =
+      isSgTemplateInstantiationDecl(*node);
+  ROSE_ASSERT(instantiationDeclChecked != NULL);
 
-      // This is a definition
-      definingDecl->set_forward(false);
-      definingDecl->set_templateName(name);
-      definingDecl->set_type(firstNondefiningDeclaration->get_type());
+  // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
+  // crash (ua test).
+  if (instantiationDeclChecked->get_firstNondefiningDeclaration() == NULL) {
+    instantiationDeclChecked->set_firstNondefiningDeclaration(
+        instantiationDeclChecked);
+  }
 
-      // setStatementSourcePosition(definingDecl, class_tpl_spec_decl);
-      applySourceRange(definingDecl, class_tpl_spec_decl->getSourceRange());
-      definingDecl->set_scope(scope);
-      definingDecl->set_parent(scope);
+  // ROOT CAUSE FIX: Ensure definition is created and linked for explicit
+  // specializations/instantiations
+  p_decl_translation_map.insert(
+      std::pair<clang::Decl *, SgNode *>(class_tpl_spec_decl, *node));
 
-      for (SgTemplateArgument *arg : definingDecl->get_templateArguments()) {
-        arg->set_parent(definingDecl);
-      }
+  // Process scope stack and children if it is a definition
+  if (isDef) {
+    SageBuilder::pushScopeStack(
+        isSgScopeStatement(instantiationDecl->get_definition()));
 
-      // Copy primary template link
-      definingDecl->set_templateDeclaration(
-          firstNondefiningDeclaration->get_templateDeclaration());
+    populateClassDefinition(
+        class_tpl_spec_decl,
+        isSgClassDefinition(instantiationDecl->get_definition()));
 
-      // Build definition body
-      SgTemplateInstantiationDefn *class_def =
-          new SgTemplateInstantiationDefn(definingDecl);
-      definingDecl->set_definition(class_def);
-      class_def->set_parent(definingDecl);
-      // setStatementSourcePosition(class_def, class_tpl_spec_decl);
-      applySourceRange(class_def, class_tpl_spec_decl->getSourceRange());
+    SageBuilder::popScopeStack();
+  }
 
-      instantiationDecl = definingDecl; // Return the defining declaration
-    }
-
-    // Ensure we return the correct node
-    *node = instantiationDecl;
-    SgTemplateInstantiationDecl *instantiationDeclChecked =
-        isSgTemplateInstantiationDecl(*node);
-    ROSE_ASSERT(instantiationDeclChecked != NULL);
-
-    // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
-    // crash (ua test).
-    if (instantiationDeclChecked->get_firstNondefiningDeclaration() == NULL) {
-      instantiationDeclChecked->set_firstNondefiningDeclaration(
-          instantiationDeclChecked);
-    }
-
-    // ROOT CAUSE FIX: Ensure definition is created and linked for explicit
-    // specializations/instantiations
-    p_decl_translation_map.insert(
-        std::pair<clang::Decl *, SgNode *>(class_tpl_spec_decl, *node));
-
-    // Process scope stack and children if it is a definition
-    if (isDef) {
-      SageBuilder::pushScopeStack(
-          isSgScopeStatement(instantiationDecl->get_definition()));
-
-      populateClassDefinition(
-          class_tpl_spec_decl,
-          isSgClassDefinition(instantiationDecl->get_definition()));
-
-      SageBuilder::popScopeStack();
-    }
-
-    return true;
+  return true;
 }
 
 bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
@@ -3393,489 +3600,526 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
   return true;
 }
 
-bool ClangToSageTranslator::VisitEnumDecl(clang::EnumDecl * enum_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitEnumDecl(clang::EnumDecl *enum_decl,
+                                          SgNode **node) {
 
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitEnumDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitEnumDecl" << std::endl;
 #endif
-    bool res = true;
-    std::string enumDeclName = enum_decl->getNameAsString();
+  bool res = true;
+  std::string enumDeclName = enum_decl->getNameAsString();
 
-    if(enumDeclName.empty())
-    {
-      enumDeclName = "__anonymous_" +  generate_source_position_string(enum_decl->getBeginLoc());  
-    }
+  if (enumDeclName.empty()) {
+    enumDeclName = "__anonymous_" +
+                   generate_source_position_string(enum_decl->getBeginLoc());
+  }
 
-    SgName name(enumDeclName);
+  SgName name(enumDeclName);
 
 #if DEBUG_VISIT_DECL
-    std::cerr << "isfreestanding:" << enum_decl->isFreeStanding() << " isembedded:" << enum_decl->isEmbeddedInDeclarator() << std::endl;
-    std::cerr << "hasNameForLinkage:" << enum_decl->hasNameForLinkage() << std::endl;
-    std::cerr << "enum name:" << enumDeclName << std::endl;
+  std::cerr << "isfreestanding:" << enum_decl->isFreeStanding()
+            << " isembedded:" << enum_decl->isEmbeddedInDeclarator()
+            << std::endl;
+  std::cerr << "hasNameForLinkage:" << enum_decl->hasNameForLinkage()
+            << std::endl;
+  std::cerr << "enum name:" << enumDeclName << std::endl;
 #endif
 
-    clang::EnumDecl * prev_enum_decl = enum_decl->getPreviousDecl();
-    SgEnumSymbol * sg_prev_enum_sym = isSgEnumSymbol(GetSymbolFromSymbolTable(prev_enum_decl));
-    SgEnumDeclaration * sg_prev_enum_decl = sg_prev_enum_sym == NULL ? NULL : isSgEnumDeclaration(sg_prev_enum_sym->get_declaration());
-    sg_prev_enum_decl = sg_prev_enum_decl == NULL ? NULL : isSgEnumDeclaration(sg_prev_enum_decl->get_definingDeclaration());
+  clang::EnumDecl *prev_enum_decl = enum_decl->getPreviousDecl();
+  SgEnumSymbol *sg_prev_enum_sym =
+      isSgEnumSymbol(GetSymbolFromSymbolTable(prev_enum_decl));
+  SgEnumDeclaration *sg_prev_enum_decl =
+      sg_prev_enum_sym == NULL
+          ? NULL
+          : isSgEnumDeclaration(sg_prev_enum_sym->get_declaration());
+  sg_prev_enum_decl =
+      sg_prev_enum_decl == NULL
+          ? NULL
+          : isSgEnumDeclaration(sg_prev_enum_decl->get_definingDeclaration());
 
-    SgEnumDeclaration * sg_enum_decl = SageBuilder::buildEnumDeclaration(name, SageBuilder::topScopeStack());
-    *node = sg_enum_decl;
+  SgEnumDeclaration *sg_enum_decl =
+      SageBuilder::buildEnumDeclaration(name, SageBuilder::topScopeStack());
+  *node = sg_enum_decl;
 
-    if(enumDeclName.empty())
-    {
-      sg_enum_decl->set_isUnNamed(true);
+  if (enumDeclName.empty()) {
+    sg_enum_decl->set_isUnNamed(true);
+  }
+
+  if (sg_prev_enum_decl == NULL ||
+      sg_prev_enum_decl->get_enumerators().size() == 0) {
+    clang::EnumDecl::enumerator_iterator it;
+    for (it = enum_decl->enumerator_begin(); it != enum_decl->enumerator_end();
+         it++) {
+      SgNode *tmp_enumerator = Traverse(*it);
+      SgInitializedName *enumerator = isSgInitializedName(tmp_enumerator);
+
+      ROSE_ASSERT(enumerator);
+
+      enumerator->set_scope(SageBuilder::topScopeStack());
+      sg_enum_decl->append_enumerator(enumerator);
+
+      // CLANG FRONTEND FIX: Set declptr for enum constant's SgInitializedName
+      // declptr should point to the enum declaration that contains this
+      // constant
+      enumerator->set_declptr(sg_enum_decl);
     }
+  } else {
+    sg_enum_decl->set_definingDeclaration(sg_prev_enum_decl);
+    sg_enum_decl->set_firstNondefiningDeclaration(
+        sg_prev_enum_decl->get_firstNondefiningDeclaration());
+  }
 
-    if (sg_prev_enum_decl == NULL || sg_prev_enum_decl->get_enumerators().size() == 0) {
-      clang::EnumDecl::enumerator_iterator it;
-      for (it = enum_decl->enumerator_begin(); it != enum_decl->enumerator_end(); it++) {
-          SgNode * tmp_enumerator = Traverse(*it);
-          SgInitializedName * enumerator = isSgInitializedName(tmp_enumerator);
-
-          ROSE_ASSERT(enumerator);
-
-          enumerator->set_scope(SageBuilder::topScopeStack());
-          sg_enum_decl->append_enumerator(enumerator);
-
-          // CLANG FRONTEND FIX: Set declptr for enum constant's SgInitializedName
-          // declptr should point to the enum declaration that contains this constant
-          enumerator->set_declptr(sg_enum_decl);
-      }
-    }
-    else {
-      sg_enum_decl->set_definingDeclaration(sg_prev_enum_decl);
-      sg_enum_decl->set_firstNondefiningDeclaration(sg_prev_enum_decl->get_firstNondefiningDeclaration());
-    }
-
-    // REX FIX: Handle AS_none for EnumDecl
-    clang::AccessSpecifier access = enum_decl->getAccess();
-    if (access == clang::AS_public) {
-      sg_enum_decl->get_declarationModifier().get_accessModifier().setPublic();
-    } else if (access == clang::AS_private) {
-      sg_enum_decl->get_declarationModifier().get_accessModifier().setPrivate();
-    } else if (access == clang::AS_protected) {
-      sg_enum_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setProtected();
-    } else if (access == clang::AS_none) {
-      if (isSgClassDefinition(SageBuilder::topScopeStack())) {
-        SgClassDefinition *class_def =
-            isSgClassDefinition(SageBuilder::topScopeStack());
-        if (class_def->get_declaration()->get_class_type() ==
-            SgClassDeclaration::e_class) {
-          sg_enum_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPrivate();
-        } else {
-          sg_enum_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPublic();
-        }
+  // REX FIX: Handle AS_none for EnumDecl
+  clang::AccessSpecifier access = enum_decl->getAccess();
+  if (access == clang::AS_public) {
+    sg_enum_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    sg_enum_decl->get_declarationModifier().get_accessModifier().setPrivate();
+  } else if (access == clang::AS_protected) {
+    sg_enum_decl->get_declarationModifier().get_accessModifier().setProtected();
+  } else if (access == clang::AS_none) {
+    if (isSgClassDefinition(SageBuilder::topScopeStack())) {
+      SgClassDefinition *class_def =
+          isSgClassDefinition(SageBuilder::topScopeStack());
+      if (class_def->get_declaration()->get_class_type() ==
+          SgClassDeclaration::e_class) {
+        sg_enum_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPrivate();
       } else {
         sg_enum_decl->get_declarationModifier()
             .get_accessModifier()
             .setPublic();
       }
+    } else {
+      sg_enum_decl->get_declarationModifier().get_accessModifier().setPublic();
     }
-/*
-     SgEnumDeclaration* firstNondefEnumDecl = isSgEnumDeclaration(sg_enum_decl->get_firstNondefiningDeclaration());
-     if(enum_decl->isEmbeddedInDeclarator())
-     {
-       firstNondefEnumDecl->set_isAutonomousDeclaration(true);
-     }
+  }
+  /*
+       SgEnumDeclaration* firstNondefEnumDecl =
+  isSgEnumDeclaration(sg_enum_decl->get_firstNondefiningDeclaration());
+       if(enum_decl->isEmbeddedInDeclarator())
+       {
+         firstNondefEnumDecl->set_isAutonomousDeclaration(true);
+       }
 
-     SgSymbol* sym = firstNondefEnumDecl->get_symbol_from_symbol_table();
-#if DEBUG_VISIT_DECL
-     std::cout << "VisitEnumDecl symbol: " << sym << " type:" << firstNondefEnumDecl->get_type() << std::endl;
-#endif
-*/
-    return VisitDecl(enum_decl, node) && res;
+       SgSymbol* sym = firstNondefEnumDecl->get_symbol_from_symbol_table();
+  #if DEBUG_VISIT_DECL
+       std::cout << "VisitEnumDecl symbol: " << sym << " type:" <<
+  firstNondefEnumDecl->get_type() << std::endl; #endif
+  */
+  return VisitDecl(enum_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTemplateTypeParmDecl(clang::TemplateTypeParmDecl * template_type_parm_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitTemplateTypeParmDecl(
+    clang::TemplateTypeParmDecl *template_type_parm_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTemplateTypeParmDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTemplateTypeParmDecl" << std::endl;
 #endif
-    SgDeclarationStatement* owning_template = NULL;
-    if (clang::DeclContext* ctx = template_type_parm_decl->getDeclContext()) {
-        if (clang::TemplateDecl* template_ctx = llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
-            auto it = p_decl_translation_map.find(template_ctx);
-            if (it != p_decl_translation_map.end()) {
-                owning_template = isSgDeclarationStatement(it->second);
-            }
-        }
+  SgDeclarationStatement *owning_template = NULL;
+  if (clang::DeclContext *ctx = template_type_parm_decl->getDeclContext()) {
+    if (clang::TemplateDecl *template_ctx =
+            llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
+      auto it = p_decl_translation_map.find(template_ctx);
+      if (it != p_decl_translation_map.end()) {
+        owning_template = isSgDeclarationStatement(it->second);
+      }
     }
+  }
 
-    unsigned position = template_type_parm_decl->getIndex();
-    SgTemplateParameter* sg_param =
-        translateTemplateParameter(template_type_parm_decl, owning_template, position);
+  unsigned position = template_type_parm_decl->getIndex();
+  SgTemplateParameter *sg_param = translateTemplateParameter(
+      template_type_parm_decl, owning_template, position);
 
-    *node = sg_param;
+  *node = sg_param;
 
-    if (sg_param != NULL) {
-        std::string kw = template_type_parm_decl->wasDeclaredWithTypename() ? "typename" : "class";
-        SageInterface::setTemplateParameterKeyword(sg_param, kw);
-    }
+  if (sg_param != NULL) {
+    std::string kw = template_type_parm_decl->wasDeclaredWithTypename()
+                         ? "typename"
+                         : "class";
+    SageInterface::setTemplateParameterKeyword(sg_param, kw);
+  }
 
-    return sg_param != NULL;
+  return sg_param != NULL;
 }
 
-bool ClangToSageTranslator::VisitTypedefNameDecl(clang::TypedefNameDecl * typedef_name_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypedefNameDecl(
+    clang::TypedefNameDecl *typedef_name_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTypedefNameDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTypedefNameDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitTypeDecl(typedef_name_decl, node) && res;
+  return VisitTypeDecl(typedef_name_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl * typedef_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
+                                             SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTypedefDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTypedefDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    SgName name(typedef_decl->getNameAsString());
-//    SgType * type = buildTypeFromQualifiedType(typedef_decl->getUnderlyingType());
+  SgName name(typedef_decl->getNameAsString());
+  //    SgType * type =
+  //    buildTypeFromQualifiedType(typedef_decl->getUnderlyingType());
 
+  clang::QualType underlyingQualType = typedef_decl->getUnderlyingType();
 
-    clang::QualType underlyingQualType = typedef_decl->getUnderlyingType();
+  const clang::Type *underlyingType = underlyingQualType.getTypePtr();
 
-    const clang::Type* underlyingType = underlyingQualType.getTypePtr();
+  // Pei-Hung (06/01/2022) check if the declaration is considered embedded in
+  // Clang AST. If it is embedded, no explicit SgDeclaration should be placed
+  // for ROSE AST.
+  bool isembedded = false;
+  bool iscompleteDefined = false;
 
+  // Adding check for EaboratedType and PointerType to retrieve base EnumType
+  while ((llvm::isa<clang::ElaboratedType>(underlyingType)) ||
+         (llvm::isa<clang::PointerType>(underlyingType)) ||
+         (llvm::isa<clang::ArrayType>(underlyingType))) {
+    if (llvm::isa<clang::ElaboratedType>(underlyingType)) {
+      underlyingQualType =
+          ((clang::ElaboratedType *)underlyingType)->getNamedType();
+    } else if (llvm::isa<clang::PointerType>(underlyingType)) {
+      underlyingQualType =
+          ((clang::PointerType *)underlyingType)->getPointeeType();
+    } else if (llvm::isa<clang::ArrayType>(underlyingType)) {
+      underlyingQualType =
+          ((clang::ArrayType *)underlyingType)->getElementType();
+    }
+    underlyingType = underlyingQualType.getTypePtr();
+  }
 
-    // Pei-Hung (06/01/2022) check if the declaration is considered embedded in Clang AST.
-    // If it is embedded, no explicit SgDeclaration should be placed for ROSE AST.
-    bool isembedded = false;
-    bool iscompleteDefined = false;
+  if (llvm::isa<clang::EnumType>(underlyingType)) {
+    clang::EnumType *underlyingEnumType = (clang::EnumType *)underlyingType;
+    clang::EnumDecl *enumDeclaration = underlyingEnumType->getDecl();
+    isembedded = enumDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = enumDeclaration->isCompleteDefinition();
+  }
 
-    // Adding check for EaboratedType and PointerType to retrieve base EnumType
-    while((llvm::isa<clang::ElaboratedType>(underlyingType)) || (llvm::isa<clang::PointerType>(underlyingType)) || (llvm::isa<clang::ArrayType>(underlyingType)))
-    {
-       if(llvm::isa<clang::ElaboratedType>(underlyingType))
-       {
-         underlyingQualType = ((clang::ElaboratedType *)underlyingType)->getNamedType();
-       }
-       else if(llvm::isa<clang::PointerType>(underlyingType))
-       {
-         underlyingQualType = ((clang::PointerType *)underlyingType)->getPointeeType();
-       }
-       else if(llvm::isa<clang::ArrayType>(underlyingType))
-       {
-         underlyingQualType = ((clang::ArrayType *)underlyingType)->getElementType();
-       }
-       underlyingType = underlyingQualType.getTypePtr();
+  if (llvm::isa<clang::RecordType>(underlyingType)) {
+    clang::RecordType *underlyingRecordType =
+        (clang::RecordType *)underlyingType;
+    clang::RecordDecl *recordDeclaration = underlyingRecordType->getDecl();
+    isembedded = recordDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = recordDeclaration->isCompleteDefinition();
+  }
+
+  SgType *sg_underlyingType = buildTypeFromQualifiedType(underlyingQualType);
+  SgType *type = buildTypeFromQualifiedType(typedef_decl->getUnderlyingType());
+
+  bool type_has_unknown = containsUnknownType(type);
+  if (type_has_unknown && SgProject::get_verbose() > 0) {
+    std::cerr << "CFE: Typedef with unknown underlying type '" << name
+              << "' spelled as '"
+              << typedef_decl->getUnderlyingType().getAsString()
+              << "' (sg_type=" << (type != NULL ? type->class_name() : "null")
+              << ", base="
+              << (type != NULL && type->findBaseType() != NULL
+                      ? type->findBaseType()->class_name()
+                      : "null")
+              << ")" << std::endl;
+  }
+
+  if (type_has_unknown) {
+    std::string spelled = typedef_decl->getUnderlyingType().getAsString();
+    type = SageBuilder::buildOpaqueType(spelled, SageBuilder::topScopeStack());
+    sg_underlyingType = type;
+  }
+
+  SgTypedefDeclaration *sg_typedef_decl =
+      SageBuilder::buildTypedefDeclaration_nfi(name, type,
+                                               SageBuilder::topScopeStack());
+  if (SgProject::get_verbose() > 0) {
+    if (name == "uint8_t" || name == "uint16_t" || name == "uint32_t" ||
+        name == "in_port_t" || name == "in_addr_t") {
+      std::cerr << "CFE: Created typedef '" << name << "' with type "
+                << (type != NULL ? type->class_name() : "null")
+                << " (underlying "
+                << (sg_underlyingType != NULL ? sg_underlyingType->class_name()
+                                              : "null")
+                << ")" << std::endl;
+    }
+  }
+
+  // finding the bottom base type and check
+  while (type->findBaseType() != type) {
+    type = type->findBaseType();
+    if (type == sg_underlyingType)
+      break;
+  }
+
+  // Pei-Hung (05/31/2022) set "bool_it->second = false" to avoid duplicated
+  // definition
+  if (isSgClassType(type) && iscompleteDefined) {
+    SgClassDeclaration *classDecl =
+        isSgClassDeclaration(isSgClassType(type)->get_declaration());
+    SgClassDeclaration *classDefDecl = isSgClassDeclaration(
+        isSgClassType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && classDefDecl != nullptr &&
+        !isSgDeclarationStatement(classDefDecl->get_parent())) {
+      classDefDecl->set_parent(sg_typedef_decl);
+      classDefDecl->set_isAutonomousDeclaration(false);
+      sg_typedef_decl->set_declaration(classDefDecl);
+      sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
+
+      if (classDefDecl->get_firstNondefiningDeclaration() == NULL) {
+        fprintf(stderr,
+                "DEBUG: VisitTypedefDecl detected NULL firstNondef for %p. "
+                "Fixing.\n",
+                classDefDecl);
+        classDefDecl->set_firstNondefiningDeclaration(classDefDecl);
+      }
     }
 
-    if(llvm::isa<clang::EnumType>(underlyingType))
-    {
-       clang::EnumType* underlyingEnumType = (clang::EnumType*)underlyingType;
-       clang::EnumDecl* enumDeclaration = underlyingEnumType->getDecl();
-       isembedded = enumDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = enumDeclaration->isCompleteDefinition();
+    std::map<SgClassType *, bool>::iterator bool_it =
+        p_class_type_decl_first_see_in_type.find(isSgClassType(type));
+    ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
+    if (bool_it->second) {
+      sg_typedef_decl->set_declaration(
+          isSgNamedType(type)->get_declaration()->get_definingDeclaration());
+      sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
+      bool_it->second = false;
+    }
+  } else if (isSgEnumType(type) && iscompleteDefined) {
+
+    // Pei-Hung (06/01/2022) Clang places a EnumDecl before TypedefDecl.
+    // A SgEnumDeclaration for an  embedded EnumDecl is not attached to the
+    // scope but its parent node needs to be setup as the SgTypedefDeclaration
+
+    SgEnumDeclaration *enumDecl =
+        isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
+    SgEnumDeclaration *enumDefDecl = isSgEnumDeclaration(
+        isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && enumDefDecl != nullptr &&
+        !isSgDeclarationStatement(enumDefDecl->get_parent())) {
+      enumDefDecl->set_parent(sg_typedef_decl);
+      enumDefDecl->set_isAutonomousDeclaration(false);
+      sg_typedef_decl->set_declaration(enumDefDecl);
+      sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
     }
 
-    if(llvm::isa<clang::RecordType>(underlyingType))
-    {
-       clang::RecordType* underlyingRecordType = (clang::RecordType*)underlyingType;
-       clang::RecordDecl* recordDeclaration = underlyingRecordType->getDecl();
-       isembedded = recordDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = recordDeclaration->isCompleteDefinition();
+    std::map<SgEnumType *, bool>::iterator bool_it =
+        p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
+    ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
+    if (bool_it->second) {
+      sg_typedef_decl->set_declaration(
+          isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+      sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
+      bool_it->second = false;
     }
+  }
 
-    SgType * sg_underlyingType = buildTypeFromQualifiedType(underlyingQualType);
-    SgType * type = buildTypeFromQualifiedType(typedef_decl->getUnderlyingType());
+  sg_typedef_decl->set_typedef_type(SgTypedefDeclaration::e_typedef);
 
-    bool type_has_unknown = containsUnknownType(type);
-    if (type_has_unknown && SgProject::get_verbose() > 0) {
-        std::cerr << "CFE: Typedef with unknown underlying type '" << name << "' spelled as '"
-                  << typedef_decl->getUnderlyingType().getAsString() << "' (sg_type="
-                  << (type != NULL ? type->class_name() : "null") << ", base="
-                  << (type != NULL && type->findBaseType() != NULL ? type->findBaseType()->class_name() : "null")
-                  << ")" << std::endl;
-    }
+  // REX FIX: Handle AS_none for TypedefDecl to avoid unparser assertion
+  clang::AccessSpecifier access = typedef_decl->getAccess();
 
-    if (type_has_unknown) {
-        std::string spelled = typedef_decl->getUnderlyingType().getAsString();
-        type = SageBuilder::buildOpaqueType(spelled, SageBuilder::topScopeStack());
-        sg_underlyingType = type;
-    }
-
-    SgTypedefDeclaration * sg_typedef_decl = SageBuilder::buildTypedefDeclaration_nfi(name, type, SageBuilder::topScopeStack());
-    if (SgProject::get_verbose() > 0) {
-        if (name == "uint8_t" || name == "uint16_t" || name == "uint32_t" ||
-            name == "in_port_t" || name == "in_addr_t") {
-            std::cerr << "CFE: Created typedef '" << name << "' with type "
-                      << (type != NULL ? type->class_name() : "null") << " (underlying "
-                      << (sg_underlyingType != NULL ? sg_underlyingType->class_name() : "null") << ")"
-                      << std::endl;
-        }
-    }
-
-    // finding the bottom base type and check
-    while(type->findBaseType() != type)
-    {
-      type = type->findBaseType();
-      if(type == sg_underlyingType)
-        break;
-    }
-
-// Pei-Hung (05/31/2022) set "bool_it->second = false" to avoid duplicated definition
-    if (isSgClassType(type) && iscompleteDefined) {
-        SgClassDeclaration* classDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration());
-        SgClassDeclaration* classDefDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration()->get_definingDeclaration());
-        if(isembedded && classDefDecl != nullptr && !isSgDeclarationStatement(classDefDecl->get_parent()))
-        {
-          classDefDecl->set_parent(sg_typedef_decl);
-          classDefDecl->set_isAutonomousDeclaration(false);
-          sg_typedef_decl->set_declaration(classDefDecl);
-          sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
-
-          if (classDefDecl->get_firstNondefiningDeclaration() == NULL) {
-            fprintf(stderr,
-                    "DEBUG: VisitTypedefDecl detected NULL firstNondef for %p. "
-                    "Fixing.\n",
-                    classDefDecl);
-            classDefDecl->set_firstNondefiningDeclaration(classDefDecl);
-          }
-        }
-
-        std::map<SgClassType *, bool>::iterator bool_it = p_class_type_decl_first_see_in_type.find(isSgClassType(type));
-        ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
-        if (bool_it->second) {
-            sg_typedef_decl->set_declaration(isSgNamedType(type)->get_declaration()->get_definingDeclaration());
-            sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
-            bool_it->second = false;
-        }
-    }
-    else if (isSgEnumType(type) && iscompleteDefined) {
-
-// Pei-Hung (06/01/2022) Clang places a EnumDecl before TypedefDecl.  
-// A SgEnumDeclaration for an  embedded EnumDecl is not attached to the scope but its parent node needs to be setup as the SgTypedefDeclaration
-
-        SgEnumDeclaration* enumDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
-        SgEnumDeclaration* enumDefDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-        if(isembedded && enumDefDecl != nullptr && !isSgDeclarationStatement(enumDefDecl->get_parent()))
-        {
-          enumDefDecl->set_parent(sg_typedef_decl);
-          enumDefDecl->set_isAutonomousDeclaration(false);
-          sg_typedef_decl->set_declaration(enumDefDecl);
-          sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
-        }
-
-        std::map<SgEnumType *, bool>::iterator bool_it = p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
-        ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
-        if (bool_it->second) {
-            sg_typedef_decl->set_declaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-            sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
-            bool_it->second = false;
-        }
-    }
-
-    sg_typedef_decl->set_typedef_type(SgTypedefDeclaration::e_typedef);
-
-    // REX FIX: Handle AS_none for TypedefDecl to avoid unparser assertion
-    clang::AccessSpecifier access = typedef_decl->getAccess();
-
-    if (access == clang::AS_public) {
-      sg_typedef_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setPublic();
-    } else if (access == clang::AS_private) {
-      sg_typedef_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setPrivate();
-    } else if (access == clang::AS_protected) {
-      sg_typedef_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setProtected();
-    } else if (access == clang::AS_none) {
-      if (isSgClassDefinition(SageBuilder::topScopeStack())) {
-        SgClassDefinition *class_def =
-            isSgClassDefinition(SageBuilder::topScopeStack());
-        if (class_def->get_declaration()->get_class_type() ==
-            SgClassDeclaration::e_class) {
-          sg_typedef_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPrivate();
-        } else {
-          sg_typedef_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPublic();
-        }
+  if (access == clang::AS_public) {
+    sg_typedef_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    sg_typedef_decl->get_declarationModifier()
+        .get_accessModifier()
+        .setPrivate();
+  } else if (access == clang::AS_protected) {
+    sg_typedef_decl->get_declarationModifier()
+        .get_accessModifier()
+        .setProtected();
+  } else if (access == clang::AS_none) {
+    if (isSgClassDefinition(SageBuilder::topScopeStack())) {
+      SgClassDefinition *class_def =
+          isSgClassDefinition(SageBuilder::topScopeStack());
+      if (class_def->get_declaration()->get_class_type() ==
+          SgClassDeclaration::e_class) {
+        sg_typedef_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPrivate();
       } else {
         sg_typedef_decl->get_declarationModifier()
             .get_accessModifier()
             .setPublic();
       }
+    } else {
+      sg_typedef_decl->get_declarationModifier()
+          .get_accessModifier()
+          .setPublic();
     }
+  }
 
-    *node = sg_typedef_decl;
+  *node = sg_typedef_decl;
 
-    return VisitTypedefNameDecl(typedef_decl, node) && res;
+  return VisitTypedefNameDecl(typedef_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeAliasDecl(clang::TypeAliasDecl * type_alias_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypeAliasDecl(
+    clang::TypeAliasDecl *type_alias_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTypeAliasDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTypeAliasDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // C++11 type aliases (using foo = int) are semantically equivalent to typedefs
-    // TypeAliasDecl and TypedefDecl both inherit from TypedefNameDecl
-    // Use the same implementation logic as VisitTypedefDecl
+  // C++11 type aliases (using foo = int) are semantically equivalent to
+  // typedefs TypeAliasDecl and TypedefDecl both inherit from TypedefNameDecl
+  // Use the same implementation logic as VisitTypedefDecl
 
-    SgName name(type_alias_decl->getNameAsString());
-    clang::QualType underlyingQualType = type_alias_decl->getUnderlyingType();
-    SgType *type = NULL;
+  SgName name(type_alias_decl->getNameAsString());
+  clang::QualType underlyingQualType = type_alias_decl->getUnderlyingType();
+  SgType *type = NULL;
 
-    // Prefer explicit template specialization type to preserve template
-    // arguments.
-    const clang::Type *qt = underlyingQualType.getTypePtr();
-    const clang::Type *named = qt;
-    if (const clang::ElaboratedType *elab =
-            llvm::dyn_cast<clang::ElaboratedType>(qt)) {
-      named = elab->getNamedType().getTypePtr();
+  // Prefer explicit template specialization type to preserve template
+  // arguments.
+  const clang::Type *qt = underlyingQualType.getTypePtr();
+  const clang::Type *named = qt;
+  if (const clang::ElaboratedType *elab =
+          llvm::dyn_cast<clang::ElaboratedType>(qt)) {
+    named = elab->getNamedType().getTypePtr();
+  }
+  if (const clang::TemplateSpecializationType *spec =
+          llvm::dyn_cast<clang::TemplateSpecializationType>(named)) {
+    clang::TemplateName tname = spec->getTemplateName();
+    if (clang::TemplateDecl *clang_tpl = tname.getAsTemplateDecl()) {
+      if (SgNode *tpl_node = Traverse(clang_tpl)) {
+        if (SgTemplateClassDeclaration *tpl_decl =
+                isSgTemplateClassDeclaration(tpl_node)) {
+          SgTemplateInstantiationDecl *inst =
+              getOrCreateTemplateInstantiation(tpl_decl, spec);
+          type = inst->get_type();
+        }
+      }
     }
-    if (const clang::TemplateSpecializationType *spec =
-            llvm::dyn_cast<clang::TemplateSpecializationType>(named)) {
-      clang::TemplateName tname = spec->getTemplateName();
-      if (clang::TemplateDecl *clang_tpl = tname.getAsTemplateDecl()) {
-        if (SgNode *tpl_node = Traverse(clang_tpl)) {
-          if (SgTemplateClassDeclaration *tpl_decl =
-                  isSgTemplateClassDeclaration(tpl_node)) {
-            SgTemplateInstantiationDecl *inst =
-                getOrCreateTemplateInstantiation(tpl_decl, spec);
-            type = inst->get_type();
+  }
+
+  if (type == NULL) {
+    type = buildTypeFromQualifiedType(underlyingQualType);
+  }
+
+  // Ensure template argument list is populated on the instantiation type.
+  if (SgClassType *cls_type = isSgClassType(type)) {
+    if (SgTemplateInstantiationDecl *inst =
+            isSgTemplateInstantiationDecl(cls_type->get_declaration())) {
+      if (inst->get_templateArguments().empty()) {
+        const clang::Type *qt = underlyingQualType.getTypePtr();
+        const clang::Type *named = qt;
+        if (const clang::ElaboratedType *elab =
+                llvm::dyn_cast<clang::ElaboratedType>(qt)) {
+          named = elab->getNamedType().getTypePtr();
+        }
+        if (const clang::TemplateSpecializationType *spec =
+                llvm::dyn_cast<clang::TemplateSpecializationType>(named)) {
+          SgTemplateArgumentPtrList args = buildTemplateArguments(spec);
+          inst->get_templateArguments() = args;
+          for (SgTemplateArgument *arg : inst->get_templateArguments()) {
+            if (arg != NULL)
+              arg->set_parent(inst);
           }
         }
       }
     }
+  }
 
-    if (type == NULL) {
-      type = buildTypeFromQualifiedType(underlyingQualType);
-    }
+  SgTypedefDeclaration *sg_typedef_decl =
+      SageBuilder::buildTypedefDeclaration_nfi(name, type,
+                                               SageBuilder::topScopeStack());
 
-    // Ensure template argument list is populated on the instantiation type.
-    if (SgClassType *cls_type = isSgClassType(type)) {
-      if (SgTemplateInstantiationDecl *inst =
-              isSgTemplateInstantiationDecl(cls_type->get_declaration())) {
-        if (inst->get_templateArguments().empty()) {
-          const clang::Type *qt = underlyingQualType.getTypePtr();
-          const clang::Type *named = qt;
-          if (const clang::ElaboratedType *elab =
-                  llvm::dyn_cast<clang::ElaboratedType>(qt)) {
-            named = elab->getNamedType().getTypePtr();
-          }
-          if (const clang::TemplateSpecializationType *spec =
-                  llvm::dyn_cast<clang::TemplateSpecializationType>(named)) {
-            SgTemplateArgumentPtrList args = buildTemplateArguments(spec);
-            inst->get_templateArguments() = args;
-            for (SgTemplateArgument *arg : inst->get_templateArguments()) {
-              if (arg != NULL)
-                arg->set_parent(inst);
+  sg_typedef_decl->set_typedef_type(SgTypedefDeclaration::e_using);
+
+  *node = sg_typedef_decl;
+
+  return VisitTypedefNameDecl(type_alias_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitUnresolvedUsingTypenameDecl(
+    clang::UnresolvedUsingTypenameDecl *unresolved_using_type_name_decl,
+    SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitUnresolvedUsingTypenameDecl"
+            << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitTypeDecl(unresolved_using_type_name_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitUsingDecl(clang::UsingDecl *using_decl,
+                                           SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitUsingDecl" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: Implement proper support for using declarations (e.g.,
+  // using std::cout;) Build a SgUsingDeclarationStatement to represent the
+  // using declaration
+
+  // A UsingDecl refers to declarations through shadow declarations
+  // Get the first shadow decl's target to create the using statement
+  SgDeclarationStatement *sg_target_decl = NULL;
+  SgInitializedName *sg_init_name = NULL;
+
+  // Try to get the target declaration through shadow decls
+  // Note: We only check the cache to avoid traversing the entire target
+  if (using_decl->shadow_size() > 0) {
+    clang::UsingShadowDecl *shadow = *(using_decl->shadow_begin());
+    if (shadow != NULL) {
+      clang::NamedDecl *target = shadow->getTargetDecl();
+      if (target != NULL) {
+        // Check if target was already translated
+        if (clang::Decl *target_decl = llvm::dyn_cast<clang::Decl>(target)) {
+          std::map<clang::Decl *, SgNode *>::iterator it =
+              p_decl_translation_map.find(target_decl);
+          if (it != p_decl_translation_map.end()) {
+            // Try to cast to declaration or initialized name
+            sg_target_decl = isSgDeclarationStatement(it->second);
+            if (sg_target_decl == NULL) {
+              sg_init_name = isSgInitializedName(it->second);
+            }
+          } else {
+            // ROOT CAUSE FIX: Target not in cache, traverse it to build the
+            // declaration
+            SgNode *tmp_node = Traverse(target_decl);
+            if (tmp_node != NULL) {
+              sg_target_decl = isSgDeclarationStatement(tmp_node);
+              if (sg_target_decl == NULL) {
+                sg_init_name = isSgInitializedName(tmp_node);
+              }
             }
           }
         }
       }
     }
+  }
 
-    SgTypedefDeclaration *sg_typedef_decl =
-        SageBuilder::buildTypedefDeclaration_nfi(name, type,
-                                                 SageBuilder::topScopeStack());
-
-    sg_typedef_decl->set_typedef_type(SgTypedefDeclaration::e_using);
-
-    *node = sg_typedef_decl;
-
-    return VisitTypedefNameDecl(type_alias_decl, node) && res;
-}
-
-
-
-bool ClangToSageTranslator::VisitUnresolvedUsingTypenameDecl(clang::UnresolvedUsingTypenameDecl * unresolved_using_type_name_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUnresolvedUsingTypenameDecl" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitTypeDecl(unresolved_using_type_name_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitUsingDecl(clang::UsingDecl * using_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUsingDecl" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Implement proper support for using declarations (e.g., using std::cout;)
-    // Build a SgUsingDeclarationStatement to represent the using declaration
-
-    // A UsingDecl refers to declarations through shadow declarations
-    // Get the first shadow decl's target to create the using statement
-    SgDeclarationStatement* sg_target_decl = NULL;
-    SgInitializedName* sg_init_name = NULL;
-
-    // Try to get the target declaration through shadow decls
-    // Note: We only check the cache to avoid traversing the entire target
-    if (using_decl->shadow_size() > 0) {
-        clang::UsingShadowDecl* shadow = *(using_decl->shadow_begin());
-        if (shadow != NULL) {
-            clang::NamedDecl* target = shadow->getTargetDecl();
-            if (target != NULL) {
-                // Check if target was already translated
-                if (clang::Decl* target_decl = llvm::dyn_cast<clang::Decl>(target)) {
-                    std::map<clang::Decl *, SgNode *>::iterator it = p_decl_translation_map.find(target_decl);
-                    if (it != p_decl_translation_map.end()) {
-                        // Try to cast to declaration or initialized name
-                        sg_target_decl = isSgDeclarationStatement(it->second);
-                        if (sg_target_decl == NULL) {
-                            sg_init_name = isSgInitializedName(it->second);
-                        }
-                    } else {
-                        // ROOT CAUSE FIX: Target not in cache, traverse it to build the declaration
-                        SgNode* tmp_node = Traverse(target_decl);
-                        if (tmp_node != NULL) {
-                            sg_target_decl = isSgDeclarationStatement(tmp_node);
-                            if (sg_target_decl == NULL) {
-                                sg_init_name = isSgInitializedName(tmp_node);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // ROOT CAUSE FIX: Ensure at least one parameter is non-NULL for unparser
-    // If both are NULL, the unparser will fail with assertion
-    // In this case, skip creating the using declaration
-    if (sg_target_decl == NULL && sg_init_name == NULL) {
-        // Cannot resolve target - create null statement as placeholder
-        *node = new SgNullStatement();
-        return VisitNamedDecl(using_decl, node) && res;
-    }
-
-    // Build the using declaration statement
-    // Constructor signature: SgUsingDeclarationStatement(SgDeclarationStatement* declaration, SgInitializedName* initializedName)
-    SgUsingDeclarationStatement* using_stmt = new SgUsingDeclarationStatement(sg_target_decl, sg_init_name);
-    using_stmt->set_definingDeclaration(using_stmt);
-    using_stmt->set_firstNondefiningDeclaration(using_stmt);
-
-    if (SgScopeStatement *current_scope = SageBuilder::topScopeStack()) {
-      using_stmt->set_scope(current_scope);
-      using_stmt->set_parent(current_scope);
-    }
-    diagnose_null_scope(using_stmt, "UsingDecl");
-
-    *node = using_stmt;
-
+  // ROOT CAUSE FIX: Ensure at least one parameter is non-NULL for unparser
+  // If both are NULL, the unparser will fail with assertion
+  // In this case, skip creating the using declaration
+  if (sg_target_decl == NULL && sg_init_name == NULL) {
+    // Cannot resolve target - create null statement as placeholder
+    *node = new SgNullStatement();
     return VisitNamedDecl(using_decl, node) && res;
+  }
+
+  // Build the using declaration statement
+  // Constructor signature: SgUsingDeclarationStatement(SgDeclarationStatement*
+  // declaration, SgInitializedName* initializedName)
+  SgUsingDeclarationStatement *using_stmt =
+      new SgUsingDeclarationStatement(sg_target_decl, sg_init_name);
+  using_stmt->set_definingDeclaration(using_stmt);
+  using_stmt->set_firstNondefiningDeclaration(using_stmt);
+
+  if (SgScopeStatement *current_scope = SageBuilder::topScopeStack()) {
+    using_stmt->set_scope(current_scope);
+    using_stmt->set_parent(current_scope);
+  }
+  diagnose_null_scope(using_stmt, "UsingDecl");
+
+  *node = using_stmt;
+
+  return VisitNamedDecl(using_decl, node) && res;
 }
 
 // Helper to ensure a namespace declaration exists (creating stubs if needed)
@@ -3937,1229 +4181,1350 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
   return sg_ns_decl;
 }
 
-bool ClangToSageTranslator::VisitUsingDirectiveDecl(clang::UsingDirectiveDecl * using_directive_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitUsingDirectiveDecl(
+    clang::UsingDirectiveDecl *using_directive_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUsingDirectiveDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUsingDirectiveDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Implement proper support for using directives (e.g., using namespace std;)
-    // Build a SgUsingDirectiveStatement to represent the using directive
+  // ROOT CAUSE FIX: Implement proper support for using directives (e.g., using
+  // namespace std;) Build a SgUsingDirectiveStatement to represent the using
+  // directive
 
-    // Get the namespace being imported
-    clang::NamespaceDecl* clang_ns_decl = using_directive_decl->getNominatedNamespace();
+  // Get the namespace being imported
+  clang::NamespaceDecl *clang_ns_decl =
+      using_directive_decl->getNominatedNamespace();
 
-    // Ensure the namespace exists in the AST (creating stubs if needed,
-    // supporting nested namespaces)
-    SgNamespaceDeclarationStatement *sg_ns_decl =
-        ensureNamespaceDeclaration(clang_ns_decl);
+  // Ensure the namespace exists in the AST (creating stubs if needed,
+  // supporting nested namespaces)
+  SgNamespaceDeclarationStatement *sg_ns_decl =
+      ensureNamespaceDeclaration(clang_ns_decl);
 
-    // Build the using directive statement using the existing builder
-    SgUsingDirectiveStatement* using_dir_stmt = SageBuilder::buildUsingDirectiveStatement(sg_ns_decl);
+  // Build the using directive statement using the existing builder
+  SgUsingDirectiveStatement *using_dir_stmt =
+      SageBuilder::buildUsingDirectiveStatement(sg_ns_decl);
 
-    // Note: Scope is set automatically by parent visitor, don't set it explicitly here
+  // Note: Scope is set automatically by parent visitor, don't set it explicitly
+  // here
 
-    *node = using_dir_stmt;
+  *node = using_dir_stmt;
 
-    return VisitNamedDecl(using_directive_decl, node) && res;
+  return VisitNamedDecl(using_directive_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitUsingPackDecl(clang::UsingPackDecl * using_pack_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitUsingPackDecl(
+    clang::UsingPackDecl *using_pack_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUsingPackDecl" << std::endl;
-#endif  
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitNamedDecl(using_pack_decl, node) && res;
-}
-
-bool ClangToSageTranslator::VisitUsingShadowDecl(clang::UsingShadowDecl * using_shadow_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUsingShadowDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUsingPackDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: UsingShadowDecl is an implicit declaration created by the compiler
-    // to represent declarations brought into scope by a using declaration.
-    // These are implementation details and don't need explicit SAGE representation.
-    // The parent UsingDecl already represents the user-visible declaration.
-    // Silently use null statement without warning.
-    *node = SageBuilder::buildNullStatement();
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitNamedDecl(using_shadow_decl, node) && res;
+  return VisitNamedDecl(using_pack_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitConstructorUsingShadowDecl(clang::ConstructorUsingShadowDecl * constructor_using_shadow_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitUsingShadowDecl(
+    clang::UsingShadowDecl *using_shadow_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitConstructorUsingShadowDecl" << std::endl;
-#endif  
-    bool res = true;
+  std::cerr << "ClangToSageTranslator::VisitUsingShadowDecl" << std::endl;
+#endif
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  // ROOT CAUSE FIX: UsingShadowDecl is an implicit declaration created by the
+  // compiler to represent declarations brought into scope by a using
+  // declaration. These are implementation details and don't need explicit SAGE
+  // representation. The parent UsingDecl already represents the user-visible
+  // declaration. Silently use null statement without warning.
+  *node = SageBuilder::buildNullStatement();
 
-    return VisitNamedDecl(constructor_using_shadow_decl, node) && res;
+  return VisitNamedDecl(using_shadow_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitValueDecl(clang::ValueDecl * value_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitConstructorUsingShadowDecl(
+    clang::ConstructorUsingShadowDecl *constructor_using_shadow_decl,
+    SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitValueDecl" << std::endl;
-#endif  
-    bool res = true;
+  std::cerr << "ClangToSageTranslator::VisitConstructorUsingShadowDecl"
+            << std::endl;
+#endif
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitNamedDecl(value_decl, node) && res;
+  return VisitNamedDecl(constructor_using_shadow_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBindingDecl(clang::BindingDecl * binding_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitValueDecl(clang::ValueDecl *value_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitBindingDecl" << std::endl;
-#endif  
-    bool res = true;
+  std::cerr << "ClangToSageTranslator::VisitValueDecl" << std::endl;
+#endif
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitValueDecl(binding_decl, node) && res;
+  return VisitNamedDecl(value_decl, node) && res;
 }
-    
-bool ClangToSageTranslator::VisitDeclaratorDecl(clang::DeclaratorDecl * declarator_decl, SgNode ** node) {
+
+bool ClangToSageTranslator::VisitBindingDecl(clang::BindingDecl *binding_decl,
+                                             SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitDeclaratorDecl" << std::endl;
-#endif  
-    bool res = true;
+  std::cerr << "ClangToSageTranslator::VisitBindingDecl" << std::endl;
+#endif
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitValueDecl(declarator_decl, node) && res;
+  return VisitValueDecl(binding_decl, node) && res;
 }
-    
 
-bool ClangToSageTranslator::VisitFieldDecl(clang::FieldDecl * field_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitDeclaratorDecl(
+    clang::DeclaratorDecl *declarator_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFieldDecl" << std::endl;
-#endif  
-    bool res = true;
-    
+  std::cerr << "ClangToSageTranslator::VisitDeclaratorDecl" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitValueDecl(declarator_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitFieldDecl(clang::FieldDecl *field_decl,
+                                           SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFieldDecl name:" <<field_decl->getNameAsString() <<  "\n";
-    std:: cerr << "isAnonymousStructOrUnion() " << field_decl->isAnonymousStructOrUnion() << "\n";
+  std::cerr << "ClangToSageTranslator::VisitFieldDecl" << std::endl;
+#endif
+  bool res = true;
+
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitFieldDecl name:"
+            << field_decl->getNameAsString() << "\n";
+  std::cerr << "isAnonymousStructOrUnion() "
+            << field_decl->isAnonymousStructOrUnion() << "\n";
 #endif
 
-    SgName name(field_decl->getNameAsString());
+  SgName name(field_decl->getNameAsString());
 
-    clang::QualType fieldQualType = field_decl->getType();
+  clang::QualType fieldQualType = field_decl->getType();
 
-    const clang::Type* fieldType = fieldQualType.getTypePtr();
+  const clang::Type *fieldType = fieldQualType.getTypePtr();
 
-    // Pei-Hung (06/01/2022) check if the declaration is considered embedded in Clang AST.
-    // If it is embedded, no explicit SgDeclaration should be placed for ROSE AST.
-    bool isembedded = false;
-    bool iscompleteDefined = false;
-    bool isNamedNonEmbeddedRecord = false;
-    bool isAnonymousStructOrUnion = false;
+  // Pei-Hung (06/01/2022) check if the declaration is considered embedded in
+  // Clang AST. If it is embedded, no explicit SgDeclaration should be placed
+  // for ROSE AST.
+  bool isembedded = false;
+  bool iscompleteDefined = false;
+  bool isNamedNonEmbeddedRecord = false;
+  bool isAnonymousStructOrUnion = false;
 
-    // Adding check for EaboratedType and PointerType to retrieve base EnumType
-    // Removing PointerType here before finding a better implementation to handle pointer
-    while((llvm::isa<clang::ElaboratedType>(fieldType)) || (llvm::isa<clang::ArrayType>(fieldType)))
-    {
-       if(llvm::isa<clang::ElaboratedType>(fieldType))
-       {
-         fieldQualType = ((clang::ElaboratedType *)fieldType)->getNamedType();
-       }
-       else if(llvm::isa<clang::ArrayType>(fieldType))
-       {
-         fieldQualType = ((clang::ArrayType *)fieldType)->getElementType();
-       }
-       fieldType = fieldQualType.getTypePtr();
+  // Adding check for EaboratedType and PointerType to retrieve base EnumType
+  // Removing PointerType here before finding a better implementation to handle
+  // pointer
+  while ((llvm::isa<clang::ElaboratedType>(fieldType)) ||
+         (llvm::isa<clang::ArrayType>(fieldType))) {
+    if (llvm::isa<clang::ElaboratedType>(fieldType)) {
+      fieldQualType = ((clang::ElaboratedType *)fieldType)->getNamedType();
+    } else if (llvm::isa<clang::ArrayType>(fieldType)) {
+      fieldQualType = ((clang::ArrayType *)fieldType)->getElementType();
+    }
+    fieldType = fieldQualType.getTypePtr();
+  }
+
+  if (llvm::isa<clang::EnumType>(fieldType)) {
+    clang::EnumType *underlyingEnumType = (clang::EnumType *)fieldType;
+    clang::EnumDecl *enumDeclaration = underlyingEnumType->getDecl();
+    isembedded = enumDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = enumDeclaration->isCompleteDefinition();
+  }
+
+  if (llvm::isa<clang::RecordType>(fieldType)) {
+    clang::RecordType *underlyingRecordType = (clang::RecordType *)fieldType;
+    clang::RecordDecl *recordDeclaration = underlyingRecordType->getDecl();
+    isembedded = recordDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = recordDeclaration->isCompleteDefinition();
+    isNamedNonEmbeddedRecord = !recordDeclaration->isEmbeddedInDeclarator() &&
+                               !recordDeclaration->isAnonymousStructOrUnion() &&
+                               recordDeclaration->getIdentifier() != NULL;
+  }
+
+  isAnonymousStructOrUnion = field_decl->isAnonymousStructOrUnion();
+
+  const clang::CXXRecordDecl *parent_record =
+      llvm::dyn_cast<clang::CXXRecordDecl>(field_decl->getParent());
+  bool is_lambda_field = (parent_record != NULL && parent_record->isLambda());
+
+  if (is_lambda_field) {
+    // Lambda closure fields are implicit captures; they should always
+    // materialize as real member variables even if Clang marks them anonymous.
+    // Give them stable names so the symbol table can reference them during
+    // conversion of the lambda body.
+    isAnonymousStructOrUnion = false;
+    if (name.getString().empty()) {
+      std::string synthesized_name =
+          "__lambda_field_" + std::to_string(field_decl->getFieldIndex());
+      name = synthesized_name;
+    }
+  }
+
+  SgType *sg_fieldType = buildTypeFromQualifiedType(fieldQualType);
+  SgType *type = buildTypeFromQualifiedType(field_decl->getType());
+
+  bool type_has_unknown = containsUnknownType(type);
+  if (type_has_unknown && SgProject::get_verbose() > 0) {
+    std::cerr << "CFE: Field with unknown type '" << name << "' spelled as '"
+              << field_decl->getType().getAsString()
+              << "' (sg_type=" << (type != NULL ? type->class_name() : "null")
+              << ", base="
+              << (type != NULL && type->findBaseType() != NULL
+                      ? type->findBaseType()->class_name()
+                      : "null")
+              << ")" << std::endl;
+  }
+
+  if (type_has_unknown) {
+    type = SageBuilder::buildOpaqueType(field_decl->getType().getAsString(),
+                                        SageBuilder::topScopeStack());
+    sg_fieldType = type;
+  }
+
+  clang::Expr *init_expr = field_decl->getInClassInitializer();
+  SgNode *tmp_init = Traverse(init_expr);
+  SgExpression *expr = isSgExpression(tmp_init);
+  // TODO expression list if aggregated initializer !
+  if (tmp_init != NULL && expr == NULL) {
+    std::cerr << "Runtime error: not a SgInitializer..." << std::endl;
+    res = false;
+  }
+  SgInitializer *init =
+      expr != NULL
+          ? SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type())
+          : NULL;
+  if (init != NULL)
+    applySourceRange(init, init_expr->getSourceRange());
+
+  if (isAnonymousStructOrUnion && !is_lambda_field) {
+    if (isSgClassType(type) && iscompleteDefined) {
+      SgClassDeclaration *classDecl =
+          isSgClassDeclaration(isSgClassType(type)->get_declaration());
+      if (classDecl != NULL) {
+        SgClassDeclaration *classDefDecl =
+            isSgClassDeclaration(classDecl->get_definingDeclaration());
+        if (classDefDecl != NULL) {
+          *node = classDefDecl;
+          return VisitDeclaratorDecl(field_decl, node) && res;
+        }
+      }
+    } else if (isSgEnumType(type) && iscompleteDefined) {
+      SgEnumDeclaration *enumDecl =
+          isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
+      if (enumDecl != NULL) {
+        SgEnumDeclaration *enumDefDecl =
+            isSgEnumDeclaration(enumDecl->get_definingDeclaration());
+        if (enumDefDecl != NULL) {
+          *node = enumDefDecl;
+          return VisitDeclaratorDecl(field_decl, node) && res;
+        }
+      }
+    }
+  }
+
+  // Cannot use 'SageBuilder::buildVariableDeclaration' because of anonymous
+  // field *node = SageBuilder::buildVariableDeclaration(name, type, init,
+  // SageBuilder::topScopeStack());
+  // Build it by hand...
+  SgVariableDeclaration *var_decl = new SgVariableDeclaration(name, type, init);
+
+  // CLANG FRONTEND FIX: Capture access modifier from Clang AST
+  clang::AccessSpecifier access = field_decl->getAccess();
+  if (access == clang::AS_public) {
+    var_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    var_decl->get_declarationModifier().get_accessModifier().setPrivate();
+  } else if (access == clang::AS_protected) {
+    var_decl->get_declarationModifier().get_accessModifier().setProtected();
+  }
+  // AS_none means default access (private for class, public for struct)
+  if (access == clang::AS_none && parent_record != NULL) {
+    if (parent_record->isClass()) {
+      var_decl->get_declarationModifier().get_accessModifier().setPrivate();
+    } else {
+      var_decl->get_declarationModifier().get_accessModifier().setPublic();
+    }
+  }
+
+  // finding the bottom base type and check
+  while (type->findBaseType() != type) {
+    type = type->findBaseType();
+    if (type == sg_fieldType)
+      break;
+  }
+
+  if (isSgClassType(type) && iscompleteDefined) {
+    SgClassDeclaration *classDecl =
+        isSgClassDeclaration(isSgClassType(type)->get_declaration());
+    SgClassDeclaration *classDefDecl = isSgClassDeclaration(
+        isSgClassType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && classDefDecl != nullptr &&
+        !isSgDeclarationStatement(classDefDecl->get_parent())) {
+      classDefDecl->set_parent(var_decl);
+      classDefDecl->set_isAutonomousDeclaration(false);
+      var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
+      var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
     }
 
-    if(llvm::isa<clang::EnumType>(fieldType))
-    {
-       clang::EnumType* underlyingEnumType = (clang::EnumType*)fieldType;
-       clang::EnumDecl* enumDeclaration = underlyingEnumType->getDecl();
-       isembedded = enumDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = enumDeclaration->isCompleteDefinition();
+    std::map<SgClassType *, bool>::iterator bool_it =
+        p_class_type_decl_first_see_in_type.find(isSgClassType(type));
+    ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
+    if (isNamedNonEmbeddedRecord) {
+      // Named records should keep their standalone definition; avoid embedding
+      // on first use.
+      bool_it->second = false;
+    }
+    if (bool_it->second) {
+      var_decl->set_baseTypeDefiningDeclaration(
+          isSgNamedType(type)->get_declaration()->get_definingDeclaration());
+      var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
+      bool_it->second = false;
+    }
+  } else if (isSgEnumType(type) && iscompleteDefined) {
+    SgEnumDeclaration *enumDecl =
+        isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
+    SgEnumDeclaration *enumDefDecl = isSgEnumDeclaration(
+        isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && enumDefDecl != nullptr &&
+        !isSgDeclarationStatement(enumDefDecl->get_parent())) {
+      enumDefDecl->set_parent(var_decl);
+      enumDefDecl->set_isAutonomousDeclaration(false);
+      var_decl->set_baseTypeDefiningDeclaration(enumDefDecl);
+      var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
     }
 
-    if(llvm::isa<clang::RecordType>(fieldType))
-    {
-       clang::RecordType* underlyingRecordType = (clang::RecordType*)fieldType;
-       clang::RecordDecl* recordDeclaration = underlyingRecordType->getDecl();
-       isembedded = recordDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = recordDeclaration->isCompleteDefinition();
-       isNamedNonEmbeddedRecord = !recordDeclaration->isEmbeddedInDeclarator() &&
-                                  !recordDeclaration->isAnonymousStructOrUnion() &&
-                                  recordDeclaration->getIdentifier() != NULL;
+    std::map<SgEnumType *, bool>::iterator bool_it =
+        p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
+    ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
+    if (bool_it->second) {
+      var_decl->set_baseTypeDefiningDeclaration(
+          isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+      var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
+      bool_it->second = false;
     }
+  }
 
-    isAnonymousStructOrUnion = field_decl->isAnonymousStructOrUnion();
+  var_decl->set_firstNondefiningDeclaration(var_decl);
+  var_decl->set_parent(SageBuilder::topScopeStack());
 
-    const clang::CXXRecordDecl* parent_record = llvm::dyn_cast<clang::CXXRecordDecl>(field_decl->getParent());
-    bool is_lambda_field = (parent_record != NULL && parent_record->isLambda());
+  ROSE_ASSERT(var_decl->get_variables().size() == 1);
 
-    if (is_lambda_field) {
-        // Lambda closure fields are implicit captures; they should always materialize as
-        // real member variables even if Clang marks them anonymous. Give them stable names
-        // so the symbol table can reference them during conversion of the lambda body.
-        isAnonymousStructOrUnion = false;
-        if (name.getString().empty()) {
-            std::string synthesized_name = "__lambda_field_" + std::to_string(field_decl->getFieldIndex());
-            name = synthesized_name;
-        }
+  SgInitializedName *init_name = var_decl->get_variables()[0];
+  ROSE_ASSERT(init_name != NULL);
+  init_name->set_parent(var_decl);
+  init_name->set_scope(SageBuilder::topScopeStack());
+
+  applySourceRange(init_name, field_decl->getSourceRange());
+
+  // CLANG FRONTEND FIX: declptr should point to SgVariableDefinition, not
+  // SgVariableDeclaration Check if it's already set, if not get it from
+  // var_decl
+  SgVariableDefinition *var_def =
+      isSgVariableDefinition(init_name->get_declptr());
+  if (var_def == NULL) {
+    var_def = var_decl->get_definition();
+    if (var_def != NULL) {
+      init_name->set_declptr(var_def);
     }
+  }
+  ROSE_ASSERT(var_def != NULL);
+  applySourceRange(var_def, field_decl->getSourceRange());
 
-    SgType * sg_fieldType = buildTypeFromQualifiedType(fieldQualType);
-    SgType * type = buildTypeFromQualifiedType(field_decl->getType());
+  SgVariableSymbol *var_symbol = new SgVariableSymbol(init_name);
+  SageBuilder::topScopeStack()->insert_symbol(name, var_symbol);
 
-    bool type_has_unknown = containsUnknownType(type);
-    if (type_has_unknown && SgProject::get_verbose() > 0) {
-        std::cerr << "CFE: Field with unknown type '" << name << "' spelled as '"
-                  << field_decl->getType().getAsString() << "' (sg_type="
-                  << (type != NULL ? type->class_name() : "null") << ", base="
-                  << (type != NULL && type->findBaseType() != NULL ? type->findBaseType()->class_name() : "null")
-                  << ")" << std::endl;
-    }
-
-    if (type_has_unknown) {
-        type = SageBuilder::buildOpaqueType(field_decl->getType().getAsString(), SageBuilder::topScopeStack());
-        sg_fieldType = type;
-    }
-
-    clang::Expr * init_expr = field_decl->getInClassInitializer();
-    SgNode * tmp_init = Traverse(init_expr);
-    SgExpression * expr = isSgExpression(tmp_init);
-    // TODO expression list if aggregated initializer !
-    if (tmp_init != NULL && expr == NULL) {
-        std::cerr << "Runtime error: not a SgInitializer..." << std::endl;
-        res = false;
-    }
-    SgInitializer * init = expr != NULL ? SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type()) : NULL;
-    if (init != NULL)
-        applySourceRange(init, init_expr->getSourceRange());
-
-    if (isAnonymousStructOrUnion && !is_lambda_field) {
-        if (isSgClassType(type) && iscompleteDefined) {
-            SgClassDeclaration* classDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration());
-            if (classDecl != NULL) {
-                SgClassDeclaration* classDefDecl = isSgClassDeclaration(classDecl->get_definingDeclaration());
-                if (classDefDecl != NULL) {
-                    *node = classDefDecl;
-                    return VisitDeclaratorDecl(field_decl, node) && res;
-                }
-            }
-        } else if (isSgEnumType(type) && iscompleteDefined) {
-            SgEnumDeclaration* enumDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
-            if (enumDecl != NULL) {
-                SgEnumDeclaration* enumDefDecl = isSgEnumDeclaration(enumDecl->get_definingDeclaration());
-                if (enumDefDecl != NULL) {
-                    *node = enumDefDecl;
-                    return VisitDeclaratorDecl(field_decl, node) && res;
-                }
-            }
-        }
-    }
-
-      // Cannot use 'SageBuilder::buildVariableDeclaration' because of anonymous field
-        // *node = SageBuilder::buildVariableDeclaration(name, type, init, SageBuilder::topScopeStack());
-      // Build it by hand...
-        SgVariableDeclaration * var_decl = new SgVariableDeclaration(name, type, init);
-
-        // CLANG FRONTEND FIX: Capture access modifier from Clang AST
-        clang::AccessSpecifier access = field_decl->getAccess();
-        if (access == clang::AS_public) {
-            var_decl->get_declarationModifier().get_accessModifier().setPublic();
-        } else if (access == clang::AS_private) {
-            var_decl->get_declarationModifier().get_accessModifier().setPrivate();
-        } else if (access == clang::AS_protected) {
-            var_decl->get_declarationModifier().get_accessModifier().setProtected();
-        }
-        // AS_none means default access (private for class, public for struct)
-        if (access == clang::AS_none && parent_record != NULL) {
-          if (parent_record->isClass()) {
-            var_decl->get_declarationModifier()
-                .get_accessModifier()
-                .setPrivate();
-          } else {
-            var_decl->get_declarationModifier()
-                .get_accessModifier()
-                .setPublic();
-          }
-        }
-
-        // finding the bottom base type and check
-        while(type->findBaseType() != type)
-        {
-          type = type->findBaseType();
-          if(type == sg_fieldType)
-            break;
-        }
-     
-        if (isSgClassType(type) && iscompleteDefined) {
-            SgClassDeclaration* classDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration());
-            SgClassDeclaration* classDefDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration()->get_definingDeclaration());
-            if(isembedded && classDefDecl != nullptr && !isSgDeclarationStatement(classDefDecl->get_parent()))
-            {
-              classDefDecl->set_parent(var_decl);
-              classDefDecl->set_isAutonomousDeclaration(false);
-              var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
-              var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-            }
-     
-            std::map<SgClassType *, bool>::iterator bool_it = p_class_type_decl_first_see_in_type.find(isSgClassType(type));
-            ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
-            if (isNamedNonEmbeddedRecord) {
-                // Named records should keep their standalone definition; avoid embedding on first use.
-                bool_it->second = false;
-            }
-            if (bool_it->second) {
-                var_decl->set_baseTypeDefiningDeclaration(isSgNamedType(type)->get_declaration()->get_definingDeclaration());
-                var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-                bool_it->second = false;
-            }
-        }
-        else if (isSgEnumType(type) && iscompleteDefined) {
-            SgEnumDeclaration* enumDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
-            SgEnumDeclaration* enumDefDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-            if(isembedded && enumDefDecl != nullptr && !isSgDeclarationStatement(enumDefDecl->get_parent()))
-            {
-              enumDefDecl->set_parent(var_decl);
-              enumDefDecl->set_isAutonomousDeclaration(false);
-              var_decl->set_baseTypeDefiningDeclaration(enumDefDecl);
-              var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-            }
-     
-            std::map<SgEnumType *, bool>::iterator bool_it = p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
-            ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
-            if (bool_it->second) {
-                var_decl->set_baseTypeDefiningDeclaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-                var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-                bool_it->second = false;
-            }
-        }
-     
-        var_decl->set_firstNondefiningDeclaration(var_decl);
-        var_decl->set_parent(SageBuilder::topScopeStack());
-     
-        ROSE_ASSERT(var_decl->get_variables().size() == 1);
-
-        SgInitializedName * init_name = var_decl->get_variables()[0];
-        ROSE_ASSERT(init_name != NULL);
-        init_name->set_scope(SageBuilder::topScopeStack());
-
-        applySourceRange(init_name, field_decl->getSourceRange());
-
-        // CLANG FRONTEND FIX: declptr should point to SgVariableDefinition, not SgVariableDeclaration
-        // Check if it's already set, if not get it from var_decl
-        SgVariableDefinition * var_def = isSgVariableDefinition(init_name->get_declptr());
-        if (var_def == NULL) {
-            var_def = var_decl->get_definition();
-            if (var_def != NULL) {
-                init_name->set_declptr(var_def);
-            }
-        }
-        ROSE_ASSERT(var_def != NULL);
-        applySourceRange(var_def, field_decl->getSourceRange());
-     
-        SgVariableSymbol * var_symbol = new SgVariableSymbol(init_name);
-        SageBuilder::topScopeStack()->insert_symbol(name, var_symbol);
-     
-        *node = var_decl;
-    return VisitDeclaratorDecl(field_decl, node) && res; 
+  *node = var_decl;
+  return VisitDeclaratorDecl(field_decl, node) && res;
 }
 
 bool ClangToSageTranslator::translateFunctionDeclCommon(
     clang::FunctionDecl *function_decl,
     clang::FunctionTemplateDecl *template_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFunctionDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFunctionDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // FIXME: There is something weird here when try to Traverse a function reference in a recursive function (when first Traverse is not complete)
-    //        It seems that it tries to instantiate the decl inside the function...
-    //        It may be faster to recode from scratch...
-    //   If I am not wrong this have been fixed....
+  // FIXME: There is something weird here when try to Traverse a function
+  // reference in a recursive function (when first Traverse is not complete)
+  //        It seems that it tries to instantiate the decl inside the
+  //        function... It may be faster to recode from scratch...
+  //   If I am not wrong this have been fixed....
 
-    SgName name(function_decl->getNameAsString());
-    std::string func_name = function_decl->getNameAsString();
+  SgName name(function_decl->getNameAsString());
+  std::string func_name = function_decl->getNameAsString();
 
-    bool is_builtin_decl = (function_decl->getBuiltinID() != clang::Builtin::NotBuiltin);
-    if (!is_builtin_decl && func_name.rfind("__builtin_", 0) == 0) {
-        is_builtin_decl = true;
-    }
-    if (!is_builtin_decl && p_compiler_instance != NULL) {
-        is_builtin_decl = p_compiler_instance->getSourceManager().isWrittenInBuiltinFile(function_decl->getLocation());
-    }
+  bool is_builtin_decl =
+      (function_decl->getBuiltinID() != clang::Builtin::NotBuiltin);
+  if (!is_builtin_decl && func_name.rfind("__builtin_", 0) == 0) {
+    is_builtin_decl = true;
+  }
+  if (!is_builtin_decl && p_compiler_instance != NULL) {
+    is_builtin_decl =
+        p_compiler_instance->getSourceManager().isWrittenInBuiltinFile(
+            function_decl->getLocation());
+  }
 
-    clang::QualType funcQualType = function_decl->getType();
+  clang::QualType funcQualType = function_decl->getType();
 
-    const clang::Type* funcType = funcQualType.getTypePtr();
+  const clang::Type *funcType = funcQualType.getTypePtr();
 
-    const clang::FunctionProtoType* funcProtoType = (llvm::isa<clang::FunctionProtoType>(funcType)) ? (clang::FunctionProtoType*)funcType : nullptr;
+  const clang::FunctionProtoType *funcProtoType =
+      (llvm::isa<clang::FunctionProtoType>(funcType))
+          ? (clang::FunctionProtoType *)funcType
+          : nullptr;
 
-    bool diffInProtoType = false;
+  bool diffInProtoType = false;
 
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitFunctionDecl name:" << name.getString() << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFunctionDecl name:"
+            << name.getString() << std::endl;
 #endif
 
-    // CLANG FRONTEND FIX #21: Constructors use void type but are marked with special modifier
-    // buildDefiningFunctionDeclaration requires non-NULL return type, so we use void for constructors
-    // and mark them with the constructor modifier flag later
-    SgType * ret_type = buildTypeFromQualifiedType(function_decl->getReturnType());
+  // CLANG FRONTEND FIX #21: Constructors use void type but are marked with
+  // special modifier buildDefiningFunctionDeclaration requires non-NULL return
+  // type, so we use void for constructors and mark them with the constructor
+  // modifier flag later
+  SgType *ret_type = buildTypeFromQualifiedType(function_decl->getReturnType());
 
-    SgFunctionParameterList * param_list = SageBuilder::buildFunctionParameterList_nfi();
-      applySourceRange(param_list, function_decl->getSourceRange()); // FIXME find the good SourceRange (should be stored by Clang...)
+  SgFunctionParameterList *param_list =
+      SageBuilder::buildFunctionParameterList_nfi();
+  applySourceRange(
+      param_list,
+      function_decl->getSourceRange()); // FIXME find the good SourceRange
+                                        // (should be stored by Clang...)
 
-    if(funcProtoType != nullptr && funcProtoType->getNumParams() != function_decl->getNumParams())
-        diffInProtoType = true;
+  if (funcProtoType != nullptr &&
+      funcProtoType->getNumParams() != function_decl->getNumParams())
+    diffInProtoType = true;
 
-    SgDeclarationScope* declScope = SageBuilder::buildDeclarationScope();
-    declScope->set_parent(SageBuilder::topScopeStack());
-    SageBuilder::pushScopeStack(declScope);
-    
+  SgDeclarationScope *declScope = SageBuilder::buildDeclarationScope();
+  declScope->set_parent(SageBuilder::topScopeStack());
+  SageBuilder::pushScopeStack(declScope);
 
-    for (unsigned i = 0; i < function_decl->getNumParams(); i++) {
-        if(funcProtoType != nullptr && function_decl->getParamDecl(i)->getType() != funcProtoType->getParamType(i))
-        {
+  for (unsigned i = 0; i < function_decl->getNumParams(); i++) {
+    if (funcProtoType != nullptr && function_decl->getParamDecl(i)->getType() !=
+                                        funcProtoType->getParamType(i)) {
 #if DEBUG_VISIT_DECL
-            std::cout << "Func arg type :" << function_decl->getParamDecl(i)->getType().getAsString() << " funcProtoType arg type:" << funcProtoType->getParamType(i).getAsString() << std::endl;
+      std::cout << "Func arg type :"
+                << function_decl->getParamDecl(i)->getType().getAsString()
+                << " funcProtoType arg type:"
+                << funcProtoType->getParamType(i).getAsString() << std::endl;
 #endif
-            diffInProtoType = true;
-        } 
-        SgNode * tmp_init_name = Traverse(function_decl->getParamDecl(i));
-        SgInitializedName * init_name = isSgInitializedName(tmp_init_name);
+      diffInProtoType = true;
+    }
+    SgNode *tmp_init_name = Traverse(function_decl->getParamDecl(i));
+    SgInitializedName *init_name = isSgInitializedName(tmp_init_name);
 
-        // Pei-Hung (05/09/2022) Need to setup set_needs_definitions to SgInitializedName when the
-        // Enum or Class type is actually declared in a function prototype scope
-        if(isSgEnumType(init_name->get_type()) || isSgClassType(init_name->get_type()))
-        {
-          SgNamedType* namedType = isSgNamedType(init_name->get_type());
-          SgDeclarationStatement* namedTypeDecl = isSgDeclarationStatement(namedType->get_declaration());
-          SgDeclarationStatement* definingDecl = namedTypeDecl->get_definingDeclaration(); 
-          if(definingDecl != NULL)
-          {
-            SgDeclarationStatement* definingNamedTypeDecl = isSgDeclarationStatement(definingDecl);
-            SgScopeStatement* definitionEnclosingScope = definingNamedTypeDecl->get_scope();
-            // case 1: definition is under SgDeclarationScope
-            if(isSgScopeStatement(definitionEnclosingScope) == SageBuilder::topScopeStack()) 
-            {
+    // Pei-Hung (05/09/2022) Need to setup set_needs_definitions to
+    // SgInitializedName when the Enum or Class type is actually declared in a
+    // function prototype scope
+    if (isSgEnumType(init_name->get_type()) ||
+        isSgClassType(init_name->get_type())) {
+      SgNamedType *namedType = isSgNamedType(init_name->get_type());
+      SgDeclarationStatement *namedTypeDecl =
+          isSgDeclarationStatement(namedType->get_declaration());
+      SgDeclarationStatement *definingDecl =
+          namedTypeDecl->get_definingDeclaration();
+      if (definingDecl != NULL) {
+        SgDeclarationStatement *definingNamedTypeDecl =
+            isSgDeclarationStatement(definingDecl);
+        SgScopeStatement *definitionEnclosingScope =
+            definingNamedTypeDecl->get_scope();
+        // case 1: definition is under SgDeclarationScope
+        if (isSgScopeStatement(definitionEnclosingScope) ==
+            SageBuilder::topScopeStack()) {
+          init_name->set_needs_definitions(true);
+        }
+        // case 2: definition is at other scope but not in the
+        // SgDeclarationStatementPtrList from that scope e.g. test2018_15.c,
+        // test2018_13.c
+        else {
+          // ROOT CAUSE FIX: Only certain scope types support
+          // getDeclarationList() Match the exact set of types from
+          // Cxx_Grammar.C:116211-116268 Supported: SgGlobal,
+          // SgNamespaceDefinitionStatement, SgClassDefinition,
+          //            SgTemplateClassDefinition, SgTemplateInstantiationDefn,
+          //            SgFunctionParameterScope
+          // NOT supported: SgBasicBlock, SgDeclarationScope,
+          // SgForInitStatement, etc.
+          if (isSgGlobal(definitionEnclosingScope) ||
+              isSgNamespaceDefinitionStatement(definitionEnclosingScope) ||
+              isSgClassDefinition(definitionEnclosingScope) ||
+              isSgTemplateClassDefinition(definitionEnclosingScope) ||
+              isSgTemplateInstantiationDefn(definitionEnclosingScope) ||
+              isSgFunctionParameterScope(definitionEnclosingScope)) {
+            SgDeclarationStatementPtrList &declList =
+                definitionEnclosingScope->getDeclarationList();
+            if (std::find(declList.begin(), declList.end(),
+                          definingNamedTypeDecl) == declList.end()) {
               init_name->set_needs_definitions(true);
             }
-            // case 2: definition is at other scope but not in the SgDeclarationStatementPtrList from that scope
-            // e.g. test2018_15.c, test2018_13.c
-            else
-            {
-              // ROOT CAUSE FIX: Only certain scope types support getDeclarationList()
-              // Match the exact set of types from Cxx_Grammar.C:116211-116268
-              // Supported: SgGlobal, SgNamespaceDefinitionStatement, SgClassDefinition,
-              //            SgTemplateClassDefinition, SgTemplateInstantiationDefn, SgFunctionParameterScope
-              // NOT supported: SgBasicBlock, SgDeclarationScope, SgForInitStatement, etc.
-              if (isSgGlobal(definitionEnclosingScope) ||
-                  isSgNamespaceDefinitionStatement(definitionEnclosingScope) ||
-                  isSgClassDefinition(definitionEnclosingScope) ||
-                  isSgTemplateClassDefinition(definitionEnclosingScope) ||
-                  isSgTemplateInstantiationDefn(definitionEnclosingScope) ||
-                  isSgFunctionParameterScope(definitionEnclosingScope))
-              {
-                SgDeclarationStatementPtrList& declList = definitionEnclosingScope->getDeclarationList();
-                if(std::find(declList.begin(), declList.end(), definingNamedTypeDecl) == declList.end())
-                {
-                  init_name->set_needs_definitions(true);
-                }
+          }
+        }
+      }
+    }
+
+    if (tmp_init_name != NULL && init_name == NULL) {
+      std::cerr << "Runtime error: tmp_init_name != NULL && init_name == NULL"
+                << std::endl;
+      res = false;
+      continue;
+    }
+
+    param_list->append_arg(init_name);
+  }
+
+  SageBuilder::popScopeStack();
+
+  if (function_decl->isVariadic()) {
+    SgName empty = "";
+    SgType *ellipses_type = SgTypeEllipse::createType();
+    SgInitializedName *ellipses_param =
+        SageBuilder::buildInitializedName_nfi(empty, ellipses_type, NULL);
+    // Set scope and parent to avoid unparser assertion
+    SgScopeStatement *scope = SageBuilder::topScopeStack();
+    ellipses_param->set_scope(scope);
+    ellipses_param->set_parent(scope);
+    param_list->append_arg(ellipses_param);
+  }
+
+  // ROOT CAUSE FIX: Get proper scope for this function from its Clang
+  // declaration context For out-of-line member functions, ensure scope is the
+  // class definition, not global CRITICAL: Friend functions are declared in
+  // class but are NOT members - keep them in the class syntactically and expose
+  // them via the enclosing namespace/global scope symbol table.
+  clang::DeclContext *decl_context = function_decl->getDeclContext();
+  SgScopeStatement *proper_scope = getGlobalScope(); // Default fallback
+
+  bool isDefinition = function_decl->isThisDeclarationADefinition();
+
+  // Check if this is a friend function - friends are free functions, not
+  // members
+  bool isFriendFunction =
+      (function_decl->getFriendObjectKind() != clang::Decl::FOK_None);
+  bool isFriendMethod = llvm::isa<clang::CXXMethodDecl>(function_decl);
+  bool isFriendFreeFunction = (isFriendFunction && !isFriendMethod);
+
+  // Lexical class enclosing scope needed so friend free functions stay visible
+  // in the namespace
+  SgScopeStatement *lexical_friend_enclosing_scope = NULL;
+  SgClassDefinition *lexical_friend_class_def = NULL;
+  bool friend_lexically_inside_class = false;
+  auto getEnclosingNamespaceScope =
+      [](SgScopeStatement *scope) -> SgScopeStatement * {
+    SgScopeStatement *current = scope;
+    while (current != NULL && !isSgGlobal(current) &&
+           !isSgNamespaceDefinitionStatement(current)) {
+      SgScopeStatement *next_scope =
+          SageInterface::getEnclosingScope(current, false);
+      if (next_scope == current)
+        break;
+      current = next_scope;
+    }
+    return current;
+  };
+
+  if (isFriendFreeFunction) {
+    clang::DeclContext *lexical_context =
+        function_decl->getLexicalDeclContext();
+    if (lexical_context && llvm::isa<clang::CXXRecordDecl>(lexical_context)) {
+      clang::CXXRecordDecl *lexical_class =
+          llvm::cast<clang::CXXRecordDecl>(lexical_context);
+      std::map<clang::Decl *, SgNode *>::iterator lexical_it =
+          p_decl_translation_map.find(lexical_class);
+      if (lexical_it != p_decl_translation_map.end()) {
+        SgNode *class_node = lexical_it->second;
+        SgScopeStatement *class_scope = NULL;
+        if (SgClassDeclaration *class_decl = isSgClassDeclaration(class_node)) {
+          class_scope = class_decl->get_scope();
+          if (class_decl->get_definition())
+            lexical_friend_class_def = class_decl->get_definition();
+        } else if (SgClassDefinition *class_def =
+                       isSgClassDefinition(class_node)) {
+          lexical_friend_class_def = class_def;
+          if (SgClassDeclaration *decl =
+                  isSgClassDeclaration(class_def->get_declaration())) {
+            class_scope = decl->get_scope();
+          }
+        } else if (SgTemplateClassDeclaration *template_class_decl =
+                       isSgTemplateClassDeclaration(class_node)) {
+          class_scope = template_class_decl->get_scope();
+          if (template_class_decl->get_definition())
+            lexical_friend_class_def = template_class_decl->get_definition();
+        }
+        if (lexical_friend_class_def != NULL) {
+          friend_lexically_inside_class = true;
+        }
+        if (class_scope != NULL) {
+          lexical_friend_enclosing_scope =
+              getEnclosingNamespaceScope(class_scope);
+          if (lexical_friend_enclosing_scope == NULL) {
+            lexical_friend_enclosing_scope = getGlobalScope();
+          }
+        }
+      }
+    }
+  }
+
+  bool scope_assigned = false;
+  if (isFriendFreeFunction) {
+    bool keep_in_class_scope = (!isDefinition) || friend_lexically_inside_class;
+    if (keep_in_class_scope) {
+      if (lexical_friend_class_def != NULL) {
+        proper_scope = lexical_friend_class_def;
+        scope_assigned = true;
+      }
+    } else {
+      if (lexical_friend_enclosing_scope != NULL) {
+        proper_scope = lexical_friend_enclosing_scope;
+        scope_assigned = true;
+      }
+    }
+  }
+
+  // For member functions (including friend methods), use the class definition
+  // as scope
+  if (!scope_assigned && llvm::isa<clang::CXXMethodDecl>(function_decl)) {
+    clang::CXXMethodDecl *method_decl =
+        llvm::cast<clang::CXXMethodDecl>(function_decl);
+    clang::CXXRecordDecl *parent_class = method_decl->getParent();
+    if (parent_class) {
+      std::map<clang::Decl *, SgNode *>::iterator it =
+          p_decl_translation_map.find(parent_class);
+      if (it != p_decl_translation_map.end()) {
+        SgNode *class_node = it->second;
+        if (SgClassDeclaration *class_decl = isSgClassDeclaration(class_node)) {
+          if (class_decl->get_definition()) {
+            proper_scope = class_decl->get_definition();
+          }
+        } else if (SgClassDefinition *class_def =
+                       isSgClassDefinition(class_node)) {
+          proper_scope = class_def;
+        } else if (SgTemplateClassDeclaration *template_class_decl =
+                       isSgTemplateClassDeclaration(class_node)) {
+          if (template_class_decl->get_definition()) {
+            proper_scope = template_class_decl->get_definition();
+          }
+        }
+      }
+    }
+  }
+  // For non-member functions, use DeclContext (namespace or class)
+  else if (!scope_assigned && decl_context &&
+           !decl_context->isTranslationUnit()) {
+    clang::Decl *context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
+    if (context_decl) {
+      std::map<clang::Decl *, SgNode *>::iterator it =
+          p_decl_translation_map.find(context_decl);
+      if (it != p_decl_translation_map.end()) {
+        SgNode *context_node = it->second;
+        if (SgClassDeclaration *class_decl =
+                isSgClassDeclaration(context_node)) {
+          if (class_decl->get_definition()) {
+            proper_scope = class_decl->get_definition();
+          }
+        } else if (SgClassDefinition *class_def =
+                       isSgClassDefinition(context_node)) {
+          proper_scope = class_def;
+        } else if (SgTemplateClassDeclaration *template_class_decl =
+                       isSgTemplateClassDeclaration(context_node)) {
+          if (template_class_decl->get_definition()) {
+            proper_scope = template_class_decl->get_definition();
+          }
+        } else if (SgNamespaceDeclarationStatement *ns_decl =
+                       isSgNamespaceDeclarationStatement(context_node)) {
+          if (ns_decl->get_definition())
+            proper_scope = ns_decl->get_definition();
+        } else if (SgNamespaceDefinitionStatement *ns_def =
+                       isSgNamespaceDefinitionStatement(context_node)) {
+          proper_scope = ns_def;
+        }
+      } else if (llvm::isa<clang::NamespaceDecl>(context_decl)) {
+        // REX FIX Issue 87: Functions inside namespaces lost.
+        // If the context is a namespace but it's not in the map yet, it
+        // likely means we are currently traversing it
+        // (VisistNamespaceDecl pushes scope). We must verify that the top
+        // of the scope stack is indeed the namespace we expect.
+        clang::NamespaceDecl *ns_decl =
+            llvm::cast<clang::NamespaceDecl>(context_decl);
+        SgScopeStatement *topScope = SageBuilder::topScopeStack();
+
+        if (SgNamespaceDefinitionStatement *nsDef =
+                isSgNamespaceDefinitionStatement(topScope)) {
+          // REX FIX CAUTION: Do not mess with system headers (std
+          // namespace) as it breaks regressions. Only apply this fix for
+          // user code.
+          bool inSystemHeader = false;
+          if (p_compiler_instance) {
+            inSystemHeader =
+                p_compiler_instance->getSourceManager().isInSystemHeader(
+                    ns_decl->getLocation());
+          }
+
+          if (!inSystemHeader) {
+            SgNamespaceDeclarationStatement *nsDeclObj =
+                nsDef->get_namespaceDeclaration();
+            bool match = false;
+
+            if (ns_decl->isAnonymousNamespace()) {
+              if (nsDeclObj->get_isUnnamedNamespace()) {
+                match = true;
+              }
+            } else {
+              if (nsDeclObj->get_name().getString() ==
+                  ns_decl->getNameAsString()) {
+                match = true;
               }
             }
-          } 
-        }
 
-        if (tmp_init_name != NULL && init_name == NULL) {
-            std::cerr << "Runtime error: tmp_init_name != NULL && init_name == NULL" << std::endl;
-            res = false;
-            continue;
-        }
-
-        param_list->append_arg(init_name);
-    }
-
-    SageBuilder::popScopeStack();
-
-    if (function_decl->isVariadic()) {
-        SgName empty = "";
-        SgType * ellipses_type = SgTypeEllipse::createType();
-        SgInitializedName* ellipses_param = SageBuilder::buildInitializedName_nfi(empty, ellipses_type, NULL);
-        // Set scope and parent to avoid unparser assertion
-        SgScopeStatement* scope = SageBuilder::topScopeStack();
-        ellipses_param->set_scope(scope);
-        ellipses_param->set_parent(scope);
-        param_list->append_arg(ellipses_param);
-    }
-
-    // ROOT CAUSE FIX: Get proper scope for this function from its Clang declaration context
-    // For out-of-line member functions, ensure scope is the class definition, not global
-    // CRITICAL: Friend functions are declared in class but are NOT members - keep them in the class
-    // syntactically and expose them via the enclosing namespace/global scope symbol table.
-    clang::DeclContext* decl_context = function_decl->getDeclContext();
-    SgScopeStatement* proper_scope = getGlobalScope();  // Default fallback
-
-    bool isDefinition = function_decl->isThisDeclarationADefinition();
-
-    // Check if this is a friend function - friends are free functions, not members
-    bool isFriendFunction = (function_decl->getFriendObjectKind() != clang::Decl::FOK_None);
-    bool isFriendMethod = llvm::isa<clang::CXXMethodDecl>(function_decl);
-    bool isFriendFreeFunction = (isFriendFunction && !isFriendMethod);
-
-    // Lexical class enclosing scope needed so friend free functions stay visible in the namespace
-    SgScopeStatement* lexical_friend_enclosing_scope = NULL;
-    SgClassDefinition* lexical_friend_class_def = NULL;
-    bool friend_lexically_inside_class = false;
-    auto getEnclosingNamespaceScope = [](SgScopeStatement* scope) -> SgScopeStatement* {
-        SgScopeStatement* current = scope;
-        while (current != NULL && !isSgGlobal(current) && !isSgNamespaceDefinitionStatement(current)) {
-            SgScopeStatement* next_scope = SageInterface::getEnclosingScope(current, false);
-            if (next_scope == current) break;
-            current = next_scope;
-        }
-        return current;
-    };
-
-    if (isFriendFreeFunction) {
-        clang::DeclContext* lexical_context = function_decl->getLexicalDeclContext();
-        if (lexical_context && llvm::isa<clang::CXXRecordDecl>(lexical_context)) {
-            clang::CXXRecordDecl* lexical_class = llvm::cast<clang::CXXRecordDecl>(lexical_context);
-            std::map<clang::Decl*, SgNode*>::iterator lexical_it = p_decl_translation_map.find(lexical_class);
-            if (lexical_it != p_decl_translation_map.end()) {
-                SgNode* class_node = lexical_it->second;
-                SgScopeStatement* class_scope = NULL;
-                if (SgClassDeclaration* class_decl = isSgClassDeclaration(class_node)) {
-                    class_scope = class_decl->get_scope();
-                    if (class_decl->get_definition())
-                        lexical_friend_class_def = class_decl->get_definition();
-                } else if (SgClassDefinition* class_def = isSgClassDefinition(class_node)) {
-                    lexical_friend_class_def = class_def;
-                    if (SgClassDeclaration* decl = isSgClassDeclaration(class_def->get_declaration())) {
-                        class_scope = decl->get_scope();
-                    }
-                } else if (SgTemplateClassDeclaration* template_class_decl = isSgTemplateClassDeclaration(class_node)) {
-                    class_scope = template_class_decl->get_scope();
-                    if (template_class_decl->get_definition())
-                        lexical_friend_class_def = template_class_decl->get_definition();
-                }
-                if (lexical_friend_class_def != NULL) {
-                    friend_lexically_inside_class = true;
-                }
-                if (class_scope != NULL) {
-                    lexical_friend_enclosing_scope = getEnclosingNamespaceScope(class_scope);
-                    if (lexical_friend_enclosing_scope == NULL) {
-                        lexical_friend_enclosing_scope = getGlobalScope();
-                    }
-                }
+            if (match) {
+              proper_scope = topScope;
             }
+          }
         }
+      }
     }
+  }
 
-    bool scope_assigned = false;
-    if (isFriendFreeFunction) {
-        bool keep_in_class_scope = (!isDefinition) || friend_lexically_inside_class;
-        if (keep_in_class_scope) {
-            if (lexical_friend_class_def != NULL) {
-                proper_scope = lexical_friend_class_def;
-                scope_assigned = true;
-            }
-        } else {
-            if (lexical_friend_enclosing_scope != NULL) {
-                proper_scope = lexical_friend_enclosing_scope;
-                scope_assigned = true;
-            }
-        }
-    }
+  SgFunctionDeclaration *sg_function_decl;
 
-    // For member functions (including friend methods), use the class definition as scope
-    if (!scope_assigned && llvm::isa<clang::CXXMethodDecl>(function_decl)) {
-        clang::CXXMethodDecl* method_decl = llvm::cast<clang::CXXMethodDecl>(function_decl);
-        clang::CXXRecordDecl* parent_class = method_decl->getParent();
-        if (parent_class) {
-            std::map<clang::Decl*, SgNode*>::iterator it = p_decl_translation_map.find(parent_class);
-            if (it != p_decl_translation_map.end()) {
-                SgNode* class_node = it->second;
-                if (SgClassDeclaration* class_decl = isSgClassDeclaration(class_node)) {
-                    if (class_decl->get_definition()) {
-                        proper_scope = class_decl->get_definition();
-                    }
-                } else if (SgClassDefinition* class_def = isSgClassDefinition(class_node)) {
-                    proper_scope = class_def;
-                } else if (SgTemplateClassDeclaration* template_class_decl = isSgTemplateClassDeclaration(class_node)) {
-                    if (template_class_decl->get_definition()) {
-                        proper_scope = template_class_decl->get_definition();
-                    }
-                }
-            }
-        }
-    }
-    // For non-member functions, use DeclContext (namespace or class)
-    else if (!scope_assigned && decl_context && !decl_context->isTranslationUnit()) {
-        clang::Decl* context_decl = llvm::dyn_cast<clang::Decl>(decl_context);
-        if (context_decl) {
-            std::map<clang::Decl*, SgNode*>::iterator it = p_decl_translation_map.find(context_decl);
-            if (it != p_decl_translation_map.end()) {
-                SgNode* context_node = it->second;
-                if (SgClassDeclaration* class_decl = isSgClassDeclaration(context_node)) {
-                    if (class_decl->get_definition()) {
-                        proper_scope = class_decl->get_definition();
-                    }
-                } else if (SgClassDefinition* class_def = isSgClassDefinition(context_node)) {
-                    proper_scope = class_def;
-                } else if (SgTemplateClassDeclaration* template_class_decl = isSgTemplateClassDeclaration(context_node)) {
-                    if (template_class_decl->get_definition()) {
-                        proper_scope = template_class_decl->get_definition();
-                    }
-                } else if (SgNamespaceDeclarationStatement* ns_decl = isSgNamespaceDeclarationStatement(context_node)) {
-                    if (ns_decl->get_definition()) proper_scope = ns_decl->get_definition();
-                } else if (SgNamespaceDefinitionStatement* ns_def = isSgNamespaceDefinitionStatement(context_node)) {
-                    proper_scope = ns_def;
-                }
-            } else if (llvm::isa<clang::NamespaceDecl>(context_decl)) {
-              // REX FIX Issue 87: Functions inside namespaces lost.
-              // If the context is a namespace but it's not in the map yet, it
-              // likely means we are currently traversing it
-              // (VisistNamespaceDecl pushes scope). We must verify that the top
-              // of the scope stack is indeed the namespace we expect.
-              clang::NamespaceDecl *ns_decl =
-                  llvm::cast<clang::NamespaceDecl>(context_decl);
-              SgScopeStatement *topScope = SageBuilder::topScopeStack();
+  // REX FIX: Check if this is a function template pattern
+  clang::FunctionTemplateDecl *templateDecl =
+      template_decl != NULL ? template_decl
+                            : function_decl->getDescribedFunctionTemplate();
+  SgTemplateParameterPtrList *templateParams = NULL;
+  if (templateDecl) {
+    // Translate template parameters
+    // Pass NULL as owning template for now, we'll set it later if needed,
+    // but SgTemplateFunctionDeclaration IS the owning template.
+    // However, we can't pass it before creating it.
+    templateParams = translateTemplateParameterList(
+        templateDecl->getTemplateParameters(), NULL);
+  }
 
-              if (SgNamespaceDefinitionStatement *nsDef =
-                      isSgNamespaceDefinitionStatement(topScope)) {
-                // REX FIX CAUTION: Do not mess with system headers (std
-                // namespace) as it breaks regressions. Only apply this fix for
-                // user code.
-                bool inSystemHeader = false;
-                if (p_compiler_instance) {
-                  inSystemHeader =
-                      p_compiler_instance->getSourceManager().isInSystemHeader(
-                          ns_decl->getLocation());
-                }
+  if (function_decl->isThisDeclarationADefinition()) {
+    // Build friend free-function definitions as free functions regardless of
+    // lexical class scope.
+    bool builder_force_free_scope = isFriendFreeFunction;
+    SgScopeStatement *builder_scope = proper_scope;
 
-                if (!inSystemHeader) {
-                  SgNamespaceDeclarationStatement *nsDeclObj =
-                      nsDef->get_namespaceDeclaration();
-                  bool match = false;
-
-                  if (ns_decl->isAnonymousNamespace()) {
-                    if (nsDeclObj->get_isUnnamedNamespace()) {
-                      match = true;
-                    }
-                  } else {
-                    if (nsDeclObj->get_name().getString() ==
-                        ns_decl->getNameAsString()) {
-                      match = true;
-                    }
-                  }
-
-                  if (match) {
-                    proper_scope = topScope;
-                  }
-                }
-              }
-            }
-        }
-    }
-
-    SgFunctionDeclaration * sg_function_decl;
-
-    // REX FIX: Check if this is a function template pattern
-    clang::FunctionTemplateDecl *templateDecl =
-        template_decl != NULL ? template_decl
-                              : function_decl->getDescribedFunctionTemplate();
-    SgTemplateParameterPtrList* templateParams = NULL;
     if (templateDecl) {
-        // Translate template parameters
-        // Pass NULL as owning template for now, we'll set it later if needed, 
-        // but SgTemplateFunctionDeclaration IS the owning template.
-        // However, we can't pass it before creating it.
-        templateParams = translateTemplateParameterList(templateDecl->getTemplateParameters(), NULL);
-    }
+      // Template definitions require a prior non-defining declaration for
+      // SageBuilder. Reuse an existing one when a forward declaration was
+      // already seen to keep declaration/definition chains consistent.
+      SgTemplateFunctionDeclaration *first_nondef = NULL;
 
-    if (function_decl->isThisDeclarationADefinition()) {
-        // Build friend free-function definitions as free functions regardless of lexical class scope.
-        bool builder_force_free_scope = isFriendFreeFunction;
-        SgScopeStatement *builder_scope = proper_scope;
-
-        if (templateDecl) {
-          // Template definitions require a prior non-defining declaration for
-          // SageBuilder. Reuse an existing one when a forward declaration was
-          // already seen to keep declaration/definition chains consistent.
-          SgTemplateFunctionDeclaration *first_nondef = NULL;
-
-          if (function_decl->getFirstDecl() != function_decl) {
-            auto map_it = p_decl_translation_map.find(function_decl->getFirstDecl());
-            if (map_it != p_decl_translation_map.end()) {
-              first_nondef = isSgTemplateFunctionDeclaration(map_it->second);
-            }
-            if (first_nondef == NULL) {
-              auto tmpl_it = p_decl_translation_map.find(templateDecl);
-              if (tmpl_it != p_decl_translation_map.end()) {
-                first_nondef = isSgTemplateFunctionDeclaration(tmpl_it->second);
-              }
-            }
-            if (first_nondef == NULL) {
-              SgSymbol *tmp_symbol = GetSymbolFromSymbolTable(function_decl->getFirstDecl());
-              if (SgTemplateSymbol *tmpl_sym = isSgTemplateSymbol(tmp_symbol)) {
-                first_nondef = isSgTemplateFunctionDeclaration(tmpl_sym->get_declaration());
-              } else if (SgFunctionSymbol *func_sym = isSgFunctionSymbol(tmp_symbol)) {
-                first_nondef = isSgTemplateFunctionDeclaration(func_sym->get_declaration());
-              }
-            }
-          }
-
-          if (first_nondef == NULL) {
-            SgFunctionParameterList *first_param_list =
-                SageBuilder::buildFunctionParameterList_nfi();
-            applySourceRange(first_param_list, function_decl->getSourceRange());
-
-            for (SgInitializedName *init_name : param_list->get_args()) {
-              if (init_name == NULL)
-                continue;
-
-              SgInitializer *cloned_init = NULL;
-              if (SgInitializer *init = init_name->get_initializer()) {
-                if (SgExpression *expr_init = isSgExpression(init)) {
-                  cloned_init = SageBuilder::buildAssignInitializer_nfi(
-                      SageInterface::copyExpression(expr_init),
-                      expr_init->get_type());
-                }
-              }
-
-              SgInitializedName *cloned_param =
-                  SageBuilder::buildInitializedName_nfi(
-                      init_name->get_name(), init_name->get_type(), cloned_init);
-              cloned_param->set_scope(SageBuilder::topScopeStack());
-              cloned_param->set_parent(first_param_list);
-              first_param_list->append_arg(cloned_param);
-            }
-
-            if (function_decl->isVariadic()) {
-              SgName empty = "";
-              SgType *ellipses_type = SgTypeEllipse::createType();
-              SgInitializedName *ellipses_param =
-                  SageBuilder::buildInitializedName_nfi(empty, ellipses_type,
-                                                        NULL);
-              ellipses_param->set_scope(SageBuilder::topScopeStack());
-              ellipses_param->set_parent(first_param_list);
-              first_param_list->append_arg(ellipses_param);
-            }
-
-            first_nondef =
-                SageBuilder::buildNondefiningTemplateFunctionDeclaration(
-                    name, ret_type, first_param_list, builder_scope, NULL,
-                    templateParams);
-            ROSE_ASSERT(first_nondef != NULL);
-
-            applySourceRange(first_nondef, function_decl->getSourceRange());
-            first_param_list->set_parent(first_nondef);
-            if (function_decl->isVariadic())
-              first_nondef->hasEllipses();
-          }
-
-          first_nondef->set_firstNondefiningDeclaration(first_nondef);
-
-          if (SgFunctionParameterList *first_param_list = first_nondef->get_parameterList()) {
-            for (SgInitializedName *param : first_param_list->get_args()) {
-              if (param != NULL) {
-                param->set_declptr(first_nondef);
-              }
-            }
-          }
-
-          // Fix for Issue 84: Friend template definitions inside a class should
-          // be in the enclosing scope
-          // SageBuilder::buildDefiningTemplateFunctionDeclaration does not
-          // accept a forceFreeFunctionScope flag unlike
-          // buildDefiningFunctionDeclaration, so we must rely on passing the
-          // correct scope.
-          SgScopeStatement *target_scope = builder_scope;
-          if (builder_force_free_scope &&
-              lexical_friend_enclosing_scope != NULL) {
-            target_scope = lexical_friend_enclosing_scope;
-          }
-
-          SgTemplateFunctionDeclaration *defining_template =
-              SageBuilder::buildDefiningTemplateFunctionDeclaration(
-                  name, ret_type, param_list, target_scope, NULL, first_nondef);
-
-          sg_function_decl = defining_template;
-          sg_function_decl->set_definingDeclaration(sg_function_decl);
-
-          if (function_decl->isVariadic()) {
-            sg_function_decl->hasEllipses();
-          }
-
-          for (SgInitializedName *param : param_list->get_args()) {
-            if (param != NULL) {
-              param->set_declptr(sg_function_decl);
-            }
-          }
-
-          if (defining_template->get_firstNondefiningDeclaration() == NULL) {
-            defining_template->set_firstNondefiningDeclaration(first_nondef);
-          }
-          first_nondef->set_definingDeclaration(defining_template);
-        } else {
-          sg_function_decl = SageBuilder::buildDefiningFunctionDeclaration(
-              name, ret_type, param_list, builder_scope,
-              builder_force_free_scope);
-
-          sg_function_decl->set_definingDeclaration(sg_function_decl);
-
-          if (function_decl->isVariadic()) {
-            sg_function_decl->hasEllipses();
-          }
-
-          // CLANG FRONTEND FIX: Set declptr for all function parameters
-          // declptr should point to the function declaration for parameters
-          SgInitializedNamePtrList &param_names = param_list->get_args();
-          for (SgInitializedName *param : param_names) {
-            if (param != NULL) {
-              param->set_declptr(sg_function_decl);
-            }
+      if (function_decl->getFirstDecl() != function_decl) {
+        auto map_it =
+            p_decl_translation_map.find(function_decl->getFirstDecl());
+        if (map_it != p_decl_translation_map.end()) {
+          first_nondef = isSgTemplateFunctionDeclaration(map_it->second);
+        }
+        if (first_nondef == NULL) {
+          auto tmpl_it = p_decl_translation_map.find(templateDecl);
+          if (tmpl_it != p_decl_translation_map.end()) {
+            first_nondef = isSgTemplateFunctionDeclaration(tmpl_it->second);
           }
         }
+        if (first_nondef == NULL) {
+          SgSymbol *tmp_symbol =
+              GetSymbolFromSymbolTable(function_decl->getFirstDecl());
+          if (SgTemplateSymbol *tmpl_sym = isSgTemplateSymbol(tmp_symbol)) {
+            first_nondef =
+                isSgTemplateFunctionDeclaration(tmpl_sym->get_declaration());
+          } else if (SgFunctionSymbol *func_sym =
+                         isSgFunctionSymbol(tmp_symbol)) {
+            first_nondef =
+                isSgTemplateFunctionDeclaration(func_sym->get_declaration());
+          }
+        }
+      }
 
-        // Only process the function body if it exists
-        // Template functions and forward declarations may be marked as definitions but have no body
-        if (function_decl->hasBody()) {
-/*
-            if (sg_function_decl->get_definition() != NULL) SageInterface::deleteAST(sg_function_decl->get_definition());
+      if (first_nondef == NULL) {
+        SgFunctionParameterList *first_param_list =
+            SageBuilder::buildFunctionParameterList_nfi();
+        applySourceRange(first_param_list, function_decl->getSourceRange());
 
-            SgFunctionDefinition * function_definition = new SgFunctionDefinition(sg_function_decl, NULL);
+        for (SgInitializedName *init_name : param_list->get_args()) {
+          if (init_name == NULL)
+            continue;
 
-            SgInitializedNamePtrList & init_names = param_list->get_args();
-            SgInitializedNamePtrList::iterator it;
-            for (it = init_names.begin(); it != init_names.end(); it++) {
-                (*it)->set_scope(function_definition);
-                SgSymbolTable * st = function_definition->get_symbol_table();
-                ROSE_ASSERT(st != NULL);
-                SgVariableSymbol * tmp_sym  = new SgVariableSymbol(*it);
-                st->insert((*it)->get_name(), tmp_sym);
+          SgInitializer *cloned_init = NULL;
+          if (SgInitializer *init = init_name->get_initializer()) {
+            if (SgExpression *expr_init = isSgExpression(init)) {
+              cloned_init = SageBuilder::buildAssignInitializer_nfi(
+                  SageInterface::copyExpression(expr_init),
+                  expr_init->get_type());
             }
-*/
-            SgFunctionDefinition * function_definition = sg_function_decl->get_definition();
+          }
 
-            // P1 Badge Fix: Recursive Cache Invalidation.
-            // We must invalidate the cache for the body statements and
-            // declarations BEFORE potentially deleting the existing body AST.
-            // This prevents Use-After-Free (accessing deleted nodes parents)
-            // and ensures we don't reuse "stolen" nodes from templates. We
-            // erase unconditionally because we are about to rebuild the body
-            // for this definition.
+          SgInitializedName *cloned_param =
+              SageBuilder::buildInitializedName_nfi(
+                  init_name->get_name(), init_name->get_type(), cloned_init);
+          cloned_param->set_scope(SageBuilder::topScopeStack());
+          cloned_param->set_parent(first_param_list);
+          first_param_list->append_arg(cloned_param);
+        }
 
-            clang::Stmt *body_stmt = function_decl->getBody();
-            if (body_stmt) {
-              std::function<void(clang::Decl *)> recursive_invalidate_decl;
-              std::function<void(clang::Stmt *)> recursive_invalidate_stmt;
+        if (function_decl->isVariadic()) {
+          SgName empty = "";
+          SgType *ellipses_type = SgTypeEllipse::createType();
+          SgInitializedName *ellipses_param =
+              SageBuilder::buildInitializedName_nfi(empty, ellipses_type, NULL);
+          ellipses_param->set_scope(SageBuilder::topScopeStack());
+          ellipses_param->set_parent(first_param_list);
+          first_param_list->append_arg(ellipses_param);
+        }
 
-              recursive_invalidate_decl = [&](clang::Decl *d) {
-                if (!d)
-                  return;
-                auto it = p_decl_translation_map.find(d);
-                if (it != p_decl_translation_map.end()) {
-                  p_decl_translation_map.erase(it);
-                }
+        first_nondef = SageBuilder::buildNondefiningTemplateFunctionDeclaration(
+            name, ret_type, first_param_list, builder_scope, NULL,
+            templateParams);
+        ROSE_ASSERT(first_nondef != NULL);
 
-                // Recurse into DeclContext (e.g. structs)
-                if (auto *ctx = llvm::dyn_cast<clang::DeclContext>(d)) {
-                  for (auto *child : ctx->decls()) {
-                    recursive_invalidate_decl(child);
+        applySourceRange(first_nondef, function_decl->getSourceRange());
+        first_param_list->set_parent(first_nondef);
+        if (function_decl->isVariadic())
+          first_nondef->hasEllipses();
+      }
+
+      first_nondef->set_firstNondefiningDeclaration(first_nondef);
+
+      if (SgFunctionParameterList *first_param_list =
+              first_nondef->get_parameterList()) {
+        for (SgInitializedName *param : first_param_list->get_args()) {
+          if (param != NULL) {
+            param->set_declptr(first_nondef);
+          }
+        }
+      }
+
+      // Fix for Issue 84: Friend template definitions inside a class should
+      // be in the enclosing scope
+      // SageBuilder::buildDefiningTemplateFunctionDeclaration does not
+      // accept a forceFreeFunctionScope flag unlike
+      // buildDefiningFunctionDeclaration, so we must rely on passing the
+      // correct scope.
+      SgScopeStatement *target_scope = builder_scope;
+      if (builder_force_free_scope && lexical_friend_enclosing_scope != NULL) {
+        target_scope = lexical_friend_enclosing_scope;
+      }
+
+      SgTemplateFunctionDeclaration *defining_template =
+          SageBuilder::buildDefiningTemplateFunctionDeclaration(
+              name, ret_type, param_list, target_scope, NULL, first_nondef);
+
+      sg_function_decl = defining_template;
+      sg_function_decl->set_definingDeclaration(sg_function_decl);
+
+      if (function_decl->isVariadic()) {
+        sg_function_decl->hasEllipses();
+      }
+
+      for (SgInitializedName *param : param_list->get_args()) {
+        if (param != NULL) {
+          param->set_declptr(sg_function_decl);
+        }
+      }
+
+      if (defining_template->get_firstNondefiningDeclaration() == NULL) {
+        defining_template->set_firstNondefiningDeclaration(first_nondef);
+      }
+      first_nondef->set_definingDeclaration(defining_template);
+    } else {
+      sg_function_decl = SageBuilder::buildDefiningFunctionDeclaration(
+          name, ret_type, param_list, builder_scope, builder_force_free_scope);
+
+      sg_function_decl->set_definingDeclaration(sg_function_decl);
+
+      if (function_decl->isVariadic()) {
+        sg_function_decl->hasEllipses();
+      }
+
+      // CLANG FRONTEND FIX: Set declptr for all function parameters
+      // declptr should point to the function declaration for parameters
+      SgInitializedNamePtrList &param_names = param_list->get_args();
+      for (SgInitializedName *param : param_names) {
+        if (param != NULL) {
+          param->set_declptr(sg_function_decl);
+        }
+      }
+    }
+
+    // Only process the function body if it exists
+    // Template functions and forward declarations may be marked as definitions
+    // but have no body
+    if (function_decl->hasBody()) {
+      /*
+                  if (sg_function_decl->get_definition() != NULL)
+         SageInterface::deleteAST(sg_function_decl->get_definition());
+
+                  SgFunctionDefinition * function_definition = new
+         SgFunctionDefinition(sg_function_decl, NULL);
+
+                  SgInitializedNamePtrList & init_names =
+         param_list->get_args(); SgInitializedNamePtrList::iterator it; for (it
+         = init_names.begin(); it != init_names.end(); it++) {
+                      (*it)->set_scope(function_definition);
+                      SgSymbolTable * st =
+         function_definition->get_symbol_table(); ROSE_ASSERT(st != NULL);
+                      SgVariableSymbol * tmp_sym  = new SgVariableSymbol(*it);
+                      st->insert((*it)->get_name(), tmp_sym);
                   }
-                }
+      */
+      SgFunctionDefinition *function_definition =
+          sg_function_decl->get_definition();
 
-                // Handle FunctionDecl body
-                if (auto *fd = llvm::dyn_cast<clang::FunctionDecl>(d)) {
-                  if (fd->hasBody())
-                    recursive_invalidate_stmt(fd->getBody());
-                }
-                // Handle VarDecl init
-                if (auto *vd = llvm::dyn_cast<clang::VarDecl>(d)) {
-                  if (vd->getInit())
-                    recursive_invalidate_stmt(vd->getInit());
-                }
-              };
+      // P1 Badge Fix: Recursive Cache Invalidation.
+      // We must invalidate the cache for the body statements and
+      // declarations BEFORE potentially deleting the existing body AST.
+      // This prevents Use-After-Free (accessing deleted nodes parents)
+      // and ensures we don't reuse "stolen" nodes from templates. We
+      // erase unconditionally because we are about to rebuild the body
+      // for this definition.
 
-              recursive_invalidate_stmt = [&](clang::Stmt *s) {
-                if (!s)
-                  return;
-                auto it = p_stmt_translation_map.find(s);
-                if (it != p_stmt_translation_map.end()) {
-                  p_stmt_translation_map.erase(it);
-                }
+      clang::Stmt *body_stmt = function_decl->getBody();
+      if (body_stmt) {
+        std::function<void(clang::Decl *)> recursive_invalidate_decl;
+        std::function<void(clang::Stmt *)> recursive_invalidate_stmt;
 
-                // Handle DeclStmt specifically to descend into Decls
-                if (auto *ds = llvm::dyn_cast<clang::DeclStmt>(s)) {
-                  for (auto *d : ds->decls()) {
-                    recursive_invalidate_decl(d);
-                  }
-                }
+        recursive_invalidate_decl = [&](clang::Decl *d) {
+          if (!d)
+            return;
+          auto it = p_decl_translation_map.find(d);
+          if (it != p_decl_translation_map.end()) {
+            p_decl_translation_map.erase(it);
+          }
 
-                // Handle Stmt children
-                for (auto *child : s->children()) {
-                  recursive_invalidate_stmt(child);
-                }
-              };
-
-              recursive_invalidate_stmt(body_stmt);
+          // Recurse into DeclContext (e.g. structs)
+          if (auto *ctx = llvm::dyn_cast<clang::DeclContext>(d)) {
+            for (auto *child : ctx->decls()) {
+              recursive_invalidate_decl(child);
             }
+          }
 
-            if (sg_function_decl->get_definition()->get_body() != NULL)
-              SageInterface::deleteAST(
-                  sg_function_decl->get_definition()->get_body());
+          // Handle FunctionDecl body
+          if (auto *fd = llvm::dyn_cast<clang::FunctionDecl>(d)) {
+            if (fd->hasBody())
+              recursive_invalidate_stmt(fd->getBody());
+          }
+          // Handle VarDecl init
+          if (auto *vd = llvm::dyn_cast<clang::VarDecl>(d)) {
+            if (vd->getInit())
+              recursive_invalidate_stmt(vd->getInit());
+          }
+        };
 
-            SageBuilder::pushScopeStack(function_definition);
+        recursive_invalidate_stmt = [&](clang::Stmt *s) {
+          if (!s)
+            return;
+          auto it = p_stmt_translation_map.find(s);
+          if (it != p_stmt_translation_map.end()) {
+            p_stmt_translation_map.erase(it);
+          }
 
-            SgNode * tmp_body = Traverse(function_decl->getBody());
-            SgBasicBlock * body = isSgBasicBlock(tmp_body);
-
-            SageBuilder::popScopeStack();
-
-            if (body == NULL && tmp_body != NULL) {
-              std::cerr << "Traverse(function_decl->getBody()) returned a "
-                           "non-SgBasicBlock node: "
-                        << tmp_body->class_name() << std::endl;
-              res = false;
+          // Handle DeclStmt specifically to descend into Decls
+          if (auto *ds = llvm::dyn_cast<clang::DeclStmt>(s)) {
+            for (auto *d : ds->decls()) {
+              recursive_invalidate_decl(d);
             }
-            if (body != NULL) {
-              // DQ (11/24/2020): This fails for test2020_00.C (in C_tests).
-              // It seems that even though function_definition was used to set
-              // the scope in the connection to the body, that the body's parent
-              // is set to NULL. ROSE_ASSERT(body->get_parent() ==
-              // function_definition);
-              if (body->get_parent() != function_definition) {
+          }
+
+          // Handle Stmt children
+          for (auto *child : s->children()) {
+            recursive_invalidate_stmt(child);
+          }
+        };
+
+        recursive_invalidate_stmt(body_stmt);
+      }
+
+      if (sg_function_decl->get_definition()->get_body() != NULL)
+        SageInterface::deleteAST(
+            sg_function_decl->get_definition()->get_body());
+
+      SageBuilder::pushScopeStack(function_definition);
+
+      SgNode *tmp_body = Traverse(function_decl->getBody());
+      SgBasicBlock *body = isSgBasicBlock(tmp_body);
+
+      SageBuilder::popScopeStack();
+
+      if (body == NULL && tmp_body != NULL) {
+        std::cerr << "Traverse(function_decl->getBody()) returned a "
+                     "non-SgBasicBlock node: "
+                  << tmp_body->class_name() << std::endl;
+        res = false;
+      }
+      if (body != NULL) {
+        // DQ (11/24/2020): This fails for test2020_00.C (in C_tests).
+        // It seems that even though function_definition was used to set
+        // the scope in the connection to the body, that the body's parent
+        // is set to NULL. ROSE_ASSERT(body->get_parent() ==
+        // function_definition);
+        if (body->get_parent() != function_definition) {
 #if 0
                       printf ("In visitFunctionDecl(): resetting the body parent to function_definition = %p = %s \n",
                            function_definition,function_definition->class_name().c_str());
 #endif
-                body->set_parent(function_definition);
-              }
-              ROSE_ASSERT(body->get_parent() == function_definition);
-            }
-
-            function_definition->set_body(body);
-            if (body) {
-                body->set_parent(function_definition);
-            }
-            applySourceRange(function_definition,
-                             function_decl->getSourceRange());
-
-            sg_function_decl->set_definition(function_definition);
-            function_definition->set_parent(sg_function_decl);
-
-            // P1 Badge Fix: Ensure consistency of the function symbol after
-            // potential re-translation. If the symbol was created but lost its
-            // declaration link (or points to NULL), fix it. Also, if the symbol
-            // is MISSING (e.g. friend function not added to scope correctly),
-            // create it. This prevents assertions in backend unparsing
-            // (nameQualificationSupport).
-            if (sg_function_decl) {
-              SgFunctionSymbol *sym = isSgFunctionSymbol(
-                  sg_function_decl->get_symbol_from_symbol_table());
-              if (sym == NULL) {
-                // Create missing symbol
-                SgScopeStatement *scope = sg_function_decl->get_scope();
-                if (scope) {
-                  sym = new SgFunctionSymbol(sg_function_decl);
-                  scope->insert_symbol(sg_function_decl->get_name(), sym);
-                }
-              }
-
-              if (sym && sym->get_declaration() == NULL) {
-                sym->set_declaration(sg_function_decl);
-              }
-            }
+          body->set_parent(function_definition);
         }
-        else {
-            // Function declaration without body (e.g., template function in header, forward declaration)
-            // This is normal for template functions and should not cause an error
-            // The get_definition() will return NULL, which is expected
-        }
-/*
-        SgFunctionDeclaration * first_decl;
-        if (function_decl->isFirstDecl()) {
-            SgFunctionParameterList * param_list_ = SageBuilder::buildFunctionParameterList_nfi();
-              setCompilerGeneratedFileInfo(param_list_);
-            SgInitializedNamePtrList & init_names = param_list->get_args();
-            SgInitializedNamePtrList::iterator it;
-            for (it = init_names.begin(); it != init_names.end(); it++) {
-                SgInitializedName * init_param = new SgInitializedName(**it);
-                setCompilerGeneratedFileInfo(init_param);
-                param_list_->append_arg(init_param);
-            }
+        ROSE_ASSERT(body->get_parent() == function_definition);
+      }
 
-            first_decl = SageBuilder::buildNondefiningFunctionDeclaration(name, ret_type, param_list_, NULL);
-//            first_decl = SageBuilder::buildNondefiningFunctionDeclaration(sg_function_decl, NULL,  NULL);
-            setCompilerGeneratedFileInfo(first_decl);
-            first_decl->set_parent(SageBuilder::topScopeStack());
-            first_decl->set_firstNondefiningDeclaration(first_decl);
-            if (function_decl->isVariadic()) first_decl->hasEllipses();
-        }
-        else {
-            SgSymbol * tmp_symbol = GetSymbolFromSymbolTable(function_decl->getFirstDecl());
-            SgFunctionSymbol * symbol = isSgFunctionSymbol(tmp_symbol);
-            if (tmp_symbol != NULL && symbol == NULL) {
-                std::cerr << "Runtime error: tmp_symbol != NULL && symbol == NULL" << std::endl;
-                res = false;
-            }
-            if (symbol != NULL)
-                first_decl = isSgFunctionDeclaration(symbol->get_declaration());
+      function_definition->set_body(body);
+      if (body) {
+        body->set_parent(function_definition);
+      }
+      applySourceRange(function_definition, function_decl->getSourceRange());
+
+      sg_function_decl->set_definition(function_definition);
+      function_definition->set_parent(sg_function_decl);
+
+      // P1 Badge Fix: Ensure consistency of the function symbol after
+      // potential re-translation. If the symbol was created but lost its
+      // declaration link (or points to NULL), fix it. Also, if the symbol
+      // is MISSING (e.g. friend function not added to scope correctly),
+      // create it. This prevents assertions in backend unparsing
+      // (nameQualificationSupport).
+      if (sg_function_decl) {
+        SgFunctionSymbol *sym = isSgFunctionSymbol(
+            sg_function_decl->get_symbol_from_symbol_table());
+        if (sym == NULL) {
+          // Create missing symbol
+          SgScopeStatement *scope = sg_function_decl->get_scope();
+          if (scope) {
+            sym = new SgFunctionSymbol(sg_function_decl);
+            scope->insert_symbol(sg_function_decl->get_name(), sym);
+          }
         }
 
-        sg_function_decl->set_firstNondefiningDeclaration(first_decl);
-        first_decl->set_definingDeclaration(sg_function_decl);
-*/ 
-        // Pei-Hung (06/27/22) This seems to be the way to get test2004_21.c unprarsed properly
-        // by checking if the functionProtoType has different argument types.
-
-        if(diffInProtoType)
-        {
-            sg_function_decl->set_parameterList_syntax(param_list);
-            sg_function_decl->set_type_syntax_is_available(true);
-            sg_function_decl->set_oldStyleDefinition(true);
+        if (sym && sym->get_declaration() == NULL) {
+          sym->set_declaration(sg_function_decl);
         }
+      }
+    } else {
+      // Function declaration without body (e.g., template function in header,
+      // forward declaration) This is normal for template functions and should
+      // not cause an error The get_definition() will return NULL, which is
+      // expected
     }
-    else {
-        if (templateDecl) {
-             sg_function_decl = SageBuilder::buildNondefiningTemplateFunctionDeclaration(name, ret_type, param_list, proper_scope, NULL, templateParams);
-             
-             // Set parameter list parent
-             param_list->set_parent(sg_function_decl);
-             sg_function_decl->set_parameterList(param_list);
-        } else {
-             sg_function_decl = SageBuilder::buildNondefiningFunctionDeclaration(name, ret_type, param_list, proper_scope, NULL, false, NULL, SgStorageModifier::e_default, isFriendFreeFunction);
-        }
+    /*
+            SgFunctionDeclaration * first_decl;
+            if (function_decl->isFirstDecl()) {
+                SgFunctionParameterList * param_list_ =
+    SageBuilder::buildFunctionParameterList_nfi();
+                  setCompilerGeneratedFileInfo(param_list_);
+                SgInitializedNamePtrList & init_names = param_list->get_args();
+                SgInitializedNamePtrList::iterator it;
+                for (it = init_names.begin(); it != init_names.end(); it++) {
+                    SgInitializedName * init_param = new
+    SgInitializedName(**it); setCompilerGeneratedFileInfo(init_param);
+                    param_list_->append_arg(init_param);
+                }
 
-        if (function_decl->isVariadic()) sg_function_decl->hasEllipses();
-
-        SgInitializedNamePtrList & init_names = param_list->get_args();
-        SgInitializedNamePtrList::iterator it;
-        for (it = init_names.begin(); it != init_names.end(); it++) {
-             (*it)->set_scope(SageBuilder::topScopeStack());
-             // CLANG FRONTEND FIX: Set declptr for function parameters
-             (*it)->set_declptr(sg_function_decl);
-        }
-
-        if (function_decl->getFirstDecl() != function_decl) {
-            SgSymbol * tmp_symbol = GetSymbolFromSymbolTable(function_decl->getFirstDecl());
-            SgFunctionSymbol * symbol = isSgFunctionSymbol(tmp_symbol);
-            if (tmp_symbol != NULL && symbol == NULL) {
-                std::cerr << "Runtime error: tmp_symbol != NULL && symbol == NULL" << std::endl;
-                res = false;
-            }
-            SgFunctionDeclaration * first_decl = NULL;
-            if (symbol != NULL) {
-                first_decl = isSgFunctionDeclaration(symbol->get_declaration());
+                first_decl =
+    SageBuilder::buildNondefiningFunctionDeclaration(name, ret_type,
+    param_list_, NULL);
+    //            first_decl =
+    SageBuilder::buildNondefiningFunctionDeclaration(sg_function_decl, NULL,
+    NULL); setCompilerGeneratedFileInfo(first_decl);
+                first_decl->set_parent(SageBuilder::topScopeStack());
+                first_decl->set_firstNondefiningDeclaration(first_decl);
+                if (function_decl->isVariadic()) first_decl->hasEllipses();
             }
             else {
-                // FIXME Is it correct?
-                SgNode * tmp_first_decl = Traverse(function_decl->getFirstDecl());
-                first_decl = isSgFunctionDeclaration(tmp_first_decl);
-                ROSE_ASSERT(first_decl != NULL);
-                // ROSE_ASSERT(!"We should have see the first declaration already");
-            }
-
-            if (first_decl != NULL) {
-                // CLANG FRONTEND FIX: Only set firstNondefiningDeclaration if variant types match
-                // to avoid assertion failure when mixing SgFunctionDeclaration with SgMemberFunctionDeclaration
-                if (first_decl->variantT() == sg_function_decl->variantT()) {
-                    if (first_decl->get_firstNondefiningDeclaration() != NULL)
-                        sg_function_decl->set_firstNondefiningDeclaration(first_decl->get_firstNondefiningDeclaration());
-                    else {
-                        ROSE_ASSERT(first_decl->get_firstNondefiningDeclaration() != NULL);
-                    }
-                } else {
-                    // Variant types don't match - this can happen with member functions
-                    // Just set to self to avoid assertion
-                    sg_function_decl->set_firstNondefiningDeclaration(sg_function_decl);
+                SgSymbol * tmp_symbol =
+    GetSymbolFromSymbolTable(function_decl->getFirstDecl()); SgFunctionSymbol *
+    symbol = isSgFunctionSymbol(tmp_symbol); if (tmp_symbol != NULL && symbol ==
+    NULL) { std::cerr << "Runtime error: tmp_symbol != NULL && symbol == NULL"
+    << std::endl; res = false;
                 }
+                if (symbol != NULL)
+                    first_decl =
+    isSgFunctionDeclaration(symbol->get_declaration());
             }
-            else {
-              // REX FIX: Do not assert yet, retry with explicit lookup
-              // ROSE_ASSERT(!"First declaration not found!");
-            }
-        }
-        else {
-            sg_function_decl->set_firstNondefiningDeclaration(sg_function_decl);
-        }
+
+            sg_function_decl->set_firstNondefiningDeclaration(first_decl);
+            first_decl->set_definingDeclaration(sg_function_decl);
+    */
+    // Pei-Hung (06/27/22) This seems to be the way to get test2004_21.c
+    // unprarsed properly by checking if the functionProtoType has different
+    // argument types.
+
+    if (diffInProtoType) {
+      sg_function_decl->set_parameterList_syntax(param_list);
+      sg_function_decl->set_type_syntax_is_available(true);
+      sg_function_decl->set_oldStyleDefinition(true);
+    }
+  } else {
+    if (templateDecl) {
+      sg_function_decl =
+          SageBuilder::buildNondefiningTemplateFunctionDeclaration(
+              name, ret_type, param_list, proper_scope, NULL, templateParams);
+
+      // Set parameter list parent
+      param_list->set_parent(sg_function_decl);
+      sg_function_decl->set_parameterList(param_list);
+    } else {
+      sg_function_decl = SageBuilder::buildNondefiningFunctionDeclaration(
+          name, ret_type, param_list, proper_scope, NULL, false, NULL,
+          SgStorageModifier::e_default, isFriendFreeFunction);
     }
 
-    sg_function_decl->set_declarationScope(declScope);
-    declScope->set_parent(sg_function_decl);
+    if (function_decl->isVariadic())
+      sg_function_decl->hasEllipses();
 
-    if (is_builtin_decl) {
-        auto mark_compgen = [this](SgLocatedNode* n) {
-            if (n != NULL) {
-                setCompilerGeneratedFileInfo(n);
-                n->set_isModified(false);
-                if (Sg_File_Info* fi = n->get_file_info()) fi->unsetOutputInCodeGeneration();
-                if (Sg_File_Info* fi = n->get_startOfConstruct()) fi->unsetOutputInCodeGeneration();
-                if (Sg_File_Info* fi = n->get_endOfConstruct()) fi->unsetOutputInCodeGeneration();
-            }
-        };
-
-        mark_compgen(sg_function_decl);
-        mark_compgen(sg_function_decl->get_firstNondefiningDeclaration());
-        mark_compgen(sg_function_decl->get_parameterList());
-
-        SgInitializedNamePtrList& builtin_params = sg_function_decl->get_parameterList()->get_args();
-        for (SgInitializedName* param : builtin_params) {
-            mark_compgen(param);
-        }
-
-        if (SgFunctionDefinition* def = sg_function_decl->get_definition()) {
-            mark_compgen(def);
-            mark_compgen(def->get_body());
-        }
+    SgInitializedNamePtrList &init_names = param_list->get_args();
+    SgInitializedNamePtrList::iterator it;
+    for (it = init_names.begin(); it != init_names.end(); it++) {
+      (*it)->set_scope(SageBuilder::topScopeStack());
+      // CLANG FRONTEND FIX: Set declptr for function parameters
+      (*it)->set_declptr(sg_function_decl);
     }
 
-    // REX FIX: Handle AS_none for FunctionDecl to avoid unparser assertion
-    clang::AccessSpecifier access = function_decl->getAccess();
+    if (function_decl->getFirstDecl() != function_decl) {
+      SgSymbol *tmp_symbol =
+          GetSymbolFromSymbolTable(function_decl->getFirstDecl());
+      SgFunctionSymbol *symbol = isSgFunctionSymbol(tmp_symbol);
+      if (tmp_symbol != NULL && symbol == NULL) {
+        std::cerr << "Runtime error: tmp_symbol != NULL && symbol == NULL"
+                  << std::endl;
+        res = false;
+      }
+      SgFunctionDeclaration *first_decl = NULL;
+      if (symbol != NULL) {
+        first_decl = isSgFunctionDeclaration(symbol->get_declaration());
+      } else {
+        // FIXME Is it correct?
+        SgNode *tmp_first_decl = Traverse(function_decl->getFirstDecl());
+        first_decl = isSgFunctionDeclaration(tmp_first_decl);
+        ROSE_ASSERT(first_decl != NULL);
+        // ROSE_ASSERT(!"We should have see the first declaration already");
+      }
 
-    if (name.getString() == "foo") {
-    }
-
-    SgDeclarationStatement *target_decl = sg_function_decl;
-    if (access == clang::AS_public) {
-      target_decl->get_declarationModifier().get_accessModifier().setPublic();
-    } else if (access == clang::AS_private) {
-      target_decl->get_declarationModifier().get_accessModifier().setPrivate();
-    } else if (access == clang::AS_protected) {
-      target_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setProtected();
-    } else if (access == clang::AS_none) {
-      if (isSgClassDefinition(proper_scope)) {
-        SgClassDefinition *class_def = isSgClassDefinition(proper_scope);
-        if (class_def->get_declaration()->get_class_type() ==
-            SgClassDeclaration::e_class) {
-          target_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPrivate();
+      if (first_decl != NULL) {
+        // CLANG FRONTEND FIX: Only set firstNondefiningDeclaration if variant
+        // types match to avoid assertion failure when mixing
+        // SgFunctionDeclaration with SgMemberFunctionDeclaration
+        if (first_decl->variantT() == sg_function_decl->variantT()) {
+          if (first_decl->get_firstNondefiningDeclaration() != NULL)
+            sg_function_decl->set_firstNondefiningDeclaration(
+                first_decl->get_firstNondefiningDeclaration());
+          else {
+            ROSE_ASSERT(first_decl->get_firstNondefiningDeclaration() != NULL);
+          }
         } else {
-          target_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPublic();
+          // Variant types don't match - this can happen with member functions
+          // Just set to self to avoid assertion
+          sg_function_decl->set_firstNondefiningDeclaration(sg_function_decl);
         }
       } else {
-        // REX FIX: For global or namespace scope, set to public to satisfy
-        // unparser assertion (info.isUnsetAccess() == false)
+        // REX FIX: Do not assert yet, retry with explicit lookup
+        // ROSE_ASSERT(!"First declaration not found!");
+      }
+    } else {
+      sg_function_decl->set_firstNondefiningDeclaration(sg_function_decl);
+    }
+  }
+
+  sg_function_decl->set_declarationScope(declScope);
+  declScope->set_parent(sg_function_decl);
+
+  if (is_builtin_decl) {
+    auto mark_compgen = [this](SgLocatedNode *n) {
+      if (n != NULL) {
+        setCompilerGeneratedFileInfo(n);
+        n->set_isModified(false);
+        if (Sg_File_Info *fi = n->get_file_info())
+          fi->unsetOutputInCodeGeneration();
+        if (Sg_File_Info *fi = n->get_startOfConstruct())
+          fi->unsetOutputInCodeGeneration();
+        if (Sg_File_Info *fi = n->get_endOfConstruct())
+          fi->unsetOutputInCodeGeneration();
+      }
+    };
+
+    mark_compgen(sg_function_decl);
+    mark_compgen(sg_function_decl->get_firstNondefiningDeclaration());
+    mark_compgen(sg_function_decl->get_parameterList());
+
+    SgInitializedNamePtrList &builtin_params =
+        sg_function_decl->get_parameterList()->get_args();
+    for (SgInitializedName *param : builtin_params) {
+      mark_compgen(param);
+    }
+
+    if (SgFunctionDefinition *def = sg_function_decl->get_definition()) {
+      mark_compgen(def);
+      mark_compgen(def->get_body());
+    }
+  }
+
+  // REX FIX: Handle AS_none for FunctionDecl to avoid unparser assertion
+  clang::AccessSpecifier access = function_decl->getAccess();
+
+  if (name.getString() == "foo") {
+  }
+
+  SgDeclarationStatement *target_decl = sg_function_decl;
+  if (access == clang::AS_public) {
+    target_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    target_decl->get_declarationModifier().get_accessModifier().setPrivate();
+  } else if (access == clang::AS_protected) {
+    target_decl->get_declarationModifier().get_accessModifier().setProtected();
+  } else if (access == clang::AS_none) {
+    if (isSgClassDefinition(proper_scope)) {
+      SgClassDefinition *class_def = isSgClassDefinition(proper_scope);
+      if (class_def->get_declaration()->get_class_type() ==
+          SgClassDeclaration::e_class) {
+        target_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPrivate();
+      } else {
         target_decl->get_declarationModifier().get_accessModifier().setPublic();
       }
+    } else {
+      // REX FIX: For global or namespace scope, set to public to satisfy
+      // unparser assertion (info.isUnsetAccess() == false)
+      target_decl->get_declarationModifier().get_accessModifier().setPublic();
     }
+  }
 
-    ROSE_ASSERT(sg_function_decl->get_firstNondefiningDeclaration() != NULL);
-/* // TODO Fix problem with function symbols...
-    SgSymbol * symbol = GetSymbolFromSymbolTable(function_decl);
-    if (symbol == NULL) {
-        SgFunctionSymbol * func_sym = new SgFunctionSymbol(isSgFunctionDeclaration(sg_function_decl->get_firstNondefiningDeclaration()));
-        SageBuilder::topScopeStack()->insert_symbol(name, func_sym);        
-    }
-*/
-//  ROSE_ASSERT(GetSymbolFromSymbolTable(function_decl) != NULL);
+  ROSE_ASSERT(sg_function_decl->get_firstNondefiningDeclaration() != NULL);
+  /* // TODO Fix problem with function symbols...
+      SgSymbol * symbol = GetSymbolFromSymbolTable(function_decl);
+      if (symbol == NULL) {
+          SgFunctionSymbol * func_sym = new
+     SgFunctionSymbol(isSgFunctionDeclaration(sg_function_decl->get_firstNondefiningDeclaration()));
+          SageBuilder::topScopeStack()->insert_symbol(name, func_sym);
+      }
+  */
+  //  ROSE_ASSERT(GetSymbolFromSymbolTable(function_decl) != NULL);
 
-    // Pei-Hung (06/16/22) added "extern" modifier
-    bool hasExternalStorage = function_decl->isLocalExternDecl();
-    if(hasExternalStorage)
-    {
-      sg_function_decl->get_declarationModifier().get_storageModifier().setExtern();
-    }
+  // Pei-Hung (06/16/22) added "extern" modifier
+  bool hasExternalStorage = function_decl->isLocalExternDecl();
+  if (hasExternalStorage) {
+    sg_function_decl->get_declarationModifier()
+        .get_storageModifier()
+        .setExtern();
+  }
 
-    // CLANG FRONTEND FIX: Set friend modifier for friend functions
-    // Friend functions are free functions (not members) with special access rights
-    if (isFriendFunction) {
-        sg_function_decl->get_declarationModifier().setFriend();
-    }
+  // CLANG FRONTEND FIX: Set friend modifier for friend functions
+  // Friend functions are free functions (not members) with special access
+  // rights
+  if (isFriendFunction) {
+    sg_function_decl->get_declarationModifier().setFriend();
+  }
 
-    // Friend declarations written inside a class are still free functions. Keep them
-    // in the lexical class for syntactic correctness but ensure they remain visible
-    // from the enclosing namespace/global scope.
-    if (isFriendFreeFunction && lexical_friend_enclosing_scope != NULL) {
-        SgFunctionDeclaration* symbol_decl = isSgFunctionDeclaration(sg_function_decl->get_firstNondefiningDeclaration());
-        if (symbol_decl == NULL) symbol_decl = sg_function_decl;
+  // Friend declarations written inside a class are still free functions. Keep
+  // them in the lexical class for syntactic correctness but ensure they remain
+  // visible from the enclosing namespace/global scope.
+  if (isFriendFreeFunction && lexical_friend_enclosing_scope != NULL) {
+    SgFunctionDeclaration *symbol_decl = isSgFunctionDeclaration(
+        sg_function_decl->get_firstNondefiningDeclaration());
+    if (symbol_decl == NULL)
+      symbol_decl = sg_function_decl;
 
-        // REX FIX: If scope is already correct (e.g. handled during
-        // construction), skip symbol patching to avoid type mismatches (e.g.
-        // replacing SgTemplateSymbol with SgFunctionSymbol). This is critical
-        // for friend templates where SageBuilder created the correct
-        // SgTemplateSymbol.
-        if (symbol_decl != NULL &&
-            symbol_decl->get_scope() != lexical_friend_enclosing_scope) {
-          SgFunctionSymbol *friend_symbol = NULL;
-          if (SgSymbol *class_symbol =
-                  symbol_decl->search_for_symbol_from_symbol_table()) {
-            if (SgFunctionSymbol *class_func_sym =
-                    isSgFunctionSymbol(class_symbol)) {
-              if (SgScopeStatement *class_scope = class_func_sym->get_scope()) {
-                class_scope->remove_symbol(class_func_sym);
-              }
-              // Do not reuse the class-owned symbol to avoid stale scope
-              // metadata; build a fresh one below.
-              friend_symbol = NULL;
-            }
+    // REX FIX: If scope is already correct (e.g. handled during
+    // construction), skip symbol patching to avoid type mismatches (e.g.
+    // replacing SgTemplateSymbol with SgFunctionSymbol). This is critical
+    // for friend templates where SageBuilder created the correct
+    // SgTemplateSymbol.
+    if (symbol_decl != NULL &&
+        symbol_decl->get_scope() != lexical_friend_enclosing_scope) {
+      SgFunctionSymbol *friend_symbol = NULL;
+      if (SgSymbol *class_symbol =
+              symbol_decl->search_for_symbol_from_symbol_table()) {
+        if (SgFunctionSymbol *class_func_sym =
+                isSgFunctionSymbol(class_symbol)) {
+          if (SgScopeStatement *class_scope = class_func_sym->get_scope()) {
+            class_scope->remove_symbol(class_func_sym);
           }
+          // Do not reuse the class-owned symbol to avoid stale scope
+          // metadata; build a fresh one below.
+          friend_symbol = NULL;
+        }
+      }
 
-          SgType *symbol_type = symbol_decl->get_type();
-          if (symbol_type != NULL) {
-            SgFunctionSymbol *existing_sym =
-                lexical_friend_enclosing_scope->lookup_function_symbol(
-                    symbol_decl->get_name(), symbol_type);
-            if (existing_sym == NULL) {
-              if (friend_symbol == NULL) {
-                friend_symbol = new SgFunctionSymbol(symbol_decl);
-              }
-              lexical_friend_enclosing_scope->insert_symbol(
-                  symbol_decl->get_name(), friend_symbol);
-              if (SgSymbolTable *ns_table =
-                      lexical_friend_enclosing_scope->get_symbol_table()) {
-                friend_symbol->set_parent(ns_table);
-              }
-            }
+      SgType *symbol_type = symbol_decl->get_type();
+      if (symbol_type != NULL) {
+        SgFunctionSymbol *existing_sym =
+            lexical_friend_enclosing_scope->lookup_function_symbol(
+                symbol_decl->get_name(), symbol_type);
+        if (existing_sym == NULL) {
+          if (friend_symbol == NULL) {
+            friend_symbol = new SgFunctionSymbol(symbol_decl);
+          }
+          lexical_friend_enclosing_scope->insert_symbol(symbol_decl->get_name(),
+                                                        friend_symbol);
+          if (SgSymbolTable *ns_table =
+                  lexical_friend_enclosing_scope->get_symbol_table()) {
+            friend_symbol->set_parent(ns_table);
           }
         }
+      }
     }
+  }
 
-    // ROOT CAUSE FIX: Set access modifiers for member functions from Clang AST
-    if (llvm::isa<clang::CXXMethodDecl>(function_decl)) {
-        clang::CXXMethodDecl* method_decl = llvm::cast<clang::CXXMethodDecl>(function_decl);
-        clang::AccessSpecifier access = method_decl->getAccess();
-        if (access == clang::AS_public) {
-            sg_function_decl->get_declarationModifier().get_accessModifier().setPublic();
-        } else if (access == clang::AS_private) {
-            sg_function_decl->get_declarationModifier().get_accessModifier().setPrivate();
-        } else if (access == clang::AS_protected) {
-            sg_function_decl->get_declarationModifier().get_accessModifier().setProtected();
-        }
+  // ROOT CAUSE FIX: Set access modifiers for member functions from Clang AST
+  if (llvm::isa<clang::CXXMethodDecl>(function_decl)) {
+    clang::CXXMethodDecl *method_decl =
+        llvm::cast<clang::CXXMethodDecl>(function_decl);
+    clang::AccessSpecifier access = method_decl->getAccess();
+    if (access == clang::AS_public) {
+      sg_function_decl->get_declarationModifier()
+          .get_accessModifier()
+          .setPublic();
+    } else if (access == clang::AS_private) {
+      sg_function_decl->get_declarationModifier()
+          .get_accessModifier()
+          .setPrivate();
+    } else if (access == clang::AS_protected) {
+      sg_function_decl->get_declarationModifier()
+          .get_accessModifier()
+          .setProtected();
     }
+  }
 
-    // CLANG FRONTEND FIX #21: Mark constructors, destructors, and conversion operators
-    // with special function modifiers so unparser handles them correctly
-    if (SgMemberFunctionDeclaration* member_func = isSgMemberFunctionDeclaration(sg_function_decl)) {
-        if (llvm::isa<clang::CXXConstructorDecl>(function_decl)) {
-            member_func->get_specialFunctionModifier().setConstructor();
-        } else if (llvm::isa<clang::CXXDestructorDecl>(function_decl)) {
-            member_func->get_specialFunctionModifier().setDestructor();
-        } else if (llvm::isa<clang::CXXConversionDecl>(function_decl)) {
-            member_func->get_specialFunctionModifier().setConversion();
-        }
+  // CLANG FRONTEND FIX #21: Mark constructors, destructors, and conversion
+  // operators with special function modifiers so unparser handles them
+  // correctly
+  if (SgMemberFunctionDeclaration *member_func =
+          isSgMemberFunctionDeclaration(sg_function_decl)) {
+    if (llvm::isa<clang::CXXConstructorDecl>(function_decl)) {
+      member_func->get_specialFunctionModifier().setConstructor();
+    } else if (llvm::isa<clang::CXXDestructorDecl>(function_decl)) {
+      member_func->get_specialFunctionModifier().setDestructor();
+    } else if (llvm::isa<clang::CXXConversionDecl>(function_decl)) {
+      member_func->get_specialFunctionModifier().setConversion();
     }
+  }
 
-    // REX FIX: Always require global qualification for template instantiations
-    // This ensures that the unparser prints "::" (e.g. "::std::sort")
-    // which prevents ambiguity when global templates are shadowed.
-    if (function_decl->getTemplateSpecializationKind() != clang::TSK_Undeclared) {
-        sg_function_decl->set_global_qualification_required(true);
-    }
+  // REX FIX: Always require global qualification for template instantiations
+  // This ensures that the unparser prints "::" (e.g. "::std::sort")
+  // which prevents ambiguity when global templates are shadowed.
+  if (function_decl->getTemplateSpecializationKind() != clang::TSK_Undeclared) {
+    sg_function_decl->set_global_qualification_required(true);
+  }
 
-    *node = sg_function_decl;
+  *node = sg_function_decl;
 
-    return VisitDeclaratorDecl(function_decl, node) && res;
+  return VisitDeclaratorDecl(function_decl, node) && res;
 }
 
 bool ClangToSageTranslator::VisitFunctionDecl(
@@ -5168,810 +5533,898 @@ bool ClangToSageTranslator::VisitFunctionDecl(
       function_decl, function_decl->getDescribedFunctionTemplate(), node);
 }
 
-bool ClangToSageTranslator::VisitCXXDeductionGuideDecl(clang::CXXDeductionGuideDecl * cxx_deduction_guide_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXDeductionGuideDecl(
+    clang::CXXDeductionGuideDecl *cxx_deduction_guide_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXDeductionGuideDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXDeductionGuideDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO: Full C++17 deduction guide support not yet implemented
-    // For now, delegate to FunctionDecl handler for basic processing
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // TODO: Full C++17 deduction guide support not yet implemented
+  // For now, delegate to FunctionDecl handler for basic processing
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitFunctionDecl(cxx_deduction_guide_decl, node) && res;
+  return VisitFunctionDecl(cxx_deduction_guide_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXMethodDecl(clang::CXXMethodDecl * cxx_method_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXMethodDecl(
+    clang::CXXMethodDecl *cxx_method_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXMethodDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXMethodDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // CXXMethodDecl represents member functions in C++ classes
-    // For now, treat them like regular functions - this is incomplete but allows progress
-    // TODO: Properly handle member function context, this pointer, virtual methods, etc.
+  // CXXMethodDecl represents member functions in C++ classes
+  // For now, treat them like regular functions - this is incomplete but allows
+  // progress
+  // TODO: Properly handle member function context, this pointer, virtual
+  // methods, etc.
 
-    return VisitFunctionDecl(cxx_method_decl, node) && res;
+  return VisitFunctionDecl(cxx_method_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXConstructorDecl(clang::CXXConstructorDecl * cxx_constructor_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXConstructorDecl(
+    clang::CXXConstructorDecl *cxx_constructor_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXConstructorDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXConstructorDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow constructors to be processed via CXXMethodDecl
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow constructors to be processed via CXXMethodDecl
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitCXXMethodDecl(cxx_constructor_decl, node) && res;
+  return VisitCXXMethodDecl(cxx_constructor_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXConversionDecl(clang::CXXConversionDecl * cxx_conversion_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXConversionDecl(
+    clang::CXXConversionDecl *cxx_conversion_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXConversionDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXConversionDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitCXXMethodDecl(cxx_conversion_decl, node) && res;
+  return VisitCXXMethodDecl(cxx_conversion_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXDestructorDecl(clang::CXXDestructorDecl * cxx_destructor_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXDestructorDecl(
+    clang::CXXDestructorDecl *cxx_destructor_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitCXXDestructorDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXDestructorDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitCXXMethodDecl(cxx_destructor_decl, node) && res;
+  return VisitCXXMethodDecl(cxx_destructor_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitMSPropertyDecl(clang::MSPropertyDecl * ms_property_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitMSPropertyDecl(
+    clang::MSPropertyDecl *ms_property_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitMSPropertyDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitMSPropertyDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDeclaratorDecl(ms_property_decl, node) && res;
+  return VisitDeclaratorDecl(ms_property_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitNonTypeTemplateParmDecl(clang::NonTypeTemplateParmDecl * non_type_template_param_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitNonTypeTemplateParmDecl(
+    clang::NonTypeTemplateParmDecl *non_type_template_param_decl,
+    SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitNonTypeTemplateParmDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitNonTypeTemplateParmDecl"
+            << std::endl;
 #endif
 
-    SgDeclarationStatement* owning_template = NULL;
-    if (clang::DeclContext* ctx = non_type_template_param_decl->getDeclContext()) {
-        if (clang::TemplateDecl* template_ctx = llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
-            auto it = p_decl_translation_map.find(template_ctx);
-            if (it != p_decl_translation_map.end()) {
-                owning_template = isSgDeclarationStatement(it->second);
-            }
-        }
+  SgDeclarationStatement *owning_template = NULL;
+  if (clang::DeclContext *ctx =
+          non_type_template_param_decl->getDeclContext()) {
+    if (clang::TemplateDecl *template_ctx =
+            llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
+      auto it = p_decl_translation_map.find(template_ctx);
+      if (it != p_decl_translation_map.end()) {
+        owning_template = isSgDeclarationStatement(it->second);
+      }
     }
+  }
 
-    unsigned position = non_type_template_param_decl->getIndex();
-    SgTemplateParameter* sg_param =
-        translateTemplateParameter(non_type_template_param_decl, owning_template, position);
+  unsigned position = non_type_template_param_decl->getIndex();
+  SgTemplateParameter *sg_param = translateTemplateParameter(
+      non_type_template_param_decl, owning_template, position);
 
-    *node = sg_param;
-    return sg_param != NULL;
+  *node = sg_param;
+  return sg_param != NULL;
 }
 
-bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl * var_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
+                                         SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitVarDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitVarDecl" << std::endl;
 #endif
-    // std::cerr << "DEBUG: VisitVarDecl for " << var_decl->getNameAsString() << std::endl;
-    if (var_decl->getNameAsString() == "pack") {
-        // std::cerr << "DEBUG: VisitVarDecl for pack. Type: " << var_decl->getType().getAsString() << std::endl;
-    }
-    bool res = true;
+  // std::cerr << "DEBUG: VisitVarDecl for " << var_decl->getNameAsString() <<
+  // std::endl;
+  if (var_decl->getNameAsString() == "pack") {
+    // std::cerr << "DEBUG: VisitVarDecl for pack. Type: " <<
+    // var_decl->getType().getAsString() << std::endl;
+  }
+  bool res = true;
 
   // Create the SAGE node: SgVariableDeclaration
 
-    SgName name(var_decl->getNameAsString());
+  SgName name(var_decl->getNameAsString());
 
-    clang::QualType varQualType = var_decl->getType();
+  clang::QualType varQualType = var_decl->getType();
 
-    const clang::Type* varType = varQualType.getTypePtr();
+  const clang::Type *varType = varQualType.getTypePtr();
 
 #if DEBUG_VISIT_DECL
-    // Wrap debug output in conditional to prevent production output
-    if (name.getString() == "x") {
-        // std::cerr << "DEBUG VarDecl: Variable 'x' has type class = " << varType->getTypeClassName() << std::endl;
-    }
+  // Wrap debug output in conditional to prevent production output
+  if (name.getString() == "x") {
+    // std::cerr << "DEBUG VarDecl: Variable 'x' has type class = " <<
+    // varType->getTypeClassName() << std::endl;
+  }
 #endif
 
-    // Pei-Hung (06/01/2022) check if the declaration is considered embedded in Clang AST.
-    // If it is embedded, no explicit SgDeclaration should be placed for ROSE AST.
-    bool isembedded = false;
-    bool iscompleteDefined = false;
+  // Pei-Hung (06/01/2022) check if the declaration is considered embedded in
+  // Clang AST. If it is embedded, no explicit SgDeclaration should be placed
+  // for ROSE AST.
+  bool isembedded = false;
+  bool iscompleteDefined = false;
 
-    // Adding check for EaboratedType and PointerType to retrieve base EnumType
-    //while((varType->getTypeClass() == clang::Type::Elaborated) || (varType->getTypeClass() == clang::Type::Pointer) || (varType->getTypeClass() == clang::Type::Array))
-    while((llvm::isa<clang::ElaboratedType>(varType)) || (llvm::isa<clang::PointerType>(varType)) || (llvm::isa<clang::ArrayType>(varType)))
-    {
-       if(llvm::isa<clang::ElaboratedType>(varType))
-       {
-         varQualType = ((clang::ElaboratedType *)varType)->getNamedType();
-       }
-       else if(llvm::isa<clang::PointerType>(varType))
-       {
-         varQualType = ((clang::PointerType *)varType)->getPointeeType();
-       }
-       else if(llvm::isa<clang::ArrayType>(varType))
-       {
-         varQualType = ((clang::ArrayType *)varType)->getElementType();
-       }
-       varType = varQualType.getTypePtr();
+  // Adding check for EaboratedType and PointerType to retrieve base EnumType
+  // while((varType->getTypeClass() == clang::Type::Elaborated) ||
+  // (varType->getTypeClass() == clang::Type::Pointer) ||
+  // (varType->getTypeClass() == clang::Type::Array))
+  while ((llvm::isa<clang::ElaboratedType>(varType)) ||
+         (llvm::isa<clang::PointerType>(varType)) ||
+         (llvm::isa<clang::ArrayType>(varType))) {
+    if (llvm::isa<clang::ElaboratedType>(varType)) {
+      varQualType = ((clang::ElaboratedType *)varType)->getNamedType();
+    } else if (llvm::isa<clang::PointerType>(varType)) {
+      varQualType = ((clang::PointerType *)varType)->getPointeeType();
+    } else if (llvm::isa<clang::ArrayType>(varType)) {
+      varQualType = ((clang::ArrayType *)varType)->getElementType();
+    }
+    varType = varQualType.getTypePtr();
+  }
+
+  if (llvm::isa<clang::EnumType>(varType)) {
+    clang::EnumType *underlyingEnumType = (clang::EnumType *)varType;
+    clang::EnumDecl *enumDeclaration = underlyingEnumType->getDecl();
+    isembedded = enumDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = enumDeclaration->isCompleteDefinition();
+  }
+
+  if (llvm::isa<clang::RecordType>(varType)) {
+    clang::RecordType *underlyingRecordType = (clang::RecordType *)varType;
+    clang::RecordDecl *recordDeclaration = underlyingRecordType->getDecl();
+    isembedded = recordDeclaration->isEmbeddedInDeclarator();
+    iscompleteDefined = recordDeclaration->isCompleteDefinition();
+  }
+
+  SgType *sg_varType = buildTypeFromQualifiedType(varQualType);
+  SgType *type = buildTypeFromQualifiedType(var_decl->getType());
+
+  //    SgVariableDeclaration * sg_var_decl = new SgVariableDeclaration(name,
+  //    type, init); // scope: obtain from the scope stack.
+  // Pei-Hung (09/01/2022) In test2022_3.c, the variable symbol needs to be
+  // avaiable before processing the RHS. calling buildVariableDeclaration_nfi to
+  // get the symbol in place.
+  SgVariableDeclaration *sg_var_decl =
+      SageBuilder::buildVariableDeclaration_nfi(name, type, NULL,
+                                                SageBuilder::topScopeStack());
+
+  // CLANG FRONTEND FIX: Check if variable has an initializer before traversing
+  clang::Expr *init_expr = var_decl->getInit();
+  SgExpression *expr = NULL;
+  SgExprListExp *expr_list_expr = NULL;
+
+  if (init_expr != NULL) {
+    SgNode *tmp_init = Traverse(init_expr);
+    expr = isSgExpression(tmp_init);
+    if (tmp_init != NULL && expr == NULL) {
+      std::cerr << "Runtime error: not a SgInitializer..." << std::endl; // TODO
+      res = false;
+    }
+    expr_list_expr = isSgExprListExp(expr);
+  }
+
+  SgInitializer *init = NULL;
+  if (expr_list_expr != NULL)
+    init = SageBuilder::buildAggregateInitializer(expr_list_expr, type);
+  else if (expr != NULL) {
+    // CLANG FRONTEND FIX: Check if expr is already an initializer (e.g.,
+    // SgConstructorInitializer) If so, use it directly instead of wrapping it
+    // in SgAssignInitializer This preserves constructor syntax: std::string
+    // str("hello") instead of std::string str = ("hello")
+    SgInitializer *existing_init = isSgInitializer(expr);
+    if (existing_init != NULL) {
+      // Expression is already an initializer (e.g., from CXXConstructExpr)
+      // Use it directly without wrapping
+      init = existing_init;
+    } else {
+      // Expression is not an initializer, wrap it in SgAssignInitializer
+      // This handles cases like: int x = 5;
+      init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
+    }
+  }
+
+  // Pei-Hung (09/01/2022) setup initializer once the RHS is processed.
+  // CLANG FRONTEND FIX: Only set initializer if it's not NULL
+  if (init != NULL) {
+    sg_var_decl->reset_initializer(init);
+  }
+
+  // CLANG FRONTEND FIX: Set initializer parent AFTER reset_initializer
+  // reset_initializer sets the parent of the initializer to the
+  // SgInitializedName, not the SgVariableDeclaration. Setting it to sg_var_decl
+  // here was wrong. Only apply source range if we have both the initializer and
+  // the original expression
+  if (init != NULL && init_expr != NULL) {
+    applySourceRange(init, init_expr->getSourceRange());
+  }
+
+  // finding the bottom base type and check
+  while (type->findBaseType() != type) {
+    type = type->findBaseType();
+    if (type == sg_varType)
+      break;
+  }
+
+  if (isSgClassType(type) && iscompleteDefined) {
+    SgClassDeclaration *classDecl =
+        isSgClassDeclaration(isSgClassType(type)->get_declaration());
+    SgClassDeclaration *classDefDecl = isSgClassDeclaration(
+        isSgClassType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && classDefDecl != nullptr &&
+        !isSgDeclarationStatement(classDefDecl->get_parent())) {
+      classDefDecl->set_parent(sg_var_decl);
+      classDefDecl->set_isAutonomousDeclaration(false);
+      sg_var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
+      sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
     }
 
-    if(llvm::isa<clang::EnumType>(varType))
-    {
-       clang::EnumType* underlyingEnumType = (clang::EnumType*)varType;
-       clang::EnumDecl* enumDeclaration = underlyingEnumType->getDecl();
-       isembedded = enumDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = enumDeclaration->isCompleteDefinition();
+    std::map<SgClassType *, bool>::iterator bool_it =
+        p_class_type_decl_first_see_in_type.find(isSgClassType(type));
+    ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
+    if (bool_it->second) {
+      sg_var_decl->set_baseTypeDefiningDeclaration(
+          isSgNamedType(type)->get_declaration()->get_definingDeclaration());
+      sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
+      bool_it->second = false;
+    }
+  } else if (isSgEnumType(type) && iscompleteDefined) {
+    SgEnumDeclaration *enumDecl =
+        isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
+    SgEnumDeclaration *enumDefDecl = isSgEnumDeclaration(
+        isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+    if (isembedded && enumDefDecl != nullptr &&
+        !isSgDeclarationStatement(enumDefDecl->get_parent())) {
+      enumDefDecl->set_parent(sg_var_decl);
+      enumDefDecl->set_isAutonomousDeclaration(false);
+      sg_var_decl->set_baseTypeDefiningDeclaration(enumDefDecl);
+      sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
     }
 
-    if(llvm::isa<clang::RecordType>(varType))
-    {
-       clang::RecordType* underlyingRecordType = (clang::RecordType*)varType;
-       clang::RecordDecl* recordDeclaration = underlyingRecordType->getDecl();
-       isembedded = recordDeclaration->isEmbeddedInDeclarator();
-       iscompleteDefined = recordDeclaration->isCompleteDefinition();
+    std::map<SgEnumType *, bool>::iterator bool_it =
+        p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
+    ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
+    if (bool_it->second) {
+      sg_var_decl->set_baseTypeDefiningDeclaration(
+          isSgEnumType(type)->get_declaration()->get_definingDeclaration());
+      sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
+      bool_it->second = false;
     }
+  }
 
-    SgType * sg_varType = buildTypeFromQualifiedType(varQualType);
-    SgType * type = buildTypeFromQualifiedType(var_decl->getType());
+  sg_var_decl->set_firstNondefiningDeclaration(sg_var_decl);
+  sg_var_decl->set_parent(SageBuilder::topScopeStack());
 
-//    SgVariableDeclaration * sg_var_decl = new SgVariableDeclaration(name, type, init); // scope: obtain from the scope stack.
-   // Pei-Hung (09/01/2022) In test2022_3.c, the variable symbol needs to be avaiable before processing the RHS.
-   // calling buildVariableDeclaration_nfi to get the symbol in place.
-   SgVariableDeclaration * sg_var_decl = SageBuilder::buildVariableDeclaration_nfi(name,type, NULL ,SageBuilder::topScopeStack());
-
-   // CLANG FRONTEND FIX: Check if variable has an initializer before traversing
-   clang::Expr * init_expr = var_decl->getInit();
-    SgExpression * expr = NULL;
-    SgExprListExp * expr_list_expr = NULL;
-
-    if (init_expr != NULL) {
-        SgNode * tmp_init = Traverse(init_expr);
-        expr = isSgExpression(tmp_init);
-        if (tmp_init != NULL && expr == NULL) {
-            std::cerr << "Runtime error: not a SgInitializer..." << std::endl; // TODO
-            res = false;
-        }
-        expr_list_expr = isSgExprListExp(expr);
-    }
-
-    SgInitializer * init = NULL;
-    if (expr_list_expr != NULL)
-        init = SageBuilder::buildAggregateInitializer(expr_list_expr, type);
-    else if (expr != NULL)
-    {
-        // CLANG FRONTEND FIX: Check if expr is already an initializer (e.g., SgConstructorInitializer)
-        // If so, use it directly instead of wrapping it in SgAssignInitializer
-        // This preserves constructor syntax: std::string str("hello") instead of std::string str = ("hello")
-        SgInitializer* existing_init = isSgInitializer(expr);
-        if (existing_init != NULL) {
-            // Expression is already an initializer (e.g., from CXXConstructExpr)
-            // Use it directly without wrapping
-            init = existing_init;
-        } else {
-            // Expression is not an initializer, wrap it in SgAssignInitializer
-            // This handles cases like: int x = 5;
-            init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
-        }
-    }
-
-    // Pei-Hung (09/01/2022) setup initializer once the RHS is processed.
-    // CLANG FRONTEND FIX: Only set initializer if it's not NULL
-    if (init != NULL) {
-        sg_var_decl->reset_initializer(init);
-    }
-
-    // CLANG FRONTEND FIX: Set initializer parent AFTER reset_initializer
-    // reset_initializer sets the parent of the initializer to the SgInitializedName,
-    // not the SgVariableDeclaration. Setting it to sg_var_decl here was wrong.
-    // Only apply source range if we have both the initializer and the original expression
-    if (init != NULL && init_expr != NULL)
-    {
-        applySourceRange(init, init_expr->getSourceRange());
-    }
-
-    // finding the bottom base type and check
-    while(type->findBaseType() != type)
-    {
-      type = type->findBaseType();
-      if(type == sg_varType)
-        break;
-    }
-
-    if (isSgClassType(type) && iscompleteDefined) {
-        SgClassDeclaration* classDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration());
-        SgClassDeclaration* classDefDecl = isSgClassDeclaration(isSgClassType(type)->get_declaration()->get_definingDeclaration());
-        if(isembedded && classDefDecl != nullptr && !isSgDeclarationStatement(classDefDecl->get_parent()))
-        {
-          classDefDecl->set_parent(sg_var_decl);
-          classDefDecl->set_isAutonomousDeclaration(false);
-          sg_var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
-          sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-        }
-
-        std::map<SgClassType *, bool>::iterator bool_it = p_class_type_decl_first_see_in_type.find(isSgClassType(type));
-        ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
-        if (bool_it->second) {
-            sg_var_decl->set_baseTypeDefiningDeclaration(isSgNamedType(type)->get_declaration()->get_definingDeclaration());
-            sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-            bool_it->second = false;
-        }
-    }
-    else if (isSgEnumType(type) && iscompleteDefined) {
-        SgEnumDeclaration* enumDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration());
-        SgEnumDeclaration* enumDefDecl = isSgEnumDeclaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-        if(isembedded && enumDefDecl != nullptr && !isSgDeclarationStatement(enumDefDecl->get_parent()))
-        {
-          enumDefDecl->set_parent(sg_var_decl);
-          enumDefDecl->set_isAutonomousDeclaration(false);
-          sg_var_decl->set_baseTypeDefiningDeclaration(enumDefDecl);
-          sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-        }
-
-        std::map<SgEnumType *, bool>::iterator bool_it = p_enum_type_decl_first_see_in_type.find(isSgEnumType(type));
-        ROSE_ASSERT(bool_it != p_enum_type_decl_first_see_in_type.end());
-        if (bool_it->second) {
-            sg_var_decl->set_baseTypeDefiningDeclaration(isSgEnumType(type)->get_declaration()->get_definingDeclaration());
-            sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-            bool_it->second = false;
-        }
-    }
-
-    sg_var_decl->set_firstNondefiningDeclaration(sg_var_decl);
-    sg_var_decl->set_parent(SageBuilder::topScopeStack());
-
-    // REX FIX: Handle AS_none for VarDecl to avoid unparser assertion
-    clang::AccessSpecifier access = var_decl->getAccess();
-    if (access == clang::AS_public) {
-      sg_var_decl->get_declarationModifier().get_accessModifier().setPublic();
-    } else if (access == clang::AS_private) {
-      sg_var_decl->get_declarationModifier().get_accessModifier().setPrivate();
-    } else if (access == clang::AS_protected) {
-      sg_var_decl->get_declarationModifier()
-          .get_accessModifier()
-          .setProtected();
-    } else if (access == clang::AS_none) {
-      if (isSgClassDefinition(SageBuilder::topScopeStack())) {
-        SgClassDefinition *class_def =
-            isSgClassDefinition(SageBuilder::topScopeStack());
-        if (class_def->get_declaration()->get_class_type() ==
-            SgClassDeclaration::e_class) {
-          sg_var_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPrivate();
-        } else {
-          sg_var_decl->get_declarationModifier()
-              .get_accessModifier()
-              .setPublic();
-        }
+  // REX FIX: Handle AS_none for VarDecl to avoid unparser assertion
+  clang::AccessSpecifier access = var_decl->getAccess();
+  if (access == clang::AS_public) {
+    sg_var_decl->get_declarationModifier().get_accessModifier().setPublic();
+  } else if (access == clang::AS_private) {
+    sg_var_decl->get_declarationModifier().get_accessModifier().setPrivate();
+  } else if (access == clang::AS_protected) {
+    sg_var_decl->get_declarationModifier().get_accessModifier().setProtected();
+  } else if (access == clang::AS_none) {
+    if (isSgClassDefinition(SageBuilder::topScopeStack())) {
+      SgClassDefinition *class_def =
+          isSgClassDefinition(SageBuilder::topScopeStack());
+      if (class_def->get_declaration()->get_class_type() ==
+          SgClassDeclaration::e_class) {
+        sg_var_decl->get_declarationModifier()
+            .get_accessModifier()
+            .setPrivate();
       } else {
         sg_var_decl->get_declarationModifier().get_accessModifier().setPublic();
       }
+    } else {
+      sg_var_decl->get_declarationModifier().get_accessModifier().setPublic();
     }
+  }
 
-    ROSE_ASSERT(sg_var_decl->get_variables().size() == 1);
+  ROSE_ASSERT(sg_var_decl->get_variables().size() == 1);
 
-    SgInitializedName * init_name = sg_var_decl->get_variables()[0];
-    ROSE_ASSERT(init_name != NULL);
-    init_name->set_scope(SageBuilder::topScopeStack());
+  SgInitializedName *init_name = sg_var_decl->get_variables()[0];
+  ROSE_ASSERT(init_name != NULL);
+  init_name->set_scope(SageBuilder::topScopeStack());
 
-    // CLANG FRONTEND FIX: Set initializer parent to SgInitializedName
-    // The initializer is a child of the SgInitializedName, not the SgVariableDeclaration
-    if (init != NULL) {
-        init->set_parent(init_name);
+  // CLANG FRONTEND FIX: Set initializer parent to SgInitializedName
+  // The initializer is a child of the SgInitializedName, not the
+  // SgVariableDeclaration
+  if (init != NULL) {
+    init->set_parent(init_name);
+  }
+
+  applySourceRange(init_name, var_decl->getSourceRange());
+
+  // CLANG FRONTEND FIX: The declptr should already be set by
+  // SgVariableDeclaration constructor to point to the SgVariableDefinition. If
+  // it's null, we need to check why.
+  SgVariableDefinition *var_def =
+      isSgVariableDefinition(init_name->get_declptr());
+  if (var_def == NULL) {
+    // If declptr is null, try to get it from the variable declaration
+    // buildVariableDeclaration_nfi should have created a definition
+    var_def = sg_var_decl->get_definition();
+    if (var_def != NULL) {
+      init_name->set_declptr(var_def);
+    } else {
+      // Debug: why is var_def null?
+      printf("ERROR: Variable definition is null for variable: %s\n",
+             init_name->get_name().str());
+      printf("  sg_var_decl = %p\n", sg_var_decl);
+      printf("  init_name = %p\n", init_name);
+      printf("  init_name->get_declptr() = %p\n", init_name->get_declptr());
+      fflush(stdout);
     }
+  }
+  ROSE_ASSERT(var_def != NULL);
+  applySourceRange(var_def, var_decl->getSourceRange());
 
-    applySourceRange(init_name, var_decl->getSourceRange());
+  // Pei-Hung (06/16/22) added "extern" modifier
+  bool hasExternalStorage = var_decl->hasExternalStorage();
+  if (hasExternalStorage) {
+    sg_var_decl->get_declarationModifier().get_storageModifier().setExtern();
+  }
 
-    // CLANG FRONTEND FIX: The declptr should already be set by SgVariableDeclaration constructor
-    // to point to the SgVariableDefinition. If it's null, we need to check why.
-    SgVariableDefinition * var_def = isSgVariableDefinition(init_name->get_declptr());
-    if (var_def == NULL) {
-        // If declptr is null, try to get it from the variable declaration
-        // buildVariableDeclaration_nfi should have created a definition
-        var_def = sg_var_decl->get_definition();
-        if (var_def != NULL) {
-            init_name->set_declptr(var_def);
-        } else {
-            // Debug: why is var_def null?
-            printf("ERROR: Variable definition is null for variable: %s\n", init_name->get_name().str());
-            printf("  sg_var_decl = %p\n", sg_var_decl);
-            printf("  init_name = %p\n", init_name);
-            printf("  init_name->get_declptr() = %p\n", init_name->get_declptr());
-            fflush(stdout);
-        }
-    }
-    ROSE_ASSERT(var_def != NULL);
-    applySourceRange(var_def, var_decl->getSourceRange());
+  // Pei-Hung (06/16/22) added "static" modifier
+  bool isStaticDecl = var_decl->isStaticLocal();
+  if (isStaticDecl) {
+    sg_var_decl->get_declarationModifier().get_storageModifier().setStatic();
+  }
 
-    // Pei-Hung (06/16/22) added "extern" modifier
-    bool hasExternalStorage = var_decl->hasExternalStorage();
-    if(hasExternalStorage)
-    {
-      sg_var_decl->get_declarationModifier().get_storageModifier().setExtern();
-    }
+  if (!isembedded) {
+    sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+        false);
+  }
 
-    // Pei-Hung (06/16/22) added "static" modifier
-    bool isStaticDecl = var_decl->isStaticLocal();
-    if(isStaticDecl)
-    {
-      sg_var_decl->get_declarationModifier().get_storageModifier().setStatic();
-    }
+  *node = sg_var_decl;
 
-    if (!isembedded) {
-        sg_var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(false);
-    }
-
-    *node = sg_var_decl;
-
-    return VisitDeclaratorDecl(var_decl, node) && res;
+  return VisitDeclaratorDecl(var_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDecompositionDecl(clang::DecompositionDecl * decomposition_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitDecompositionDecl(
+    clang::DecompositionDecl *decomposition_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitDecompositionDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDecompositionDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitVarDecl(decomposition_decl, node) && res;
+  return VisitVarDecl(decomposition_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitImplicitParamDecl(clang::ImplicitParamDecl * implicit_param_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitImplicitParamDecl(
+    clang::ImplicitParamDecl *implicit_param_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitImplicitParamDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitImplicitParamDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitVarDecl(implicit_param_decl, node) && res;
+  return VisitVarDecl(implicit_param_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPCaptureExprDecl(clang::OMPCapturedExprDecl * omp_capture_expr_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPCaptureExprDecl(
+    clang::OMPCapturedExprDecl *omp_capture_expr_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPCaptureExprDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPCaptureExprDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitVarDecl(omp_capture_expr_decl, node) && res;
+  return VisitVarDecl(omp_capture_expr_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl * param_var_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
+                                             SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitParmVarDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitParmVarDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    SgName name(param_var_decl->getNameAsString());
+  SgName name(param_var_decl->getNameAsString());
 
-    // use getOriginalType instead of getType.  This type has to match the DecayedType when VLA is used in parameter
-    SgType * type = buildTypeFromQualifiedType(param_var_decl->getOriginalType());
+  // use getOriginalType instead of getType.  This type has to match the
+  // DecayedType when VLA is used in parameter
+  SgType *type = buildTypeFromQualifiedType(param_var_decl->getOriginalType());
 
-    SgInitializer * init = NULL;
+  SgInitializer *init = NULL;
 
-    if (param_var_decl->hasDefaultArg()) {
-        SgNode * tmp_expr = Traverse(param_var_decl->getDefaultArg());
-        SgExpression * expr = isSgExpression(tmp_expr);
-        // ROOT CAUSE FIX: Check that expr is not NULL before using it
-        // The conversion from tmp_expr to expr can fail, leaving expr == NULL
-        if (tmp_expr != NULL && expr == NULL) {
-            std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
-            res = false;
-        }
-        else if (expr != NULL) {
-            applySourceRange(expr, param_var_decl->getDefaultArgRange());
-            init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
-            applySourceRange(init, param_var_decl->getDefaultArgRange());
-        }
+  if (param_var_decl->hasDefaultArg()) {
+    SgNode *tmp_expr = Traverse(param_var_decl->getDefaultArg());
+    SgExpression *expr = isSgExpression(tmp_expr);
+    // ROOT CAUSE FIX: Check that expr is not NULL before using it
+    // The conversion from tmp_expr to expr can fail, leaving expr == NULL
+    if (tmp_expr != NULL && expr == NULL) {
+      std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL"
+                << std::endl;
+      res = false;
+    } else if (expr != NULL) {
+      applySourceRange(expr, param_var_decl->getDefaultArgRange());
+      init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
+      applySourceRange(init, param_var_decl->getDefaultArgRange());
     }
+  }
 
-    SgInitializedName* param_init_name = SageBuilder::buildInitializedName(name, type, init);
-    if (param_var_decl->isParameterPack()) {
-      param_init_name->set_is_parameter_pack(true);
-      param_init_name->set_is_pack_element(true);
-      if (SgTemplateType *template_type = isSgTemplateType(type)) {
-        template_type->set_packed(true);
+  SgInitializedName *param_init_name =
+      SageBuilder::buildInitializedName(name, type, init);
+  if (param_var_decl->isParameterPack()) {
+    param_init_name->set_is_parameter_pack(true);
+    param_init_name->set_is_pack_element(true);
+    if (SgTemplateType *template_type = isSgTemplateType(type)) {
+      template_type->set_packed(true);
+    }
+  }
+  // Set scope and parent to avoid unparser assertion - function declaration
+  // builder will adjust this later
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+  param_init_name->set_scope(scope);
+  param_init_name->set_parent(scope);
+  *node = param_init_name;
+
+  return VisitDeclaratorDecl(param_var_decl, node) && res;
+}
+
+bool ClangToSageTranslator::VisitVarTemplateSpecializationDecl(
+    clang::VarTemplateSpecializationDecl *var_template_specialization_decl,
+    SgNode **node) {
+#if DEBUG_VISIT_DECL
+  std::cerr << "ClangToSageTranslator::VisitVarTemplateSpecializationDecl"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: Variable template specializations (e.g., template<> int
+  // x<int> = 5;) Treat them as regular variable declarations since SAGE doesn't
+  // have specific support for variable templates yet
+
+  // Get variable name and type
+  SgName name(var_template_specialization_decl->getNameAsString());
+  clang::QualType qual_type = var_template_specialization_decl->getType();
+  SgType *type = buildTypeFromQualifiedType(qual_type);
+
+  // Get initializer if present
+  SgInitializer *init = NULL;
+  if (var_template_specialization_decl->hasInit()) {
+    clang::Expr *init_expr = var_template_specialization_decl->getInit();
+    if (init_expr != NULL) {
+      SgNode *tmp_node = Traverse(init_expr);
+      SgExpression *sg_init_expr = isSgExpression(tmp_node);
+      if (sg_init_expr != NULL) {
+        init = SageBuilder::buildAssignInitializer(sg_init_expr, type);
       }
     }
-    // Set scope and parent to avoid unparser assertion - function declaration builder will adjust this later
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-    param_init_name->set_scope(scope);
-    param_init_name->set_parent(scope);
-    *node = param_init_name;
+  }
 
-    return VisitDeclaratorDecl(param_var_decl, node) && res;
+  // Build variable declaration
+  SgVariableDeclaration *var_decl =
+      SageBuilder::buildVariableDeclaration(name, type, init, NULL);
+
+  *node = var_decl;
+
+  return VisitDeclaratorDecl(var_template_specialization_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitVarTemplateSpecializationDecl(clang::VarTemplateSpecializationDecl * var_template_specialization_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitVarTemplatePartialSpecializationDecl(
+    clang::VarTemplatePartialSpecializationDecl
+        *var_template_partial_specialization_decl,
+    SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitVarTemplateSpecializationDecl" << std::endl;
+  std::cerr
+      << "ClangToSageTranslator::VisitVarTemplatePartialSpecializationDecl"
+      << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Variable template specializations (e.g., template<> int x<int> = 5;)
-    // Treat them as regular variable declarations since SAGE doesn't have specific support
-    // for variable templates yet
+  // TODO: Full variable template partial specialization support not yet
+  // implemented For now, delegate to VarTemplateSpecializationDecl handler This
+  // allows basic processing of variable template partial specializations
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    // Get variable name and type
-    SgName name(var_template_specialization_decl->getNameAsString());
-    clang::QualType qual_type = var_template_specialization_decl->getType();
-    SgType* type = buildTypeFromQualifiedType(qual_type);
-
-    // Get initializer if present
-    SgInitializer* init = NULL;
-    if (var_template_specialization_decl->hasInit()) {
-        clang::Expr* init_expr = var_template_specialization_decl->getInit();
-        if (init_expr != NULL) {
-            SgNode* tmp_node = Traverse(init_expr);
-            SgExpression* sg_init_expr = isSgExpression(tmp_node);
-            if (sg_init_expr != NULL) {
-                init = SageBuilder::buildAssignInitializer(sg_init_expr, type);
-            }
-        }
-    }
-
-    // Build variable declaration
-    SgVariableDeclaration* var_decl = SageBuilder::buildVariableDeclaration(name, type, init, NULL);
-
-    *node = var_decl;
-
-    return VisitDeclaratorDecl(var_template_specialization_decl, node) && res;
+  return VisitVarTemplateSpecializationDecl(
+             var_template_partial_specialization_decl, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitVarTemplatePartialSpecializationDecl(clang::VarTemplatePartialSpecializationDecl * var_template_partial_specialization_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitEnumConstantDecl(
+    clang::EnumConstantDecl *enum_constant_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitVarTemplatePartialSpecializationDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitEnumConstantDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO: Full variable template partial specialization support not yet implemented
-    // For now, delegate to VarTemplateSpecializationDecl handler
-    // This allows basic processing of variable template partial specializations
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // Safely get the name - check if the declaration name is valid first
+  SgName name;
+  if (enum_constant_decl && enum_constant_decl->getDeclName().isIdentifier()) {
+    name = SgName(enum_constant_decl->getNameAsString());
+  } else {
+    // Fallback to empty name if declaration name is not a simple identifier
+    name = SgName("");
+  }
 
-    return VisitVarTemplateSpecializationDecl(var_template_partial_specialization_decl, node) && res;
-}
+  // CRITICAL: Create a placeholder node and add to translation map BEFORE
+  // visiting the type This prevents infinite recursion when VisitEnumType ->
+  // VisitEnumDecl tries to visit this constant again Use int type as
+  // placeholder since buildInitializedName requires non-null type
+  SgInitializedName *init_name_placeholder = SageBuilder::buildInitializedName(
+      name, SageBuilder::buildIntType(), nullptr);
+  p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(
+      enum_constant_decl, init_name_placeholder));
 
-bool  ClangToSageTranslator::VisitEnumConstantDecl(clang::EnumConstantDecl * enum_constant_decl, SgNode ** node) {
-#if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitEnumConstantDecl" << std::endl;
-#endif
-    bool res = true;
+  // Get the enum constant's type - this should be the enum type itself, not the
+  // underlying integer type This is critical for type safety, especially for
+  // scoped enums (enum class) where the enumerator must have the enum type, not
+  // int
+  SgType *type = buildTypeFromQualifiedType(enum_constant_decl->getType());
 
-    // Safely get the name - check if the declaration name is valid first
-    SgName name;
-    if (enum_constant_decl && enum_constant_decl->getDeclName().isIdentifier()) {
-        name = SgName(enum_constant_decl->getNameAsString());
+  // Update the placeholder with the actual type
+  init_name_placeholder->set_type(type);
+
+  SgInitializer *init = NULL;
+
+  if (enum_constant_decl->getInitExpr() != NULL) {
+    SgNode *tmp_expr = Traverse(enum_constant_decl->getInitExpr());
+    SgExpression *expr = isSgExpression(tmp_expr);
+    if (tmp_expr != NULL && expr == NULL) {
+      std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL"
+                << std::endl;
+      res = false;
     } else {
-        // Fallback to empty name if declaration name is not a simple identifier
-        name = SgName("");
+      init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
     }
+  }
 
-    // CRITICAL: Create a placeholder node and add to translation map BEFORE visiting the type
-    // This prevents infinite recursion when VisitEnumType -> VisitEnumDecl tries to visit this constant again
-    // Use int type as placeholder since buildInitializedName requires non-null type
-    SgInitializedName * init_name_placeholder = SageBuilder::buildInitializedName(name, SageBuilder::buildIntType(), nullptr);
-    p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(enum_constant_decl, init_name_placeholder));
+  // Update the placeholder with the initializer
+  init_name_placeholder->set_initializer(init);
 
-    // Get the enum constant's type - this should be the enum type itself, not the underlying integer type
-    // This is critical for type safety, especially for scoped enums (enum class)
-    // where the enumerator must have the enum type, not int
-    SgType * type = buildTypeFromQualifiedType(enum_constant_decl->getType());
+  // Use the placeholder as the final node (no need to create a new one)
+  SgInitializedName *init_name = init_name_placeholder;
 
-    // Update the placeholder with the actual type
-    init_name_placeholder->set_type(type);
+  SgEnumFieldSymbol *symbol = new SgEnumFieldSymbol(init_name);
 
-    SgInitializer * init = NULL;
+  // Set scope and parent before inserting symbol
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+  init_name->set_scope(scope);
+  init_name->set_parent(scope);
 
-    if (enum_constant_decl->getInitExpr() != NULL) {
-        SgNode * tmp_expr = Traverse(enum_constant_decl->getInitExpr());
-        SgExpression * expr = isSgExpression(tmp_expr);
-        if (tmp_expr != NULL && expr == NULL) {
-            std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
-            res = false;
-        }
-        else {
-            init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
-        }
-    }
+  // CLANG FRONTEND FIX: declptr will be set in VisitEnumDecl after appending
+  // the enumerator (we can't set it here because the enum declaration hasn't
+  // been added to translation map yet)
 
-    // Update the placeholder with the initializer
-    init_name_placeholder->set_initializer(init);
+  scope->insert_symbol(name, symbol);
 
-    // Use the placeholder as the final node (no need to create a new one)
-    SgInitializedName * init_name = init_name_placeholder;
+  *node = init_name;
 
-    SgEnumFieldSymbol * symbol = new SgEnumFieldSymbol(init_name);
-
-    // Set scope and parent before inserting symbol
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-    init_name->set_scope(scope);
-    init_name->set_parent(scope);
-
-    // CLANG FRONTEND FIX: declptr will be set in VisitEnumDecl after appending the enumerator
-    // (we can't set it here because the enum declaration hasn't been added to translation map yet)
-
-    scope->insert_symbol(name, symbol);
-
-    *node = init_name;
-
-    return VisitValueDecl(enum_constant_decl, node) && res;
+  return VisitValueDecl(enum_constant_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitIndirectFieldDecl(clang::IndirectFieldDecl * indirect_field_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitIndirectFieldDecl(
+    clang::IndirectFieldDecl *indirect_field_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitIndirectFieldDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitIndirectFieldDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitValueDecl(indirect_field_decl, node) && res;
+  return VisitValueDecl(indirect_field_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPDeclareMapperDecl(clang::OMPDeclareMapperDecl * omp_declare_mapper_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDeclareMapperDecl(
+    clang::OMPDeclareMapperDecl *omp_declare_mapper_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPDeclareMapperDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPDeclareMapperDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitValueDecl(omp_declare_mapper_decl, node) && res;
+  return VisitValueDecl(omp_declare_mapper_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPDeclareReductionDecl(clang::OMPDeclareReductionDecl * omp_declare_reduction_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDeclareReductionDecl(
+    clang::OMPDeclareReductionDecl *omp_declare_reduction_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPDeclareReductionDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPDeclareReductionDecl"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitValueDecl(omp_declare_reduction_decl, node) && res;
+  return VisitValueDecl(omp_declare_reduction_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(clang::UnresolvedUsingValueDecl * unresolved_using_value_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
+    clang::UnresolvedUsingValueDecl *unresolved_using_value_decl,
+    SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitUnresolvedUsingValueDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUnresolvedUsingValueDecl"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Build a using declaration statement to represent the dependent value.
-    // There is no resolved target yet, so capture the name with an unknown type.
-    std::string name_str = unresolved_using_value_decl->getNameAsString();
-    SgType* unknown_type = SageBuilder::buildUnknownType();
-    SgInitializedName* init_name = SageBuilder::buildInitializedName(SgName(name_str), unknown_type);
-    init_name->set_scope(SageBuilder::topScopeStack());
+  // Build a using declaration statement to represent the dependent value.
+  // There is no resolved target yet, so capture the name with an unknown type.
+  std::string name_str = unresolved_using_value_decl->getNameAsString();
+  SgType *unknown_type = SageBuilder::buildUnknownType();
+  SgInitializedName *init_name =
+      SageBuilder::buildInitializedName(SgName(name_str), unknown_type);
+  init_name->set_scope(SageBuilder::topScopeStack());
 
-    SgUsingDeclarationStatement* using_stmt = new SgUsingDeclarationStatement(NULL, init_name);
-    init_name->set_parent(using_stmt);
-    using_stmt->set_definingDeclaration(using_stmt);
-    using_stmt->set_firstNondefiningDeclaration(using_stmt);
+  SgUsingDeclarationStatement *using_stmt =
+      new SgUsingDeclarationStatement(NULL, init_name);
+  init_name->set_parent(using_stmt);
+  using_stmt->set_definingDeclaration(using_stmt);
+  using_stmt->set_firstNondefiningDeclaration(using_stmt);
 
-    SgScopeStatement *current_scope = SageBuilder::topScopeStack();
-    if (current_scope != NULL) {
-      using_stmt->set_scope(current_scope);
-      using_stmt->set_parent(current_scope);
-    }
-    diagnose_null_scope(using_stmt, "UnresolvedUsingValueDecl");
+  SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+  if (current_scope != NULL) {
+    using_stmt->set_scope(current_scope);
+    using_stmt->set_parent(current_scope);
+  }
+  diagnose_null_scope(using_stmt, "UnresolvedUsingValueDecl");
 
-    *node = using_stmt;
+  *node = using_stmt;
 
-    return VisitValueDecl(unresolved_using_value_decl, node) && res;
+  return VisitValueDecl(unresolved_using_value_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPAllocateDecl(clang::OMPAllocateDecl * omp_allocate_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPAllocateDecl(
+    clang::OMPAllocateDecl *omp_allocate_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPAllocateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPAllocateDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(omp_allocate_decl, node) && res;
+  return VisitDecl(omp_allocate_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPRequiresDecl(clang::OMPRequiresDecl * omp_requires_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPRequiresDecl(
+    clang::OMPRequiresDecl *omp_requires_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPRequiresDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPRequiresDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(omp_requires_decl, node) && res;
+  return VisitDecl(omp_requires_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPThreadPrivateDecl(clang::OMPThreadPrivateDecl * omp_thread_private_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPThreadPrivateDecl(
+    clang::OMPThreadPrivateDecl *omp_thread_private_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitOMPThreadPrivateDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPThreadPrivateDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(omp_thread_private_decl, node) && res;
+  return VisitDecl(omp_thread_private_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitPragmaCommentDecl(clang::PragmaCommentDecl * pragma_comment_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitPragmaCommentDecl(
+    clang::PragmaCommentDecl *pragma_comment_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitPragmaCommentDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitPragmaCommentDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(pragma_comment_decl, node) && res;
+  return VisitDecl(pragma_comment_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitPragmaDetectMismatchDecl(clang::PragmaDetectMismatchDecl * pragma_detect_mismatch_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitPragmaDetectMismatchDecl(
+    clang::PragmaDetectMismatchDecl *pragma_detect_mismatch_decl,
+    SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitPragmaDetectMismatchDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitPragmaDetectMismatchDecl"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
-    // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  // ROOT CAUSE FIX: Allow delegation to work - disabled FAIL_TODO
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitDecl(pragma_detect_mismatch_decl, node) && res;
+  return VisitDecl(pragma_detect_mismatch_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitStaticAssertDecl(clang::StaticAssertDecl * pragma_static_assert_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitStaticAssertDecl(
+    clang::StaticAssertDecl *pragma_static_assert_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitStaticAssertDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitStaticAssertDecl" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    SgNode * tmp_condition = Traverse(pragma_static_assert_decl->getAssertExpr());
-    SgExpression * condition = isSgExpression(tmp_condition);
-    if (tmp_condition != NULL && condition == NULL) {
-        std::cerr << "Runtime error: tmp_condition != NULL && condition == NULL" << std::endl;
-        res = false;
-    } else {
-      // In LLVM 20, getMessage() returns Expr*, need to cast to StringLiteral
-      std::string message_str = "";
-      if (auto* msg_expr = pragma_static_assert_decl->getMessage()) {
-        if (auto* str_lit = clang::dyn_cast<clang::StringLiteral>(msg_expr)) {
-          message_str = str_lit->getString().str();
-        }
+  SgNode *tmp_condition = Traverse(pragma_static_assert_decl->getAssertExpr());
+  SgExpression *condition = isSgExpression(tmp_condition);
+  if (tmp_condition != NULL && condition == NULL) {
+    std::cerr << "Runtime error: tmp_condition != NULL && condition == NULL"
+              << std::endl;
+    res = false;
+  } else {
+    // In LLVM 20, getMessage() returns Expr*, need to cast to StringLiteral
+    std::string message_str = "";
+    if (auto *msg_expr = pragma_static_assert_decl->getMessage()) {
+      if (auto *str_lit = clang::dyn_cast<clang::StringLiteral>(msg_expr)) {
+        message_str = str_lit->getString().str();
       }
-      *node = SageBuilder::buildStaticAssertionDeclaration(condition, message_str);
     }
+    *node =
+        SageBuilder::buildStaticAssertionDeclaration(condition, message_str);
+  }
 
-    return VisitDecl(pragma_static_assert_decl, node) && res;
+  return VisitDecl(pragma_static_assert_decl, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTranslationUnitDecl(clang::TranslationUnitDecl * translation_unit_decl, SgNode ** node) {
+bool ClangToSageTranslator::VisitTranslationUnitDecl(
+    clang::TranslationUnitDecl *translation_unit_decl, SgNode **node) {
 #if DEBUG_VISIT_DECL
-    std::cerr << "ClangToSageTranslator::VisitTranslationUnitDecl" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTranslationUnitDecl" << std::endl;
 #endif
-    if (*node != NULL) {
-        std::cerr << "Runtime error: The TranslationUnitDecl is already associated to a SAGE node." << std::endl;
-        return false;
-    }
+  if (*node != NULL) {
+    std::cerr << "Runtime error: The TranslationUnitDecl is already associated "
+                 "to a SAGE node."
+              << std::endl;
+    return false;
+  }
 
   // Create the SAGE node: SgGlobal
 
-    if (p_global_scope != NULL) {
-        std::cerr << "Runtime error: Global Scope have already been set !" << std::endl;
-        return false;
-    }
+  if (p_global_scope != NULL) {
+    std::cerr << "Runtime error: Global Scope have already been set !"
+              << std::endl;
+    return false;
+  }
 
-    // Create file info for global scope (following EDG pattern)
-    // Use the source file's filename and line 0
-    std::string sourceFilename;
-    if (p_sage_source_file != nullptr && p_sage_source_file->get_startOfConstruct() != nullptr) {
-        sourceFilename = p_sage_source_file->get_startOfConstruct()->get_filename();
-    } else {
-        // Fallback: will be set properly later in clang-frontend.cpp
-        sourceFilename = "TEMP_FILENAME";
-    }
-    Sg_File_Info* globalScopeFileInfo = new Sg_File_Info(sourceFilename, 0, 0);
+  // Create file info for global scope (following EDG pattern)
+  // Use the source file's filename and line 0
+  std::string sourceFilename;
+  if (p_sage_source_file != nullptr &&
+      p_sage_source_file->get_startOfConstruct() != nullptr) {
+    sourceFilename = p_sage_source_file->get_startOfConstruct()->get_filename();
+  } else {
+    // Fallback: will be set properly later in clang-frontend.cpp
+    sourceFilename = "TEMP_FILENAME";
+  }
+  Sg_File_Info *globalScopeFileInfo = new Sg_File_Info(sourceFilename, 0, 0);
 
-    // Pass file info to SgGlobal constructor (like EDG does)
-    *node = p_global_scope = new SgGlobal(globalScopeFileInfo);
+  // Pass file info to SgGlobal constructor (like EDG does)
+  *node = p_global_scope = new SgGlobal(globalScopeFileInfo);
 
-    // Set up parent relationship immediately so symbol insertion can access the project
-    if (p_sage_source_file != nullptr) {
-        p_global_scope->set_parent(p_sage_source_file);
-    }
+  // Set up parent relationship immediately so symbol insertion can access the
+  // project
+  if (p_sage_source_file != nullptr) {
+    p_global_scope->set_parent(p_sage_source_file);
+  }
 
-    p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(translation_unit_decl, p_global_scope));
+  p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(
+      translation_unit_decl, p_global_scope));
 
   // Traverse the children
 
- // DQ (4/5/2017): Fixed code to use updated SageBuilder API.
- // SageBuilder::pushScopeStack(*node);
-    SgScopeStatement* global_scope = isSgGlobal(*node);
-    ROSE_ASSERT(global_scope != NULL);
-    SageBuilder::pushScopeStack(global_scope);
+  // DQ (4/5/2017): Fixed code to use updated SageBuilder API.
+  // SageBuilder::pushScopeStack(*node);
+  SgScopeStatement *global_scope = isSgGlobal(*node);
+  ROSE_ASSERT(global_scope != NULL);
+  SageBuilder::pushScopeStack(global_scope);
 
-    clang::DeclContext * decl_context = (clang::DeclContext *)translation_unit_decl; // useless but more clear
+  clang::DeclContext *decl_context =
+      (clang::DeclContext *)translation_unit_decl; // useless but more clear
 
-    bool res = true;
-    clang::DeclContext::decl_iterator it;
-    for (it = decl_context->decls_begin(); it != decl_context->decls_end(); it++) {
-        clang::Decl* decl = (*it);
-        if (decl == nullptr) continue;
+  bool res = true;
+  clang::DeclContext::decl_iterator it;
+  for (it = decl_context->decls_begin(); it != decl_context->decls_end();
+       it++) {
+    clang::Decl *decl = (*it);
+    if (decl == nullptr)
+      continue;
 
-        if (SgProject::get_verbose() > 0) {
-            if (clang::NamedDecl* named = llvm::dyn_cast<clang::NamedDecl>(decl)) {
-                std::string n = named->getNameAsString();
-                if (n == "uint8_t" || n == "uint16_t" || n == "uint32_t" ||
-                    n == "in_port_t" || n == "in_addr_t" || n == "in6_addr" ||
-                    n == "in_addr" || n == "sockaddr_in" || n == "ntohl" ||
-                    n == "ntohs" || n == "htonl" || n == "htons") {
-                    unsigned line = 0;
-                    if (p_compiler_instance != NULL) {
-                        line = p_compiler_instance->getSourceManager().getSpellingLineNumber(named->getLocation());
-                    }
-                    std::cerr << "CFE: TU visit '" << n << "' (" << decl->getDeclKindName()
-                              << ") @" << line << std::endl;
-                }
-            }
+    if (SgProject::get_verbose() > 0) {
+      if (clang::NamedDecl *named = llvm::dyn_cast<clang::NamedDecl>(decl)) {
+        std::string n = named->getNameAsString();
+        if (n == "uint8_t" || n == "uint16_t" || n == "uint32_t" ||
+            n == "in_port_t" || n == "in_addr_t" || n == "in6_addr" ||
+            n == "in_addr" || n == "sockaddr_in" || n == "ntohl" ||
+            n == "ntohs" || n == "htonl" || n == "htons") {
+          unsigned line = 0;
+          if (p_compiler_instance != NULL) {
+            line =
+                p_compiler_instance->getSourceManager().getSpellingLineNumber(
+                    named->getLocation());
+          }
+          std::cerr << "CFE: TU visit '" << n << "' ("
+                    << decl->getDeclKindName() << ") @" << line << std::endl;
         }
-        SgNode * child = Traverse(decl);
-
-        SgDeclarationStatement * decl_stmt = isSgDeclarationStatement(child);
-        if (decl_stmt == NULL && child != NULL) {
-            std::cerr << "Runtime error: the node produce for a clang::Decl is not a SgDeclarationStatement !" << std::endl;
-            std::cerr << "    class = " << child->class_name() << std::endl;
-            res = false;
-        }
-        else if (child != NULL) {
-            // FIXME This is a hack to avoid autonomous decl of unnamed type to being added to the global scope....
-            SgClassDeclaration * class_decl = isSgClassDeclaration(child);
-            if (class_decl != NULL && (class_decl->get_name() == "" || class_decl->get_isUnNamed())) continue;
-
-            SgEnumDeclaration * enum_decl = isSgEnumDeclaration(child);
-            if (enum_decl != NULL && (enum_decl->get_name() == "" || enum_decl->get_isUnNamed())) continue;
-
-            if(clang::TagDecl::classof(decl))
-            {
-              clang::TagDecl* tagDecl = (clang::TagDecl*)decl;
-              if(tagDecl->isEmbeddedInDeclarator())  continue;
-            }
-
-            p_global_scope->append_declaration(decl_stmt);
-        }
+      }
     }
+    SgNode *child = Traverse(decl);
 
-    SageBuilder::popScopeStack();
+    SgDeclarationStatement *decl_stmt = isSgDeclarationStatement(child);
+    if (decl_stmt == NULL && child != NULL) {
+      std::cerr << "Runtime error: the node produce for a clang::Decl is not a "
+                   "SgDeclarationStatement !"
+                << std::endl;
+      std::cerr << "    class = " << child->class_name() << std::endl;
+      res = false;
+    } else if (child != NULL) {
+      // FIXME This is a hack to avoid autonomous decl of unnamed type to being
+      // added to the global scope....
+      SgClassDeclaration *class_decl = isSgClassDeclaration(child);
+      if (class_decl != NULL &&
+          (class_decl->get_name() == "" || class_decl->get_isUnNamed()))
+        continue;
+
+      SgEnumDeclaration *enum_decl = isSgEnumDeclaration(child);
+      if (enum_decl != NULL &&
+          (enum_decl->get_name() == "" || enum_decl->get_isUnNamed()))
+        continue;
+
+      if (clang::TagDecl::classof(decl)) {
+        clang::TagDecl *tagDecl = (clang::TagDecl *)decl;
+        if (tagDecl->isEmbeddedInDeclarator())
+          continue;
+      }
+
+      p_global_scope->append_declaration(decl_stmt);
+    }
+  }
+
+  SageBuilder::popScopeStack();
 
   // Traverse the class hierarchy
 
-    return VisitDecl(translation_unit_decl, node) && res;
+  return VisitDecl(translation_unit_decl, node) && res;
 }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -1,10 +1,10 @@
-#include "sage3basic.h"
 #include "clang-frontend-private.hpp"
 #include "clang-to-rose-support.hpp"
+#include "sage3basic.h"
+#include <algorithm>
+#include <cctype>
 #include <regex>
 #include <utility>
-#include <cctype>
-#include <algorithm>
 #include <vector>
 
 #include "clang/AST/LambdaCapture.h"
@@ -13,5408 +13,6141 @@
 
 #include "sageInterface.h"
 
-using llvm::isa;  // For LLVM type checking (isa<Type>)
+using llvm::isa; // For LLVM type checking (isa<Type>)
 
 namespace {
 
-std::string trimWhitespace(const std::string& input) {
-    size_t start = 0;
-    while (start < input.size() && (input[start] == ' ' || input[start] == '\t')) {
-        ++start;
+SgSymbol *findEnclosingThisSymbol(SgScopeStatement *starting_scope) {
+  for (SgNode *node = starting_scope; node != NULL; node = node->get_parent()) {
+    SgClassDefinition *class_def = isSgClassDefinition(node);
+    if (class_def == NULL) {
+      continue;
     }
-    size_t end = input.size();
-    while (end > start && (input[end - 1] == ' ' || input[end - 1] == '\t')) {
-        --end;
+
+    SgClassDeclaration *class_decl = class_def->get_declaration();
+    ROSE_ASSERT(class_decl != NULL);
+    SgScopeStatement *decl_scope = class_decl->get_scope();
+    ROSE_ASSERT(decl_scope != NULL);
+
+    if (SgClassSymbol *class_sym =
+            SageInterface::lookupClassSymbolInParentScopes(
+                class_decl->get_name(), decl_scope)) {
+      return class_sym;
     }
-    return input.substr(start, end - start);
+
+    if (SgClassSymbol *class_sym =
+            decl_scope->lookup_class_symbol(class_decl->get_name())) {
+      return class_sym;
+    }
+
+    if (SgSymbol *sym = class_decl->search_for_symbol_from_symbol_table()) {
+      if (isSgClassSymbol(sym) != NULL || isSgNonrealSymbol(sym) != NULL) {
+        return sym;
+      }
+    }
+
+    break;
+  }
+
+  return NULL;
 }
 
-bool isSkippableLineBetweenPragmaAndStatement(const std::string& trimmed_line) {
-    if (trimmed_line.empty()) {
-        return true;
-    }
-
-    if (trimmed_line.size() >= 2 && trimmed_line[0] == '/' && trimmed_line[1] == '/') {
-        return true;
-    }
-    if (trimmed_line.size() >= 2 && trimmed_line[0] == '/' && trimmed_line[1] == '*') {
-        return true;
-    }
-    if (!trimmed_line.empty() && trimmed_line[0] == '*') {
-        return true;
-    }
-    if (trimmed_line.size() >= 2 &&
-        trimmed_line[trimmed_line.size() - 2] == '*' &&
-        trimmed_line.back() == '/') {
-        return true;
-    }
-
-    if (!trimmed_line.empty() && trimmed_line.back() == '\\') {
-        return true;
-    }
-
-    if (trimmed_line.back() == ':') {
-        bool is_case = trimmed_line.rfind("case", 0) == 0;
-        bool is_default = trimmed_line.rfind("default", 0) == 0;
-        if (!is_case && !is_default) {
-            bool valid_label = true;
-            for (size_t i = 0; i + 1 < trimmed_line.size(); ++i) {
-                char c = trimmed_line[i];
-                if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) {
-                    valid_label = false;
-                    break;
-                }
-            }
-            if (valid_label) {
-                return true;
-            }
-        }
-    }
-
-    return false;
+std::string trimWhitespace(const std::string &input) {
+  size_t start = 0;
+  while (start < input.size() &&
+         (input[start] == ' ' || input[start] == '\t')) {
+    ++start;
+  }
+  size_t end = input.size();
+  while (end > start && (input[end - 1] == ' ' || input[end - 1] == '\t')) {
+    --end;
+  }
+  return input.substr(start, end - start);
 }
 
-bool getLineContent(const clang::SourceManager& source_manager,
-                    clang::FileID file_id,
-                    unsigned line,
-                    std::string& result) {
-    if (line == 0) {
-        return false;
-    }
-    clang::SourceLocation line_start = source_manager.translateLineCol(file_id, line, 1);
-    if (!line_start.isValid()) {
-        return false;
-    }
-
-    const char* begin = source_manager.getCharacterData(line_start);
-    const char* current = begin;
-    while (*current != '\n' && *current != '\r' && *current != '\0') {
-        ++current;
-    }
-
-    result.assign(begin, current - begin);
+bool isSkippableLineBetweenPragmaAndStatement(const std::string &trimmed_line) {
+  if (trimmed_line.empty()) {
     return true;
+  }
+
+  if (trimmed_line.size() >= 2 && trimmed_line[0] == '/' &&
+      trimmed_line[1] == '/') {
+    return true;
+  }
+  if (trimmed_line.size() >= 2 && trimmed_line[0] == '/' &&
+      trimmed_line[1] == '*') {
+    return true;
+  }
+  if (!trimmed_line.empty() && trimmed_line[0] == '*') {
+    return true;
+  }
+  if (trimmed_line.size() >= 2 &&
+      trimmed_line[trimmed_line.size() - 2] == '*' &&
+      trimmed_line.back() == '/') {
+    return true;
+  }
+
+  if (!trimmed_line.empty() && trimmed_line.back() == '\\') {
+    return true;
+  }
+
+  if (trimmed_line.back() == ':') {
+    bool is_case = trimmed_line.rfind("case", 0) == 0;
+    bool is_default = trimmed_line.rfind("default", 0) == 0;
+    if (!is_case && !is_default) {
+      bool valid_label = true;
+      for (size_t i = 0; i + 1 < trimmed_line.size(); ++i) {
+        char c = trimmed_line[i];
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) {
+          valid_label = false;
+          break;
+        }
+      }
+      if (valid_label) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
-std::string extractOpenMPDirective(const std::string& pragma_text) {
-    size_t pragma_pos = pragma_text.find("pragma");
-    if (pragma_pos == std::string::npos) {
-        return std::string();
-    }
+bool getLineContent(const clang::SourceManager &source_manager,
+                    clang::FileID file_id, unsigned line, std::string &result) {
+  if (line == 0) {
+    return false;
+  }
+  clang::SourceLocation line_start =
+      source_manager.translateLineCol(file_id, line, 1);
+  if (!line_start.isValid()) {
+    return false;
+  }
 
-    size_t hash_pos = pragma_text.find('#');
-    size_t spaces_after_hash = 0;
-    if (hash_pos != std::string::npos && pragma_pos > hash_pos) {
-        spaces_after_hash = pragma_pos - hash_pos - 1;
-    }
-    size_t after_pragma = pragma_pos + 6; // Skip "pragma"
+  const char *begin = source_manager.getCharacterData(line_start);
+  const char *current = begin;
+  while (*current != '\n' && *current != '\r' && *current != '\0') {
+    ++current;
+  }
 
-    if (after_pragma < pragma_text.size() && RoseOpenMPPragmaCallback::isWhitespace(pragma_text[after_pragma])) {
-        ++after_pragma;
-    }
+  result.assign(begin, current - begin);
+  return true;
+}
 
-    return std::string(spaces_after_hash, ' ') + pragma_text.substr(after_pragma);
+std::string extractOpenMPDirective(const std::string &pragma_text) {
+  size_t pragma_pos = pragma_text.find("pragma");
+  if (pragma_pos == std::string::npos) {
+    return std::string();
+  }
+
+  size_t hash_pos = pragma_text.find('#');
+  size_t spaces_after_hash = 0;
+  if (hash_pos != std::string::npos && pragma_pos > hash_pos) {
+    spaces_after_hash = pragma_pos - hash_pos - 1;
+  }
+  size_t after_pragma = pragma_pos + 6; // Skip "pragma"
+
+  if (after_pragma < pragma_text.size() &&
+      RoseOpenMPPragmaCallback::isWhitespace(pragma_text[after_pragma])) {
+    ++after_pragma;
+  }
+
+  return std::string(spaces_after_hash, ' ') + pragma_text.substr(after_pragma);
 }
 
 } // namespace
 
-SgNode * ClangToSageTranslator::Traverse(clang::Stmt * stmt) {
-    if (stmt == NULL)
-        return NULL;
+SgNode *ClangToSageTranslator::Traverse(clang::Stmt *stmt) {
+  if (stmt == NULL)
+    return NULL;
 
-    std::map<clang::Stmt *, SgNode *>::iterator it = p_stmt_translation_map.find(stmt);
-    if (it != p_stmt_translation_map.end())
-        return it->second; 
+  std::map<clang::Stmt *, SgNode *>::iterator it =
+      p_stmt_translation_map.find(stmt);
+  if (it != p_stmt_translation_map.end())
+    return it->second;
 
-    SgNode * result = NULL;
-    bool ret_status = false;
+  SgNode *result = NULL;
+  bool ret_status = false;
 
-    switch (stmt->getStmtClass()) {
-        case clang::Stmt::GCCAsmStmtClass:
-            ret_status = VisitGCCAsmStmt((clang::GCCAsmStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MSAsmStmtClass:
-            ret_status = VisitMSAsmStmt((clang::MSAsmStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::BreakStmtClass:
-            ret_status = VisitBreakStmt((clang::BreakStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CapturedStmtClass:
-            ret_status = VisitCapturedStmt((clang::CapturedStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CompoundStmtClass:
-            ret_status = VisitCompoundStmt((clang::CompoundStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ContinueStmtClass:
-            ret_status = VisitContinueStmt((clang::ContinueStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CoreturnStmtClass:
-            ret_status = VisitCoreturnStmt((clang::CoreturnStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXCatchStmtClass:
-            ret_status = VisitCXXCatchStmt((clang::CXXCatchStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXForRangeStmtClass:
-            ret_status = VisitCXXForRangeStmt((clang::CXXForRangeStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXTryStmtClass:
-            ret_status = VisitCXXTryStmt((clang::CXXTryStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DeclStmtClass:
-            ret_status = VisitDeclStmt((clang::DeclStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DoStmtClass:
-            ret_status = VisitDoStmt((clang::DoStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ForStmtClass:
-            ret_status = VisitForStmt((clang::ForStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::GotoStmtClass:
-            ret_status = VisitGotoStmt((clang::GotoStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::IfStmtClass:
-            ret_status = VisitIfStmt((clang::IfStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::IndirectGotoStmtClass:
-            ret_status = VisitIndirectGotoStmt((clang::IndirectGotoStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MSDependentExistsStmtClass:
-            ret_status = VisitMSDependentExistsStmt((clang::MSDependentExistsStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::NullStmtClass:
-            ret_status = VisitNullStmt((clang::NullStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPAtomicDirectiveClass:
-            ret_status = VisitOMPAtomicDirective((clang::OMPAtomicDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPBarrierDirectiveClass:
-            ret_status = VisitOMPBarrierDirective((clang::OMPBarrierDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPCancellationPointDirectiveClass:
-            ret_status = VisitOMPCancellationPointDirective((clang::OMPCancellationPointDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPCriticalDirectiveClass:
-            ret_status = VisitOMPCriticalDirective((clang::OMPCriticalDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPFlushDirectiveClass:
-            ret_status = VisitOMPFlushDirective((clang::OMPFlushDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPDistributeDirectiveClass:
-            ret_status = VisitOMPDistributeDirective((clang::OMPDistributeDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPDistributeParallelForDirectiveClass:
-            ret_status = VisitOMPDistributeParallelForDirective((clang::OMPDistributeParallelForDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPDistributeParallelForSimdDirectiveClass:
-            ret_status = VisitOMPDistributeParallelForSimdDirective((clang::OMPDistributeParallelForSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPDistributeSimdDirectiveClass:
-            ret_status = VisitOMPDistributeSimdDirective((clang::OMPDistributeSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPForDirectiveClass:
-            ret_status = VisitOMPForDirective((clang::OMPForDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPForSimdDirectiveClass:
-            ret_status = VisitOMPForSimdDirective((clang::OMPForSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::OMPMasterTaskLoopDirectiveClass:
-        //    ret_status = VisitOMPMasterTaskLoopDirective((clang::OMPMasterTaskLoopDirective *)stmt, &result);
-        //    break;
-        //case clang::Stmt::OMPMasterTaskLoopSimdDirectiveClass:
-        //    ret_status = VisitOMPMasterTaskLoopSimdDirective((clang::OMPMasterTaskLoopSimdDirective *)stmt, &result);
-        //    break;
-        case clang::Stmt::OMPParallelForDirectiveClass:
-            ret_status = VisitOMPParallelForDirective((clang::OMPParallelForDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPParallelForSimdDirectiveClass:
-            ret_status = VisitOMPParallelForSimdDirective((clang::OMPParallelForSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::OMPParallelMasterTaskLoopDirectiveClass:
-        //    ret_status = VisitOMPParallelMasterTaskLoopDirective((clang::OMPParallelMasterTaskLoopDirective *)stmt, &result);
-        //    break;
-        case clang::Stmt::OMPSimdDirectiveClass:
-            ret_status = VisitOMPSimdDirective((clang::OMPSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTargetParallelForDirectiveClass:
-            ret_status = VisitOMPTargetParallelForDirective((clang::OMPTargetParallelForDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTargetParallelForSimdDirectiveClass:
-            ret_status = VisitOMPTargetParallelForSimdDirective((clang::OMPTargetParallelForSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTargetSimdDirectiveClass:
-            ret_status = VisitOMPTargetSimdDirective((clang::OMPTargetSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTargetTeamsDistributeDirectiveClass:
-            ret_status = VisitOMPTargetTeamsDistributeDirective((clang::OMPTargetTeamsDistributeDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::OMPTargetTeamsDistributeParallelForSimdDirectiveClass:
-        //    ret_status = VisitOMPTargetTeamsDistributeParallelForSimdDirective((clang::OMPTargetTeamsDistributeParallelForSimdDirective *)stmt, &result);
-        //    break;
-        case clang::Stmt::OMPTargetTeamsDistributeSimdDirectiveClass:
-            ret_status = VisitOMPTargetTeamsDistributeSimdDirective((clang::OMPTargetTeamsDistributeSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTaskLoopDirectiveClass:
-            ret_status = VisitOMPTaskLoopDirective((clang::OMPTaskLoopDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPTaskLoopSimdDirectiveClass:
-            ret_status = VisitOMPTaskLoopSimdDirective((clang::OMPTaskLoopSimdDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::OMPTeamDistributeDirectiveClass:
-        //    ret_status = VisitOMPTeamDistributeDirective((clang::OMPTeamDistributeDirective *)stmt, &result);
-        //    break;
-        //case clang::Stmt::OMPTeamDistributeParallelForSimdDirectiveClass:
-        //    ret_status = VisitOMPTeamDistributeParallelForSimdDirective((clang::OMPTeamDistributeParallelForSimdDirective *)stmt, &result);
-        //    break;
-        //case clang::Stmt::OMPTeamDistributeSimdDirectiveClass:
-        //    ret_status = VisitOMPTeamDistributeSimdDirective((clang::OMPTeamDistributeSimdDirective *)stmt, &result);
-        //    break;
-        case clang::Stmt::OMPMasterDirectiveClass:
-            ret_status = VisitOMPMasterDirective((clang::OMPMasterDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPOrderedDirectiveClass:
-            ret_status = VisitOMPOrderedDirective((clang::OMPOrderedDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPParallelDirectiveClass:
-            ret_status = VisitOMPParallelDirective((clang::OMPParallelDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OMPParallelSectionsDirectiveClass:
-            ret_status = VisitOMPParallelSectionsDirective((clang::OMPParallelSectionsDirective *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ReturnStmtClass:
-            ret_status = VisitReturnStmt((clang::ReturnStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SEHExceptStmtClass:
-            ret_status = VisitSEHExceptStmt((clang::SEHExceptStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SEHFinallyStmtClass:
-            ret_status = VisitSEHFinallyStmt((clang::SEHFinallyStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SEHLeaveStmtClass:
-            ret_status = VisitSEHLeaveStmt((clang::SEHLeaveStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SEHTryStmtClass:
-            ret_status = VisitSEHTryStmt((clang::SEHTryStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CaseStmtClass:
-            ret_status = VisitCaseStmt((clang::CaseStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DefaultStmtClass:
-            ret_status = VisitDefaultStmt((clang::DefaultStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SwitchStmtClass:
-            ret_status = VisitSwitchStmt((clang::SwitchStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::AttributedStmtClass:
-            ret_status = VisitAttributedStmt((clang::AttributedStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::BinaryConditionalOperatorClass:
-            ret_status = VisitBinaryConditionalOperator((clang::BinaryConditionalOperator *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ConditionalOperatorClass:
-            ret_status = VisitConditionalOperator((clang::ConditionalOperator *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::AddrLabelExprClass:
-            ret_status = VisitAddrLabelExpr((clang::AddrLabelExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ArrayInitIndexExprClass:
-            ret_status = VisitArrayInitIndexExpr((clang::ArrayInitIndexExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ArrayInitLoopExprClass:
-            ret_status = VisitArrayInitLoopExpr((clang::ArrayInitLoopExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ArraySubscriptExprClass:
-            ret_status = VisitArraySubscriptExpr((clang::ArraySubscriptExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ArrayTypeTraitExprClass:
-            ret_status = VisitArrayTypeTraitExpr((clang::ArrayTypeTraitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::AsTypeExprClass:
-            ret_status = VisitAsTypeExpr((clang::AsTypeExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::AtomicExprClass:
-            ret_status = VisitAtomicExpr((clang::AtomicExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CompoundAssignOperatorClass:
-            ret_status = VisitCompoundAssignOperator((clang::CompoundAssignOperator *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::BlockExprClass:
-            ret_status = VisitBlockExpr((clang::BlockExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CUDAKernelCallExprClass:
-            ret_status = VisitCUDAKernelCallExpr((clang::CUDAKernelCallExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXMemberCallExprClass:
-            ret_status = VisitCXXMemberCallExpr((clang::CXXMemberCallExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXOperatorCallExprClass:
-            ret_status = VisitCXXOperatorCallExpr((clang::CXXOperatorCallExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::UserDefinedLiteralClass:
-            ret_status = VisitUserDefinedLiteral((clang::UserDefinedLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::BuiltinBitCastExprClass:
-            ret_status = VisitBuiltinBitCastExpr((clang::BuiltinBitCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CStyleCastExprClass:
-            ret_status = VisitCStyleCastExpr((clang::CStyleCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXFunctionalCastExprClass:
-            ret_status = VisitCXXFunctionalCastExpr((clang::CXXFunctionalCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXConstCastExprClass:
-            ret_status = VisitCXXConstCastExpr((clang::CXXConstCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXDynamicCastExprClass:
-            ret_status = VisitCXXDynamicCastExpr((clang::CXXDynamicCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXReinterpretCastExprClass:
-            ret_status = VisitCXXReinterpretCastExpr((clang::CXXReinterpretCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXStaticCastExprClass:
-            ret_status = VisitCXXStaticCastExpr((clang::CXXStaticCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ImplicitCastExprClass:
-            ret_status = VisitImplicitCastExpr((clang::ImplicitCastExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CharacterLiteralClass:
-            ret_status = VisitCharacterLiteral((clang::CharacterLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ChooseExprClass:
-            ret_status = VisitChooseExpr((clang::ChooseExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CompoundLiteralExprClass:
-            ret_status = VisitCompoundLiteralExpr((clang::CompoundLiteralExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::ConceptSpecializationExprClass:
-        //    ret_status = VisitConceptSpecializationExpr((clang::ConceptSpecializationExpr *)stmt, &result);
-        //    break;
-        case clang::Stmt::ConvertVectorExprClass:
-            ret_status = VisitConvertVectorExpr((clang::ConvertVectorExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CoawaitExprClass:
-            ret_status = VisitCoawaitExpr((clang::CoawaitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CoyieldExprClass:
-            ret_status = VisitCoyieldExpr((clang::CoyieldExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXBindTemporaryExprClass:
-            ret_status = VisitCXXBindTemporaryExpr((clang::CXXBindTemporaryExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXBoolLiteralExprClass:
-            ret_status = VisitCXXBoolLiteralExpr((clang::CXXBoolLiteralExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXConstructExprClass:
-            ret_status = VisitCXXConstructExpr((clang::CXXConstructExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXTemporaryObjectExprClass:
-            ret_status = VisitCXXTemporaryObjectExpr((clang::CXXTemporaryObjectExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXDefaultArgExprClass:
-            ret_status = VisitCXXDefaultArgExpr((clang::CXXDefaultArgExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXDefaultInitExprClass:
-            ret_status = VisitCXXDefaultInitExpr((clang::CXXDefaultInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXDeleteExprClass:
-            ret_status = VisitCXXDeleteExpr((clang::CXXDeleteExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXDependentScopeMemberExprClass:
-            ret_status = VisitCXXDependentScopeMemberExpr((clang::CXXDependentScopeMemberExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXFoldExprClass:
-            ret_status = VisitCXXFoldExpr((clang::CXXFoldExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXInheritedCtorInitExprClass:
-            ret_status = VisitCXXInheritedCtorInitExpr((clang::CXXInheritedCtorInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXNewExprClass:
-            ret_status = VisitCXXNewExpr((clang::CXXNewExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXNoexceptExprClass:
-            ret_status = VisitCXXNoexceptExpr((clang::CXXNoexceptExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXNullPtrLiteralExprClass:
-            ret_status = VisitCXXNullPtrLiteralExpr((clang::CXXNullPtrLiteralExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXPseudoDestructorExprClass:
-            ret_status = VisitCXXPseudoDestructorExpr((clang::CXXPseudoDestructorExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        //case clang::Stmt::CXXRewrittenBinaryOperatorClass:
-        //    ret_status = VisitCXXRewrittenBinaryOperator((clang::CXXRewrittenBinaryOperator *)stmt, &result);
-        //    break;
-        case clang::Stmt::CXXScalarValueInitExprClass:
-            ret_status = VisitCXXScalarValueInitExpr((clang::CXXScalarValueInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXStdInitializerListExprClass:
-            ret_status = VisitCXXStdInitializerListExpr((clang::CXXStdInitializerListExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXThisExprClass:
-            ret_status = VisitCXXThisExpr((clang::CXXThisExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXThrowExprClass:
-            ret_status = VisitCXXThrowExpr((clang::CXXThrowExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXTypeidExprClass:
-            ret_status = VisitCXXTypeidExpr((clang::CXXTypeidExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXUnresolvedConstructExprClass:
-            ret_status = VisitCXXUnresolvedConstructExpr((clang::CXXUnresolvedConstructExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CXXUuidofExprClass:
-            ret_status = VisitCXXUuidofExpr((clang::CXXUuidofExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DeclRefExprClass:
-            ret_status = VisitDeclRefExpr((clang::DeclRefExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DependentCoawaitExprClass:
-            ret_status = VisitDependentCoawaitExpr((clang::DependentCoawaitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DependentScopeDeclRefExprClass:
-            ret_status = VisitDependentScopeDeclRefExpr((clang::DependentScopeDeclRefExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DesignatedInitExprClass:
-            ret_status = VisitDesignatedInitExpr((clang::DesignatedInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::DesignatedInitUpdateExprClass:
-            ret_status = VisitDesignatedInitUpdateExpr((clang::DesignatedInitUpdateExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ExpressionTraitExprClass:
-            ret_status = VisitExpressionTraitExpr((clang::ExpressionTraitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ExtVectorElementExprClass:
-            ret_status = VisitExtVectorElementExpr((clang::ExtVectorElementExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::FixedPointLiteralClass:
-            ret_status = VisitFixedPointLiteral((clang::FixedPointLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::FloatingLiteralClass:
-            ret_status = VisitFloatingLiteral((clang::FloatingLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ConstantExprClass:
-            ret_status = VisitConstantExpr((clang::ConstantExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ExprWithCleanupsClass:
-            ret_status = VisitExprWithCleanups((clang::ExprWithCleanups *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::FunctionParmPackExprClass:
-            ret_status = VisitFunctionParmPackExpr((clang::FunctionParmPackExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::GenericSelectionExprClass:
-            ret_status = VisitGenericSelectionExpr((clang::GenericSelectionExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::GNUNullExprClass:
-            ret_status = VisitGNUNullExpr((clang::GNUNullExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ImaginaryLiteralClass:
-            ret_status = VisitImaginaryLiteral((clang::ImaginaryLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ImplicitValueInitExprClass:
-            ret_status = VisitImplicitValueInitExpr((clang::ImplicitValueInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::InitListExprClass:
-            ret_status = VisitInitListExpr((clang::InitListExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::IntegerLiteralClass:
-            ret_status = VisitIntegerLiteral((clang::IntegerLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::LambdaExprClass:
-            ret_status = VisitLambdaExpr((clang::LambdaExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MaterializeTemporaryExprClass:
-            ret_status = VisitMaterializeTemporaryExpr((clang::MaterializeTemporaryExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MemberExprClass:
-            ret_status = VisitMemberExpr((clang::MemberExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MSPropertyRefExprClass:
-            ret_status = VisitMSPropertyRefExpr((clang::MSPropertyRefExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::MSPropertySubscriptExprClass:
-            ret_status = VisitMSPropertySubscriptExpr((clang::MSPropertySubscriptExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::NoInitExprClass:
-            ret_status = VisitNoInitExpr((clang::NoInitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OffsetOfExprClass:
-            ret_status = VisitOffsetOfExpr((clang::OffsetOfExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ArraySectionExprClass:
-            ret_status = VisitOMPArraySectionExpr((clang::ArraySectionExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::OpaqueValueExprClass:
-            ret_status = VisitOpaqueValueExpr((clang::OpaqueValueExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::UnresolvedLookupExprClass:
-            ret_status = VisitUnresolvedLookupExpr((clang::UnresolvedLookupExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::UnresolvedMemberExprClass:
-            ret_status = VisitUnresolvedMemberExpr((clang::UnresolvedMemberExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::PackExpansionExprClass:
-            ret_status = VisitPackExpansionExpr((clang::PackExpansionExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ParenExprClass:
-            ret_status = VisitParenExpr((clang::ParenExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ParenListExprClass:
-            ret_status = VisitParenListExpr((clang::ParenListExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::PredefinedExprClass:
-            ret_status = VisitPredefinedExpr((clang::PredefinedExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::PseudoObjectExprClass:
-            ret_status = VisitPseudoObjectExpr((clang::PseudoObjectExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::ShuffleVectorExprClass:
-            ret_status = VisitShuffleVectorExpr((clang::ShuffleVectorExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SizeOfPackExprClass:
-            ret_status = VisitSizeOfPackExpr((clang::SizeOfPackExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SourceLocExprClass:
-            ret_status = VisitSourceLocExpr((clang::SourceLocExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::StmtExprClass:
-            ret_status = VisitStmtExpr((clang::StmtExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::StringLiteralClass:
-            ret_status = VisitStringLiteral((clang::StringLiteral *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SubstNonTypeTemplateParmPackExprClass:
-            ret_status = VisitSubstNonTypeTemplateParmPackExpr((clang::SubstNonTypeTemplateParmPackExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::SubstNonTypeTemplateParmExprClass:
-            ret_status = VisitSubstNonTypeTemplateParmExpr((clang::SubstNonTypeTemplateParmExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::TypeTraitExprClass:
-            ret_status = VisitTypeTraitExpr((clang::TypeTraitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        // TypoExpr was removed in LLVM 20
-        // case clang::Stmt::TypoExprClass:
-        //     ret_status = VisitTypoExpr((clang::TypoExpr *)stmt, &result);
-        //     ROSE_ASSERT(result != NULL);
-        //     break;
-        case clang::Stmt::UnaryExprOrTypeTraitExprClass:
-            ret_status = VisitUnaryExprOrTypeTraitExpr((clang::UnaryExprOrTypeTraitExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::VAArgExprClass:
-            ret_status = VisitVAArgExpr((clang::VAArgExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::LabelStmtClass:
-            ret_status = VisitLabelStmt((clang::LabelStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::WhileStmtClass:
-            ret_status = VisitWhileStmt((clang::WhileStmt *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::UnaryOperatorClass:
-            ret_status = VisitUnaryOperator((clang::UnaryOperator *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::CallExprClass:
-            ret_status = VisitCallExpr((clang::CallExpr *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::BinaryOperatorClass:
-            ret_status = VisitBinaryOperator((clang::BinaryOperator *)stmt, &result);
-            ROSE_ASSERT(result != NULL);
-            break;
-        case clang::Stmt::RecoveryExprClass:
-            // CLANG FRONTEND FIX: Use SgNullExpression instead of SgIntVal(42) for RecoveryExpr
-            // WHY: Clang creates RecoveryExpr during parse errors or incomplete template instantiations.
-            // Using SgIntVal(42) causes downstream errors when it appears as a function in function calls.
-            // SgNullExpression is better semantically as it represents a missing/unknown expression.
-            result = SageBuilder::buildNullExpression();
-            // Note: Assertion removed since RecoveryExpr is a valid (though error) state during parsing
-            // ROSE_ASSERT(FAIL_FIXME == 0); // There is no concept of recovery expression in ROSE
-            break;
-
-        default:
-            std::cerr << "Unknown statement kind: " << stmt->getStmtClassName() << " !" << std::endl;
-            ROSE_ABORT();
-    }
-
+  switch (stmt->getStmtClass()) {
+  case clang::Stmt::GCCAsmStmtClass:
+    ret_status = VisitGCCAsmStmt((clang::GCCAsmStmt *)stmt, &result);
     ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MSAsmStmtClass:
+    ret_status = VisitMSAsmStmt((clang::MSAsmStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::BreakStmtClass:
+    ret_status = VisitBreakStmt((clang::BreakStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CapturedStmtClass:
+    ret_status = VisitCapturedStmt((clang::CapturedStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CompoundStmtClass:
+    ret_status = VisitCompoundStmt((clang::CompoundStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ContinueStmtClass:
+    ret_status = VisitContinueStmt((clang::ContinueStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CoreturnStmtClass:
+    ret_status = VisitCoreturnStmt((clang::CoreturnStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXCatchStmtClass:
+    ret_status = VisitCXXCatchStmt((clang::CXXCatchStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXForRangeStmtClass:
+    ret_status = VisitCXXForRangeStmt((clang::CXXForRangeStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXTryStmtClass:
+    ret_status = VisitCXXTryStmt((clang::CXXTryStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DeclStmtClass:
+    ret_status = VisitDeclStmt((clang::DeclStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DoStmtClass:
+    ret_status = VisitDoStmt((clang::DoStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ForStmtClass:
+    ret_status = VisitForStmt((clang::ForStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::GotoStmtClass:
+    ret_status = VisitGotoStmt((clang::GotoStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::IfStmtClass:
+    ret_status = VisitIfStmt((clang::IfStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::IndirectGotoStmtClass:
+    ret_status =
+        VisitIndirectGotoStmt((clang::IndirectGotoStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MSDependentExistsStmtClass:
+    ret_status = VisitMSDependentExistsStmt(
+        (clang::MSDependentExistsStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::NullStmtClass:
+    ret_status = VisitNullStmt((clang::NullStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPAtomicDirectiveClass:
+    ret_status =
+        VisitOMPAtomicDirective((clang::OMPAtomicDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPBarrierDirectiveClass:
+    ret_status =
+        VisitOMPBarrierDirective((clang::OMPBarrierDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPCancellationPointDirectiveClass:
+    ret_status = VisitOMPCancellationPointDirective(
+        (clang::OMPCancellationPointDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPCriticalDirectiveClass:
+    ret_status =
+        VisitOMPCriticalDirective((clang::OMPCriticalDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPFlushDirectiveClass:
+    ret_status =
+        VisitOMPFlushDirective((clang::OMPFlushDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPDistributeDirectiveClass:
+    ret_status = VisitOMPDistributeDirective(
+        (clang::OMPDistributeDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPDistributeParallelForDirectiveClass:
+    ret_status = VisitOMPDistributeParallelForDirective(
+        (clang::OMPDistributeParallelForDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPDistributeParallelForSimdDirectiveClass:
+    ret_status = VisitOMPDistributeParallelForSimdDirective(
+        (clang::OMPDistributeParallelForSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPDistributeSimdDirectiveClass:
+    ret_status = VisitOMPDistributeSimdDirective(
+        (clang::OMPDistributeSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPForDirectiveClass:
+    ret_status = VisitOMPForDirective((clang::OMPForDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPForSimdDirectiveClass:
+    ret_status =
+        VisitOMPForSimdDirective((clang::OMPForSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::OMPMasterTaskLoopDirectiveClass:
+  //     ret_status =
+  //     VisitOMPMasterTaskLoopDirective((clang::OMPMasterTaskLoopDirective
+  //     *)stmt, &result); break;
+  // case clang::Stmt::OMPMasterTaskLoopSimdDirectiveClass:
+  //     ret_status =
+  //     VisitOMPMasterTaskLoopSimdDirective((clang::OMPMasterTaskLoopSimdDirective
+  //     *)stmt, &result); break;
+  case clang::Stmt::OMPParallelForDirectiveClass:
+    ret_status = VisitOMPParallelForDirective(
+        (clang::OMPParallelForDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPParallelForSimdDirectiveClass:
+    ret_status = VisitOMPParallelForSimdDirective(
+        (clang::OMPParallelForSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::OMPParallelMasterTaskLoopDirectiveClass:
+  //     ret_status =
+  //     VisitOMPParallelMasterTaskLoopDirective((clang::OMPParallelMasterTaskLoopDirective
+  //     *)stmt, &result); break;
+  case clang::Stmt::OMPSimdDirectiveClass:
+    ret_status =
+        VisitOMPSimdDirective((clang::OMPSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTargetParallelForDirectiveClass:
+    ret_status = VisitOMPTargetParallelForDirective(
+        (clang::OMPTargetParallelForDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTargetParallelForSimdDirectiveClass:
+    ret_status = VisitOMPTargetParallelForSimdDirective(
+        (clang::OMPTargetParallelForSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTargetSimdDirectiveClass:
+    ret_status = VisitOMPTargetSimdDirective(
+        (clang::OMPTargetSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTargetTeamsDistributeDirectiveClass:
+    ret_status = VisitOMPTargetTeamsDistributeDirective(
+        (clang::OMPTargetTeamsDistributeDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::OMPTargetTeamsDistributeParallelForSimdDirectiveClass:
+  //     ret_status =
+  //     VisitOMPTargetTeamsDistributeParallelForSimdDirective((clang::OMPTargetTeamsDistributeParallelForSimdDirective
+  //     *)stmt, &result); break;
+  case clang::Stmt::OMPTargetTeamsDistributeSimdDirectiveClass:
+    ret_status = VisitOMPTargetTeamsDistributeSimdDirective(
+        (clang::OMPTargetTeamsDistributeSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTaskLoopDirectiveClass:
+    ret_status =
+        VisitOMPTaskLoopDirective((clang::OMPTaskLoopDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPTaskLoopSimdDirectiveClass:
+    ret_status = VisitOMPTaskLoopSimdDirective(
+        (clang::OMPTaskLoopSimdDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::OMPTeamDistributeDirectiveClass:
+  //     ret_status =
+  //     VisitOMPTeamDistributeDirective((clang::OMPTeamDistributeDirective
+  //     *)stmt, &result); break;
+  // case clang::Stmt::OMPTeamDistributeParallelForSimdDirectiveClass:
+  //     ret_status =
+  //     VisitOMPTeamDistributeParallelForSimdDirective((clang::OMPTeamDistributeParallelForSimdDirective
+  //     *)stmt, &result); break;
+  // case clang::Stmt::OMPTeamDistributeSimdDirectiveClass:
+  //     ret_status =
+  //     VisitOMPTeamDistributeSimdDirective((clang::OMPTeamDistributeSimdDirective
+  //     *)stmt, &result); break;
+  case clang::Stmt::OMPMasterDirectiveClass:
+    ret_status =
+        VisitOMPMasterDirective((clang::OMPMasterDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPOrderedDirectiveClass:
+    ret_status =
+        VisitOMPOrderedDirective((clang::OMPOrderedDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPParallelDirectiveClass:
+    ret_status =
+        VisitOMPParallelDirective((clang::OMPParallelDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OMPParallelSectionsDirectiveClass:
+    ret_status = VisitOMPParallelSectionsDirective(
+        (clang::OMPParallelSectionsDirective *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ReturnStmtClass:
+    ret_status = VisitReturnStmt((clang::ReturnStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SEHExceptStmtClass:
+    ret_status = VisitSEHExceptStmt((clang::SEHExceptStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SEHFinallyStmtClass:
+    ret_status = VisitSEHFinallyStmt((clang::SEHFinallyStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SEHLeaveStmtClass:
+    ret_status = VisitSEHLeaveStmt((clang::SEHLeaveStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SEHTryStmtClass:
+    ret_status = VisitSEHTryStmt((clang::SEHTryStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CaseStmtClass:
+    ret_status = VisitCaseStmt((clang::CaseStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DefaultStmtClass:
+    ret_status = VisitDefaultStmt((clang::DefaultStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SwitchStmtClass:
+    ret_status = VisitSwitchStmt((clang::SwitchStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::AttributedStmtClass:
+    ret_status = VisitAttributedStmt((clang::AttributedStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::BinaryConditionalOperatorClass:
+    ret_status = VisitBinaryConditionalOperator(
+        (clang::BinaryConditionalOperator *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ConditionalOperatorClass:
+    ret_status =
+        VisitConditionalOperator((clang::ConditionalOperator *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::AddrLabelExprClass:
+    ret_status = VisitAddrLabelExpr((clang::AddrLabelExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ArrayInitIndexExprClass:
+    ret_status =
+        VisitArrayInitIndexExpr((clang::ArrayInitIndexExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ArrayInitLoopExprClass:
+    ret_status =
+        VisitArrayInitLoopExpr((clang::ArrayInitLoopExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ArraySubscriptExprClass:
+    ret_status =
+        VisitArraySubscriptExpr((clang::ArraySubscriptExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ArrayTypeTraitExprClass:
+    ret_status =
+        VisitArrayTypeTraitExpr((clang::ArrayTypeTraitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::AsTypeExprClass:
+    ret_status = VisitAsTypeExpr((clang::AsTypeExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::AtomicExprClass:
+    ret_status = VisitAtomicExpr((clang::AtomicExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CompoundAssignOperatorClass:
+    ret_status = VisitCompoundAssignOperator(
+        (clang::CompoundAssignOperator *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::BlockExprClass:
+    ret_status = VisitBlockExpr((clang::BlockExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CUDAKernelCallExprClass:
+    ret_status =
+        VisitCUDAKernelCallExpr((clang::CUDAKernelCallExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXMemberCallExprClass:
+    ret_status =
+        VisitCXXMemberCallExpr((clang::CXXMemberCallExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXOperatorCallExprClass:
+    ret_status =
+        VisitCXXOperatorCallExpr((clang::CXXOperatorCallExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::UserDefinedLiteralClass:
+    ret_status =
+        VisitUserDefinedLiteral((clang::UserDefinedLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::BuiltinBitCastExprClass:
+    ret_status =
+        VisitBuiltinBitCastExpr((clang::BuiltinBitCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CStyleCastExprClass:
+    ret_status = VisitCStyleCastExpr((clang::CStyleCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXFunctionalCastExprClass:
+    ret_status = VisitCXXFunctionalCastExpr(
+        (clang::CXXFunctionalCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXConstCastExprClass:
+    ret_status =
+        VisitCXXConstCastExpr((clang::CXXConstCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXDynamicCastExprClass:
+    ret_status =
+        VisitCXXDynamicCastExpr((clang::CXXDynamicCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXReinterpretCastExprClass:
+    ret_status = VisitCXXReinterpretCastExpr(
+        (clang::CXXReinterpretCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXStaticCastExprClass:
+    ret_status =
+        VisitCXXStaticCastExpr((clang::CXXStaticCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ImplicitCastExprClass:
+    ret_status =
+        VisitImplicitCastExpr((clang::ImplicitCastExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CharacterLiteralClass:
+    ret_status =
+        VisitCharacterLiteral((clang::CharacterLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ChooseExprClass:
+    ret_status = VisitChooseExpr((clang::ChooseExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CompoundLiteralExprClass:
+    ret_status =
+        VisitCompoundLiteralExpr((clang::CompoundLiteralExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::ConceptSpecializationExprClass:
+  //     ret_status =
+  //     VisitConceptSpecializationExpr((clang::ConceptSpecializationExpr
+  //     *)stmt, &result); break;
+  case clang::Stmt::ConvertVectorExprClass:
+    ret_status =
+        VisitConvertVectorExpr((clang::ConvertVectorExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CoawaitExprClass:
+    ret_status = VisitCoawaitExpr((clang::CoawaitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CoyieldExprClass:
+    ret_status = VisitCoyieldExpr((clang::CoyieldExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXBindTemporaryExprClass:
+    ret_status =
+        VisitCXXBindTemporaryExpr((clang::CXXBindTemporaryExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXBoolLiteralExprClass:
+    ret_status =
+        VisitCXXBoolLiteralExpr((clang::CXXBoolLiteralExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXConstructExprClass:
+    ret_status =
+        VisitCXXConstructExpr((clang::CXXConstructExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXTemporaryObjectExprClass:
+    ret_status = VisitCXXTemporaryObjectExpr(
+        (clang::CXXTemporaryObjectExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXDefaultArgExprClass:
+    ret_status =
+        VisitCXXDefaultArgExpr((clang::CXXDefaultArgExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXDefaultInitExprClass:
+    ret_status =
+        VisitCXXDefaultInitExpr((clang::CXXDefaultInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXDeleteExprClass:
+    ret_status = VisitCXXDeleteExpr((clang::CXXDeleteExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXDependentScopeMemberExprClass:
+    ret_status = VisitCXXDependentScopeMemberExpr(
+        (clang::CXXDependentScopeMemberExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXFoldExprClass:
+    ret_status = VisitCXXFoldExpr((clang::CXXFoldExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXInheritedCtorInitExprClass:
+    ret_status = VisitCXXInheritedCtorInitExpr(
+        (clang::CXXInheritedCtorInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXNewExprClass:
+    ret_status = VisitCXXNewExpr((clang::CXXNewExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXNoexceptExprClass:
+    ret_status = VisitCXXNoexceptExpr((clang::CXXNoexceptExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXNullPtrLiteralExprClass:
+    ret_status = VisitCXXNullPtrLiteralExpr(
+        (clang::CXXNullPtrLiteralExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXPseudoDestructorExprClass:
+    ret_status = VisitCXXPseudoDestructorExpr(
+        (clang::CXXPseudoDestructorExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // case clang::Stmt::CXXRewrittenBinaryOperatorClass:
+  //     ret_status =
+  //     VisitCXXRewrittenBinaryOperator((clang::CXXRewrittenBinaryOperator
+  //     *)stmt, &result); break;
+  case clang::Stmt::CXXScalarValueInitExprClass:
+    ret_status = VisitCXXScalarValueInitExpr(
+        (clang::CXXScalarValueInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXStdInitializerListExprClass:
+    ret_status = VisitCXXStdInitializerListExpr(
+        (clang::CXXStdInitializerListExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXThisExprClass:
+    ret_status = VisitCXXThisExpr((clang::CXXThisExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXThrowExprClass:
+    ret_status = VisitCXXThrowExpr((clang::CXXThrowExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXTypeidExprClass:
+    ret_status = VisitCXXTypeidExpr((clang::CXXTypeidExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXUnresolvedConstructExprClass:
+    ret_status = VisitCXXUnresolvedConstructExpr(
+        (clang::CXXUnresolvedConstructExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CXXUuidofExprClass:
+    ret_status = VisitCXXUuidofExpr((clang::CXXUuidofExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DeclRefExprClass:
+    ret_status = VisitDeclRefExpr((clang::DeclRefExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DependentCoawaitExprClass:
+    ret_status =
+        VisitDependentCoawaitExpr((clang::DependentCoawaitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DependentScopeDeclRefExprClass:
+    ret_status = VisitDependentScopeDeclRefExpr(
+        (clang::DependentScopeDeclRefExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DesignatedInitExprClass:
+    ret_status =
+        VisitDesignatedInitExpr((clang::DesignatedInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::DesignatedInitUpdateExprClass:
+    ret_status = VisitDesignatedInitUpdateExpr(
+        (clang::DesignatedInitUpdateExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ExpressionTraitExprClass:
+    ret_status =
+        VisitExpressionTraitExpr((clang::ExpressionTraitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ExtVectorElementExprClass:
+    ret_status =
+        VisitExtVectorElementExpr((clang::ExtVectorElementExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::FixedPointLiteralClass:
+    ret_status =
+        VisitFixedPointLiteral((clang::FixedPointLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::FloatingLiteralClass:
+    ret_status = VisitFloatingLiteral((clang::FloatingLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ConstantExprClass:
+    ret_status = VisitConstantExpr((clang::ConstantExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ExprWithCleanupsClass:
+    ret_status =
+        VisitExprWithCleanups((clang::ExprWithCleanups *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::FunctionParmPackExprClass:
+    ret_status =
+        VisitFunctionParmPackExpr((clang::FunctionParmPackExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::GenericSelectionExprClass:
+    ret_status =
+        VisitGenericSelectionExpr((clang::GenericSelectionExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::GNUNullExprClass:
+    ret_status = VisitGNUNullExpr((clang::GNUNullExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ImaginaryLiteralClass:
+    ret_status =
+        VisitImaginaryLiteral((clang::ImaginaryLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ImplicitValueInitExprClass:
+    ret_status = VisitImplicitValueInitExpr(
+        (clang::ImplicitValueInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::InitListExprClass:
+    ret_status = VisitInitListExpr((clang::InitListExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::IntegerLiteralClass:
+    ret_status = VisitIntegerLiteral((clang::IntegerLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::LambdaExprClass:
+    ret_status = VisitLambdaExpr((clang::LambdaExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MaterializeTemporaryExprClass:
+    ret_status = VisitMaterializeTemporaryExpr(
+        (clang::MaterializeTemporaryExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MemberExprClass:
+    ret_status = VisitMemberExpr((clang::MemberExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MSPropertyRefExprClass:
+    ret_status =
+        VisitMSPropertyRefExpr((clang::MSPropertyRefExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::MSPropertySubscriptExprClass:
+    ret_status = VisitMSPropertySubscriptExpr(
+        (clang::MSPropertySubscriptExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::NoInitExprClass:
+    ret_status = VisitNoInitExpr((clang::NoInitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OffsetOfExprClass:
+    ret_status = VisitOffsetOfExpr((clang::OffsetOfExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ArraySectionExprClass:
+    ret_status =
+        VisitOMPArraySectionExpr((clang::ArraySectionExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::OpaqueValueExprClass:
+    ret_status = VisitOpaqueValueExpr((clang::OpaqueValueExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::UnresolvedLookupExprClass:
+    ret_status =
+        VisitUnresolvedLookupExpr((clang::UnresolvedLookupExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::UnresolvedMemberExprClass:
+    ret_status =
+        VisitUnresolvedMemberExpr((clang::UnresolvedMemberExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::PackExpansionExprClass:
+    ret_status =
+        VisitPackExpansionExpr((clang::PackExpansionExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ParenExprClass:
+    ret_status = VisitParenExpr((clang::ParenExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ParenListExprClass:
+    ret_status = VisitParenListExpr((clang::ParenListExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::PredefinedExprClass:
+    ret_status = VisitPredefinedExpr((clang::PredefinedExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::PseudoObjectExprClass:
+    ret_status =
+        VisitPseudoObjectExpr((clang::PseudoObjectExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::ShuffleVectorExprClass:
+    ret_status =
+        VisitShuffleVectorExpr((clang::ShuffleVectorExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SizeOfPackExprClass:
+    ret_status = VisitSizeOfPackExpr((clang::SizeOfPackExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SourceLocExprClass:
+    ret_status = VisitSourceLocExpr((clang::SourceLocExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::StmtExprClass:
+    ret_status = VisitStmtExpr((clang::StmtExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::StringLiteralClass:
+    ret_status = VisitStringLiteral((clang::StringLiteral *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SubstNonTypeTemplateParmPackExprClass:
+    ret_status = VisitSubstNonTypeTemplateParmPackExpr(
+        (clang::SubstNonTypeTemplateParmPackExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::SubstNonTypeTemplateParmExprClass:
+    ret_status = VisitSubstNonTypeTemplateParmExpr(
+        (clang::SubstNonTypeTemplateParmExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::TypeTraitExprClass:
+    ret_status = VisitTypeTraitExpr((clang::TypeTraitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  // TypoExpr was removed in LLVM 20
+  // case clang::Stmt::TypoExprClass:
+  //     ret_status = VisitTypoExpr((clang::TypoExpr *)stmt, &result);
+  //     ROSE_ASSERT(result != NULL);
+  //     break;
+  case clang::Stmt::UnaryExprOrTypeTraitExprClass:
+    ret_status = VisitUnaryExprOrTypeTraitExpr(
+        (clang::UnaryExprOrTypeTraitExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::VAArgExprClass:
+    ret_status = VisitVAArgExpr((clang::VAArgExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::LabelStmtClass:
+    ret_status = VisitLabelStmt((clang::LabelStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::WhileStmtClass:
+    ret_status = VisitWhileStmt((clang::WhileStmt *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::UnaryOperatorClass:
+    ret_status = VisitUnaryOperator((clang::UnaryOperator *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::CallExprClass:
+    ret_status = VisitCallExpr((clang::CallExpr *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::BinaryOperatorClass:
+    ret_status = VisitBinaryOperator((clang::BinaryOperator *)stmt, &result);
+    ROSE_ASSERT(result != NULL);
+    break;
+  case clang::Stmt::RecoveryExprClass:
+    // CLANG FRONTEND FIX: Use SgNullExpression instead of SgIntVal(42) for
+    // RecoveryExpr WHY: Clang creates RecoveryExpr during parse errors or
+    // incomplete template instantiations. Using SgIntVal(42) causes downstream
+    // errors when it appears as a function in function calls. SgNullExpression
+    // is better semantically as it represents a missing/unknown expression.
+    result = SageBuilder::buildNullExpression();
+    // Note: Assertion removed since RecoveryExpr is a valid (though error)
+    // state during parsing ROSE_ASSERT(FAIL_FIXME == 0); // There is no concept
+    // of recovery expression in ROSE
+    break;
 
-    p_stmt_translation_map.insert(std::pair<clang::Stmt *, SgNode *>(stmt, result));
+  default:
+    std::cerr << "Unknown statement kind: " << stmt->getStmtClassName() << " !"
+              << std::endl;
+    ROSE_ABORT();
+  }
 
-    return result;
+  ROSE_ASSERT(result != NULL);
+
+  p_stmt_translation_map.insert(
+      std::pair<clang::Stmt *, SgNode *>(stmt, result));
+
+  return result;
 }
 
 /********************/
 /* Visit Statements */
 /********************/
 
-bool ClangToSageTranslator::VisitStmt(clang::Stmt * stmt, SgNode ** node)
-   {
+bool ClangToSageTranslator::VisitStmt(clang::Stmt *stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-     std::cerr << "ClangToSageTranslator::VisitStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitStmt" << std::endl;
 #endif
 
-     if (*node == NULL)
-        {
-          std::cerr << "Runtime error: No Sage node associated with the Statement: " << stmt->getStmtClassName() << std::endl;
-          stmt->dump();
-          return false;
-        }
+  if (*node == NULL) {
+    std::cerr << "Runtime error: No Sage node associated with the Statement: "
+              << stmt->getStmtClassName() << std::endl;
+    stmt->dump();
+    return false;
+  }
 
   // TODO Is there anything else todo?
 
-     if (isSgLocatedNode(*node) != NULL && (isSgLocatedNode(*node)->get_file_info() == NULL || !(isSgLocatedNode(*node)->get_file_info()->isCompilerGenerated()) ))
-        {
-          applySourceRange(*node, stmt->getSourceRange());
-        }
+  if (isSgLocatedNode(*node) != NULL &&
+      (isSgLocatedNode(*node)->get_file_info() == NULL ||
+       !(isSgLocatedNode(*node)->get_file_info()->isCompilerGenerated()))) {
+    applySourceRange(*node, stmt->getSourceRange());
+  }
 
-     return true;
-   }
-
-bool ClangToSageTranslator::VisitAsmStmt(clang::AsmStmt * asm_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAsmStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-    return VisitStmt(asm_stmt, node) && res;
+  return true;
 }
 
-
-bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt * gcc_asm_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitAsmStmt(clang::AsmStmt *asm_stmt,
+                                         SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitGCCAsmStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAsmStmt" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    unsigned asmNumInput = gcc_asm_stmt->getNumInputs();
-    unsigned asmNumOutput = gcc_asm_stmt->getNumOutputs();
-    unsigned asmClobber = gcc_asm_stmt->getNumClobbers();
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  return VisitStmt(asm_stmt, node) && res;
+}
 
-    // LLVM 20 returns StringLiteral*, LLVM 21 returns std::string
-    std::string AsmString;
+bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitGCCAsmStmt" << std::endl;
+#endif
+  bool res = true;
+
+  unsigned asmNumInput = gcc_asm_stmt->getNumInputs();
+  unsigned asmNumOutput = gcc_asm_stmt->getNumOutputs();
+  unsigned asmClobber = gcc_asm_stmt->getNumClobbers();
+
+  // LLVM 20 returns StringLiteral*, LLVM 21 returns std::string
+  std::string AsmString;
 #if LLVM_VERSION_MAJOR >= 21
-    AsmString = gcc_asm_stmt->getAsmString();
+  AsmString = gcc_asm_stmt->getAsmString();
 #else
-    if (auto* str_lit = gcc_asm_stmt->getAsmString()) {
-        AsmString = str_lit->getString().str();
+  if (auto *str_lit = gcc_asm_stmt->getAsmString()) {
+    AsmString = str_lit->getString().str();
+  }
+#endif
+
+  std::cout << "input op:" << asmNumInput << " output op: " << asmNumOutput
+            << std::endl;
+#if DEBUG_VISIT_STMT
+  std::cerr << "AsmString:" << AsmString << std::endl;
+#endif
+
+  SgAsmStmt *asmStmt = SageBuilder::buildAsmStatement(AsmString);
+  asmStmt->set_firstNondefiningDeclaration(asmStmt);
+  asmStmt->set_definingDeclaration(asmStmt);
+  asmStmt->set_parent(SageBuilder::topScopeStack());
+  asmStmt->set_useGnuExtendedFormat(true);
+
+  // Pei-Hung (03/22/2022)  The clobber string is available.
+  // The implementation adding clobber into ROSE AST is not in place.
+  for (unsigned i = 0; i < asmClobber; ++i) {
+    std::string clobberStr =
+        static_cast<std::string>(gcc_asm_stmt->getClobber(i));
+#if DEBUG_VISIT_STMT
+    std::cerr << "AsmOp clobber[" << i << "]: " << clobberStr << std::endl;
+#endif
+    // Pei-Hung "cc" clobber is skipped by EDG
+    if (clobberStr.compare(0, sizeof(clobberStr), "cc") == 0)
+      continue;
+
+    SgInitializedName::asm_register_name_enum sageRegisterName =
+        get_sgAsmRegister(clobberStr);
+    asmStmt->get_clobberRegisterList().push_back(sageRegisterName);
+  }
+
+  // Pei-Hung (03/22/2022) use regular expression to check the first modifier, +
+  // and =, for ouput Ops. Then the second modifier for both input and output
+  // Ops.  The rest is for constraints. regex_match should report 4 matched
+  // results:
+  // 1. the whole matched string
+  // 2. first modifier: =, +, or empty
+  // 3. second modifier: empty or &, %, *, #, ?, !
+  // 4. The constraint
+  std::regex e("([\\=\\+]*)([\\&\\%\\*\\#\\?\\!]*)(.+)",
+               std::regex_constants::ECMAScript | std::regex_constants::icase);
+
+  // process output
+  for (unsigned i = 0; i < asmNumOutput; ++i) {
+    SgNode *tmp_node = Traverse(gcc_asm_stmt->getOutputExpr(i));
+    SgExpression *outputExpr = isSgExpression(tmp_node);
+    ROSE_ASSERT(outputExpr != NULL);
+
+    std::string outputConstraintStr =
+        static_cast<std::string>(gcc_asm_stmt->getOutputConstraint(i));
+// Clang's constraint is equivalent to ROSE's modifier + operand constraints
+#if DEBUG_VISIT_STMT
+    std::cerr << "AsmOp output constraint[" << i << "]: " << outputConstraintStr
+              << std::endl;
+#endif
+
+    std::smatch sm;
+    std::regex_match(outputConstraintStr, sm, e);
+#if DEBUG_VISIT_STMT
+    std::cout << "string literal: " << outputConstraintStr << "  with "
+              << sm.size() << " matches\n";
+    if (sm.size())
+      std::cout << "the matches were: ";
+    for (unsigned i = 0; i < sm.size(); ++i) {
+      std::cout << "[" << sm[i] << "] \n";
     }
+    if (sm.size())
+      std::cout << std::endl;
 #endif
 
-    std::cout << "input op:" << asmNumInput << " output op: " << asmNumOutput<< std::endl;
+    SgAsmOp::asm_operand_constraint_enum constraint =
+        (SgAsmOp::asm_operand_constraint_enum)SgAsmOp::e_any;
+    SgAsmOp::asm_operand_modifier_enum modifiers =
+        (SgAsmOp::asm_operand_modifier_enum)SgAsmOp::e_unknown;
+    SgAsmOp *sageAsmOp = new SgAsmOp(constraint, modifiers, outputExpr);
+    outputExpr->set_parent(sageAsmOp);
+
+    sageAsmOp->set_recordRawAsmOperandDescriptions(false);
+
+    // set as an output AsmOp
+    sageAsmOp->set_isOutputOperand(true);
+
+    ROSE_ASSERT(sm.size() == 4);
+
+    unsigned modifierVal = static_cast<int>(modifiers);
+    if (!sm[1].str().empty())
+      modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[1].str()));
+
+    if (!sm[2].str().empty())
+      modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[2].str()));
+
+    sageAsmOp->set_modifiers(
+        static_cast<SgAsmOp::asm_operand_modifier_enum>(modifierVal));
+
+    // set constraint
+    sageAsmOp->set_constraint(get_sgAsmOperandConstraint(sm[3].str()));
+    sageAsmOp->set_constraintString(sm[3]);
+
+    Sg_File_Info *start_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    start_fi->setCompilerGenerated();
+    sageAsmOp->set_startOfConstruct(start_fi);
+
+    Sg_File_Info *end_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    end_fi->setCompilerGenerated();
+    sageAsmOp->set_endOfConstruct(end_fi);
+
+    asmStmt->get_operands().push_back(sageAsmOp);
+    sageAsmOp->set_parent(asmStmt);
+  }
+
+  // process input
+  for (unsigned i = 0; i < asmNumInput; ++i) {
+    SgNode *tmp_node = Traverse(gcc_asm_stmt->getInputExpr(i));
+    SgExpression *inputExpr = isSgExpression(tmp_node);
+    ROSE_ASSERT(inputExpr != NULL);
+
+    std::string inputConstraintStr =
+        static_cast<std::string>(gcc_asm_stmt->getInputConstraint(i));
+// Clang's constraint is equivalent to ROSE's modifier + operand constraints
 #if DEBUG_VISIT_STMT
-    std::cerr << "AsmString:" << AsmString << std::endl;
+    std::cerr << "AsmOp input constraint[" << i << "]: " << inputConstraintStr
+              << std::endl;
 #endif
 
-    SgAsmStmt* asmStmt = SageBuilder::buildAsmStatement(AsmString); 
-    asmStmt->set_firstNondefiningDeclaration(asmStmt);
-    asmStmt->set_definingDeclaration(asmStmt);
-    asmStmt->set_parent(SageBuilder::topScopeStack());
-    asmStmt->set_useGnuExtendedFormat(true);
-
-
-    // Pei-Hung (03/22/2022)  The clobber string is available.
-    // The implementation adding clobber into ROSE AST is not in place.
-    for(unsigned i=0; i < asmClobber; ++i)
-    {
-      std::string clobberStr = static_cast<std::string>(gcc_asm_stmt->getClobber(i));
+    std::smatch sm;
+    std::regex_match(inputConstraintStr, sm, e);
 #if DEBUG_VISIT_STMT
-      std::cerr << "AsmOp clobber["<< i<<  "]: " << clobberStr << std::endl;
-#endif
-      // Pei-Hung "cc" clobber is skipped by EDG
-      if(clobberStr.compare(0, sizeof(clobberStr), "cc") == 0)
-        continue;
-  
-      SgInitializedName::asm_register_name_enum sageRegisterName = get_sgAsmRegister(clobberStr);
-      asmStmt->get_clobberRegisterList().push_back(sageRegisterName);
+    std::cout << "string literal: " << inputConstraintStr << "  with "
+              << sm.size() << " matches\n";
+    if (sm.size())
+      std::cout << "the matches were: ";
+    for (unsigned i = 0; i < sm.size(); ++i) {
+      std::cout << "[" << sm[i] << "] \n";
     }
-
-    // Pei-Hung (03/22/2022) use regular expression to check the first modifier, + and =, for ouput Ops.  
-    // Then the second modifier for both input and output Ops.  The rest is for constraints.
-    // regex_match should report 4 matched results:
-    // 1. the whole matched string
-    // 2. first modifier: =, +, or empty
-    // 3. second modifier: empty or &, %, *, #, ?, !
-    // 4. The constraint
-    std::regex e ("([\\=\\+]*)([\\&\\%\\*\\#\\?\\!]*)(.+)", std::regex_constants::ECMAScript | std::regex_constants::icase);
-
-    // process output
-    for(unsigned i=0; i < asmNumOutput; ++i)
-    {
-      SgNode* tmp_node = Traverse(gcc_asm_stmt->getOutputExpr(i));
-      SgExpression * outputExpr = isSgExpression(tmp_node);
-      ROSE_ASSERT(outputExpr != NULL);
-
-      std::string outputConstraintStr = static_cast<std::string>(gcc_asm_stmt->getOutputConstraint(i));
-// Clang's constraint is equivalent to ROSE's modifier + operand constraints 
-#if DEBUG_VISIT_STMT
-      std::cerr << "AsmOp output constraint["<< i<<  "]: " << outputConstraintStr << std::endl;
+    if (sm.size())
+      std::cout << std::endl;
 #endif
 
-      std::smatch sm; 
-      std::regex_match (outputConstraintStr,sm,e);
-#if DEBUG_VISIT_STMT
-        std::cout << "string literal: "<< outputConstraintStr  <<"  with " << sm.size() << " matches\n";
-        if(sm.size())
-          std::cout << "the matches were: ";
-        for (unsigned i=0; i<sm.size(); ++i) {
-          std::cout << "[" << sm[i] << "] \n";
-        }
-        if(sm.size())
-          std::cout << std::endl;
-#endif
+    SgAsmOp::asm_operand_constraint_enum constraint =
+        (SgAsmOp::asm_operand_constraint_enum)SgAsmOp::e_any;
+    SgAsmOp::asm_operand_modifier_enum modifiers =
+        (SgAsmOp::asm_operand_modifier_enum)SgAsmOp::e_unknown;
+    SgAsmOp *sageAsmOp = new SgAsmOp(constraint, modifiers, inputExpr);
+    inputExpr->set_parent(sageAsmOp);
 
-      SgAsmOp::asm_operand_constraint_enum constraint = (SgAsmOp::asm_operand_constraint_enum) SgAsmOp::e_any;
-      SgAsmOp::asm_operand_modifier_enum   modifiers  = (SgAsmOp::asm_operand_modifier_enum)   SgAsmOp::e_unknown;
-      SgAsmOp* sageAsmOp = new SgAsmOp(constraint,modifiers,outputExpr);
-      outputExpr->set_parent(sageAsmOp);
+    sageAsmOp->set_recordRawAsmOperandDescriptions(false);
 
-      sageAsmOp->set_recordRawAsmOperandDescriptions(false);
+    // set as an input AsmOp
+    sageAsmOp->set_isOutputOperand(false);
 
-      // set as an output AsmOp
-      sageAsmOp->set_isOutputOperand (true);
+    ROSE_ASSERT(sm.size() == 4);
 
-      ROSE_ASSERT(sm.size() == 4);
+    unsigned modifierVal = static_cast<int>(modifiers);
 
-      unsigned modifierVal = static_cast<int>(modifiers);
-      if(!sm[1].str().empty())
-        modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[1].str()));
+    // "+" and "=" should not be part of the input AsmOp.  Skip checking sm[1]
+    // for the inputs.
 
-      if(!sm[2].str().empty())
-        modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[2].str()));
-     
-      sageAsmOp->set_modifiers(static_cast<SgAsmOp::asm_operand_modifier_enum>(modifierVal));
+    //      if(!sm[1].str().empty())
+    //        modifierVal +=
+    //        static_cast<int>(get_sgAsmOperandModifier(sm[1].str())); modifiers
+    //        &= get_sgAsmOperandModifier(sm[1].str());
 
-      // set constraint
-      sageAsmOp->set_constraint(get_sgAsmOperandConstraint(sm[3].str()));
-      sageAsmOp->set_constraintString(sm[3]);
+    if (!sm[2].str().empty())
+      modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[2].str()));
 
+    sageAsmOp->set_modifiers(
+        static_cast<SgAsmOp::asm_operand_modifier_enum>(modifierVal));
 
-      Sg_File_Info * start_fi = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-      start_fi->setCompilerGenerated();
-      sageAsmOp->set_startOfConstruct(start_fi);
+    // set constraint
+    sageAsmOp->set_constraint(get_sgAsmOperandConstraint(sm[3].str()));
+    sageAsmOp->set_constraintString(sm[3]);
 
-      Sg_File_Info * end_fi   = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-      end_fi->setCompilerGenerated();
-      sageAsmOp->set_endOfConstruct(end_fi);
-      
-      asmStmt->get_operands().push_back(sageAsmOp);
-      sageAsmOp->set_parent(asmStmt);
-    }
+    Sg_File_Info *start_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    start_fi->setCompilerGenerated();
+    sageAsmOp->set_startOfConstruct(start_fi);
 
-    // process input
-    for(unsigned i=0; i < asmNumInput; ++i)
-    {
-      SgNode* tmp_node = Traverse(gcc_asm_stmt->getInputExpr(i));
-      SgExpression * inputExpr = isSgExpression(tmp_node);
-      ROSE_ASSERT(inputExpr != NULL);
+    Sg_File_Info *end_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    end_fi->setCompilerGenerated();
+    sageAsmOp->set_endOfConstruct(end_fi);
 
-      std::string inputConstraintStr = static_cast<std::string>(gcc_asm_stmt->getInputConstraint(i));
-// Clang's constraint is equivalent to ROSE's modifier + operand constraints 
-#if DEBUG_VISIT_STMT
-      std::cerr << "AsmOp input constraint["<< i<<  "]: " << inputConstraintStr << std::endl;
-#endif
+    asmStmt->get_operands().push_back(sageAsmOp);
+    sageAsmOp->set_parent(asmStmt);
+  }
+  *node = asmStmt;
 
-      std::smatch sm; 
-      std::regex_match (inputConstraintStr,sm,e);
-#if DEBUG_VISIT_STMT
-        std::cout << "string literal: "<< inputConstraintStr  <<"  with " << sm.size() << " matches\n";
-        if(sm.size())
-          std::cout << "the matches were: ";
-        for (unsigned i=0; i<sm.size(); ++i) {
-          std::cout << "[" << sm[i] << "] \n";
-        }
-        if(sm.size())
-          std::cout << std::endl;
-#endif
-
-      SgAsmOp::asm_operand_constraint_enum constraint = (SgAsmOp::asm_operand_constraint_enum) SgAsmOp::e_any;
-      SgAsmOp::asm_operand_modifier_enum   modifiers  = (SgAsmOp::asm_operand_modifier_enum)   SgAsmOp::e_unknown;
-      SgAsmOp* sageAsmOp = new SgAsmOp(constraint,modifiers,inputExpr);
-      inputExpr->set_parent(sageAsmOp);
-
-      sageAsmOp->set_recordRawAsmOperandDescriptions(false);
-
-      // set as an input AsmOp
-      sageAsmOp->set_isOutputOperand (false);
-
-      ROSE_ASSERT(sm.size() == 4);
-
-      unsigned modifierVal = static_cast<int>(modifiers);
-
-      // "+" and "=" should not be part of the input AsmOp.  Skip checking sm[1] for the inputs.
-
-//      if(!sm[1].str().empty())
-//        modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[1].str()));
-//        modifiers &= get_sgAsmOperandModifier(sm[1].str());
-
-      if(!sm[2].str().empty())
-        modifierVal += static_cast<int>(get_sgAsmOperandModifier(sm[2].str()));
-     
-      sageAsmOp->set_modifiers(static_cast<SgAsmOp::asm_operand_modifier_enum>(modifierVal));
-
-      // set constraint
-      sageAsmOp->set_constraint(get_sgAsmOperandConstraint(sm[3].str()));
-      sageAsmOp->set_constraintString(sm[3]);
-
-
-      Sg_File_Info * start_fi = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-      start_fi->setCompilerGenerated();
-      sageAsmOp->set_startOfConstruct(start_fi);
-
-      Sg_File_Info * end_fi   = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-      end_fi->setCompilerGenerated();
-      sageAsmOp->set_endOfConstruct(end_fi);
-      
-      asmStmt->get_operands().push_back(sageAsmOp);
-      sageAsmOp->set_parent(asmStmt);
-    }
-    *node = asmStmt;
-
-    return VisitStmt(gcc_asm_stmt, node) && res;
+  return VisitStmt(gcc_asm_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitMSAsmStmt(clang::MSAsmStmt * ms_asm_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitMSAsmStmt(clang::MSAsmStmt *ms_asm_stmt,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMSAsmStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitMSAsmStmt" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    return VisitStmt(ms_asm_stmt, node) && res;
+  return VisitStmt(ms_asm_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBreakStmt(clang::BreakStmt * break_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitBreakStmt(clang::BreakStmt *break_stmt,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitBreakStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitBreakStmt" << std::endl;
 #endif
 
-    *node = SageBuilder::buildBreakStmt();
-    return VisitStmt(break_stmt, node);
+  *node = SageBuilder::buildBreakStmt();
+  return VisitStmt(break_stmt, node);
 }
 
-bool ClangToSageTranslator::VisitCapturedStmt(clang::CapturedStmt * captured_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitCapturedStmt(
+    clang::CapturedStmt *captured_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCapturedStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCapturedStmt" << std::endl;
 #endif
-    bool res = true;
-
-    clang::Stmt * clang_body = captured_stmt->getCapturedStmt();
-    SgNode * tmp_stmt = Traverse(clang_body);
-    SgStatement * body = isSgStatement(tmp_stmt);
-
-    // If the traversal returned an expression instead of a statement,
-    // wrap it in an expression statement (this happens when the captured
-    // region contains a single expression like a function call)
-    if (body == NULL && tmp_stmt != NULL) {
-        SgExpression * expr = isSgExpression(tmp_stmt);
-        if (expr != NULL) {
-            body = SageBuilder::buildExprStatement(expr);
-            if (clang_body != NULL) {
-                applySourceRange(body, clang_body->getSourceRange());
-            }
-        } else {
-            std::cerr << "Runtime error: CapturedStmt child did not translate into an SgStatement or SgExpression." << std::endl;
-            res = false;
-        }
-    }
-
-    if (body == NULL) {
-        body = SageBuilder::buildNullStatement();
-    }
-
-    *node = body;
-
-    return VisitStmt(captured_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::collectOpenMPPragmas(clang::Stmt* stmt, std::vector<CapturedPragma>& pragmas) {
-    pragmas.clear();
-
-    if (p_openmp_pragma_callback == nullptr || stmt == nullptr || p_compiler_instance == nullptr) {
-        return false;
-    }
-
-    clang::SourceLocation loc = stmt->getBeginLoc();
-    if (!loc.isValid()) {
-        return false;
-    }
-
-    clang::SourceManager& source_manager = p_compiler_instance->getSourceManager();
-    clang::FileID file_id = source_manager.getFileID(loc);
-    unsigned stmt_line = source_manager.getPresumedLineNumber(loc);
-    if (stmt_line == 0) {
-        return false;
-    }
-
-    bool found_any = false;
-    std::string pragma_text;
-
-    bool continue_across_multiline_directive = false;
-
-    for (unsigned search_line = stmt_line; search_line > 0; --search_line) {
-
-        if (p_openmp_pragma_callback->getPragmaAtLine(file_id, search_line, pragma_text)) {
-            bool is_openmp = p_openmp_pragma_callback->isOpenMPPragmaAtLine(file_id, search_line);
-            std::string directive_text = pragma_text;
-            if (is_openmp) {
-                std::string extracted = extractOpenMPDirective(pragma_text);
-                if (extracted.empty()) {
-                    continue;
-                }
-                directive_text = extracted;
-            }
-            pragmas.push_back({search_line, directive_text, is_openmp});
-            found_any = true;
-            continue_across_multiline_directive = true;
-            continue;
-        }
-
-        std::string line_content;
-        if (!getLineContent(source_manager, file_id, search_line, line_content)) {
-            break;
-        }
-
-        std::string trimmed = trimWhitespace(line_content);
-        bool is_statement_line = (search_line == stmt_line);
-
-        if (is_statement_line) {
-            continue;
-        }
-
-        if (trimmed.empty()) {
-            continue_across_multiline_directive = false;
-            continue;
-        }
-
-        // Check if this line is a continuation of a multi-line pragma (ends with backslash)
-        // We must check this regardless of whether we've found the pragma yet, because when
-        // scanning backwards, we encounter continuation lines BEFORE the pragma line itself
-        if (p_openmp_pragma_callback->isContinuationLine(file_id, search_line)) {
-            continue;
-        }
-
-        if (isSkippableLineBetweenPragmaAndStatement(trimmed)) {
-            continue_across_multiline_directive = false;
-            continue;
-        }
-
-        // Non-empty, non-continuation, non-skippable line - stop scanning
-        break;
-    }
-
-    if (found_any) {
-        std::reverse(pragmas.begin(), pragmas.end());
-    }
-
-    return found_any;
-}
-
-SgPragmaDeclaration* ClangToSageTranslator::buildOpenMPPragmaDeclaration(const std::string& directive, unsigned pragma_line, SgScopeStatement* scope) {
-    if (scope == NULL || directive.empty()) {
-        return NULL;
-    }
-
-    // Don't normalize here - OMP unparser will handle normalization
-    SgPragmaDeclaration* pragma_decl = SageBuilder::buildPragmaDeclaration(directive, scope);
-
-    // Use actual source file info instead of COMPILER_GENERATED so that attachPreprocessingInfo()
-    // can properly attach comments relative to the pragma based on source positions
-    std::string filename = p_sage_source_file->getFileName();
-    Sg_File_Info* start_fi = new Sg_File_Info(filename, pragma_line, 1);
-    Sg_File_Info* end_fi = new Sg_File_Info(filename, pragma_line, 1);
-
-    pragma_decl->set_startOfConstruct(start_fi);
-    pragma_decl->set_endOfConstruct(end_fi);
-    start_fi->set_parent(pragma_decl);
-    end_fi->set_parent(pragma_decl);
-    pragma_decl->set_parent(scope);
-
-    return pragma_decl;
-}
-
-void ClangToSageTranslator::appendOpenMPPragmasBefore(clang::Stmt* stmt, SgScopeStatement* scope) {
-    if (scope == NULL) {
-        return;
-    }
-
-    std::vector<CapturedPragma> pragmas;
-    if (!collectOpenMPPragmas(stmt, pragmas)) {
-        return;
-    }
-
-    for (const auto& entry : pragmas) {
-        SgPragmaDeclaration* pragma_decl = NULL;
-        if (entry.is_openmp) {
-            pragma_decl = buildOpenMPPragmaDeclaration(entry.text, entry.line, scope);
-        } else {
-            // Strip leading "#pragma" if present; SageBuilder re-adds it on unparse.
-            std::string pragma_body = entry.text;
-            const std::string prefix = "#pragma";
-            if (pragma_body.compare(0, prefix.size(), prefix) == 0) {
-                pragma_body = trimWhitespace(pragma_body.substr(prefix.size()));
-            }
-            pragma_decl = SageBuilder::buildPragmaDeclaration(pragma_body, scope);
-            if (pragma_decl != NULL) {
-                pragma_decl->set_parent(scope);
-            }
-        }
-        if (pragma_decl == NULL) {
-            continue;
-        }
-
-        if (SgBasicBlock* block = isSgBasicBlock(scope)) {
-            block->append_statement(pragma_decl);
-        } else {
-            SageInterface::appendStatement(pragma_decl, scope);
-        }
-    }
-}
-
-SgStatement* ClangToSageTranslator::wrapStatementWithOpenMPPragmas(clang::Stmt* stmt, SgStatement* statement) {
-    if (statement == NULL) {
-        return NULL;
-    }
-
-    std::vector<CapturedPragma> pragmas;
-    if (!collectOpenMPPragmas(stmt, pragmas)) {
-        return statement;
-    }
-
-    SgBasicBlock* wrapper_block = SageBuilder::buildBasicBlock();
-    setCompilerGeneratedFileInfo(wrapper_block, true);
-
-    for (const auto& entry : pragmas) {
-        SgPragmaDeclaration* pragma_decl = NULL;
-        if (entry.is_openmp) {
-            pragma_decl = buildOpenMPPragmaDeclaration(entry.text, entry.line, wrapper_block);
-        } else {
-            std::string pragma_body = entry.text;
-            const std::string prefix = "#pragma";
-            if (pragma_body.compare(0, prefix.size(), prefix) == 0) {
-                pragma_body = trimWhitespace(pragma_body.substr(prefix.size()));
-            }
-            pragma_decl = SageBuilder::buildPragmaDeclaration(pragma_body, wrapper_block);
-            if (pragma_decl != NULL) {
-                pragma_decl->set_parent(wrapper_block);
-            }
-        }
-        if (pragma_decl != NULL) {
-            wrapper_block->append_statement(pragma_decl);
-        }
-    }
-
-    wrapper_block->append_statement(statement);
-    return wrapper_block;
-}
-
-bool ClangToSageTranslator::VisitCompoundStmt(clang::CompoundStmt * compound_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCompoundStmt" << std::endl;
-#endif
-
-    bool res = true;
-
-    SgBasicBlock * block = SageBuilder::buildBasicBlock();
-
-    block->set_parent(SageBuilder::topScopeStack());
-
-    SageBuilder::pushScopeStack(block);
-
-    clang::CompoundStmt::body_iterator it;
-    for (it = compound_stmt->body_begin(); it != compound_stmt->body_end(); it++) {
-        clang::Stmt * child_stmt = *it;
-
-        appendOpenMPPragmasBefore(child_stmt, block);
-
-        SgNode * tmp_node = Traverse(child_stmt);
-
-#if DEBUG_VISIT_STMT
-        if (tmp_node != NULL)
-          std::cerr << "In VisitCompoundStmt : child is " << tmp_node->class_name() << std::endl;
-        else
-          std::cerr << "In VisitCompoundStmt : child is NULL" << std::endl;
-#endif
-
-        SgClassDeclaration * class_decl = isSgClassDeclaration(tmp_node);
-        if (class_decl != NULL && (class_decl->get_name() == "" || class_decl->get_isUnNamed())) continue;
-        SgEnumDeclaration * enum_decl = isSgEnumDeclaration(tmp_node);
-        if (enum_decl != NULL && (enum_decl->get_name() == "" || enum_decl->get_isUnNamed())) continue;
-#if DEBUG_VISIT_STMT
-        else if (enum_decl != NULL)
-          std::cerr << "enum_decl = " << enum_decl << " >> name: " << enum_decl->get_name() << std::endl;
-#endif
-
-        SgStatement * stmt  = isSgStatement(tmp_node);
-        SgExpression * expr = isSgExpression(tmp_node);
-        if (tmp_node != NULL && stmt == NULL && expr == NULL) {
-            std::cerr << "Runtime error: tmp_node != NULL && stmt == NULL && expr == NULL" << std::endl;
-            res = false;
-        }
-        else if (stmt != NULL) {
-            block->append_statement(stmt);
-        }
-        else if (expr != NULL) {
-            SgExprStatement * expr_stmt = SageBuilder::buildExprStatement(expr);
-            block->append_statement(expr_stmt);
-        }
-    }
-
-    SageBuilder::popScopeStack();
-
-    *node = block;
-
-    return VisitStmt(compound_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitContinueStmt(clang::ContinueStmt * continue_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitContinueStmt" << std::endl;
-#endif
-
-    *node = SageBuilder::buildContinueStmt();
-    return VisitStmt(continue_stmt, node);
-}
-
-bool ClangToSageTranslator::VisitCoreturnStmt(clang::CoreturnStmt * core_turn_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCoreturnStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-    return VisitStmt(core_turn_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCoroutineBodyStmt(clang::CoroutineBodyStmt * coroutine_body_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCoroutineBodyStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-    return VisitStmt(coroutine_body_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXCatchStmt(clang::CXXCatchStmt * cxx_catch_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXCatchStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-    return VisitStmt(cxx_catch_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXForRangeStmt(clang::CXXForRangeStmt * cxx_for_range_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXForRangeStmt" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: C++11 range-based for loop: for (auto x : container) { ... }
-    // Clang desugars this into a regular for loop with begin/end iterators
-    // For ROSE, we build a SgForStatement using the desugared components
-
-    // Get the desugared components from Clang
-    // Range init contains the range expression (e.g., the container)
-    SgNode* tmp_range_init = cxx_for_range_stmt->getRangeInit() ? Traverse(cxx_for_range_stmt->getRangeInit()) : nullptr;
-    SgStatement* range_init = isSgStatement(tmp_range_init);
-
-    // Begin/end iterator setup - must be included in init_stmts
-    // The condition and increment expressions reference __begin/__end variables created here
-    SgNode* tmp_begin = cxx_for_range_stmt->getBeginStmt() ? Traverse(cxx_for_range_stmt->getBeginStmt()) : nullptr;
-    SgStatement* begin_stmt = isSgStatement(tmp_begin);
-
-    SgNode* tmp_end = cxx_for_range_stmt->getEndStmt() ? Traverse(cxx_for_range_stmt->getEndStmt()) : nullptr;
-    SgStatement* end_stmt = isSgStatement(tmp_end);
-
-    // Loop variable declaration
-    SgNode* tmp_loop_var = cxx_for_range_stmt->getLoopVariable() ? Traverse(cxx_for_range_stmt->getLoopVariable()) : nullptr;
-    SgStatement* loop_var_decl = isSgStatement(tmp_loop_var);
-
-    // Condition, increment, and body
-    SgNode* tmp_cond = cxx_for_range_stmt->getCond() ? Traverse(cxx_for_range_stmt->getCond()) : nullptr;
-    SgExpression* cond = isSgExpression(tmp_cond);
-
-    SgNode* tmp_inc = cxx_for_range_stmt->getInc() ? Traverse(cxx_for_range_stmt->getInc()) : nullptr;
-    SgExpression* inc = isSgExpression(tmp_inc);
-
-    SgNode* tmp_body = cxx_for_range_stmt->getBody() ? Traverse(cxx_for_range_stmt->getBody()) : nullptr;
-    SgStatement* body = isSgStatement(tmp_body);
-    if (body == nullptr) {
-        SgExpression* body_expr = isSgExpression(tmp_body);
-        if (body_expr != nullptr) {
-            body = SageBuilder::buildExprStatement(body_expr);
-            applySourceRange(body, cxx_for_range_stmt->getBody()->getSourceRange());
-        }
-    }
-    if (body != nullptr) {
-        body = wrapStatementWithOpenMPPragmas(cxx_for_range_stmt->getBody(), body);
-    }
-
-    // Build initialization statement list (range init + begin/end iterators + loop variable)
-    SgStatementPtrList init_stmts;
-    if (range_init) init_stmts.push_back(range_init);
-    if (begin_stmt) init_stmts.push_back(begin_stmt);
-    if (end_stmt) init_stmts.push_back(end_stmt);
-    if (loop_var_decl) init_stmts.push_back(loop_var_decl);
-
-    // Build the for loop with these components
-    SgForInitStatement* for_init = SageBuilder::buildForInitStatement(init_stmts);
-    SgStatement* test = cond ? SageBuilder::buildExprStatement(cond) : nullptr;
-
-    *node = SageBuilder::buildForStatement(for_init, test, inc, body);
-
-    return VisitStmt(cxx_for_range_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXTryStmt(clang::CXXTryStmt * cxx_try_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXTryStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-    return VisitStmt(cxx_try_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt * decl_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDeclStmt" << std::endl;
-#endif
-
-    bool res = true;
-
-    if (decl_stmt->isSingleDecl()) {
-        *node = Traverse(decl_stmt->getSingleDecl());
-#if DEBUG_VISIT_STMT
-        printf ("In VisitDeclStmt(): *node = %p = %s \n",*node,(*node)->class_name().c_str());
-#endif
-    }
-    else {
-        std::vector<SgNode *> tmp_decls;
-        //SgDeclarationStatement * decl;
-        clang::DeclStmt::decl_iterator it;
-
-        SgScopeStatement * scope = SageBuilder::topScopeStack();
-
-        for (it = decl_stmt->decl_begin(); it != decl_stmt->decl_end()-1; it++) {
-            clang::Decl* decl = (*it);
-            if (decl == nullptr) continue;
-            SgNode * child = Traverse(decl);
-
-            SgDeclarationStatement * sub_decl_stmt = isSgDeclarationStatement(child);
-            if (sub_decl_stmt == NULL && child != NULL) {
-                std::cerr << "Runtime error: the node produce for a clang::Decl is not a SgDeclarationStatement !" << std::endl;
-                std::cerr << "    class = " << child->class_name() << std::endl;
-                res = false;
-                continue;
-            }
-            else if (child != NULL) {
-                // FIXME This is a hack to avoid autonomous decl of unnamed type to being added to the global scope....
-                SgClassDeclaration * class_decl = isSgClassDeclaration(child);
-                if (class_decl != NULL && (class_decl->get_name() == "" || class_decl->get_isUnNamed())) continue;
-
-                SgEnumDeclaration * enum_decl = isSgEnumDeclaration(child);
-                if (enum_decl != NULL && (enum_decl->get_name() == "" || enum_decl->get_isUnNamed())) continue;
-                if(clang::TagDecl::classof(decl))
-                {
-                  clang::TagDecl* tagDecl = (clang::TagDecl*)decl;
-                  if(tagDecl->isEmbeddedInDeclarator())  continue;
-                }
-
-            }
-            scope->append_statement(sub_decl_stmt);
-            sub_decl_stmt->set_parent(scope);
-        }
-        // last declaration in scope
-        it = decl_stmt->decl_end();
-        --it;
-        SgNode * lastDecl = Traverse((clang::Decl*)(*it));
-        SgDeclarationStatement * last_decl_Stmt = isSgDeclarationStatement(lastDecl);
-        if (lastDecl != NULL && last_decl_Stmt == NULL) {
-            std::cerr << "Runtime error: lastDecl != NULL && last_decl_Stmt == NULL" << std::endl;
-            res = false;
-        }
-        *node = last_decl_Stmt;
-    }
-
-#if DEBUG_VISIT_STMT
-    printf ("In VisitDeclStmt(): identify where the parent is not set: *node = %p = %s \n",*node,(*node)->class_name().c_str());
-    printf (" --- *node parent = %p \n",(*node)->get_parent());
-#endif
-
-    return res;
-}
-
-bool ClangToSageTranslator::VisitDoStmt(clang::DoStmt * do_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDoStmt" << std::endl;
-#endif
-
-    SgNode * tmp_cond = Traverse(do_stmt->getCond());
-    SgExpression * cond = isSgExpression(tmp_cond);
-    ROSE_ASSERT(cond != NULL);
-
-    SgStatement * expr_stmt = SageBuilder::buildExprStatement(cond);
-
-    ROSE_ASSERT(expr_stmt != NULL);
-
-    SgDoWhileStmt * sg_do_stmt = SageBuilder::buildDoWhileStmt_nfi(expr_stmt, NULL);
-
-    sg_do_stmt->set_condition(expr_stmt);
-
-    cond->set_parent(expr_stmt);
-    expr_stmt->set_parent(sg_do_stmt);
-
-    SageBuilder::pushScopeStack(sg_do_stmt);
-
-    SgNode * tmp_body = Traverse(do_stmt->getBody());
-    SgStatement * body = isSgStatement(tmp_body);
-    SgExpression * expr = isSgExpression(tmp_body);
+  bool res = true;
+
+  clang::Stmt *clang_body = captured_stmt->getCapturedStmt();
+  SgNode *tmp_stmt = Traverse(clang_body);
+  SgStatement *body = isSgStatement(tmp_stmt);
+
+  // If the traversal returned an expression instead of a statement,
+  // wrap it in an expression statement (this happens when the captured
+  // region contains a single expression like a function call)
+  if (body == NULL && tmp_stmt != NULL) {
+    SgExpression *expr = isSgExpression(tmp_stmt);
     if (expr != NULL) {
-        body =  SageBuilder::buildExprStatement(expr);
-        applySourceRange(body, do_stmt->getBody()->getSourceRange());
+      body = SageBuilder::buildExprStatement(expr);
+      if (clang_body != NULL) {
+        applySourceRange(body, clang_body->getSourceRange());
+      }
+    } else {
+      std::cerr << "Runtime error: CapturedStmt child did not translate into "
+                   "an SgStatement or SgExpression."
+                << std::endl;
+      res = false;
     }
-    ROSE_ASSERT(body != NULL);
-    body = wrapStatementWithOpenMPPragmas(do_stmt->getBody(), body);
+  }
 
-    body->set_parent(sg_do_stmt);
+  if (body == NULL) {
+    body = SageBuilder::buildNullStatement();
+  }
 
-    SageBuilder::popScopeStack();
+  *node = body;
 
-    sg_do_stmt->set_body(body);
-
-    *node = sg_do_stmt;
-
-    return VisitStmt(do_stmt, node); 
+  return VisitStmt(captured_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitForStmt(clang::ForStmt * for_stmt, SgNode ** node) {
+bool ClangToSageTranslator::collectOpenMPPragmas(
+    clang::Stmt *stmt, std::vector<CapturedPragma> &pragmas) {
+  pragmas.clear();
+
+  if (p_openmp_pragma_callback == nullptr || stmt == nullptr ||
+      p_compiler_instance == nullptr) {
+    return false;
+  }
+
+  clang::SourceLocation loc = stmt->getBeginLoc();
+  if (!loc.isValid()) {
+    return false;
+  }
+
+  clang::SourceManager &source_manager =
+      p_compiler_instance->getSourceManager();
+  clang::FileID file_id = source_manager.getFileID(loc);
+  unsigned stmt_line = source_manager.getPresumedLineNumber(loc);
+  if (stmt_line == 0) {
+    return false;
+  }
+
+  bool found_any = false;
+  std::string pragma_text;
+
+  bool continue_across_multiline_directive = false;
+
+  for (unsigned search_line = stmt_line; search_line > 0; --search_line) {
+
+    if (p_openmp_pragma_callback->getPragmaAtLine(file_id, search_line,
+                                                  pragma_text)) {
+      bool is_openmp =
+          p_openmp_pragma_callback->isOpenMPPragmaAtLine(file_id, search_line);
+      std::string directive_text = pragma_text;
+      if (is_openmp) {
+        std::string extracted = extractOpenMPDirective(pragma_text);
+        if (extracted.empty()) {
+          continue;
+        }
+        directive_text = extracted;
+      }
+      pragmas.push_back({search_line, directive_text, is_openmp});
+      found_any = true;
+      continue_across_multiline_directive = true;
+      continue;
+    }
+
+    std::string line_content;
+    if (!getLineContent(source_manager, file_id, search_line, line_content)) {
+      break;
+    }
+
+    std::string trimmed = trimWhitespace(line_content);
+    bool is_statement_line = (search_line == stmt_line);
+
+    if (is_statement_line) {
+      continue;
+    }
+
+    if (trimmed.empty()) {
+      continue_across_multiline_directive = false;
+      continue;
+    }
+
+    // Check if this line is a continuation of a multi-line pragma (ends with
+    // backslash) We must check this regardless of whether we've found the
+    // pragma yet, because when scanning backwards, we encounter continuation
+    // lines BEFORE the pragma line itself
+    if (p_openmp_pragma_callback->isContinuationLine(file_id, search_line)) {
+      continue;
+    }
+
+    if (isSkippableLineBetweenPragmaAndStatement(trimmed)) {
+      continue_across_multiline_directive = false;
+      continue;
+    }
+
+    // Non-empty, non-continuation, non-skippable line - stop scanning
+    break;
+  }
+
+  if (found_any) {
+    std::reverse(pragmas.begin(), pragmas.end());
+  }
+
+  return found_any;
+}
+
+SgPragmaDeclaration *ClangToSageTranslator::buildOpenMPPragmaDeclaration(
+    const std::string &directive, unsigned pragma_line,
+    SgScopeStatement *scope) {
+  if (scope == NULL || directive.empty()) {
+    return NULL;
+  }
+
+  // Don't normalize here - OMP unparser will handle normalization
+  SgPragmaDeclaration *pragma_decl =
+      SageBuilder::buildPragmaDeclaration(directive, scope);
+
+  // Use actual source file info instead of COMPILER_GENERATED so that
+  // attachPreprocessingInfo() can properly attach comments relative to the
+  // pragma based on source positions
+  std::string filename = p_sage_source_file->getFileName();
+  Sg_File_Info *start_fi = new Sg_File_Info(filename, pragma_line, 1);
+  Sg_File_Info *end_fi = new Sg_File_Info(filename, pragma_line, 1);
+
+  pragma_decl->set_startOfConstruct(start_fi);
+  pragma_decl->set_endOfConstruct(end_fi);
+  start_fi->set_parent(pragma_decl);
+  end_fi->set_parent(pragma_decl);
+  pragma_decl->set_parent(scope);
+
+  return pragma_decl;
+}
+
+void ClangToSageTranslator::appendOpenMPPragmasBefore(clang::Stmt *stmt,
+                                                      SgScopeStatement *scope) {
+  if (scope == NULL) {
+    return;
+  }
+
+  std::vector<CapturedPragma> pragmas;
+  if (!collectOpenMPPragmas(stmt, pragmas)) {
+    return;
+  }
+
+  for (const auto &entry : pragmas) {
+    SgPragmaDeclaration *pragma_decl = NULL;
+    if (entry.is_openmp) {
+      pragma_decl = buildOpenMPPragmaDeclaration(entry.text, entry.line, scope);
+    } else {
+      // Strip leading "#pragma" if present; SageBuilder re-adds it on unparse.
+      std::string pragma_body = entry.text;
+      const std::string prefix = "#pragma";
+      if (pragma_body.compare(0, prefix.size(), prefix) == 0) {
+        pragma_body = trimWhitespace(pragma_body.substr(prefix.size()));
+      }
+      pragma_decl = SageBuilder::buildPragmaDeclaration(pragma_body, scope);
+      if (pragma_decl != NULL) {
+        pragma_decl->set_parent(scope);
+      }
+    }
+    if (pragma_decl == NULL) {
+      continue;
+    }
+
+    if (SgBasicBlock *block = isSgBasicBlock(scope)) {
+      block->append_statement(pragma_decl);
+    } else {
+      SageInterface::appendStatement(pragma_decl, scope);
+    }
+  }
+}
+
+SgStatement *
+ClangToSageTranslator::wrapStatementWithOpenMPPragmas(clang::Stmt *stmt,
+                                                      SgStatement *statement) {
+  if (statement == NULL) {
+    return NULL;
+  }
+
+  std::vector<CapturedPragma> pragmas;
+  if (!collectOpenMPPragmas(stmt, pragmas)) {
+    return statement;
+  }
+
+  SgBasicBlock *wrapper_block = SageBuilder::buildBasicBlock();
+  setCompilerGeneratedFileInfo(wrapper_block, true);
+
+  for (const auto &entry : pragmas) {
+    SgPragmaDeclaration *pragma_decl = NULL;
+    if (entry.is_openmp) {
+      pragma_decl =
+          buildOpenMPPragmaDeclaration(entry.text, entry.line, wrapper_block);
+    } else {
+      std::string pragma_body = entry.text;
+      const std::string prefix = "#pragma";
+      if (pragma_body.compare(0, prefix.size(), prefix) == 0) {
+        pragma_body = trimWhitespace(pragma_body.substr(prefix.size()));
+      }
+      pragma_decl =
+          SageBuilder::buildPragmaDeclaration(pragma_body, wrapper_block);
+      if (pragma_decl != NULL) {
+        pragma_decl->set_parent(wrapper_block);
+      }
+    }
+    if (pragma_decl != NULL) {
+      wrapper_block->append_statement(pragma_decl);
+    }
+  }
+
+  wrapper_block->append_statement(statement);
+  return wrapper_block;
+}
+
+bool ClangToSageTranslator::VisitCompoundStmt(
+    clang::CompoundStmt *compound_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitForStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCompoundStmt" << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
- // DQ (11/28/2020): We have to build the scope first, and then build the rest bottom up.
-    SgForStatement* sg_for_stmt = new SgForStatement((SgStatement*)NULL,(SgExpression*)NULL,(SgStatement*)NULL);
+  SgBasicBlock *block = SageBuilder::buildBasicBlock();
+
+  block->set_parent(SageBuilder::topScopeStack());
+
+  SageBuilder::pushScopeStack(block);
+
+  clang::CompoundStmt::body_iterator it;
+  for (it = compound_stmt->body_begin(); it != compound_stmt->body_end();
+       it++) {
+    clang::Stmt *child_stmt = *it;
+
+    appendOpenMPPragmasBefore(child_stmt, block);
+
+    SgNode *tmp_node = Traverse(child_stmt);
 
 #if DEBUG_VISIT_STMT
-    printf ("In VisitForStmt(): Setting the parent of the sg_for_stmt \n");
+    if (tmp_node != NULL)
+      std::cerr << "In VisitCompoundStmt : child is " << tmp_node->class_name()
+                << std::endl;
+    else
+      std::cerr << "In VisitCompoundStmt : child is NULL" << std::endl;
 #endif
 
- // DQ (11/28/2020): this is required for test2012_127.c.
-    sg_for_stmt->set_parent(SageBuilder::topScopeStack());
+    SgClassDeclaration *class_decl = isSgClassDeclaration(tmp_node);
+    if (class_decl != NULL &&
+        (class_decl->get_name() == "" || class_decl->get_isUnNamed()))
+      continue;
+    SgEnumDeclaration *enum_decl = isSgEnumDeclaration(tmp_node);
+    if (enum_decl != NULL &&
+        (enum_decl->get_name() == "" || enum_decl->get_isUnNamed()))
+      continue;
+#if DEBUG_VISIT_STMT
+    else if (enum_decl != NULL)
+      std::cerr << "enum_decl = " << enum_decl
+                << " >> name: " << enum_decl->get_name() << std::endl;
+#endif
 
- // DQ (11/28/2020): Adding asertion.
-    ROSE_ASSERT(sg_for_stmt->get_parent() != NULL);
+    SgStatement *stmt = isSgStatement(tmp_node);
+    SgExpression *expr = isSgExpression(tmp_node);
+    if (tmp_node != NULL && stmt == NULL && expr == NULL) {
+      std::cerr
+          << "Runtime error: tmp_node != NULL && stmt == NULL && expr == NULL"
+          << std::endl;
+      res = false;
+    } else if (stmt != NULL) {
+      block->append_statement(stmt);
+    } else if (expr != NULL) {
+      SgExprStatement *expr_stmt = SageBuilder::buildExprStatement(expr);
+      block->append_statement(expr_stmt);
+    }
+  }
 
-    SageBuilder::pushScopeStack(sg_for_stmt);
+  SageBuilder::popScopeStack();
+
+  *node = block;
+
+  return VisitStmt(compound_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitContinueStmt(
+    clang::ContinueStmt *continue_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitContinueStmt" << std::endl;
+#endif
+
+  *node = SageBuilder::buildContinueStmt();
+  return VisitStmt(continue_stmt, node);
+}
+
+bool ClangToSageTranslator::VisitCoreturnStmt(
+    clang::CoreturnStmt *core_turn_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCoreturnStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  return VisitStmt(core_turn_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCoroutineBodyStmt(
+    clang::CoroutineBodyStmt *coroutine_body_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCoroutineBodyStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  return VisitStmt(coroutine_body_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXCatchStmt(
+    clang::CXXCatchStmt *cxx_catch_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXCatchStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  return VisitStmt(cxx_catch_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXForRangeStmt(
+    clang::CXXForRangeStmt *cxx_for_range_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXForRangeStmt" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: C++11 range-based for loop: for (auto x : container) { ...
+  // } Clang desugars this into a regular for loop with begin/end iterators For
+  // ROSE, we build a SgForStatement using the desugared components
+
+  // Get the desugared components from Clang
+  // Range init contains the range expression (e.g., the container)
+  SgNode *tmp_range_init = cxx_for_range_stmt->getRangeInit()
+                               ? Traverse(cxx_for_range_stmt->getRangeInit())
+                               : nullptr;
+  SgStatement *range_init = isSgStatement(tmp_range_init);
+
+  // Begin/end iterator setup - must be included in init_stmts
+  // The condition and increment expressions reference __begin/__end variables
+  // created here
+  SgNode *tmp_begin = cxx_for_range_stmt->getBeginStmt()
+                          ? Traverse(cxx_for_range_stmt->getBeginStmt())
+                          : nullptr;
+  SgStatement *begin_stmt = isSgStatement(tmp_begin);
+
+  SgNode *tmp_end = cxx_for_range_stmt->getEndStmt()
+                        ? Traverse(cxx_for_range_stmt->getEndStmt())
+                        : nullptr;
+  SgStatement *end_stmt = isSgStatement(tmp_end);
+
+  // Loop variable declaration
+  SgNode *tmp_loop_var = cxx_for_range_stmt->getLoopVariable()
+                             ? Traverse(cxx_for_range_stmt->getLoopVariable())
+                             : nullptr;
+  SgStatement *loop_var_decl = isSgStatement(tmp_loop_var);
+
+  // Condition, increment, and body
+  SgNode *tmp_cond = cxx_for_range_stmt->getCond()
+                         ? Traverse(cxx_for_range_stmt->getCond())
+                         : nullptr;
+  SgExpression *cond = isSgExpression(tmp_cond);
+
+  SgNode *tmp_inc = cxx_for_range_stmt->getInc()
+                        ? Traverse(cxx_for_range_stmt->getInc())
+                        : nullptr;
+  SgExpression *inc = isSgExpression(tmp_inc);
+
+  SgNode *tmp_body = cxx_for_range_stmt->getBody()
+                         ? Traverse(cxx_for_range_stmt->getBody())
+                         : nullptr;
+  SgStatement *body = isSgStatement(tmp_body);
+  if (body == nullptr) {
+    SgExpression *body_expr = isSgExpression(tmp_body);
+    if (body_expr != nullptr) {
+      body = SageBuilder::buildExprStatement(body_expr);
+      applySourceRange(body, cxx_for_range_stmt->getBody()->getSourceRange());
+    }
+  }
+  if (body != nullptr) {
+    body = wrapStatementWithOpenMPPragmas(cxx_for_range_stmt->getBody(), body);
+  }
+
+  // Build initialization statement list (range init + begin/end iterators +
+  // loop variable)
+  SgStatementPtrList init_stmts;
+  if (range_init)
+    init_stmts.push_back(range_init);
+  if (begin_stmt)
+    init_stmts.push_back(begin_stmt);
+  if (end_stmt)
+    init_stmts.push_back(end_stmt);
+  if (loop_var_decl)
+    init_stmts.push_back(loop_var_decl);
+
+  // Build the for loop with these components
+  SgForInitStatement *for_init = SageBuilder::buildForInitStatement(init_stmts);
+  SgStatement *test = cond ? SageBuilder::buildExprStatement(cond) : nullptr;
+
+  *node = SageBuilder::buildForStatement(for_init, test, inc, body);
+
+  return VisitStmt(cxx_for_range_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXTryStmt(clang::CXXTryStmt *cxx_try_stmt,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXTryStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  return VisitStmt(cxx_try_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
+                                          SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDeclStmt" << std::endl;
+#endif
+
+  bool res = true;
+
+  if (decl_stmt->isSingleDecl()) {
+    *node = Traverse(decl_stmt->getSingleDecl());
+#if DEBUG_VISIT_STMT
+    printf("In VisitDeclStmt(): *node = %p = %s \n", *node,
+           (*node)->class_name().c_str());
+#endif
+  } else {
+    std::vector<SgNode *> tmp_decls;
+    // SgDeclarationStatement * decl;
+    clang::DeclStmt::decl_iterator it;
+
+    SgScopeStatement *scope = SageBuilder::topScopeStack();
+
+    for (it = decl_stmt->decl_begin(); it != decl_stmt->decl_end() - 1; it++) {
+      clang::Decl *decl = (*it);
+      if (decl == nullptr)
+        continue;
+      SgNode *child = Traverse(decl);
+
+      SgDeclarationStatement *sub_decl_stmt = isSgDeclarationStatement(child);
+      if (sub_decl_stmt == NULL && child != NULL) {
+        std::cerr << "Runtime error: the node produce for a clang::Decl is not "
+                     "a SgDeclarationStatement !"
+                  << std::endl;
+        std::cerr << "    class = " << child->class_name() << std::endl;
+        res = false;
+        continue;
+      } else if (child != NULL) {
+        // FIXME This is a hack to avoid autonomous decl of unnamed type to
+        // being added to the global scope....
+        SgClassDeclaration *class_decl = isSgClassDeclaration(child);
+        if (class_decl != NULL &&
+            (class_decl->get_name() == "" || class_decl->get_isUnNamed()))
+          continue;
+
+        SgEnumDeclaration *enum_decl = isSgEnumDeclaration(child);
+        if (enum_decl != NULL &&
+            (enum_decl->get_name() == "" || enum_decl->get_isUnNamed()))
+          continue;
+        if (clang::TagDecl::classof(decl)) {
+          clang::TagDecl *tagDecl = (clang::TagDecl *)decl;
+          if (tagDecl->isEmbeddedInDeclarator())
+            continue;
+        }
+      }
+      scope->append_statement(sub_decl_stmt);
+      sub_decl_stmt->set_parent(scope);
+    }
+    // last declaration in scope
+    it = decl_stmt->decl_end();
+    --it;
+    SgNode *lastDecl = Traverse((clang::Decl *)(*it));
+    SgDeclarationStatement *last_decl_Stmt = isSgDeclarationStatement(lastDecl);
+    if (lastDecl != NULL && last_decl_Stmt == NULL) {
+      std::cerr << "Runtime error: lastDecl != NULL && last_decl_Stmt == NULL"
+                << std::endl;
+      res = false;
+    }
+    *node = last_decl_Stmt;
+  }
+
+#if DEBUG_VISIT_STMT
+  printf("In VisitDeclStmt(): identify where the parent is not set: *node = %p "
+         "= %s \n",
+         *node, (*node)->class_name().c_str());
+  printf(" --- *node parent = %p \n", (*node)->get_parent());
+#endif
+
+  return res;
+}
+
+bool ClangToSageTranslator::VisitDoStmt(clang::DoStmt *do_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDoStmt" << std::endl;
+#endif
+
+  SgNode *tmp_cond = Traverse(do_stmt->getCond());
+  SgExpression *cond = isSgExpression(tmp_cond);
+  ROSE_ASSERT(cond != NULL);
+
+  SgStatement *expr_stmt = SageBuilder::buildExprStatement(cond);
+
+  ROSE_ASSERT(expr_stmt != NULL);
+
+  SgDoWhileStmt *sg_do_stmt =
+      SageBuilder::buildDoWhileStmt_nfi(expr_stmt, NULL);
+
+  sg_do_stmt->set_condition(expr_stmt);
+
+  cond->set_parent(expr_stmt);
+  expr_stmt->set_parent(sg_do_stmt);
+
+  SageBuilder::pushScopeStack(sg_do_stmt);
+
+  SgNode *tmp_body = Traverse(do_stmt->getBody());
+  SgStatement *body = isSgStatement(tmp_body);
+  SgExpression *expr = isSgExpression(tmp_body);
+  if (expr != NULL) {
+    body = SageBuilder::buildExprStatement(expr);
+    applySourceRange(body, do_stmt->getBody()->getSourceRange());
+  }
+  ROSE_ASSERT(body != NULL);
+  body = wrapStatementWithOpenMPPragmas(do_stmt->getBody(), body);
+
+  body->set_parent(sg_do_stmt);
+
+  SageBuilder::popScopeStack();
+
+  sg_do_stmt->set_body(body);
+
+  *node = sg_do_stmt;
+
+  return VisitStmt(do_stmt, node);
+}
+
+bool ClangToSageTranslator::VisitForStmt(clang::ForStmt *for_stmt,
+                                         SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitForStmt" << std::endl;
+#endif
+
+  bool res = true;
+
+  // DQ (11/28/2020): We have to build the scope first, and then build the rest
+  // bottom up.
+  SgForStatement *sg_for_stmt = new SgForStatement(
+      (SgStatement *)NULL, (SgExpression *)NULL, (SgStatement *)NULL);
+
+#if DEBUG_VISIT_STMT
+  printf("In VisitForStmt(): Setting the parent of the sg_for_stmt \n");
+#endif
+
+  // DQ (11/28/2020): this is required for test2012_127.c.
+  sg_for_stmt->set_parent(SageBuilder::topScopeStack());
+
+  // DQ (11/28/2020): Adding asertion.
+  ROSE_ASSERT(sg_for_stmt->get_parent() != NULL);
+
+  SageBuilder::pushScopeStack(sg_for_stmt);
 
   // Initialization
 
-    SgForInitStatement * for_init_stmt = NULL;
+  SgForInitStatement *for_init_stmt = NULL;
 
-    {
-        SgStatementPtrList for_init_stmt_list;
-        SgNode * tmp_init = Traverse(for_stmt->getInit());
-        SgStatement * init_stmt = isSgStatement(tmp_init);
-        SgExpression * init_expr = isSgExpression(tmp_init);
-        if (tmp_init != NULL && init_stmt == NULL && init_expr == NULL) {
-            std::cerr << "Runtime error: tmp_init != NULL && init_stmt == NULL && init_expr == NULL (" << tmp_init->class_name() << ")" << std::endl;
-            res = false;
-        }
-        else if (init_expr != NULL) {
-            init_stmt = SageBuilder::buildExprStatement(init_expr);
-            applySourceRange(init_stmt, for_stmt->getInit()->getSourceRange());
-        }
-        if (init_stmt != NULL)
-            for_init_stmt_list.push_back(init_stmt);
+  {
+    SgStatementPtrList for_init_stmt_list;
+    SgNode *tmp_init = Traverse(for_stmt->getInit());
+    SgStatement *init_stmt = isSgStatement(tmp_init);
+    SgExpression *init_expr = isSgExpression(tmp_init);
+    if (tmp_init != NULL && init_stmt == NULL && init_expr == NULL) {
+      std::cerr << "Runtime error: tmp_init != NULL && init_stmt == NULL && "
+                   "init_expr == NULL ("
+                << tmp_init->class_name() << ")" << std::endl;
+      res = false;
+    } else if (init_expr != NULL) {
+      init_stmt = SageBuilder::buildExprStatement(init_expr);
+      applySourceRange(init_stmt, for_stmt->getInit()->getSourceRange());
+    }
+    if (init_stmt != NULL)
+      for_init_stmt_list.push_back(init_stmt);
 
-        if(for_init_stmt_list.size() == 0)
-        {
-          SgNullStatement* nullStmt = SageBuilder::buildNullStatement_nfi();
-          setCompilerGeneratedFileInfo(nullStmt, true);
-          for_init_stmt_list.push_back(nullStmt);
-        }
+    if (for_init_stmt_list.size() == 0) {
+      SgNullStatement *nullStmt = SageBuilder::buildNullStatement_nfi();
+      setCompilerGeneratedFileInfo(nullStmt, true);
+      for_init_stmt_list.push_back(nullStmt);
+    }
 
-        for_init_stmt = SageBuilder::buildForInitStatement_nfi(for_init_stmt_list);
+    for_init_stmt = SageBuilder::buildForInitStatement_nfi(for_init_stmt_list);
 
 #if DEBUG_VISIT_STMT
-        printf ("In VisitForStmt(): for_init_stmt = %p  \n");
+    printf("In VisitForStmt(): for_init_stmt = %p  \n");
 #endif
 
-        if (for_stmt->getInit() != NULL)
-            applySourceRange(for_init_stmt, for_stmt->getInit()->getSourceRange());
-        else
-            setCompilerGeneratedFileInfo(for_init_stmt, true);
-    }
+    if (for_stmt->getInit() != NULL)
+      applySourceRange(for_init_stmt, for_stmt->getInit()->getSourceRange());
+    else
+      setCompilerGeneratedFileInfo(for_init_stmt, true);
+  }
 
   // Condition
 
-    SgStatement * cond_stmt = NULL;
+  SgStatement *cond_stmt = NULL;
 
-    {
-        SgNode * tmp_cond = Traverse(for_stmt->getCond());
-        SgExpression * cond = isSgExpression(tmp_cond);
-        if (tmp_cond != NULL && cond == NULL) {
-            std::cerr << "Runtime error: tmp_cond != NULL && cond == NULL" << std::endl;
-            res = false;
-        }
-        if (cond != NULL) {
-            cond_stmt = SageBuilder::buildExprStatement(cond);
-            applySourceRange(cond_stmt, for_stmt->getCond()->getSourceRange());
-        }
-        else {
-            cond_stmt = SageBuilder::buildNullStatement_nfi();
-            setCompilerGeneratedFileInfo(cond_stmt, true);
-        }
-
-        if (cond_stmt != NULL) {
-            auto *expr_stmt = isSgExprStatement(cond_stmt);
-            if (expr_stmt != NULL) {
-                auto simplifyOperand = [](SgExpression *operand) -> SgExpression * {
-                    SgExpression *current = operand;
-                    while (auto cast = isSgCastExp(current)) {
-                        current = cast->get_operand_i();
-                    }
-                    if (isSgVarRefExp(current) != NULL || isSgIntVal(current) != NULL ||
-                        isSgUnsignedIntVal(current) != NULL || isSgLongLongIntVal(current) != NULL ||
-                        isSgUnsignedLongLongIntVal(current) != NULL) {
-                        return SageInterface::copyExpression(current);
-                    }
-                    return nullptr;
-                };
-
-                if (auto *less_than = isSgLessThanOp(expr_stmt->get_expression())) {
-                    SgExpression *lhs_simplified = simplifyOperand(less_than->get_lhs_operand());
-                    SgExpression *rhs_simplified = simplifyOperand(less_than->get_rhs_operand());
-                    if (lhs_simplified != NULL && rhs_simplified != NULL) {
-                        SgExpression *new_cond = SageBuilder::buildLessThanOp(lhs_simplified, rhs_simplified);
-                        applySourceRange(new_cond, for_stmt->getCond()->getSourceRange());
-                        expr_stmt->set_expression(new_cond);
-                        new_cond->set_parent(expr_stmt);
-                    }
-                }
-            }
-        }
+  {
+    SgNode *tmp_cond = Traverse(for_stmt->getCond());
+    SgExpression *cond = isSgExpression(tmp_cond);
+    if (tmp_cond != NULL && cond == NULL) {
+      std::cerr << "Runtime error: tmp_cond != NULL && cond == NULL"
+                << std::endl;
+      res = false;
     }
+    if (cond != NULL) {
+      cond_stmt = SageBuilder::buildExprStatement(cond);
+      applySourceRange(cond_stmt, for_stmt->getCond()->getSourceRange());
+    } else {
+      cond_stmt = SageBuilder::buildNullStatement_nfi();
+      setCompilerGeneratedFileInfo(cond_stmt, true);
+    }
+
+    if (cond_stmt != NULL) {
+      auto *expr_stmt = isSgExprStatement(cond_stmt);
+      if (expr_stmt != NULL) {
+        auto simplifyOperand = [](SgExpression *operand) -> SgExpression * {
+          SgExpression *current = operand;
+          while (auto cast = isSgCastExp(current)) {
+            current = cast->get_operand_i();
+          }
+          if (isSgVarRefExp(current) != NULL || isSgIntVal(current) != NULL ||
+              isSgUnsignedIntVal(current) != NULL ||
+              isSgLongLongIntVal(current) != NULL ||
+              isSgUnsignedLongLongIntVal(current) != NULL) {
+            return SageInterface::copyExpression(current);
+          }
+          return nullptr;
+        };
+
+        if (auto *less_than = isSgLessThanOp(expr_stmt->get_expression())) {
+          SgExpression *lhs_simplified =
+              simplifyOperand(less_than->get_lhs_operand());
+          SgExpression *rhs_simplified =
+              simplifyOperand(less_than->get_rhs_operand());
+          if (lhs_simplified != NULL && rhs_simplified != NULL) {
+            SgExpression *new_cond =
+                SageBuilder::buildLessThanOp(lhs_simplified, rhs_simplified);
+            applySourceRange(new_cond, for_stmt->getCond()->getSourceRange());
+            expr_stmt->set_expression(new_cond);
+            new_cond->set_parent(expr_stmt);
+          }
+        }
+      }
+    }
+  }
 
   // Increment
 
-    SgExpression * inc = NULL;
+  SgExpression *inc = NULL;
 
-    {
-        SgNode * tmp_inc  = Traverse(for_stmt->getInc());
-        inc = isSgExpression(tmp_inc);
-        if (tmp_inc != NULL && inc == NULL) {
-            std::cerr << "Runtime error: tmp_inc != NULL && inc == NULL" << std::endl;
-            res = false;
-        }
-        if (inc == NULL) {
-            inc = SageBuilder::buildNullExpression_nfi();
-            setCompilerGeneratedFileInfo(inc, true);
-        }
+  {
+    SgNode *tmp_inc = Traverse(for_stmt->getInc());
+    inc = isSgExpression(tmp_inc);
+    if (tmp_inc != NULL && inc == NULL) {
+      std::cerr << "Runtime error: tmp_inc != NULL && inc == NULL" << std::endl;
+      res = false;
     }
+    if (inc == NULL) {
+      inc = SageBuilder::buildNullExpression_nfi();
+      setCompilerGeneratedFileInfo(inc, true);
+    }
+  }
 
   // Body
 
-    SgStatement * body = NULL;
+  SgStatement *body = NULL;
 
-    {
-        SgNode * tmp_body = Traverse(for_stmt->getBody());
-        body = isSgStatement(tmp_body);
-        if (body == NULL) {
-            SgExpression * body_expr = isSgExpression(tmp_body);
-            if (body_expr != NULL) {
-                body = SageBuilder::buildExprStatement(body_expr);
-                applySourceRange(body, for_stmt->getBody()->getSourceRange());
-            }
-        }
-        if (tmp_body != NULL && body == NULL) {
-            std::cerr << "Runtime error: tmp_body != NULL && body == NULL" << std::endl;
-            res = false;
-        }
-        if (body == NULL) {
-            body = SageBuilder::buildNullStatement_nfi();
-            setCompilerGeneratedFileInfo(body);
-        }
+  {
+    SgNode *tmp_body = Traverse(for_stmt->getBody());
+    body = isSgStatement(tmp_body);
+    if (body == NULL) {
+      SgExpression *body_expr = isSgExpression(tmp_body);
+      if (body_expr != NULL) {
+        body = SageBuilder::buildExprStatement(body_expr);
+        applySourceRange(body, for_stmt->getBody()->getSourceRange());
+      }
     }
-    body = wrapStatementWithOpenMPPragmas(for_stmt->getBody(), body);
+    if (tmp_body != NULL && body == NULL) {
+      std::cerr << "Runtime error: tmp_body != NULL && body == NULL"
+                << std::endl;
+      res = false;
+    }
+    if (body == NULL) {
+      body = SageBuilder::buildNullStatement_nfi();
+      setCompilerGeneratedFileInfo(body);
+    }
+  }
+  body = wrapStatementWithOpenMPPragmas(for_stmt->getBody(), body);
 
-    SageBuilder::popScopeStack();
+  SageBuilder::popScopeStack();
 
   // Attach sub trees to the for statement
 
-    for_init_stmt->set_parent(sg_for_stmt);
-    if (sg_for_stmt->get_for_init_stmt() != NULL)
-        SageInterface::deleteAST(sg_for_stmt->get_for_init_stmt());
-    sg_for_stmt->set_for_init_stmt(for_init_stmt);
+  for_init_stmt->set_parent(sg_for_stmt);
+  if (sg_for_stmt->get_for_init_stmt() != NULL)
+    SageInterface::deleteAST(sg_for_stmt->get_for_init_stmt());
+  sg_for_stmt->set_for_init_stmt(for_init_stmt);
 
-    if (cond_stmt != NULL) {
-        cond_stmt->set_parent(sg_for_stmt);
-        sg_for_stmt->set_test(cond_stmt);
-    }
+  if (cond_stmt != NULL) {
+    cond_stmt->set_parent(sg_for_stmt);
+    sg_for_stmt->set_test(cond_stmt);
+  }
 
-    if (inc != NULL) {
-        inc->set_parent(sg_for_stmt);
-        sg_for_stmt->set_increment(inc);
-    }
+  if (inc != NULL) {
+    inc->set_parent(sg_for_stmt);
+    sg_for_stmt->set_increment(inc);
+  }
 
-    if (body != NULL) {
-        body->set_parent(sg_for_stmt);
-        sg_for_stmt->set_loop_body(body);
-    }
+  if (body != NULL) {
+    body->set_parent(sg_for_stmt);
+    sg_for_stmt->set_loop_body(body);
+  }
 
- // DQ (11/28/2020): Now we want to use the scope that is already on the stack (instead of adding a new one).
-    SageBuilder::buildForStatement_nfi(sg_for_stmt, for_init_stmt, cond_stmt, inc, body);
+  // DQ (11/28/2020): Now we want to use the scope that is already on the stack
+  // (instead of adding a new one).
+  SageBuilder::buildForStatement_nfi(sg_for_stmt, for_init_stmt, cond_stmt, inc,
+                                     body);
 
- // DQ (11/28/2020): Adding asertion.
-    ROSE_ASSERT(sg_for_stmt->get_parent() != NULL);
+  // DQ (11/28/2020): Adding asertion.
+  ROSE_ASSERT(sg_for_stmt->get_parent() != NULL);
 
-    *node = sg_for_stmt;
+  *node = sg_for_stmt;
 
-    return VisitStmt(for_stmt, node) && res;
+  return VisitStmt(for_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitGotoStmt(clang::GotoStmt * goto_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitGotoStmt(clang::GotoStmt *goto_stmt,
+                                          SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitGotoStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitGotoStmt" << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
-    SgSymbol * tmp_sym = GetSymbolFromSymbolTable(goto_stmt->getLabel());
-    SgLabelSymbol * sym = isSgLabelSymbol(tmp_sym);
-    if (sym == NULL) {
-        SgNode * tmp_label = Traverse(goto_stmt->getLabel()->getStmt());
-        SgLabelStatement * label_stmt = isSgLabelStatement(tmp_label);
-        if (label_stmt == NULL) {
-            std::cerr << "Runtime error: Cannot find the symbol for the label: \"" << goto_stmt->getLabel()->getStmt()->getName() << "\"." << std::endl;
-            std::cerr << "Runtime Error: Cannot find the label: \"" << goto_stmt->getLabel()->getStmt()->getName() << "\"." << std::endl;
-            res = false;
-        }
-        else {
-            *node = SageBuilder::buildGotoStatement(label_stmt);
-        }
-    }
-    else {
-        *node = SageBuilder::buildGotoStatement(sym->get_declaration());
-    }
-
-/*
-    SgNode * tmp_label = Traverse(goto_stmt->getLabel()->getStmt());
-    SgLabelStatement * label_stmt = isSgLabelStatement(tmp_label);
+  SgSymbol *tmp_sym = GetSymbolFromSymbolTable(goto_stmt->getLabel());
+  SgLabelSymbol *sym = isSgLabelSymbol(tmp_sym);
+  if (sym == NULL) {
+    SgNode *tmp_label = Traverse(goto_stmt->getLabel()->getStmt());
+    SgLabelStatement *label_stmt = isSgLabelStatement(tmp_label);
     if (label_stmt == NULL) {
-        std::cerr << "Runtime Error: Cannot find the label: \"" << goto_stmt->getLabel()->getStmt()->getName() << "\"." << std::endl;
-        res = false;
+      std::cerr << "Runtime error: Cannot find the symbol for the label: \""
+                << goto_stmt->getLabel()->getStmt()->getName() << "\"."
+                << std::endl;
+      std::cerr << "Runtime Error: Cannot find the label: \""
+                << goto_stmt->getLabel()->getStmt()->getName() << "\"."
+                << std::endl;
+      res = false;
+    } else {
+      *node = SageBuilder::buildGotoStatement(label_stmt);
     }
-    else {
-        *node = SageBuilder::buildGotoStatement(label_stmt);
+  } else {
+    *node = SageBuilder::buildGotoStatement(sym->get_declaration());
+  }
+
+  /*
+      SgNode * tmp_label = Traverse(goto_stmt->getLabel()->getStmt());
+      SgLabelStatement * label_stmt = isSgLabelStatement(tmp_label);
+      if (label_stmt == NULL) {
+          std::cerr << "Runtime Error: Cannot find the label: \"" <<
+     goto_stmt->getLabel()->getStmt()->getName() << "\"." << std::endl; res =
+     false;
+      }
+      else {
+          *node = SageBuilder::buildGotoStatement(label_stmt);
+      }
+  */
+  return VisitStmt(goto_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitIfStmt" << std::endl;
+#endif
+
+  bool res = true;
+
+  // TODO if_stmt->getConditionVariable() appears when a variable is declared in
+  // the condition...
+
+  *node = SageBuilder::buildIfStmt_nfi(NULL, NULL, NULL);
+
+  // Pei-Hung (04/22/22) Needs to setup parent node before processing the
+  // operands. Needed for test2013_55.c and other similar tests
+  (*node)->set_parent(SageBuilder::topScopeStack());
+  SageBuilder::pushScopeStack(isSgScopeStatement(*node));
+
+  SgNode *tmp_cond = Traverse(if_stmt->getCond());
+  SgExpression *cond_expr = isSgExpression(tmp_cond);
+  SgStatement *cond_stmt = SageBuilder::buildExprStatement(cond_expr);
+  applySourceRange(cond_stmt, if_stmt->getCond()->getSourceRange());
+
+  SgNode *tmp_then = Traverse(if_stmt->getThen());
+  SgStatement *then_stmt = isSgStatement(tmp_then);
+  if (then_stmt == NULL) {
+    SgExpression *then_expr = isSgExpression(tmp_then);
+    ROSE_ASSERT(then_expr != NULL);
+    then_stmt = SageBuilder::buildExprStatement(then_expr);
+  }
+  applySourceRange(then_stmt, if_stmt->getThen()->getSourceRange());
+  then_stmt = wrapStatementWithOpenMPPragmas(if_stmt->getThen(), then_stmt);
+
+  SgNode *tmp_else = Traverse(if_stmt->getElse());
+  SgStatement *else_stmt = isSgStatement(tmp_else);
+  if (else_stmt == NULL) {
+    SgExpression *else_expr = isSgExpression(tmp_else);
+    if (else_expr != NULL)
+      else_stmt = SageBuilder::buildExprStatement(else_expr);
+  }
+  if (else_stmt != NULL) {
+    applySourceRange(else_stmt, if_stmt->getElse()->getSourceRange());
+    else_stmt = wrapStatementWithOpenMPPragmas(if_stmt->getElse(), else_stmt);
+  }
+
+  SageBuilder::popScopeStack();
+
+  cond_stmt->set_parent(*node);
+  isSgIfStmt(*node)->set_conditional(cond_stmt);
+
+  then_stmt->set_parent(*node);
+  isSgIfStmt(*node)->set_true_body(then_stmt);
+  if (else_stmt != NULL) {
+    else_stmt->set_parent(*node);
+    isSgIfStmt(*node)->set_false_body(else_stmt);
+  }
+
+  return VisitStmt(if_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitIndirectGotoStmt(
+    clang::IndirectGotoStmt *indirect_goto_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitIndirectGotoStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+
+  return VisitStmt(indirect_goto_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitMSDependentExistsStmt(
+    clang::MSDependentExistsStmt *ms_dependent_exists_stmt, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitMSDependentExistsStmt" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
+
+  return VisitStmt(ms_dependent_exists_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitNullStmt(clang::NullStmt *null_stmt,
+                                          SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitNullStmt" << std::endl;
+#endif
+  bool res = true;
+
+  *node = SageBuilder::buildNullStatement();
+
+  return VisitStmt(null_stmt, node) && res;
+}
+
+bool ClangToSageTranslator::VisitOMPExecutableDirective(
+    clang::OMPExecutableDirective *omp_executable_directive, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitOMPExecutableDirective"
+            << std::endl;
+#endif
+  bool res = true;
+  SgStatement *associated_stmt = NULL;
+
+  // Traverse the body statement
+  if (clang::Stmt *clang_associated_stmt =
+          omp_executable_directive->getAssociatedStmt()) {
+    SgNode *tmp_stmt = Traverse(clang_associated_stmt);
+    associated_stmt = isSgStatement(tmp_stmt);
+    if (tmp_stmt != NULL && associated_stmt == NULL) {
+      std::cerr << "Runtime error: associated OpenMP statement did not "
+                   "translate into an SgStatement."
+                << std::endl;
+      res = false;
     }
-*/
-    return VisitStmt(goto_stmt, node) && res;
-}
-
-
-bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt * if_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitIfStmt" << std::endl;
-#endif
-
-    bool res = true;
-
-    // TODO if_stmt->getConditionVariable() appears when a variable is declared in the condition...
-
-    *node = SageBuilder::buildIfStmt_nfi(NULL, NULL, NULL);
-
-    // Pei-Hung (04/22/22) Needs to setup parent node before processing the operands.
-    // Needed for test2013_55.c and other similar tests
-    (*node)->set_parent(SageBuilder::topScopeStack());
-    SageBuilder::pushScopeStack(isSgScopeStatement(*node));
-
-    SgNode * tmp_cond = Traverse(if_stmt->getCond());
-    SgExpression * cond_expr = isSgExpression(tmp_cond);
-    SgStatement * cond_stmt = SageBuilder::buildExprStatement(cond_expr);
-    applySourceRange(cond_stmt, if_stmt->getCond()->getSourceRange());
-
-    SgNode * tmp_then = Traverse(if_stmt->getThen());
-    SgStatement * then_stmt = isSgStatement(tmp_then);
-    if (then_stmt == NULL) {
-        SgExpression * then_expr = isSgExpression(tmp_then);
-        ROSE_ASSERT(then_expr != NULL);
-        then_stmt = SageBuilder::buildExprStatement(then_expr);
-    }
-    applySourceRange(then_stmt, if_stmt->getThen()->getSourceRange());
-    then_stmt = wrapStatementWithOpenMPPragmas(if_stmt->getThen(), then_stmt);
-
-    SgNode * tmp_else = Traverse(if_stmt->getElse());
-    SgStatement * else_stmt = isSgStatement(tmp_else);
-    if (else_stmt == NULL) {
-        SgExpression * else_expr = isSgExpression(tmp_else);
-        if (else_expr != NULL)
-            else_stmt = SageBuilder::buildExprStatement(else_expr);
-    }
-    if (else_stmt != NULL) {
-        applySourceRange(else_stmt, if_stmt->getElse()->getSourceRange());
-        else_stmt = wrapStatementWithOpenMPPragmas(if_stmt->getElse(), else_stmt);
-    }
-
-    SageBuilder::popScopeStack();
-
-    cond_stmt->set_parent(*node);
-    isSgIfStmt(*node)->set_conditional(cond_stmt);
-
-    then_stmt->set_parent(*node);
-    isSgIfStmt(*node)->set_true_body(then_stmt);
-    if (else_stmt != NULL) {
-      else_stmt->set_parent(*node);
-      isSgIfStmt(*node)->set_false_body(else_stmt);
-    }
-
-    return VisitStmt(if_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitIndirectGotoStmt(clang::IndirectGotoStmt * indirect_goto_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitIndirectGotoStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-     return VisitStmt(indirect_goto_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitMSDependentExistsStmt(clang::MSDependentExistsStmt * ms_dependent_exists_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMSDependentExistsStmt" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-     return VisitStmt(ms_dependent_exists_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitNullStmt(clang::NullStmt * null_stmt, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitNullStmt" << std::endl;
-#endif
-    bool res = true;
-
-    *node = SageBuilder::buildNullStatement();
-
-    return VisitStmt(null_stmt, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPExecutableDirective(clang::OMPExecutableDirective * omp_executable_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPExecutableDirective" << std::endl;
-#endif
-    bool res = true;
-    SgStatement * associated_stmt = NULL;
-
-    // Traverse the body statement
-    if (clang::Stmt * clang_associated_stmt = omp_executable_directive->getAssociatedStmt()) {
-        SgNode * tmp_stmt = Traverse(clang_associated_stmt);
-        associated_stmt = isSgStatement(tmp_stmt);
-        if (tmp_stmt != NULL && associated_stmt == NULL) {
-            std::cerr << "Runtime error: associated OpenMP statement did not translate into an SgStatement." << std::endl;
-            res = false;
-        }
-    }
-
-    SgStatement * target_stmt = associated_stmt;
-    if (target_stmt == NULL) {
-        target_stmt = SageBuilder::buildNullStatement();
-        target_stmt->set_parent(SageBuilder::topScopeStack());
-    }
-
-    // Just return the body statement
-    // The parent (VisitCompoundStmt) will handle pragma insertion via appendOpenMPPragmasBefore
-    // DO NOT call VisitStmt here - it would apply the directive's source range to the body statement,
-    // overwriting the body's correct source info
-    *node = target_stmt;
-    return res;
-}
-
-
-
-
-bool ClangToSageTranslator::VisitOMPAtomicDirective(clang::OMPAtomicDirective * omp_atomic_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPAtomicDirective" << std::endl;
-#endif
-    bool res = true;
-
-    return VisitOMPExecutableDirective(omp_atomic_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPBarrierDirective(clang::OMPBarrierDirective * omp_barrier_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPBarrierDirective" << std::endl;
-#endif
-    bool res = true;
-
-    return VisitOMPExecutableDirective(omp_barrier_directive, node) && res;
-}
+  }
 
-bool ClangToSageTranslator::VisitOMPCancelDirective(clang::OMPCancelDirective * omp_cancel_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPCancelDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_cancel_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPCancellationPointDirective(clang::OMPCancellationPointDirective * omp_cancellation_point_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPCancellationPointDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_cancellation_point_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPCriticalDirective(clang::OMPCriticalDirective * omp_critical_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPCriticalDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_critical_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPFlushDirective(clang::OMPFlushDirective * omp_flush_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPFlushDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_flush_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPLoopDirective(clang::OMPLoopDirective * omp_loop_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPLoopDirective" << std::endl;
-#endif
-    bool res = true;
-
-    return VisitOMPExecutableDirective(omp_loop_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPDistributeDirective(clang::OMPDistributeDirective * omp_distribute_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPDistributeDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPLoopDirective(omp_distribute_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPDistributeParallelForDirective(clang::OMPDistributeParallelForDirective * omp_distribute_parallel_for_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPDistributeParallelForDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_distribute_parallel_for_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPDistributeParallelForSimdDirective(clang::OMPDistributeParallelForSimdDirective * omp_distribute_parallel_for_simd_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPDistributeParallelForSimdDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_distribute_parallel_for_simd_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPDistributeSimdDirective(clang::OMPDistributeSimdDirective * omp_distribute__simd_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPDistributeSimdDirective" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_distribute__simd_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPForDirective(clang::OMPForDirective * omp_for_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPForDirective" << std::endl;
-#endif
-    bool res = true;
+  SgStatement *target_stmt = associated_stmt;
+  if (target_stmt == NULL) {
+    target_stmt = SageBuilder::buildNullStatement();
+    target_stmt->set_parent(SageBuilder::topScopeStack());
+  }
 
-    return VisitOMPLoopDirective(omp_for_directive, node) && res;
+  // Just return the body statement
+  // The parent (VisitCompoundStmt) will handle pragma insertion via
+  // appendOpenMPPragmasBefore DO NOT call VisitStmt here - it would apply the
+  // directive's source range to the body statement, overwriting the body's
+  // correct source info
+  *node = target_stmt;
+  return res;
 }
 
-bool ClangToSageTranslator::VisitOMPForSimdDirective(clang::OMPForSimdDirective * omp_for_simd_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPAtomicDirective(
+    clang::OMPAtomicDirective *omp_atomic_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPForSimdDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPAtomicDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPLoopDirective(omp_for_simd_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_atomic_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPParallelForDirective(clang::OMPParallelForDirective * omp_parallel_for_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPBarrierDirective(
+    clang::OMPBarrierDirective *omp_barrier_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPParallelForDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPBarrierDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPLoopDirective(omp_parallel_for_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_barrier_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPParallelForSimdDirective(clang::OMPParallelForSimdDirective * omp_parallel_for_simd_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPCancelDirective(
+    clang::OMPCancelDirective *omp_cancel_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPParallelForSimdDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPCancelDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPLoopDirective(omp_parallel_for_simd_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_cancel_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPSimdDirective(clang::OMPSimdDirective * omp_simd_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPCancellationPointDirective(
+    clang::OMPCancellationPointDirective *omp_cancellation_point_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPSimdDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPCancellationPointDirective"
+            << std::endl;
 #endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  bool res = true;
 
-    return VisitOMPLoopDirective(omp_simd_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPTargetParallelForDirective(clang::OMPTargetParallelForDirective * omp_target_parallel_for_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTargetParallelForDirective" << std::endl;
-#endif
-    bool res = true;
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPLoopDirective(omp_target_parallel_for_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_cancellation_point_directive, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitOMPTargetParallelForSimdDirective(clang::OMPTargetParallelForSimdDirective * omp_target_parallel_for_simd_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPCriticalDirective(
+    clang::OMPCriticalDirective *omp_critical_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTargetParallelForSimdDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPCriticalDirective" << std::endl;
 #endif
-    bool res = true;
-
-    return VisitOMPLoopDirective(omp_target_parallel_for_simd_directive, node) && res;
-}
+  bool res = true;
 
-bool ClangToSageTranslator::VisitOMPTargetSimdDirective(clang::OMPTargetSimdDirective * omp_target_simd_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTargetSimdDirective" << std::endl;
-#endif
-    bool res = true;
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPLoopDirective(omp_target_simd_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_critical_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPTargetTeamsDistributeDirective(clang::OMPTargetTeamsDistributeDirective * omp_target_teams_distribute_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPFlushDirective(
+    clang::OMPFlushDirective *omp_flush_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTargetTeamsDistributeDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPFlushDirective" << std::endl;
 #endif
-    bool res = true;
-
-    return VisitOMPLoopDirective(omp_target_teams_distribute_directive, node) && res;
-}
+  bool res = true;
 
-bool ClangToSageTranslator::VisitOMPTargetTeamsDistributeSimdDirective(clang::OMPTargetTeamsDistributeSimdDirective * omp_target_teams_distribute_simd_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTargetTeamsDistributeSimdDirective" << std::endl;
-#endif
-    bool res = true;
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPLoopDirective(omp_target_teams_distribute_simd_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_flush_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPTaskLoopDirective(clang::OMPTaskLoopDirective * omp_task_loop_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPLoopDirective(
+    clang::OMPLoopDirective *omp_loop_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTaskLoopDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPLoopDirective" << std::endl;
 #endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  bool res = true;
 
-    return VisitOMPLoopDirective(omp_task_loop_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_loop_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPTaskLoopSimdDirective(clang::OMPTaskLoopSimdDirective * omp_task_loop_simd_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDistributeDirective(
+    clang::OMPDistributeDirective *omp_distribute_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPTaskLoopSimdDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPDistributeDirective"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPLoopDirective(omp_task_loop_simd_directive, node) && res;
+  return VisitOMPLoopDirective(omp_distribute_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitOMPMasterDirective(clang::OMPMasterDirective * omp_master_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDistributeParallelForDirective(
+    clang::OMPDistributeParallelForDirective
+        *omp_distribute_parallel_for_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPMasterDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPDistributeParallelForDirective"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPExecutableDirective(omp_master_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_distribute_parallel_for_directive,
+                                     node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitOMPOrderedDirective(clang::OMPOrderedDirective * omp_ordered_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDistributeParallelForSimdDirective(
+    clang::OMPDistributeParallelForSimdDirective
+        *omp_distribute_parallel_for_simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPOrderedDirective" << std::endl;
+  std::cerr
+      << "ClangToSageTranslator::VisitOMPDistributeParallelForSimdDirective"
+      << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
-
-    return VisitOMPExecutableDirective(omp_ordered_directive, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPParallelDirective(clang::OMPParallelDirective * omp_parallel_directive, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPParallelDirective" << std::endl;
-#endif
-    bool res = true;
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPExecutableDirective(omp_parallel_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_distribute_parallel_for_simd_directive,
+                                     node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitOMPParallelSectionsDirective(clang::OMPParallelSectionsDirective * omp_parallel_sections_directive, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPDistributeSimdDirective(
+    clang::OMPDistributeSimdDirective *omp_distribute__simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPParallelSectionsDirective" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPDistributeSimdDirective"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitOMPExecutableDirective(omp_parallel_sections_directive, node) && res;
+  return VisitOMPExecutableDirective(omp_distribute__simd_directive, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitReturnStmt(clang::ReturnStmt * return_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPForDirective(
+    clang::OMPForDirective *omp_for_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitReturnStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPForDirective" << std::endl;
 #endif
-
-    bool res = true;
-
-    SgNode * tmp_expr = Traverse(return_stmt->getRetValue());
-    SgExpression * expr = isSgExpression(tmp_expr);
-    if (tmp_expr != NULL && expr == NULL) {
-        std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
-        res = false;
-    }
-    *node = SageBuilder::buildReturnStmt(expr);
+  bool res = true;
 
-    return VisitStmt(return_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_for_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSEHExceptStmt(clang::SEHExceptStmt * seh_except_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPForSimdDirective(
+    clang::OMPForSimdDirective *omp_for_simd_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSEHExceptStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPForSimdDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitStmt(seh_except_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_for_simd_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSEHFinallyStmt(clang::SEHFinallyStmt * seh_finally_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPParallelForDirective(
+    clang::OMPParallelForDirective *omp_parallel_for_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSEHFinallyStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPParallelForDirective"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitStmt(seh_finally_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_parallel_for_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSEHLeaveStmt(clang::SEHLeaveStmt * seh_leave_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPParallelForSimdDirective(
+    clang::OMPParallelForSimdDirective *omp_parallel_for_simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSEHLeaveStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPParallelForSimdDirective"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitStmt(seh_leave_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_parallel_for_simd_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSEHTryStmt(clang::SEHTryStmt * seh_try_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPSimdDirective(
+    clang::OMPSimdDirective *omp_simd_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSEHTryStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPSimdDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitStmt(seh_try_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_simd_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSwitchCase(clang::SwitchCase * switch_case, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTargetParallelForDirective(
+    clang::OMPTargetParallelForDirective *omp_target_parallel_for_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSwitchCase" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTargetParallelForDirective"
+            << std::endl;
 #endif
-    bool res = true;
-    
-    // TODO
+  bool res = true;
 
-    return VisitStmt(switch_case, node) && res;
+  return VisitOMPLoopDirective(omp_target_parallel_for_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCaseStmt(clang::CaseStmt * case_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTargetParallelForSimdDirective(
+    clang::OMPTargetParallelForSimdDirective
+        *omp_target_parallel_for_simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCaseStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTargetParallelForSimdDirective"
+            << std::endl;
 #endif
-
-    SgNode * tmp_stmt = Traverse(case_stmt->getSubStmt());
-    SgStatement * stmt = isSgStatement(tmp_stmt);
-    SgExpression * expr = isSgExpression(tmp_stmt);
-    if (expr != NULL) {
-        stmt = SageBuilder::buildExprStatement(expr);
-        applySourceRange(stmt, case_stmt->getSubStmt()->getSourceRange());
-    }
-    ROSE_ASSERT(stmt != NULL);
-    stmt = wrapStatementWithOpenMPPragmas(case_stmt->getSubStmt(), stmt);
-
-    SgNode * tmp_lhs = Traverse(case_stmt->getLHS());
-    SgExpression * lhs = isSgExpression(tmp_lhs);
-    ROSE_ASSERT(lhs != NULL);
-
-/*  FIXME GNU extension not-handled by ROSE
-    SgNode * tmp_rhs = Traverse(case_stmt->getRHS());
-    SgExpression * rhs = isSgExpression(tmp_rhs);
-    ROSE_ASSERT(rhs != NULL);
-*/
-    ROSE_ASSERT(case_stmt->getRHS() == NULL);
-
-    *node = SageBuilder::buildCaseOptionStmt_nfi(lhs, stmt);
+  bool res = true;
 
-    return VisitSwitchCase(case_stmt, node);
+  return VisitOMPLoopDirective(omp_target_parallel_for_simd_directive, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitDefaultStmt(clang::DefaultStmt * default_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTargetSimdDirective(
+    clang::OMPTargetSimdDirective *omp_target_simd_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDefaultStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTargetSimdDirective"
+            << std::endl;
 #endif
+  bool res = true;
 
-    SgNode * tmp_stmt = Traverse(default_stmt->getSubStmt());
-    SgStatement * stmt = isSgStatement(tmp_stmt);
-    SgExpression * expr = isSgExpression(tmp_stmt);
-    if (expr != NULL) {
-        stmt = SageBuilder::buildExprStatement(expr);
-        applySourceRange(stmt, default_stmt->getSubStmt()->getSourceRange());
-    }
-    ROSE_ASSERT(stmt != NULL);
-    stmt = wrapStatementWithOpenMPPragmas(default_stmt->getSubStmt(), stmt);
-
-    *node = SageBuilder::buildDefaultOptionStmt_nfi(stmt);
-
-    return VisitSwitchCase(default_stmt, node);
+  return VisitOMPLoopDirective(omp_target_simd_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt * switch_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTargetTeamsDistributeDirective(
+    clang::OMPTargetTeamsDistributeDirective
+        *omp_target_teams_distribute_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSwitchStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTargetTeamsDistributeDirective"
+            << std::endl;
 #endif
-
-    SgNode * tmp_cond = Traverse(switch_stmt->getCond());
-    SgExpression * cond = isSgExpression(tmp_cond);
-    ROSE_ASSERT(cond != NULL);
-    
-    SgStatement * expr_stmt = SageBuilder::buildExprStatement(cond);
-        applySourceRange(expr_stmt, switch_stmt->getCond()->getSourceRange());
-
-    SgSwitchStatement * sg_switch_stmt = SageBuilder::buildSwitchStatement_nfi(expr_stmt, NULL);
-
-    sg_switch_stmt->set_parent(SageBuilder::topScopeStack());
-
-    cond->set_parent(expr_stmt);
-    expr_stmt->set_parent(sg_switch_stmt);
-
-    SageBuilder::pushScopeStack(sg_switch_stmt);
+  bool res = true;
 
-    SgNode * tmp_body = Traverse(switch_stmt->getBody());
-    SgStatement * body = isSgStatement(tmp_body);
-    ROSE_ASSERT(body != NULL);
-
-    SageBuilder::popScopeStack();
-
-    sg_switch_stmt->set_body(body);
-
-    *node = sg_switch_stmt;
-
-    return VisitStmt(switch_stmt, node);
+  return VisitOMPLoopDirective(omp_target_teams_distribute_directive, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitValueStmt(clang::ValueStmt * value_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTargetTeamsDistributeSimdDirective(
+    clang::OMPTargetTeamsDistributeSimdDirective
+        *omp_target_teams_distribute_simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitValueStmt" << std::endl;
+  std::cerr
+      << "ClangToSageTranslator::VisitOMPTargetTeamsDistributeSimdDirective"
+      << std::endl;
 #endif
-    bool res = true;
-
- // DQ (11/28/2020): In test2020_45.c: I think this is the enum field.
- // clang::Expr* expr = value_stmt->getExprStmt();
- // ROSE_ASSERT(expr != NULL);
-
- // DQ (11/28/2020): Note that value_stmt->getExprStmt() == value_stmt, but not sure why.
-
- // DQ (11/28/2020): This was previously commented out, and I think there is nothing to do here.
- // The actual implementation was done in VisitFullExp
- // ROSE_ASSERT(FAIL_TODO == 0); // TODO
+  bool res = true;
 
-    return VisitStmt(value_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_target_teams_distribute_simd_directive,
+                               node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitAttributedStmt(clang::AttributedStmt * attributed_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTaskLoopDirective(
+    clang::OMPTaskLoopDirective *omp_task_loop_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAttributedStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTaskLoopDirective" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Attributes like [[fallthrough]] wrap an inner statement. We currently drop
-    // the attribute and translate the wrapped statement directly.
-    clang::Stmt *sub_stmt = attributed_stmt->getSubStmt();
-    SgNode *sub_node = Traverse(sub_stmt);
-    if (sub_node == NULL) {
-        sub_node = SageBuilder::buildNullStatement();
-    }
-    *node = sub_node;
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    if (SgStatement *sg_stmt = isSgStatement(sub_node)) {
-        applySourceRange(sg_stmt, attributed_stmt->getSourceRange());
-    }
-
-    return VisitValueStmt(attributed_stmt, node) && res;
+  return VisitOMPLoopDirective(omp_task_loop_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitExpr(clang::Expr * expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPTaskLoopSimdDirective(
+    clang::OMPTaskLoopSimdDirective *omp_task_loop_simd_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPTaskLoopSimdDirective"
+            << std::endl;
 #endif
+  bool res = true;
 
-     // TODO Is there anything to be done? (maybe in relation with typing?)
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitValueStmt(expr, node);
+  return VisitOMPLoopDirective(omp_task_loop_simd_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAbstractConditionalOperator(clang::AbstractConditionalOperator * abstract_conditional_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPMasterDirective(
+    clang::OMPMasterDirective *omp_master_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAbstractConditionalOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPMasterDirective" << std::endl;
 #endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitStmt(abstract_conditional_operator, node) && res;
+  return VisitOMPExecutableDirective(omp_master_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBinaryConditionalOperator(clang::BinaryConditionalOperator * binary_conditional_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPOrderedDirective(
+    clang::OMPOrderedDirective *omp_ordered_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitBinaryConditionalOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPOrderedDirective" << std::endl;
 #endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitStmt(binary_conditional_operator, node) && res;
+  return VisitOMPExecutableDirective(omp_ordered_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitConditionalOperator(clang::ConditionalOperator * conditional_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPParallelDirective(
+    clang::OMPParallelDirective *omp_parallel_directive, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitConditionalOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPParallelDirective" << std::endl;
 #endif
-
-    bool res = true;
-
-    SgNode * tmp_cond  = Traverse(conditional_operator->getCond());
-    SgExpression * cond_expr = isSgExpression(tmp_cond);
-    ROSE_ASSERT(cond_expr);
-    SgNode * tmp_true  = Traverse(conditional_operator->getTrueExpr());
-    SgExpression * true_expr = isSgExpression(tmp_true);
-    ROSE_ASSERT(true_expr);
-    SgNode * tmp_false = Traverse(conditional_operator->getFalseExpr());
-    SgExpression * false_expr = isSgExpression(tmp_false);
-    ROSE_ASSERT(false_expr);
+  bool res = true;
 
-    *node = SageBuilder::buildConditionalExp(cond_expr, true_expr, false_expr);
-
-    return VisitAbstractConditionalOperator(conditional_operator, node) && res;
+  return VisitOMPExecutableDirective(omp_parallel_directive, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAddrLabelExpr(clang::AddrLabelExpr * addr_label_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitOMPParallelSectionsDirective(
+    clang::OMPParallelSectionsDirective *omp_parallel_sections_directive,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAddrLabelExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitOMPParallelSectionsDirective"
+            << std::endl;
 #endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitExpr(addr_label_expr, node) && res;
+  return VisitOMPExecutableDirective(omp_parallel_sections_directive, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitArrayInitIndexExpr(clang::ArrayInitIndexExpr * array_init_index_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitReturnStmt(clang::ReturnStmt *return_stmt,
+                                            SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitArrayInitIndexExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitReturnStmt" << std::endl;
 #endif
-     bool res = true;
-
-     // TODO 
-
-     return VisitExpr(array_init_index_expr, node) && res;
-}
 
-bool ClangToSageTranslator::VisitArrayInitLoopExpr(clang::ArrayInitLoopExpr * array_init_loop_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitArrayInitLoopExpr" << std::endl;
-#endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  SgNode *tmp_expr = Traverse(return_stmt->getRetValue());
+  SgExpression *expr = isSgExpression(tmp_expr);
+  if (tmp_expr != NULL && expr == NULL) {
+    std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
+    res = false;
+  }
+  *node = SageBuilder::buildReturnStmt(expr);
 
-     return VisitExpr(array_init_loop_expr, node) && res;
+  return VisitStmt(return_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitArraySubscriptExpr(clang::ArraySubscriptExpr * array_subscript_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSEHExceptStmt(
+    clang::SEHExceptStmt *seh_except_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitArraySubscriptExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSEHExceptStmt" << std::endl;
 #endif
-
-    bool res = true;
+  bool res = true;
 
-    SgNode * tmp_base = Traverse(array_subscript_expr->getBase());
-    SgExpression * base = isSgExpression(tmp_base);
-    if (tmp_base != NULL && base == NULL) {
-        std::cerr << "Runtime error: tmp_base != NULL && base == NULL" << std::endl;
-        res = false;
-    }
-    if (SgCastExp *cast = isSgCastExp(base)) {
-        auto pointerInfo = [](SgType *type) -> std::pair<int, SgType *> {
-            int depth = 0;
-            SgType *current = type;
-            while (current != nullptr) {
-                current = current->stripTypedefsAndModifiers();
-                SgPointerType *ptrType = isSgPointerType(current);
-                if (ptrType == nullptr) {
-                    break;
-                }
-                ++depth;
-                current = ptrType->get_base_type();
-            }
-            return std::make_pair(depth, current != nullptr ? current->stripTypedefsAndModifiers() : nullptr);
-        };
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-        SgType *operandType = cast->get_operand_i()->get_type();
-        if (operandType != nullptr) {
-            operandType = operandType->stripTypedefsAndModifiers();
-            if (SgArrayType *arrayType = isSgArrayType(operandType)) {
-                SgType *elementType = arrayType->get_base_type();
-                ROSE_ASSERT(elementType != nullptr);
-                SgType *targetType = SgPointerType::createType(elementType);
-                ROSE_ASSERT(targetType != nullptr);
-                if (pointerInfo(cast->get_type()) != pointerInfo(targetType)) {
-                    cast->set_type(targetType);
-                }
-            }
-        }
-    }
-
-    SgNode * tmp_idx = Traverse(array_subscript_expr->getIdx());
-    SgExpression * idx = isSgExpression(tmp_idx);
-    if (tmp_idx != NULL && idx == NULL) {
-        std::cerr << "Runtime error: tmp_idx != NULL && idx == NULL" << std::endl;
-        res = false;
-    }
-
-    *node = SageBuilder::buildPntrArrRefExp(base, idx);
-
-    return VisitExpr(array_subscript_expr, node) && res;
+  return VisitStmt(seh_except_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitArrayTypeTraitExpr(clang::ArrayTypeTraitExpr * array_type_trait_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSEHFinallyStmt(
+    clang::SEHFinallyStmt *seh_finally_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitArrayTypeTraitExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSEHFinallyStmt" << std::endl;
 #endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitExpr(array_type_trait_expr, node) && res;
+  return VisitStmt(seh_finally_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAsTypeExpr(clang::AsTypeExpr * as_type_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSEHLeaveStmt(
+    clang::SEHLeaveStmt *seh_leave_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAsTypeExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSEHLeaveStmt" << std::endl;
 #endif
-     bool res = true;
+  bool res = true;
 
-     // TODO 
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     return VisitExpr(as_type_expr, node) && res;
+  return VisitStmt(seh_leave_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr * atomic_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSEHTryStmt(clang::SEHTryStmt *seh_try_stmt,
+                                            SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitAtomicExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSEHTryStmt" << std::endl;
 #endif
-     bool res = true;
-
-     // ROOT CAUSE FIX: AtomicExpr represents C11/C++11 atomic operations like:
-     // __atomic_load, __atomic_store, __atomic_fetch_add, __atomic_exchange, etc.
-     // Build a function call expression to represent the atomic builtin.
+  bool res = true;
 
-     // Traverse all sub-expressions (pointer, values, memory orders, etc.)
-     SgExprListExp* args = SageBuilder::buildExprListExp();
-     for (unsigned i = 0; i < atomic_expr->getNumSubExprs(); i++) {
-         SgNode* tmp_arg = Traverse(atomic_expr->getSubExprs()[i]);
-         SgExpression* arg = isSgExpression(tmp_arg);
-         if (arg != NULL) {
-             args->append_expression(arg);
-         } else if (tmp_arg != NULL) {
-             std::cerr << "Warning: AtomicExpr argument " << i << " is not an expression" << std::endl;
-             res = false;
-         }
-     }
+  ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-     // Build the function call expression with the actual builtin name
-     // Get the real builtin name (e.g., "__atomic_load", "__atomic_fetch_add", etc.)
-     // so the unparsed code will compile correctly
-     std::string builtin_name = atomic_expr->getOpAsString().str();
-
-     // Use the actual return type from Clang, not void - many atomics return values
-     // Example: __atomic_fetch_add returns the old value before addition
-     SgType* return_type = buildTypeFromQualifiedType(atomic_expr->getType());
-     *node = SageBuilder::buildFunctionCallExp(builtin_name, return_type, args, SageBuilder::topScopeStack());
-
-     return VisitExpr(atomic_expr, node) && res;
+  return VisitStmt(seh_try_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBinaryOperator(clang::BinaryOperator * binary_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitSwitchCase(clang::SwitchCase *switch_case,
+                                            SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitBinaryOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSwitchCase" << std::endl;
 #endif
-
-    bool res = true;
+  bool res = true;
 
-    SgNode * tmp_lhs = Traverse(binary_operator->getLHS());
-    SgExpression * lhs = isSgExpression(tmp_lhs);
-    if (tmp_lhs != NULL && lhs == NULL) {
-        std::cerr << "Runtime error: tmp_lhs != NULL && lhs == NULL" << std::endl;
-        res = false;
-    }
+  // TODO
 
-    SgNode * tmp_rhs = Traverse(binary_operator->getRHS());
-    SgExpression * rhs = isSgExpression(tmp_rhs);
-    if (tmp_rhs != NULL && rhs == NULL) {
-        std::cerr << "Runtime error: tmp_rhs != NULL && rhs == NULL" << std::endl;
-        res = false;
-    }
-
-    switch (binary_operator->getOpcode()) {
-        // ROOT CAUSE FIX: Pointer-to-member operators for C++ member function pointers
-        case clang::BO_PtrMemD:   *node = SageBuilder::buildDotStarOp(lhs, rhs); break;  // obj.*ptr_to_member
-        case clang::BO_PtrMemI:   *node = SageBuilder::buildArrowStarOp(lhs, rhs); break; // ptr->*ptr_to_member
-        case clang::BO_Mul:       *node = SageBuilder::buildMultiplyOp(lhs, rhs); break;
-        case clang::BO_Div:       *node = SageBuilder::buildDivideOp(lhs, rhs); break;
-        case clang::BO_Rem:       *node = SageBuilder::buildModOp(lhs, rhs); break;
-        case clang::BO_Add:       *node = SageBuilder::buildAddOp(lhs, rhs); break;
-        case clang::BO_Sub:       *node = SageBuilder::buildSubtractOp(lhs, rhs); break;
-        case clang::BO_Shl:       *node = SageBuilder::buildLshiftOp(lhs, rhs); break;
-        case clang::BO_Shr:       *node = SageBuilder::buildRshiftOp(lhs, rhs); break;
-        case clang::BO_LT:        *node = SageBuilder::buildLessThanOp(lhs, rhs); break;
-        case clang::BO_GT:        *node = SageBuilder::buildGreaterThanOp(lhs, rhs); break;
-        case clang::BO_LE:        *node = SageBuilder::buildLessOrEqualOp(lhs, rhs); break;
-        case clang::BO_GE:        *node = SageBuilder::buildGreaterOrEqualOp(lhs, rhs); break;
-        case clang::BO_EQ:        *node = SageBuilder::buildEqualityOp(lhs, rhs); break;
-        case clang::BO_NE:        *node = SageBuilder::buildNotEqualOp(lhs, rhs); break;
-        case clang::BO_And:       *node = SageBuilder::buildBitAndOp(lhs, rhs); break;
-        case clang::BO_Xor:       *node = SageBuilder::buildBitXorOp(lhs, rhs); break;
-        case clang::BO_Or:        *node = SageBuilder::buildBitOrOp(lhs, rhs); break;
-        case clang::BO_LAnd:      *node = SageBuilder::buildAndOp(lhs, rhs); break;
-        case clang::BO_LOr:       *node = SageBuilder::buildOrOp(lhs, rhs); break;
-        case clang::BO_Assign:    *node = SageBuilder::buildAssignOp(lhs, rhs); break;
-        case clang::BO_MulAssign: *node = SageBuilder::buildMultAssignOp(lhs, rhs); break;
-        case clang::BO_DivAssign: *node = SageBuilder::buildDivAssignOp(lhs, rhs); break;
-        case clang::BO_RemAssign: *node = SageBuilder::buildModAssignOp(lhs, rhs); break;
-        case clang::BO_AddAssign: *node = SageBuilder::buildPlusAssignOp(lhs, rhs); break;
-        case clang::BO_SubAssign: *node = SageBuilder::buildMinusAssignOp(lhs, rhs); break;
-        case clang::BO_ShlAssign: *node = SageBuilder::buildLshiftAssignOp(lhs, rhs); break;
-        case clang::BO_ShrAssign: *node = SageBuilder::buildRshiftAssignOp(lhs, rhs); break;
-        case clang::BO_AndAssign: *node = SageBuilder::buildAndAssignOp(lhs, rhs); break;
-        case clang::BO_XorAssign: *node = SageBuilder::buildXorAssignOp(lhs, rhs); break;
-        case clang::BO_OrAssign:  *node = SageBuilder::buildIorAssignOp(lhs, rhs); break;
-        case clang::BO_Comma:     *node = SageBuilder::buildCommaOpExp(lhs, rhs); break;
-        default:
-            std::cerr << "Unknown opcode for binary operator: " << binary_operator->getOpcodeStr().str() << std::endl;
-            res = false;
-    }
-
-    return VisitExpr(binary_operator, node) && res;
+  return VisitStmt(switch_case, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCompoundAssignOperator(clang::CompoundAssignOperator * compound_assign_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitCaseStmt(clang::CaseStmt *case_stmt,
+                                          SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCompoundAssignOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCaseStmt" << std::endl;
 #endif
-     bool res = true;
 
-     // TODO 
+  SgNode *tmp_stmt = Traverse(case_stmt->getSubStmt());
+  SgStatement *stmt = isSgStatement(tmp_stmt);
+  SgExpression *expr = isSgExpression(tmp_stmt);
+  if (expr != NULL) {
+    stmt = SageBuilder::buildExprStatement(expr);
+    applySourceRange(stmt, case_stmt->getSubStmt()->getSourceRange());
+  }
+  ROSE_ASSERT(stmt != NULL);
+  stmt = wrapStatementWithOpenMPPragmas(case_stmt->getSubStmt(), stmt);
 
-     return VisitBinaryOperator(compound_assign_operator, node) && res;
-}
+  SgNode *tmp_lhs = Traverse(case_stmt->getLHS());
+  SgExpression *lhs = isSgExpression(tmp_lhs);
+  ROSE_ASSERT(lhs != NULL);
 
-bool ClangToSageTranslator::VisitBlockExpr(clang::BlockExpr * block_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitBlockExpr" << std::endl;
-#endif
-     bool res = true;
+  /*  FIXME GNU extension not-handled by ROSE
+      SgNode * tmp_rhs = Traverse(case_stmt->getRHS());
+      SgExpression * rhs = isSgExpression(tmp_rhs);
+      ROSE_ASSERT(rhs != NULL);
+  */
+  ROSE_ASSERT(case_stmt->getRHS() == NULL);
 
-     // TODO 
+  *node = SageBuilder::buildCaseOptionStmt_nfi(lhs, stmt);
 
-     return VisitExpr(block_expr, node) && res;
+  return VisitSwitchCase(case_stmt, node);
 }
 
-bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr * call_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitDefaultStmt(clang::DefaultStmt *default_stmt,
+                                             SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCallExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDefaultStmt" << std::endl;
 #endif
-
-    bool res = true;
 
-    SgNode * tmp_expr = Traverse(call_expr->getCallee());
-    SgExpression * expr = isSgExpression(tmp_expr);
-    if (tmp_expr != NULL && expr == NULL) {
-        std::cerr << "Runtime error: tmp_expr != NULL && expr == NULLL" << std::endl;
-        res = false;
-    }
+  SgNode *tmp_stmt = Traverse(default_stmt->getSubStmt());
+  SgStatement *stmt = isSgStatement(tmp_stmt);
+  SgExpression *expr = isSgExpression(tmp_stmt);
+  if (expr != NULL) {
+    stmt = SageBuilder::buildExprStatement(expr);
+    applySourceRange(stmt, default_stmt->getSubStmt()->getSourceRange());
+  }
+  ROSE_ASSERT(stmt != NULL);
+  stmt = wrapStatementWithOpenMPPragmas(default_stmt->getSubStmt(), stmt);
 
-    SgExprListExp * param_list = SageBuilder::buildExprListExp_nfi();
-        applySourceRange(param_list, call_expr->getSourceRange());
+  *node = SageBuilder::buildDefaultOptionStmt_nfi(stmt);
 
-    clang::CallExpr::arg_iterator it;
-    for (it = call_expr->arg_begin(); it != call_expr->arg_end(); ++it) {
-        SgNode * tmp_expr = Traverse(*it);
-        SgExpression * expr = isSgExpression(tmp_expr);
-        if (tmp_expr != NULL && expr == NULL) {
-            std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
-            res = false;
-            continue;
-        }
-        param_list->append_expression(expr);
-    }
-
-    *node = SageBuilder::buildFunctionCallExp_nfi(expr, param_list);
-
-    return VisitExpr(call_expr, node) && res;
+  return VisitSwitchCase(default_stmt, node);
 }
 
-bool ClangToSageTranslator::VisitCUDAKernelCallExpr(clang::CUDAKernelCallExpr * cuda_kernel_call_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
+                                            SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCUDAKernelCallExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSwitchStmt" << std::endl;
 #endif
-     bool res = true;
 
-     // TODO 
+  SgNode *tmp_cond = Traverse(switch_stmt->getCond());
+  SgExpression *cond = isSgExpression(tmp_cond);
+  ROSE_ASSERT(cond != NULL);
 
-     return VisitExpr(cuda_kernel_call_expr, node) && res;
-}
+  SgStatement *expr_stmt = SageBuilder::buildExprStatement(cond);
+  applySourceRange(expr_stmt, switch_stmt->getCond()->getSourceRange());
 
-bool ClangToSageTranslator::VisitCXXMemberCallExpr(clang::CXXMemberCallExpr * cxx_member_call_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXMemberCallExpr" << std::endl;
-#endif
-     bool res = true;
+  SgSwitchStatement *sg_switch_stmt =
+      SageBuilder::buildSwitchStatement_nfi(expr_stmt, NULL);
 
-     // CXXMemberCallExpr represents calls to member functions (e.g., obj.method() or ptr->method())
-     // Delegate to CallExpr handler which will handle function call expression generation
-     return VisitCallExpr(cxx_member_call_expr, node) && res;
-}
+  sg_switch_stmt->set_parent(SageBuilder::topScopeStack());
 
-bool ClangToSageTranslator::VisitCXXOperatorCallExpr(clang::CXXOperatorCallExpr * cxx_operator_call_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXOperatorCallExpr" << std::endl;
-#endif
-     bool res = true;
+  cond->set_parent(expr_stmt);
+  expr_stmt->set_parent(sg_switch_stmt);
 
-     // C++ overloaded operators (operator+, operator[], etc.) are represented as function calls
-     // Delegate to CallExpr handler for proper function call expression generation
-     res = VisitCallExpr(cxx_operator_call_expr, node) && res;
+  SageBuilder::pushScopeStack(sg_switch_stmt);
 
-     // CLANG FRONTEND FIX: Set uses_operator_syntax flag to true for operator overloads
-     // This tells the unparser to generate operator syntax (e.g., a + b) instead of
-     // explicit function call syntax (e.g., operator+(a, b))
-     if (*node != NULL && res) {
-         SgFunctionCallExp* funcCall = isSgFunctionCallExp(*node);
-         if (funcCall != NULL) {
-             funcCall->set_uses_operator_syntax(true);
-         }
-     }
+  SgNode *tmp_body = Traverse(switch_stmt->getBody());
+  SgStatement *body = isSgStatement(tmp_body);
+  ROSE_ASSERT(body != NULL);
 
-     return res;
-}
+  SageBuilder::popScopeStack();
 
-bool ClangToSageTranslator::VisitUserDefinedLiteral(clang::UserDefinedLiteral * user_defined_literal, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitUserDefinedLiteral" << std::endl;
-#endif
-     bool res = true;
+  sg_switch_stmt->set_body(body);
 
-     // TODO 
+  *node = sg_switch_stmt;
 
-     return VisitExpr(user_defined_literal, node) && res;
+  return VisitStmt(switch_stmt, node);
 }
 
-bool ClangToSageTranslator::VisitCastExpr(clang::CastExpr * cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitValueStmt(clang::ValueStmt *value_stmt,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitValueStmt" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Process the sub-expression being cast
-    SgNode * tmp_expr = Traverse(cast_expr->getSubExpr());
-    SgExpression * sg_expr = isSgExpression(tmp_expr);
-    ROSE_ASSERT(sg_expr != NULL);
+  // DQ (11/28/2020): In test2020_45.c: I think this is the enum field.
+  // clang::Expr* expr = value_stmt->getExprStmt();
+  // ROSE_ASSERT(expr != NULL);
 
-    // Get the target type
-    SgType * sg_type = buildTypeFromQualifiedType(cast_expr->getType());
+  // DQ (11/28/2020): Note that value_stmt->getExprStmt() == value_stmt, but not
+  // sure why.
 
-    // Create the cast expression
-    *node = SageBuilder::buildCastExp(sg_expr, sg_type);
+  // DQ (11/28/2020): This was previously commented out, and I think there is
+  // nothing to do here. The actual implementation was done in VisitFullExp
+  // ROSE_ASSERT(FAIL_TODO == 0); // TODO
 
-    return VisitExpr(cast_expr, node) && res;
+  return VisitStmt(value_stmt, node) && res;
 }
-
-bool ClangToSageTranslator::VisitExplicitCastExpr(clang::ExplicitCastExpr * explicit_cast_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitExplicitCastExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitCastExpr(explicit_cast_expr, node) && res;
-}
-    
-bool ClangToSageTranslator::VisitBuiltinBitCastExpr(clang::BuiltinBitCastExpr * builtin_bit_cast_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitBuiltinBitCastExpr" << std::endl;
-#endif
-    bool res = true;
 
-    // TODO
-
-    return VisitExplicitCastExpr(builtin_bit_cast_expr, node) && res;
-}
-    
-bool ClangToSageTranslator::VisitCStyleCastExpr(clang::CStyleCastExpr * c_style_cast, SgNode ** node) {
+bool ClangToSageTranslator::VisitAttributedStmt(
+    clang::AttributedStmt *attributed_stmt, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCStyleCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAttributedStmt" << std::endl;
 #endif
+  bool res = true;
 
-    bool res = true;
+  // Attributes like [[fallthrough]] wrap an inner statement. We currently drop
+  // the attribute and translate the wrapped statement directly.
+  clang::Stmt *sub_stmt = attributed_stmt->getSubStmt();
+  SgNode *sub_node = Traverse(sub_stmt);
+  if (sub_node == NULL) {
+    sub_node = SageBuilder::buildNullStatement();
+  }
+  *node = sub_node;
 
-    SgNode * tmp_expr = Traverse(c_style_cast->getSubExpr());
-    SgExpression * expr = isSgExpression(tmp_expr);
+  if (SgStatement *sg_stmt = isSgStatement(sub_node)) {
+    applySourceRange(sg_stmt, attributed_stmt->getSourceRange());
+  }
 
-    ROSE_ASSERT(expr);
-
-    SgType * type = buildTypeFromQualifiedType(c_style_cast->getTypeAsWritten());
-
-    *node = SageBuilder::buildCastExp(expr, type, SgCastExp::e_C_style_cast);
-
-    return VisitExplicitCastExpr(c_style_cast, node) && res;
+  return VisitValueStmt(attributed_stmt, node) && res;
 }
-    
-bool ClangToSageTranslator::VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr * cxx_functional_cast_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXFunctionalCastExpr" << std::endl;
-#endif
-    bool res = true;
 
-    // TODO
-
-    return VisitExplicitCastExpr(cxx_functional_cast_expr, node) && res;
-}
-    
-bool ClangToSageTranslator::VisitCXXNamedCastExpr(clang::CXXNamedCastExpr * cxx_named_cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitExpr(clang::Expr *expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXNamedCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitExpr" << std::endl;
 #endif
-    bool res = true;
 
-    // TODO
+  // TODO Is there anything to be done? (maybe in relation with typing?)
 
-    return VisitExplicitCastExpr(cxx_named_cast_expr, node) && res;
+  return VisitValueStmt(expr, node);
 }
 
-bool ClangToSageTranslator::VisitCXXConstCastExpr(clang::CXXConstCastExpr * cxx_const_cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitAbstractConditionalOperator(
+    clang::AbstractConditionalOperator *abstract_conditional_operator,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXConstCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAbstractConditionalOperator"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitCXXNamedCastExpr(cxx_const_cast_expr, node) && res;
+  return VisitStmt(abstract_conditional_operator, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXDynamicCastExpr(clang::CXXDynamicCastExpr * cxx_dynamic_cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitBinaryConditionalOperator(
+    clang::BinaryConditionalOperator *binary_conditional_operator,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXDynamicCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitBinaryConditionalOperator"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitCXXNamedCastExpr(cxx_dynamic_cast_expr, node) && res;
+  return VisitStmt(binary_conditional_operator, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXReinterpretCastExpr(clang::CXXReinterpretCastExpr * cxx_reinterpret_cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitConditionalOperator(
+    clang::ConditionalOperator *conditional_operator, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXReinterpretCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitConditionalOperator" << std::endl;
 #endif
-    bool res = true;
 
-    // TODO
+  bool res = true;
 
-    return VisitCXXNamedCastExpr(cxx_reinterpret_cast_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXStaticCastExpr(clang::CXXStaticCastExpr * cxx_static_cast_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXStaticCastExpr" << std::endl;
-#endif
-    bool res = true;
+  SgNode *tmp_cond = Traverse(conditional_operator->getCond());
+  SgExpression *cond_expr = isSgExpression(tmp_cond);
+  ROSE_ASSERT(cond_expr);
+  SgNode *tmp_true = Traverse(conditional_operator->getTrueExpr());
+  SgExpression *true_expr = isSgExpression(tmp_true);
+  ROSE_ASSERT(true_expr);
+  SgNode *tmp_false = Traverse(conditional_operator->getFalseExpr());
+  SgExpression *false_expr = isSgExpression(tmp_false);
+  ROSE_ASSERT(false_expr);
 
-    // TODO
+  *node = SageBuilder::buildConditionalExp(cond_expr, true_expr, false_expr);
 
-    return VisitCXXNamedCastExpr(cxx_static_cast_expr, node) && res;
+  return VisitAbstractConditionalOperator(conditional_operator, node) && res;
 }
 
-
-bool ClangToSageTranslator::VisitImplicitCastExpr(clang::ImplicitCastExpr * implicit_cast_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitAddrLabelExpr(
+    clang::AddrLabelExpr *addr_label_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitImplicitCastExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAddrLabelExpr" << std::endl;
 #endif
-
-    SgNode * tmp_expr = Traverse(implicit_cast_expr->getSubExpr());
-    SgExpression * expr = isSgExpression(tmp_expr);
-
-    ROSE_ASSERT(expr != NULL);
+  bool res = true;
 
-    // FIX: Pass through implicit casts without creating SgCastExp nodes
-    // EDG frontend doesn't create explicit cast nodes for implicit casts
-    // Creating them breaks parent pointer relationships (e.g., FunctionRefExp parent becomes CastExp instead of FunctionCallExp)
-    // This matches the behavior expected by existing ROSE tests
+  // TODO
 
-    // LIMITATION: The sub-expression retains its original type (e.g., int stays int even if cast to double).
-    // SgExpression types are immutable in ROSE - there is no set_type() method.
-    // This matches EDG frontend behavior where implicit casts don't create SgCastExp nodes.
-    // Most ROSE analyses handle this correctly. If type correctness is critical for a specific analysis,
-    // that analysis should consult the Clang AST context or implement its own type inference.
-    *node = expr;
-
-    return VisitExpr(implicit_cast_expr, node);
+  return VisitExpr(addr_label_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCharacterLiteral(clang::CharacterLiteral * character_literal, SgNode ** node) {
+bool ClangToSageTranslator::VisitArrayInitIndexExpr(
+    clang::ArrayInitIndexExpr *array_init_index_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCharacterLiteral" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitArrayInitIndexExpr" << std::endl;
 #endif
+  bool res = true;
 
-    *node = SageBuilder::buildCharVal(character_literal->getValue());
+  // TODO
 
-    return VisitExpr(character_literal, node);
+  return VisitExpr(array_init_index_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitChooseExpr(clang::ChooseExpr * choose_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitArrayInitLoopExpr(
+    clang::ArrayInitLoopExpr *array_init_loop_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitChooseExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitArrayInitLoopExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(choose_expr, node) && res;
+  return VisitExpr(array_init_loop_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCompoundLiteralExpr(clang::CompoundLiteralExpr * compound_literal, SgNode ** node) {
+bool ClangToSageTranslator::VisitArraySubscriptExpr(
+    clang::ArraySubscriptExpr *array_subscript_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCompoundLiteralExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitArraySubscriptExpr" << std::endl;
 #endif
-
-    SgNode * tmp_node = Traverse(compound_literal->getInitializer());
-    SgExprListExp * expr = isSgExprListExp(tmp_node);
-    ROSE_ASSERT(expr != NULL);
-
-    SgType * type = buildTypeFromQualifiedType(compound_literal->getType());
-    ROSE_ASSERT(type != NULL);
-
-    SgAggregateInitializer * initializer = SageBuilder::buildAggregateInitializer_nfi(expr,type);
-
-    initializer->set_uses_compound_literal(true);
-
-    SgName name = std::string("compound_literal_") + Rose::StringUtility::numberToString(compound_literal);
-    SgInitializedName* iname = SageBuilder::buildInitializedName_nfi(name, type, initializer);
-
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-    iname->set_scope(scope);
-    iname->set_parent(scope);
-
-    SgVariableSymbol * vsym = new SgVariableSymbol(iname);
-    ROSE_ASSERT(vsym != nullptr);
-
-    scope->insert_symbol(name,vsym);
-
-    // REX FIX: Check if the type is defined inside the compound literal
-    // If so, mark the declaration as non-autonomous so it gets unparsed
-    // correctly
-    if (clang::TypeSourceInfo *TInfo = compound_literal->getTypeSourceInfo()) {
-      clang::TypeLoc TL = TInfo->getTypeLoc();
-      // Drill down to the underlying TagTypeLoc, stripping common wrappers
-      // (const qualifiers, parens, attributes, arrays, pointers, elaborations).
-      while (true) {
-        bool advanced = false;
-
-        // Strip top-level qualifiers
-        TL = TL.getUnqualifiedLoc();
 
-        if (auto ParenTL = TL.getAs<clang::ParenTypeLoc>()) {
-          TL = ParenTL.getInnerLoc();
-          advanced = true;
-        } else if (auto AttrTL = TL.getAs<clang::AttributedTypeLoc>()) {
-          TL = AttrTL.getModifiedLoc();
-          advanced = true;
-        } else if (auto AdjTL = TL.getAs<clang::AdjustedTypeLoc>()) {
-          TL = AdjTL.getOriginalLoc();
-          advanced = true;
-        } else if (auto ETL = TL.getAs<clang::ElaboratedTypeLoc>()) {
-          TL = ETL.getNamedTypeLoc();
-          advanced = true;
-        } else if (auto ATL = TL.getAs<clang::ArrayTypeLoc>()) {
-          TL = ATL.getElementLoc();
-          advanced = true;
-        } else if (auto PTL = TL.getAs<clang::PointerTypeLoc>()) {
-          TL = PTL.getPointeeLoc();
-          advanced = true;
-        }
+  bool res = true;
 
-        if (!advanced)
+  SgNode *tmp_base = Traverse(array_subscript_expr->getBase());
+  SgExpression *base = isSgExpression(tmp_base);
+  if (tmp_base != NULL && base == NULL) {
+    std::cerr << "Runtime error: tmp_base != NULL && base == NULL" << std::endl;
+    res = false;
+  }
+  if (SgCastExp *cast = isSgCastExp(base)) {
+    auto pointerInfo = [](SgType *type) -> std::pair<int, SgType *> {
+      int depth = 0;
+      SgType *current = type;
+      while (current != nullptr) {
+        current = current->stripTypedefsAndModifiers();
+        SgPointerType *ptrType = isSgPointerType(current);
+        if (ptrType == nullptr) {
           break;
+        }
+        ++depth;
+        current = ptrType->get_base_type();
+      }
+      return std::make_pair(depth, current != nullptr
+                                       ? current->stripTypedefsAndModifiers()
+                                       : nullptr);
+    };
+
+    SgType *operandType = cast->get_operand_i()->get_type();
+    if (operandType != nullptr) {
+      operandType = operandType->stripTypedefsAndModifiers();
+      if (SgArrayType *arrayType = isSgArrayType(operandType)) {
+        SgType *elementType = arrayType->get_base_type();
+        ROSE_ASSERT(elementType != nullptr);
+        SgType *targetType = SgPointerType::createType(elementType);
+        ROSE_ASSERT(targetType != nullptr);
+        if (pointerInfo(cast->get_type()) != pointerInfo(targetType)) {
+          cast->set_type(targetType);
+        }
+      }
+    }
+  }
+
+  SgNode *tmp_idx = Traverse(array_subscript_expr->getIdx());
+  SgExpression *idx = isSgExpression(tmp_idx);
+  if (tmp_idx != NULL && idx == NULL) {
+    std::cerr << "Runtime error: tmp_idx != NULL && idx == NULL" << std::endl;
+    res = false;
+  }
+
+  *node = SageBuilder::buildPntrArrRefExp(base, idx);
+
+  return VisitExpr(array_subscript_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitArrayTypeTraitExpr(
+    clang::ArrayTypeTraitExpr *array_type_trait_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitArrayTypeTraitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(array_type_trait_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitAsTypeExpr(clang::AsTypeExpr *as_type_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitAsTypeExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(as_type_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitAtomicExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: AtomicExpr represents C11/C++11 atomic operations like:
+  // __atomic_load, __atomic_store, __atomic_fetch_add, __atomic_exchange, etc.
+  // Build a function call expression to represent the atomic builtin.
+
+  // Traverse all sub-expressions (pointer, values, memory orders, etc.)
+  SgExprListExp *args = SageBuilder::buildExprListExp();
+  for (unsigned i = 0; i < atomic_expr->getNumSubExprs(); i++) {
+    SgNode *tmp_arg = Traverse(atomic_expr->getSubExprs()[i]);
+    SgExpression *arg = isSgExpression(tmp_arg);
+    if (arg != NULL) {
+      args->append_expression(arg);
+    } else if (tmp_arg != NULL) {
+      std::cerr << "Warning: AtomicExpr argument " << i
+                << " is not an expression" << std::endl;
+      res = false;
+    }
+  }
+
+  // Build the function call expression with the actual builtin name
+  // Get the real builtin name (e.g., "__atomic_load", "__atomic_fetch_add",
+  // etc.) so the unparsed code will compile correctly
+  std::string builtin_name = atomic_expr->getOpAsString().str();
+
+  // Use the actual return type from Clang, not void - many atomics return
+  // values Example: __atomic_fetch_add returns the old value before addition
+  SgType *return_type = buildTypeFromQualifiedType(atomic_expr->getType());
+  *node = SageBuilder::buildFunctionCallExp(builtin_name, return_type, args,
+                                            SageBuilder::topScopeStack());
+
+  return VisitExpr(atomic_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitBinaryOperator(
+    clang::BinaryOperator *binary_operator, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitBinaryOperator" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgNode *tmp_lhs = Traverse(binary_operator->getLHS());
+  SgExpression *lhs = isSgExpression(tmp_lhs);
+  if (tmp_lhs != NULL && lhs == NULL) {
+    std::cerr << "Runtime error: tmp_lhs != NULL && lhs == NULL" << std::endl;
+    res = false;
+  }
+
+  SgNode *tmp_rhs = Traverse(binary_operator->getRHS());
+  SgExpression *rhs = isSgExpression(tmp_rhs);
+  if (tmp_rhs != NULL && rhs == NULL) {
+    std::cerr << "Runtime error: tmp_rhs != NULL && rhs == NULL" << std::endl;
+    res = false;
+  }
+
+  switch (binary_operator->getOpcode()) {
+  // ROOT CAUSE FIX: Pointer-to-member operators for C++ member function
+  // pointers
+  case clang::BO_PtrMemD:
+    *node = SageBuilder::buildDotStarOp(lhs, rhs);
+    break; // obj.*ptr_to_member
+  case clang::BO_PtrMemI:
+    *node = SageBuilder::buildArrowStarOp(lhs, rhs);
+    break; // ptr->*ptr_to_member
+  case clang::BO_Mul:
+    *node = SageBuilder::buildMultiplyOp(lhs, rhs);
+    break;
+  case clang::BO_Div:
+    *node = SageBuilder::buildDivideOp(lhs, rhs);
+    break;
+  case clang::BO_Rem:
+    *node = SageBuilder::buildModOp(lhs, rhs);
+    break;
+  case clang::BO_Add:
+    *node = SageBuilder::buildAddOp(lhs, rhs);
+    break;
+  case clang::BO_Sub:
+    *node = SageBuilder::buildSubtractOp(lhs, rhs);
+    break;
+  case clang::BO_Shl:
+    *node = SageBuilder::buildLshiftOp(lhs, rhs);
+    break;
+  case clang::BO_Shr:
+    *node = SageBuilder::buildRshiftOp(lhs, rhs);
+    break;
+  case clang::BO_LT:
+    *node = SageBuilder::buildLessThanOp(lhs, rhs);
+    break;
+  case clang::BO_GT:
+    *node = SageBuilder::buildGreaterThanOp(lhs, rhs);
+    break;
+  case clang::BO_LE:
+    *node = SageBuilder::buildLessOrEqualOp(lhs, rhs);
+    break;
+  case clang::BO_GE:
+    *node = SageBuilder::buildGreaterOrEqualOp(lhs, rhs);
+    break;
+  case clang::BO_EQ:
+    *node = SageBuilder::buildEqualityOp(lhs, rhs);
+    break;
+  case clang::BO_NE:
+    *node = SageBuilder::buildNotEqualOp(lhs, rhs);
+    break;
+  case clang::BO_And:
+    *node = SageBuilder::buildBitAndOp(lhs, rhs);
+    break;
+  case clang::BO_Xor:
+    *node = SageBuilder::buildBitXorOp(lhs, rhs);
+    break;
+  case clang::BO_Or:
+    *node = SageBuilder::buildBitOrOp(lhs, rhs);
+    break;
+  case clang::BO_LAnd:
+    *node = SageBuilder::buildAndOp(lhs, rhs);
+    break;
+  case clang::BO_LOr:
+    *node = SageBuilder::buildOrOp(lhs, rhs);
+    break;
+  case clang::BO_Assign:
+    *node = SageBuilder::buildAssignOp(lhs, rhs);
+    break;
+  case clang::BO_MulAssign:
+    *node = SageBuilder::buildMultAssignOp(lhs, rhs);
+    break;
+  case clang::BO_DivAssign:
+    *node = SageBuilder::buildDivAssignOp(lhs, rhs);
+    break;
+  case clang::BO_RemAssign:
+    *node = SageBuilder::buildModAssignOp(lhs, rhs);
+    break;
+  case clang::BO_AddAssign:
+    *node = SageBuilder::buildPlusAssignOp(lhs, rhs);
+    break;
+  case clang::BO_SubAssign:
+    *node = SageBuilder::buildMinusAssignOp(lhs, rhs);
+    break;
+  case clang::BO_ShlAssign:
+    *node = SageBuilder::buildLshiftAssignOp(lhs, rhs);
+    break;
+  case clang::BO_ShrAssign:
+    *node = SageBuilder::buildRshiftAssignOp(lhs, rhs);
+    break;
+  case clang::BO_AndAssign:
+    *node = SageBuilder::buildAndAssignOp(lhs, rhs);
+    break;
+  case clang::BO_XorAssign:
+    *node = SageBuilder::buildXorAssignOp(lhs, rhs);
+    break;
+  case clang::BO_OrAssign:
+    *node = SageBuilder::buildIorAssignOp(lhs, rhs);
+    break;
+  case clang::BO_Comma:
+    *node = SageBuilder::buildCommaOpExp(lhs, rhs);
+    break;
+  default:
+    std::cerr << "Unknown opcode for binary operator: "
+              << binary_operator->getOpcodeStr().str() << std::endl;
+    res = false;
+  }
+
+  return VisitExpr(binary_operator, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCompoundAssignOperator(
+    clang::CompoundAssignOperator *compound_assign_operator, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCompoundAssignOperator"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitBinaryOperator(compound_assign_operator, node) && res;
+}
+
+bool ClangToSageTranslator::VisitBlockExpr(clang::BlockExpr *block_expr,
+                                           SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitBlockExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(block_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
+                                          SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCallExpr" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgNode *tmp_expr = Traverse(call_expr->getCallee());
+  SgExpression *expr = isSgExpression(tmp_expr);
+  if (tmp_expr != NULL && expr == NULL) {
+    std::cerr << "Runtime error: tmp_expr != NULL && expr == NULLL"
+              << std::endl;
+    res = false;
+  }
+
+  SgExprListExp *param_list = SageBuilder::buildExprListExp_nfi();
+  applySourceRange(param_list, call_expr->getSourceRange());
+
+  clang::CallExpr::arg_iterator it;
+  for (it = call_expr->arg_begin(); it != call_expr->arg_end(); ++it) {
+    SgNode *tmp_expr = Traverse(*it);
+    SgExpression *expr = isSgExpression(tmp_expr);
+    if (tmp_expr != NULL && expr == NULL) {
+      std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL"
+                << std::endl;
+      res = false;
+      continue;
+    }
+    param_list->append_expression(expr);
+  }
+
+  *node = SageBuilder::buildFunctionCallExp_nfi(expr, param_list);
+
+  return VisitExpr(call_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCUDAKernelCallExpr(
+    clang::CUDAKernelCallExpr *cuda_kernel_call_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCUDAKernelCallExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cuda_kernel_call_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXMemberCallExpr(
+    clang::CXXMemberCallExpr *cxx_member_call_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXMemberCallExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // CXXMemberCallExpr represents calls to member functions (e.g., obj.method()
+  // or ptr->method()) Delegate to CallExpr handler which will handle function
+  // call expression generation
+  return VisitCallExpr(cxx_member_call_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
+    clang::CXXOperatorCallExpr *cxx_operator_call_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXOperatorCallExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // C++ overloaded operators (operator+, operator[], etc.) are represented as
+  // function calls Delegate to CallExpr handler for proper function call
+  // expression generation
+  res = VisitCallExpr(cxx_operator_call_expr, node) && res;
+
+  // CLANG FRONTEND FIX: Set uses_operator_syntax flag to true for operator
+  // overloads This tells the unparser to generate operator syntax (e.g., a + b)
+  // instead of explicit function call syntax (e.g., operator+(a, b))
+  if (*node != NULL && res) {
+    SgFunctionCallExp *funcCall = isSgFunctionCallExp(*node);
+    if (funcCall != NULL) {
+      funcCall->set_uses_operator_syntax(true);
+    }
+  }
+
+  return res;
+}
+
+bool ClangToSageTranslator::VisitUserDefinedLiteral(
+    clang::UserDefinedLiteral *user_defined_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitUserDefinedLiteral" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(user_defined_literal, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCastExpr(clang::CastExpr *cast_expr,
+                                          SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // Process the sub-expression being cast
+  SgNode *tmp_expr = Traverse(cast_expr->getSubExpr());
+  SgExpression *sg_expr = isSgExpression(tmp_expr);
+  ROSE_ASSERT(sg_expr != NULL);
+
+  // Get the target type
+  SgType *sg_type = buildTypeFromQualifiedType(cast_expr->getType());
+
+  // Create the cast expression
+  *node = SageBuilder::buildCastExp(sg_expr, sg_type);
+
+  return VisitExpr(cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitExplicitCastExpr(
+    clang::ExplicitCastExpr *explicit_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitExplicitCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitCastExpr(explicit_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitBuiltinBitCastExpr(
+    clang::BuiltinBitCastExpr *builtin_bit_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitBuiltinBitCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExplicitCastExpr(builtin_bit_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCStyleCastExpr(
+    clang::CStyleCastExpr *c_style_cast, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCStyleCastExpr" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgNode *tmp_expr = Traverse(c_style_cast->getSubExpr());
+  SgExpression *expr = isSgExpression(tmp_expr);
+
+  ROSE_ASSERT(expr);
+
+  SgType *type = buildTypeFromQualifiedType(c_style_cast->getTypeAsWritten());
+
+  *node = SageBuilder::buildCastExp(expr, type, SgCastExp::e_C_style_cast);
+
+  return VisitExplicitCastExpr(c_style_cast, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXFunctionalCastExpr(
+    clang::CXXFunctionalCastExpr *cxx_functional_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXFunctionalCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExplicitCastExpr(cxx_functional_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXNamedCastExpr(
+    clang::CXXNamedCastExpr *cxx_named_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXNamedCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExplicitCastExpr(cxx_named_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXConstCastExpr(
+    clang::CXXConstCastExpr *cxx_const_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXConstCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitCXXNamedCastExpr(cxx_const_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXDynamicCastExpr(
+    clang::CXXDynamicCastExpr *cxx_dynamic_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXDynamicCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitCXXNamedCastExpr(cxx_dynamic_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXReinterpretCastExpr(
+    clang::CXXReinterpretCastExpr *cxx_reinterpret_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXReinterpretCastExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitCXXNamedCastExpr(cxx_reinterpret_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXStaticCastExpr(
+    clang::CXXStaticCastExpr *cxx_static_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXStaticCastExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitCXXNamedCastExpr(cxx_static_cast_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitImplicitCastExpr(
+    clang::ImplicitCastExpr *implicit_cast_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitImplicitCastExpr" << std::endl;
+#endif
+
+  SgNode *tmp_expr = Traverse(implicit_cast_expr->getSubExpr());
+  SgExpression *expr = isSgExpression(tmp_expr);
+
+  ROSE_ASSERT(expr != NULL);
+
+  // FIX: Pass through implicit casts without creating SgCastExp nodes
+  // EDG frontend doesn't create explicit cast nodes for implicit casts
+  // Creating them breaks parent pointer relationships (e.g., FunctionRefExp
+  // parent becomes CastExp instead of FunctionCallExp) This matches the
+  // behavior expected by existing ROSE tests
+
+  // LIMITATION: The sub-expression retains its original type (e.g., int stays
+  // int even if cast to double). SgExpression types are immutable in ROSE -
+  // there is no set_type() method. This matches EDG frontend behavior where
+  // implicit casts don't create SgCastExp nodes. Most ROSE analyses handle this
+  // correctly. If type correctness is critical for a specific analysis, that
+  // analysis should consult the Clang AST context or implement its own type
+  // inference.
+  *node = expr;
+
+  return VisitExpr(implicit_cast_expr, node);
+}
+
+bool ClangToSageTranslator::VisitCharacterLiteral(
+    clang::CharacterLiteral *character_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCharacterLiteral" << std::endl;
+#endif
+
+  *node = SageBuilder::buildCharVal(character_literal->getValue());
+
+  return VisitExpr(character_literal, node);
+}
+
+bool ClangToSageTranslator::VisitChooseExpr(clang::ChooseExpr *choose_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitChooseExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(choose_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCompoundLiteralExpr(
+    clang::CompoundLiteralExpr *compound_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCompoundLiteralExpr" << std::endl;
+#endif
+
+  SgNode *tmp_node = Traverse(compound_literal->getInitializer());
+  SgExprListExp *expr = isSgExprListExp(tmp_node);
+  ROSE_ASSERT(expr != NULL);
+
+  SgType *type = buildTypeFromQualifiedType(compound_literal->getType());
+  ROSE_ASSERT(type != NULL);
+
+  SgAggregateInitializer *initializer =
+      SageBuilder::buildAggregateInitializer_nfi(expr, type);
+
+  initializer->set_uses_compound_literal(true);
+
+  SgName name = std::string("compound_literal_") +
+                Rose::StringUtility::numberToString(compound_literal);
+  SgScopeStatement *scope = SageBuilder::topScopeStack();
+  SgVariableDeclaration *var_decl =
+      new SgVariableDeclaration(SgName(name), type, initializer);
+  var_decl->set_scope(scope);
+  var_decl->set_parent(scope);
+  var_decl->set_firstNondefiningDeclaration(var_decl);
+  var_decl->set_definingDeclaration(var_decl);
+  var_decl->set_file_info(
+      Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode());
+  if (Sg_File_Info *fi = var_decl->get_file_info()) {
+    fi->setCompilerGenerated();
+    fi->unsetOutputInCodeGeneration();
+  }
+
+  ROSE_ASSERT(!var_decl->get_variables().empty());
+  SgInitializedName *iname = var_decl->get_variables()[0];
+  iname->set_scope(scope);
+  iname->set_parent(var_decl);
+  iname->set_file_info(
+      Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode());
+  if (Sg_File_Info *fi = iname->get_file_info()) {
+    fi->setCompilerGenerated();
+    fi->unsetOutputInCodeGeneration();
+  }
+
+  if (initializer != NULL) {
+    initializer->set_parent(iname);
+  }
+
+  SgVariableSymbol *vsym = new SgVariableSymbol(iname);
+  ROSE_ASSERT(vsym != nullptr);
+
+  scope->insert_symbol(name, vsym);
+
+  // REX FIX: Check if the type is defined inside the compound literal
+  // If so, mark the declaration as non-autonomous so it gets unparsed
+  // correctly
+  if (clang::TypeSourceInfo *TInfo = compound_literal->getTypeSourceInfo()) {
+    clang::TypeLoc TL = TInfo->getTypeLoc();
+    // Drill down to the underlying TagTypeLoc, stripping common wrappers
+    // (const qualifiers, parens, attributes, arrays, pointers, elaborations).
+    while (true) {
+      bool advanced = false;
+
+      // Strip top-level qualifiers
+      TL = TL.getUnqualifiedLoc();
+
+      if (auto ParenTL = TL.getAs<clang::ParenTypeLoc>()) {
+        TL = ParenTL.getInnerLoc();
+        advanced = true;
+      } else if (auto AttrTL = TL.getAs<clang::AttributedTypeLoc>()) {
+        TL = AttrTL.getModifiedLoc();
+        advanced = true;
+      } else if (auto AdjTL = TL.getAs<clang::AdjustedTypeLoc>()) {
+        TL = AdjTL.getOriginalLoc();
+        advanced = true;
+      } else if (auto ETL = TL.getAs<clang::ElaboratedTypeLoc>()) {
+        TL = ETL.getNamedTypeLoc();
+        advanced = true;
+      } else if (auto ATL = TL.getAs<clang::ArrayTypeLoc>()) {
+        TL = ATL.getElementLoc();
+        advanced = true;
+      } else if (auto PTL = TL.getAs<clang::PointerTypeLoc>()) {
+        TL = PTL.getPointeeLoc();
+        advanced = true;
       }
 
-      if (auto TagTL = TL.getAs<clang::TagTypeLoc>()) {
-        if (TagTL.isDefinition()) {
-          clang::TagDecl *TD = TagTL.getDecl();
-          std::map<clang::Decl *, SgNode *>::iterator it =
-              p_decl_translation_map.find(TD);
-          if (it != p_decl_translation_map.end()) {
-            SgNode *node = it->second;
-            if (SgClassDeclaration *classDecl = isSgClassDeclaration(node)) {
-              classDecl->set_isAutonomousDeclaration(false);
-              if (classDecl->get_definingDeclaration()) {
-                if (SgClassDeclaration *defDecl = isSgClassDeclaration(
-                        classDecl->get_definingDeclaration())) {
-                  defDecl->set_isAutonomousDeclaration(false);
-                }
+      if (!advanced)
+        break;
+    }
+
+    if (auto TagTL = TL.getAs<clang::TagTypeLoc>()) {
+      if (TagTL.isDefinition()) {
+        clang::TagDecl *TD = TagTL.getDecl();
+        std::map<clang::Decl *, SgNode *>::iterator it =
+            p_decl_translation_map.find(TD);
+        if (it != p_decl_translation_map.end()) {
+          SgNode *node = it->second;
+          if (SgClassDeclaration *classDecl = isSgClassDeclaration(node)) {
+            classDecl->set_isAutonomousDeclaration(false);
+            if (classDecl->get_definingDeclaration()) {
+              if (SgClassDeclaration *defDecl = isSgClassDeclaration(
+                      classDecl->get_definingDeclaration())) {
+                defDecl->set_isAutonomousDeclaration(false);
               }
-            } else if (SgEnumDeclaration *enumDecl =
-                           isSgEnumDeclaration(node)) {
-              enumDecl->set_isAutonomousDeclaration(false);
-              if (enumDecl->get_definingDeclaration()) {
-                if (SgEnumDeclaration *defDecl = isSgEnumDeclaration(
-                        enumDecl->get_definingDeclaration())) {
-                  defDecl->set_isAutonomousDeclaration(false);
-                }
+            }
+          } else if (SgEnumDeclaration *enumDecl = isSgEnumDeclaration(node)) {
+            enumDecl->set_isAutonomousDeclaration(false);
+            if (enumDecl->get_definingDeclaration()) {
+              if (SgEnumDeclaration *defDecl = isSgEnumDeclaration(
+                      enumDecl->get_definingDeclaration())) {
+                defDecl->set_isAutonomousDeclaration(false);
               }
             }
           }
         }
       }
     }
+  }
 
-    *node = SageBuilder::buildCompoundLiteralExp_nfi(vsym);
+  *node = SageBuilder::buildCompoundLiteralExp_nfi(vsym);
 
-    return VisitExpr(compound_literal, node);
+  return VisitExpr(compound_literal, node);
 }
 
-//bool ClangToSageTranslator::VisitConceptSpecializationExpr(clang::ConceptSpecializationExpr * concept_specialization_expr, SgNode ** node) {
-//#if DEBUG_VISIT_STMT
-//    std::cerr << "ClangToSageTranslator::VisitConceptSpecializationExpr" << std::endl;
-//#endif
-//    bool res = true;
+// bool
+// ClangToSageTranslator::VisitConceptSpecializationExpr(clang::ConceptSpecializationExpr
+// * concept_specialization_expr, SgNode ** node) { #if DEBUG_VISIT_STMT
+//     std::cerr << "ClangToSageTranslator::VisitConceptSpecializationExpr" <<
+//     std::endl;
+// #endif
+//     bool res = true;
 //
-//    // TODO
+//     // TODO
 //
-//    return VisitExpr(concept_specialization_expr, node) && res;
-//}
+//     return VisitExpr(concept_specialization_expr, node) && res;
+// }
 
-bool ClangToSageTranslator::VisitConvertVectorExpr(clang::ConvertVectorExpr * convert_vector_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitConvertVectorExpr(
+    clang::ConvertVectorExpr *convert_vector_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitConvertVectorExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitConvertVectorExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(convert_vector_expr, node) && res;
+  return VisitExpr(convert_vector_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCoroutineSuspendExpr(clang::CoroutineSuspendExpr * coroutine_suspend_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCoroutineSuspendExpr(
+    clang::CoroutineSuspendExpr *coroutine_suspend_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCoroutineSuspendExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCoroutineSuspendExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(coroutine_suspend_expr, node) && res;
+  return VisitExpr(coroutine_suspend_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCoawaitExpr(clang::CoawaitExpr * coawait_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCoawaitExpr(clang::CoawaitExpr *coawait_expr,
+                                             SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCoawaitExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCoawaitExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitCoroutineSuspendExpr(coawait_expr, node) && res;
+  return VisitCoroutineSuspendExpr(coawait_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCoyieldExpr(clang::CoyieldExpr * coyield_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCoyieldExpr(clang::CoyieldExpr *coyield_expr,
+                                             SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCoyieldExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCoyieldExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitCoroutineSuspendExpr(coyield_expr, node) && res;
+  return VisitCoroutineSuspendExpr(coyield_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXBindTemporaryExpr(clang::CXXBindTemporaryExpr * cxx_bind_temporary_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXBindTemporaryExpr(
+    clang::CXXBindTemporaryExpr *cxx_bind_temporary_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXBindTemporaryExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXBindTemporaryExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: CXXBindTemporaryExpr extends lifetime of temporary object
-    // ROSE handles temporaries differently - just traverse the subexpression
-    clang::Expr* sub_expr = cxx_bind_temporary_expr->getSubExpr();
-    if (sub_expr != NULL) {
-        *node = Traverse(sub_expr);
-        if (*node == NULL) {
-            return false;
-        }
-    } else {
-        return false;
+  // ROOT CAUSE FIX: CXXBindTemporaryExpr extends lifetime of temporary object
+  // ROSE handles temporaries differently - just traverse the subexpression
+  clang::Expr *sub_expr = cxx_bind_temporary_expr->getSubExpr();
+  if (sub_expr != NULL) {
+    *node = Traverse(sub_expr);
+    if (*node == NULL) {
+      return false;
     }
+  } else {
+    return false;
+  }
 
-    return VisitExpr(cxx_bind_temporary_expr, node) && res;
+  return VisitExpr(cxx_bind_temporary_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr * cxx_bool_literal_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXBoolLiteralExpr(
+    clang::CXXBoolLiteralExpr *cxx_bool_literal_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXBoolLiteralExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXBoolLiteralExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // C++ boolean literals (true/false)
-    bool value = cxx_bool_literal_expr->getValue();
-    *node = SageBuilder::buildBoolValExp(value);
+  // C++ boolean literals (true/false)
+  bool value = cxx_bool_literal_expr->getValue();
+  *node = SageBuilder::buildBoolValExp(value);
 
-    return VisitExpr(cxx_bool_literal_expr, node) && res;
+  return VisitExpr(cxx_bool_literal_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitCXXConstructExpr(clang::CXXConstructExpr * cxx_construct_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXConstructExpr(
+    clang::CXXConstructExpr *cxx_construct_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXConstructExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXConstructExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Get the constructor being called
-    clang::CXXConstructorDecl *ctor_decl = cxx_construct_expr->getConstructor();
+  // Get the constructor being called
+  clang::CXXConstructorDecl *ctor_decl = cxx_construct_expr->getConstructor();
 
-    if (ctor_decl != nullptr) {
-        // Get the type being constructed
-        SgType *constructed_type = buildTypeFromQualifiedType(cxx_construct_expr->getType());
+  if (ctor_decl != nullptr) {
+    // Get the type being constructed
+    SgType *constructed_type =
+        buildTypeFromQualifiedType(cxx_construct_expr->getType());
 
-        // Build argument list for constructor call
-        // Note: Empty argument lists are intentional and valid for default constructors
-        // or when all arguments fail traversal (e.g., template-dependent arguments)
-        SgExprListExp *args = SageBuilder::buildExprListExp_nfi();
+    // Build argument list for constructor call
+    // Note: Empty argument lists are intentional and valid for default
+    // constructors or when all arguments fail traversal (e.g.,
+    // template-dependent arguments)
+    SgExprListExp *args = SageBuilder::buildExprListExp_nfi();
 
-        // CLANG FRONTEND DEBUG: Print constructor info
-        #if 1
-        std::string ctor_name = "unknown";
-        if (cxx_construct_expr->getConstructor()) {
-            ctor_name = cxx_construct_expr->getConstructor()->getNameAsString();
+// CLANG FRONTEND DEBUG: Print constructor info
+#if 1
+    std::string ctor_name = "unknown";
+    if (cxx_construct_expr->getConstructor()) {
+      ctor_name = cxx_construct_expr->getConstructor()->getNameAsString();
+    }
+// DEBUG: std::cerr << "DEBUG VisitCXXConstructExpr: Processing constructor " <<
+// ctor_name
+//           << " with " << cxx_construct_expr->getNumArgs() << " args" <<
+//           std::endl;
+#endif
+
+    // Traverse constructor arguments
+    for (unsigned i = 0; i < cxx_construct_expr->getNumArgs(); ++i) {
+      clang::Expr *arg = cxx_construct_expr->getArg(i);
+      if (arg != nullptr) {
+// CLANG FRONTEND DEBUG: Print arg details
+#if 0
+#endif
+
+        // CLANG FRONTEND FIX #19: Skip default arguments
+        // CXXDefaultArgExpr represents implicit default arguments that
+        // shouldn't appear in the explicit argument list. For example:
+        //   std::string str("hello");  // Should have 1 arg, not 2
+        // The allocator parameter is a default argument and should be omitted.
+        if (clang::isa<clang::CXXDefaultArgExpr>(arg)) {
+#if 0
+#endif
+          continue;
         }
-        // DEBUG: std::cerr << "DEBUG VisitCXXConstructExpr: Processing constructor " << ctor_name
-        //           << " with " << cxx_construct_expr->getNumArgs() << " args" << std::endl;
-        #endif
 
-        // Traverse constructor arguments
-        for (unsigned i = 0; i < cxx_construct_expr->getNumArgs(); ++i) {
-            clang::Expr *arg = cxx_construct_expr->getArg(i);
-            if (arg != nullptr) {
-                // CLANG FRONTEND DEBUG: Print arg details
-                #if 0
-                #endif
-
-                // CLANG FRONTEND FIX #19: Skip default arguments
-                // CXXDefaultArgExpr represents implicit default arguments that shouldn't appear
-                // in the explicit argument list. For example:
-                //   std::string str("hello");  // Should have 1 arg, not 2
-                // The allocator parameter is a default argument and should be omitted.
-                if (clang::isa<clang::CXXDefaultArgExpr>(arg)) {
-                    #if 0
-                    #endif
-                    continue;
-                }
-
-                SgNode *sg_arg = Traverse(arg);
-                if (SgExpression *sg_expr = isSgExpression(sg_arg)) {
-                    // CLANG FRONTEND DEBUG: Print what we're adding to the arg list
-                    #if 0
-                    #endif
-                    args->append_expression(sg_expr);
-                } else {
-                    // CLANG FRONTEND DEBUG: Print skipped nodes
-                    #if 0
+        SgNode *sg_arg = Traverse(arg);
+        if (SgExpression *sg_expr = isSgExpression(sg_arg)) {
+// CLANG FRONTEND DEBUG: Print what we're adding to the arg list
+#if 0
+#endif
+          args->append_expression(sg_expr);
+        } else {
+// CLANG FRONTEND DEBUG: Print skipped nodes
+#if 0
                     std::cerr << "DEBUG VisitCXXConstructExpr:   Skipping arg " << i
                               << " sage type=" << (sg_arg ? sg_arg->class_name() : "null")
                               << " (not an expression)" << std::endl;
-                    #endif
-                }
-            }
+#endif
         }
+      }
+    }
 
-        // CLANG FRONTEND DEBUG: Print final arg list size
-        #if 0
+// CLANG FRONTEND DEBUG: Print final arg list size
+#if 0
         // DEBUG: std::cerr << "DEBUG VisitCXXConstructExpr: Final args list for " << ctor_name
         //           << " has " << args->get_expressions().size() << " elements" << std::endl;
-        #endif
+#endif
 
-        // Use SgConstructorInitializer to properly represent constructor calls
-        // This ensures the expression has the constructed class type, not void
+    // Use SgConstructorInitializer to properly represent constructor calls
+    // This ensures the expression has the constructed class type, not void
 
-        // Check if the type satisfies SgConstructorInitializer requirements
-        // The assertion requires: isSgTypedefType or isSgClassType or associated_class_unknown==true
-        bool class_unknown = false;
-        if (constructed_type != nullptr) {
-            if (isSgTypedefType(constructed_type) == nullptr && isSgClassType(constructed_type) == nullptr) {
-                // Type is neither typedef nor class type, set flag to true
-                class_unknown = true;
-            }
-        } else {
-            // No type available, set flag to true
-            class_unknown = true;
-        }
+    // Check if the type satisfies SgConstructorInitializer requirements
+    // The assertion requires: isSgTypedefType or isSgClassType or
+    // associated_class_unknown==true
+    bool class_unknown = false;
+    if (constructed_type != nullptr) {
+      if (isSgTypedefType(constructed_type) == nullptr &&
+          isSgClassType(constructed_type) == nullptr) {
+        // Type is neither typedef nor class type, set flag to true
+        class_unknown = true;
+      }
+    } else {
+      // No type available, set flag to true
+      class_unknown = true;
+    }
 
-        SgConstructorInitializer *ctor_init = SageBuilder::buildConstructorInitializer_nfi(
-            NULL,  // declaration (filled in later by AST fixup if needed)
-            args,
-            constructed_type,
-            false,  // need_name
-            false,  // need_qualifier
-            false,  // need_parenthesis_after_name
-            class_unknown   // associated_class_unknown
+    SgConstructorInitializer *ctor_init =
+        SageBuilder::buildConstructorInitializer_nfi(
+            NULL, // declaration (filled in later by AST fixup if needed)
+            args, constructed_type,
+            false,        // need_name
+            false,        // need_qualifier
+            false,        // need_parenthesis_after_name
+            class_unknown // associated_class_unknown
         );
 
-        *node = ctor_init;
-    } else {
-        // No constructor available, create a null expression
-        *node = SageBuilder::buildNullExpression();
-    }
-
-    return VisitExpr(cxx_construct_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXTemporaryObjectExpr(clang::CXXTemporaryObjectExpr * cxx_temporary_object_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXTemporaryObjectExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitCXXConstructExpr(cxx_temporary_object_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr * cxx_default_arg_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXDefaultArgExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // CXXDefaultArgExpr represents use of a default argument in a function call
-    // Traverse to the actual default expression
-    if (cxx_default_arg_expr->getExpr() != nullptr) {
-        *node = Traverse(cxx_default_arg_expr->getExpr());
-    } else {
-        // No expression available, use null expression as placeholder
-        *node = SageBuilder::buildNullExpression();
-    }
-
-    return VisitExpr(cxx_default_arg_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXDefaultInitExpr(clang::CXXDefaultInitExpr * cxx_default_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXDefaultInitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(cxx_default_init_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXDeleteExpr(clang::CXXDeleteExpr * cxx_delete_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXDeleteExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: CXXDeleteExpr represents the C++ delete operator
-    // Examples: delete ptr; or delete[] array;
-
-    // Get the expression being deleted
-    SgNode* tmp_arg = Traverse(cxx_delete_expr->getArgument());
-    SgExpression* arg = isSgExpression(tmp_arg);
-
-    if (arg == NULL) {
-        // If we can't get the argument, create a null expression as placeholder
-        arg = SageBuilder::buildNullExpression();
-    }
-
-    // Check if this is array delete (delete[]) or single object delete (delete)
-    bool is_array = cxx_delete_expr->isArrayForm();
-
-    // Build the delete expression
-    *node = SageBuilder::buildDeleteExp(arg, is_array, false, NULL);
-
-    return VisitExpr(cxx_delete_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXDependentScopeMemberExpr(clang::CXXDependentScopeMemberExpr * cxx_dependent_scope_member_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXDependentScopeMemberExpr" << std::endl;
-#endif
-    // std::cerr << "DEBUG: VisitCXXDependentScopeMemberExpr. Member: " << cxx_dependent_scope_member_expr->getMember().getAsString() << std::endl;
-    bool res = true;
-
-    // CXXDependentScopeMemberExpr represents member access on a template-dependent type
-    // (e.g., obj.begin(), obj->data())
-    // Extract the base expression and member name to create proper member access
-
-    SgExpression* base_expr = NULL;
-    if (cxx_dependent_scope_member_expr->getBase() != NULL) {
-        // Traverse the base expression
-        clang::Expr* base = const_cast<clang::Expr*>(cxx_dependent_scope_member_expr->getBase());
-        // std::cerr << "DEBUG: Base Stmt Class: " << base->getStmtClassName() << std::endl;
-        SgNode* tmp_base = Traverse(base);
-        base_expr = isSgExpression(tmp_base);
-        // if (base_expr) std::cerr << "DEBUG: VisitCXXDependentScopeMemberExpr base node type: " << base_expr->class_name() << std::endl;
-        // else std::cerr << "DEBUG: VisitCXXDependentScopeMemberExpr base node is NULL" << std::endl;
-    }
-
-    // Get the member name
-    std::string member_name = cxx_dependent_scope_member_expr->getMember().getAsString();
-
-    if (base_expr != NULL) {
-        // Create an arrow or dot expression depending on the operator used
-        if (cxx_dependent_scope_member_expr->isArrow()) {
-            // Use arrow expression (obj->member)
-            *node = SageBuilder::buildArrowExp(base_expr, SageBuilder::buildVarRefExp(member_name));
-        } else {
-            // Use dot expression (obj.member)
-            *node = SageBuilder::buildDotExp(base_expr, SageBuilder::buildVarRefExp(member_name));
-        }
-    } else {
-        // If we can't get the base expression, use a simple variable reference
-        *node = SageBuilder::buildVarRefExp(member_name);
-    }
-
-    // Set source position
-    SgExpression* expr = isSgExpression(*node);
-    if (expr != NULL) {
-        applySourceRange(expr, cxx_dependent_scope_member_expr->getSourceRange());
-    }
-
-    return VisitExpr(cxx_dependent_scope_member_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXFoldExpr(clang::CXXFoldExpr * cxx_fold_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXFoldExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // CXXFoldExpr represents C++17 fold expressions like (... && args)
-    // These are template-dependent, use placeholder for now
-    *node = SageBuilder::buildNullExpression();
-
-    return VisitExpr(cxx_fold_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXInheritedCtorInitExpr(clang::CXXInheritedCtorInitExpr * cxx_inherited_ctor_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXInheritedCtorInitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(cxx_inherited_ctor_init_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr * cxx_new_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXNewExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Implement new expression support
-    // Get the allocated type
-    SgType* allocated_type = buildTypeFromQualifiedType(cxx_new_expr->getAllocatedType());
-
-    // Handle array size if this is array new
-    SgExpression* array_size = NULL;
-    if (cxx_new_expr->isArray()) {
-        if (clang::Expr* size_expr = cxx_new_expr->getArraySize().value_or(nullptr)) {
-            SgNode* tmp_size = Traverse(size_expr);
-            array_size = isSgExpression(tmp_size);
-        }
-    }
-
-    // Handle initializer (constructor call)
-    SgConstructorInitializer* ctor_init = NULL;
-    if (cxx_new_expr->hasInitializer()) {
-        clang::Expr* initializer = cxx_new_expr->getInitializer();
-        if (initializer != NULL) {
-            SgNode* tmp_init = Traverse(initializer);
-            // The initializer might be a CXXConstructExpr or other expression
-            ctor_init = isSgConstructorInitializer(tmp_init);
-        }
-    }
-
-    // Build the expression list for array new (if any)
-    SgExprListExp* array_expr_list = NULL;
-    if (array_size != NULL) {
-        array_expr_list = SageBuilder::buildExprListExp(array_size);
-    }
-
-    // Build the new expression
-    // buildNewExp(type, exprListExp, constInit, expr, val, funcDecl)
-    SgNewExp* new_exp = SageBuilder::buildNewExp(
-        allocated_type,      // type
-        array_expr_list,     // exprListExp (array size list)
-        ctor_init,           // constInit (constructor initializer)
-        NULL,                // expr (placement new expression)
-        0,                   // val (need_global_specifier as short)
-        NULL                 // funcDecl (operator new function)
-    );
-
-    *node = new_exp;
-
-    return VisitExpr(cxx_new_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXNoexceptExpr(clang::CXXNoexceptExpr * cxx_noexcept_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXNoexceptExpr" << std::endl;
-#endif
-    bool res = true;
-
-    if (cxx_noexcept_expr->isValueDependent()) {
-        // Value-dependent noexcept results can't be evaluated until instantiation
-        // Create a placeholder expression so translation can proceed
-        *node = SageBuilder::buildNullExpression();
-        if (SgExpression* expr = isSgExpression(*node)) {
-            expr->get_file_info()->setCompilerGenerated();
-        }
-    } else {
-        // noexcept operator evaluates at compile-time whether an expression can throw
-        bool can_throw = cxx_noexcept_expr->getValue();
-        *node = SageBuilder::buildBoolValExp(can_throw);
-    }
-
-    if (SgExpression* expr = isSgExpression(*node)) {
-        applySourceRange(expr, cxx_noexcept_expr->getSourceRange());
-    }
-
-    return VisitExpr(cxx_noexcept_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXNullPtrLiteralExpr(clang::CXXNullPtrLiteralExpr * cxx_null_ptr_literal_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXNullPtrLiteralExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: CXXNullPtrLiteralExpr represents C++11's nullptr literal
-    // nullptr is a null pointer constant of type std::nullptr_t
-    // In SAGE, we represent it with SgNullptrValExp
-
-    // Get the type (should be std::nullptr_t)
-    SgType* nullptr_type = buildTypeFromQualifiedType(cxx_null_ptr_literal_expr->getType());
-
-    if (nullptr_type == NULL) {
-        // Fallback: if type conversion fails, use void pointer type
-        nullptr_type = SageBuilder::buildPointerType(SageBuilder::buildVoidType());
-    }
-
-    // Create the nullptr value expression
-    *node = SageBuilder::buildNullptrValExp();
-
-    return VisitExpr(cxx_null_ptr_literal_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(clang::CXXPseudoDestructorExpr * cxx_pseudo_destructor_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXPseudoDestructorExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: CXXPseudoDestructorExpr represents a call to a destructor on a non-class type
-    // Example: ptr->~T() where T is a primitive type (used in templates)
-    // Get the destroyed type
-    clang::QualType destroyed_type = cxx_pseudo_destructor_expr->getDestroyedType();
-    SgType* sg_type = buildTypeFromQualifiedType(destroyed_type);
-    ROSE_ASSERT(sg_type != NULL);
-
-    // Create source location info
-    Sg_File_Info* file_info = Sg_File_Info::generateDefaultFileInfoForTransformationNode();
-    ROSE_ASSERT(file_info != NULL);
-
-    // Create the pseudo destructor reference expression
-    SgPseudoDestructorRefExp* pseudo_dtor = new SgPseudoDestructorRefExp(file_info, sg_type);
-    ROSE_ASSERT(pseudo_dtor != NULL);
-
-    // Call post_construction_initialization which sets up the member function type
-    pseudo_dtor->post_construction_initialization();
-
-    *node = pseudo_dtor;
-
-    return VisitExpr(cxx_pseudo_destructor_expr, node) && res;
-}
-
-//bool ClangToSageTranslator::VisitCXXRewrittenBinaryOperator(clang::CXXRewrittenBinaryOperator * cxx_rewrite_binary_operator, SgNode ** node) {
-//#if DEBUG_VISIT_STMT
-//    std::cerr << "ClangToSageTranslator::VisitCXXRewrittenBinaryOperator" << std::endl;
-//#endif
-//    bool res = true;
-//
-//    // TODO
-//
-//    return VisitExpr(cxx_rewrite_binary_operator, node) && res;
-//}
-
-bool ClangToSageTranslator::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr * cxx_scalar_value_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXScalarValueInitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: CXXScalarValueInitExpr represents value initialization of scalar types
-    // Examples: int(), char(), double*() - all initialize to zero/null
-    // This is equivalent to a cast expression with default initialization
-
-    // Get the type being initialized
-    SgType* type = buildTypeFromQualifiedType(cxx_scalar_value_init_expr->getType());
-
-    if (type == NULL) {
-        type = SageBuilder::buildVoidType();
-    }
-
-    // Create a cast expression with a null operand to represent the default initialization
-    // The cast will produce the zero-initialized value of the target type
-    *node = SageBuilder::buildCastExp(SageBuilder::buildIntVal(0), type);
-
-    return VisitExpr(cxx_scalar_value_init_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXStdInitializerListExpr(clang::CXXStdInitializerListExpr * cxx_std_initializer_list_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXStdInitializerListExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(cxx_std_initializer_list_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXThisExpr(clang::CXXThisExpr * cxx_this_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXThisExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // CXXThisExpr represents the 'this' pointer in C++ member functions
-    // For now, use a placeholder variable reference named "this" since buildThisExp doesn't properly set type
-    SgType* this_type = buildTypeFromQualifiedType(cxx_this_expr->getType());
-    if (this_type == nullptr) {
-        // Fallback to opaque type if we can't determine the type
-        this_type = SageBuilder::buildOpaqueType("this_type", getGlobalScope());
-    }
-
-    // Create a placeholder "this" variable
-    SgInitializedName* this_var = SageBuilder::buildInitializedName("this", this_type);
-    this_var->get_file_info()->setCompilerGenerated();
-    SgScopeStatement* scope = SageBuilder::topScopeStack();
-    this_var->set_scope(scope);
-    this_var->set_parent(scope);
-    SgVariableSymbol* this_sym = new SgVariableSymbol(this_var);
-
-    *node = SageBuilder::buildVarRefExp(this_sym);
-
-    return VisitExpr(cxx_this_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXThrowExpr(clang::CXXThrowExpr * cxx_throw_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXThrowExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: CXXThrowExpr represents C++ throw expressions
-    // Can be either "throw expr;" or bare "throw;" (rethrow)
-    SgExpression* throw_operand = NULL;
-    SgThrowOp::e_throw_kind throw_kind;
-
-    // Check if this is a rethrow (bare "throw;") or throw with expression
-    clang::Expr* sub_expr = cxx_throw_expr->getSubExpr();
-    if (sub_expr != NULL) {
-        // Regular throw with an expression
-        SgNode* tmp_expr = Traverse(sub_expr);
-        throw_operand = isSgExpression(tmp_expr);
-        if (throw_operand == NULL) {
-            std::cerr << "Error: Failed to convert throw operand expression" << std::endl;
-            return false;
-        }
-        throw_kind = SgThrowOp::throw_expression;
-    } else {
-        // Rethrow (bare "throw;")
-        throw_kind = SgThrowOp::rethrow;
-    }
-
-    // Build the throw operation
-    SgThrowOp* throw_op = SageBuilder::buildThrowOp(throw_operand, throw_kind);
-    ROSE_ASSERT(throw_op != NULL);
-
-    *node = throw_op;
-
-    return VisitExpr(cxx_throw_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXTypeidExpr(clang::CXXTypeidExpr * cxx_typeid_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXTypeidExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(cxx_typeid_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXUnresolvedConstructExpr(clang::CXXUnresolvedConstructExpr * cxx_unresolved_construct_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXUnresolvedConstructExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Template-dependent constructor calls (e.g., T(args) where T is a template parameter)
-    // Build a proper constructor call expression instead of using null placeholder
-
-    // Get the type being constructed (may be a dependent type)
-    SgType* type = buildTypeFromQualifiedType(cxx_unresolved_construct_expr->getTypeAsWritten());
-
-    // Build expression list for constructor arguments
-    SgExprListExp* args = SageBuilder::buildExprListExp_nfi();
-    for (unsigned i = 0; i < cxx_unresolved_construct_expr->getNumArgs(); i++) {
-        SgNode* tmp_expr = Traverse(cxx_unresolved_construct_expr->getArg(i));
-        SgExpression* arg = isSgExpression(tmp_expr);
-        if (arg != NULL) {
-            args->append_expression(arg);
-        }
-    }
-
-    // Build constructor initializer for the unresolved construct
-    SgConstructorInitializer* ctor_init = SageBuilder::buildConstructorInitializer_nfi(
-        NULL,  // declaration will be NULL for unresolved/dependent constructors
-        args,
-        type,
-        false, // need_name
-        false, // need_qualifier
-        false, // need_parenthesis_after_name
-        true   // associated_class_unknown - set to true for template-dependent types
-    );
-
     *node = ctor_init;
-
-    return VisitExpr(cxx_unresolved_construct_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitCXXUuidofExpr(clang::CXXUuidofExpr * cxx_uuidof_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitCXXUuidofExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(cxx_uuidof_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr * decl_ref_expr, SgNode ** node) {
-    // std::cerr << "DEBUG: ClangToSageTranslator::VisitDeclRefExpr" << std::endl;
-    if (clang::NamedDecl* nd = llvm::dyn_cast<clang::NamedDecl>(decl_ref_expr->getDecl())) {
-        // std::cerr << "DEBUG: DeclRefExpr to " << nd->getNameAsString() << " kind: " << nd->getDeclKindName() << std::endl;
-    }
-
-    if (clang::NonTypeTemplateParmDecl* non_type_param =
-            llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(decl_ref_expr->getDecl())) {
-        SgDeclarationStatement* owning_template = NULL;
-        if (clang::DeclContext* ctx = non_type_param->getDeclContext()) {
-            if (clang::TemplateDecl* template_ctx = llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
-                auto it = p_decl_translation_map.find(template_ctx);
-                if (it != p_decl_translation_map.end()) {
-                    owning_template = isSgDeclarationStatement(it->second);
-                }
-            }
-        }
-
-        unsigned position = non_type_param->getIndex();
-        SgTemplateParameter* sg_param =
-            translateTemplateParameter(non_type_param, owning_template, position);
-
-        if (sg_param != NULL) {
-            SgTemplateParameterVal* param_val =
-                SageBuilder::buildTemplateParameterVal(non_type_param->getIndex());
-            param_val->set_valueString(non_type_param->getNameAsString());
-            if (sg_param->get_type() != NULL) {
-                param_val->set_valueType(sg_param->get_type());
-            }
-            applySourceRange(param_val, decl_ref_expr->getSourceRange());
-            *node = param_val;
-            return true;
-        }
-    }
-
-    bool res = true;
-
-    // SgNode * tmp_node = Traverse(decl_ref_expr->getDecl());
-    // DONE: Do not use Traverse(...) as the declaration can not be complete (recursive functions)
-    //       Instead use SymbolTable from ROSE as the symbol should be ready (cannot have a reference before the declaration)
-    // FIXME: This fix will not work for C++ (methods/fields can be use before they are declared...)
-    // FIXME: I feel like it could work now, we will see ....
-
-     SgSymbol * sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
-
-     if (sym == NULL) 
-        {
-          SgNode * tmp_decl = Traverse(decl_ref_expr->getDecl());
-
-       // DQ (11/29/2020): Added assertion.
-          ROSE_ASSERT(tmp_decl != NULL);
-
-#if DEBUG_VISIT_STMT
-          printf ("tmp_decl = %p = %s \n",tmp_decl,tmp_decl->class_name().c_str());
-#endif
-          SgInitializedName* initializedName = isSgInitializedName(tmp_decl);
-#if DEBUG_VISIT_STMT
-          if (initializedName != NULL)
-             {
-               printf ("Found SgInitializedName: initializedName->get_name() = %s \n",initializedName->get_name().str());
-             }
-#endif
-
-          if (tmp_decl != NULL)
-             {
-               sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
-             }
-
-       // FIXME hack Traverse have added the symbol but we cannot find it (probably: problem with type and function lookup)
-
-          if (sym == NULL && isSgFunctionDeclaration(tmp_decl) != NULL)
-             {
-               sym = new SgFunctionSymbol(isSgFunctionDeclaration(tmp_decl));
-               sym->set_parent(tmp_decl);
-             }
-          // ROOT CAUSE FIX: Handle SgVariableDeclaration from VisitVarDecl
-          // Extract the InitializedName and create symbol if needed
-          if (sym == NULL && isSgVariableDeclaration(tmp_decl) != NULL)
-             {
-               SgVariableDeclaration* var_decl_result = isSgVariableDeclaration(tmp_decl);
-               if (var_decl_result->get_variables().size() > 0)
-                  {
-                    SgInitializedName* init_name = var_decl_result->get_variables()[0];
-                    if (init_name != NULL)
-                       {
-                         // Try to get existing symbol first
-                         SgScopeStatement* init_scope = init_name->get_scope();
-                         if (init_scope != NULL)
-                            {
-                              sym = init_scope->lookup_variable_symbol(init_name->get_name());
-                            }
-                         // If still not found, create new symbol
-                         if (sym == NULL)
-                            {
-                              sym = new SgVariableSymbol(init_name);
-                              sym->set_parent(init_name);
-                              if (init_scope != NULL)
-                                 {
-                                   init_scope->insert_symbol(init_name->get_name(), sym);
-                                 }
-                            }
-                       }
-                  }
-             }
-          // Pei-Hung (04/07/2022) sym can be NULL in the case for C99 VLA
-          if (sym == NULL && isSgInitializedName(tmp_decl) != NULL)
-             {
-               sym = new SgVariableSymbol(isSgInitializedName(tmp_decl));
-               sym->set_parent(tmp_decl);
-               SageBuilder::topScopeStack()->insert_symbol(isSgInitializedName(tmp_decl)->get_name(), sym);
-             }
-        }
-
-     if (sym != NULL) 
-        {
-       // Not else if it was NULL we have try to traverse it....
-          SgVariableSymbol  * var_sym  = isSgVariableSymbol(sym);
-          SgFunctionSymbol  * func_sym = isSgFunctionSymbol(sym);
-          SgEnumFieldSymbol * enum_sym = isSgEnumFieldSymbol(sym);
-
-          if (var_sym != NULL) 
-             {
-               *node = SageBuilder::buildVarRefExp(var_sym);
-          } else {
-            if (func_sym != NULL) {
-              SgFunctionSymbol *ref_func_sym = func_sym;
-
-              if (decl_ref_expr->hasExplicitTemplateArgs()) {
-                clang::TemplateArgumentListInfo arg_info;
-                decl_ref_expr->copyTemplateArgumentsInto(arg_info);
-
-                // Mark arguments as explicitly specified so the unparser keeps
-                // them
-                SgTemplateArgumentPtrList template_args =
-                    buildTemplateArguments(arg_info, true);
-
-                SgScopeStatement *func_scope = func_sym->get_scope();
-                if (func_scope == NULL) {
-                  func_scope = SageBuilder::topScopeStack();
-                }
-
-                SgFunctionType *func_type =
-                    isSgFunctionType(func_sym->get_type());
-                SgType *ret_type =
-                    func_type != NULL ? func_type->get_return_type() : NULL;
-                if (ret_type == NULL) {
-                  ret_type = SageBuilder::buildUnknownType();
-                }
-
-                SgFunctionParameterList *param_list = NULL;
-                if (func_type != NULL &&
-                    func_type->get_argument_list() != NULL) {
-                  param_list = SageBuilder::buildFunctionParameterList_nfi(
-                      func_type->get_argument_list());
-                } else {
-                  param_list = SageBuilder::buildFunctionParameterList_nfi();
-                }
-
-                SgTemplateInstantiationFunctionDecl *inst_decl =
-                    isSgTemplateInstantiationFunctionDecl(
-                        SageBuilder::buildNondefiningFunctionDeclaration(
-                            func_sym->get_name(), ret_type, param_list,
-                            func_scope,
-                            /*decoratorList=*/NULL,
-                            /*buildTemplateInstantiation=*/true, &template_args,
-                            SgStorageModifier::e_default,
-                            /*forceFreeFunctionScope=*/false));
-
-                if (inst_decl != NULL) {
-                  inst_decl->set_template_argument_list_is_explicit(true);
-                  inst_decl->get_templateArguments() = template_args;
-
-                  SgFunctionDeclaration *base_decl =
-                      isSgFunctionDeclaration(func_sym->get_declaration());
-                  if (base_decl != NULL) {
-                    if (SgTemplateFunctionDeclaration *tmpl_decl =
-                            isSgTemplateFunctionDeclaration(base_decl)) {
-                      inst_decl->set_templateDeclaration(tmpl_decl);
-                      inst_decl->set_templateName(tmpl_decl->get_name());
-                    } else if (
-                        SgTemplateFunctionDeclaration *first_nondef =
-                            isSgTemplateFunctionDeclaration(
-                                base_decl->get_firstNondefiningDeclaration())) {
-                      inst_decl->set_templateDeclaration(first_nondef);
-                      inst_decl->set_templateName(first_nondef->get_name());
-                    }
-                  }
-
-                  SgFunctionSymbol *inst_sym = isSgFunctionSymbol(
-                      inst_decl->get_symbol_from_symbol_table());
-                  if (inst_sym == NULL && func_scope != NULL &&
-                      func_type != NULL) {
-                    inst_sym = func_scope->lookup_function_symbol(
-                        func_sym->get_name(), func_type);
-                  }
-                  if (inst_sym != NULL) {
-                    ref_func_sym = inst_sym;
-                  }
-                }
-              }
-
-              *node = SageBuilder::buildFunctionRefExp(ref_func_sym);
-
-              // ROOT CAUSE FIX: Set qualified name prefix (namespace) from
-              // Clang declaration This preserves namespace information (e.g.,
-              // std::) even when scope is global
-              SgFunctionRefExp *func_ref = isSgFunctionRefExp(*node);
-              if (func_ref != NULL) {
-                clang::FunctionDecl *func_decl =
-                    llvm::dyn_cast<clang::FunctionDecl>(
-                        decl_ref_expr->getDecl());
-                if (func_decl != NULL) {
-                  std::string qualified_name =
-                      func_decl->getQualifiedNameAsString();
-                  std::string simple_name = func_decl->getNameAsString();
-                  // Extract namespace prefix by removing simple name from
-                  // qualified name
-                  if (qualified_name.length() > simple_name.length() &&
-                      qualified_name.substr(qualified_name.length() -
-                                            simple_name.length()) ==
-                          simple_name) {
-                    // Remove the simple name and the trailing ::
-                    std::string namespace_prefix = qualified_name.substr(
-                        0, qualified_name.length() - simple_name.length());
-                    if (namespace_prefix.length() >= 2 &&
-                        namespace_prefix.substr(namespace_prefix.length() -
-                                                2) == "::") {
-                      namespace_prefix = namespace_prefix.substr(
-                          0, namespace_prefix.length() - 2);
-                    }
-                    if (!namespace_prefix.empty()) {
-                      // Add to global qualified name map so unparser can
-                      // retrieve it
-                      SgNode::get_globalQualifiedNameMapForNames()[func_ref] =
-                          namespace_prefix + "::";
-                    }
-                  }
-                }
-              }
-            } else {
-              if (enum_sym != NULL) {
-                // ROOT CAUSE FIX: Get enum declaration from the type instead of
-                // parent The Clang frontend may not set parent pointers
-                // correctly for enum constants But the type is always set
-                // correctly to an SgEnumType
-                SgInitializedName *init_name = enum_sym->get_declaration();
-                SgEnumDeclaration *enum_decl = NULL;
-
-                if (init_name != NULL && init_name->get_type() != NULL) {
-                  SgEnumType *enum_type = isSgEnumType(init_name->get_type());
-                  if (enum_type != NULL) {
-                    enum_decl =
-                        isSgEnumDeclaration(enum_type->get_declaration());
-                  }
-                }
-
-                // Fallback: try getting from parent if type method didn't work
-                if (enum_decl == NULL && init_name != NULL) {
-                  enum_decl = isSgEnumDeclaration(init_name->get_parent());
-                }
-
-                ROSE_ASSERT(enum_decl != NULL);
-                SgName name = enum_sym->get_name();
-                *node = SageBuilder::buildEnumVal_nfi(0, enum_decl, name);
-              } else {
-                if (sym != NULL) {
-                  std::cerr << "Runtime error: Unknown type of symbol for a "
-                               "declaration reference."
-                            << std::endl;
-                  std::cerr << "    sym->class_name() = " << sym->class_name()
-                            << std::endl;
-                  ROSE_ABORT();
-                }
-              }
-            }
-          }
-        }
-       else
-        {
-          // ROOT CAUSE FIX: Handle template-dependent and unresolved declarations
-          clang::Decl* clang_decl = decl_ref_expr->getDecl();
-          std::string decl_name = "unresolved_symbol";
-
-          // Get declaration name and type info for better handling
-          if (clang_decl && clang::isa<clang::NamedDecl>(clang_decl)) {
-              clang::NamedDecl* named_decl = clang::cast<clang::NamedDecl>(clang_decl);
-              decl_name = named_decl->getNameAsString();
-
-              // Log what type of declaration couldn't be resolved
-              std::cerr << "Warning: Cannot resolve symbol for " << clang_decl->getDeclKindName()
-                        << " '" << decl_name << "', using placeholder" << std::endl;
-          } else {
-              std::cerr << "Warning: Cannot resolve symbol for declaration reference, using placeholder" << std::endl;
-          }
-
-          // Create a placeholder variable with unknown type
-          SgType* unknown_type = SageBuilder::buildOpaqueType(decl_name + "_type", getGlobalScope());
-          SgInitializedName* placeholder_var = SageBuilder::buildInitializedName(decl_name, unknown_type);
-          placeholder_var->get_file_info()->setCompilerGenerated();
-          SgScopeStatement* scope = SageBuilder::topScopeStack();
-          placeholder_var->set_scope(scope);
-          placeholder_var->set_parent(scope);
-
-          SgVariableSymbol* placeholder_sym = new SgVariableSymbol(placeholder_var);
-          *node = SageBuilder::buildVarRefExp(placeholder_sym);
-        }
-
-    return VisitExpr(decl_ref_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitDependentCoawaitExpr(clang::DependentCoawaitExpr * dependent_coawait_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDependentCoawaitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(dependent_coawait_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitDependentScopeDeclRefExpr(clang::DependentScopeDeclRefExpr * dependent_scope_decl_ref_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDependentScopeDeclRefExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // DependentScopeDeclRefExpr represents a reference to a declaration that depends on template parameters
-    // (e.g., variable references like 'x' or 'y' in template-dependent contexts)
-    // Extract the name and create a variable reference expression
-
-    std::string decl_name = dependent_scope_decl_ref_expr->getDeclName().getAsString();
-
-    // Check for qualified names (e.g., namespace::var)
-    if (dependent_scope_decl_ref_expr->getQualifier() != NULL) {
-        std::string qualifier_str;
-        llvm::raw_string_ostream qualifier_stream(qualifier_str);
-        dependent_scope_decl_ref_expr->getQualifier()->print(qualifier_stream, clang::PrintingPolicy(clang::LangOptions()));
-        decl_name = qualifier_stream.str() + decl_name;
-    }
-
-    // Create a variable reference expression
-    // NOTE: Using topScopeStack() may not correctly resolve variables in nested scopes
-    // since dependent scope information isn't always available at this stage.
-    // Ideally, the variable lookup should search upward through parent scopes,
-    // but for template-dependent contexts, complete scope information may not be
-    // available until instantiation time.
-    SgName sg_name(decl_name);
-    *node = SageBuilder::buildVarRefExp(sg_name, SageBuilder::topScopeStack());
-
-    // Set source position
-    SgExpression* expr = isSgExpression(*node);
-    if (expr != NULL) {
-        applySourceRange(expr, dependent_scope_decl_ref_expr->getSourceRange());
-    }
-
-    return VisitExpr(dependent_scope_decl_ref_expr, node) && res;
-}
-
-// bool ClangToSageTranslator::VisitDependentScopeDeclRefExpr(clang::DependentScopeDeclRefExpr * dependent_scope_decl_ref_expr);
-
-bool ClangToSageTranslator::VisitDesignatedInitExpr(clang::DesignatedInitExpr * designated_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDesignatedInitExpr" << std::endl;
-#endif
-
-    SgInitializer * base_init = NULL;    
-    SgDesignatedInitializer * designated_init = NULL;    
-    SgExprListExp * expr_list_exp = NULL; 
-    {
-        SgNode * tmp_expr = Traverse(designated_init_expr->getInit());
-        SgExpression * expr = isSgExpression(tmp_expr);
-        ROSE_ASSERT(expr != NULL);
-        SgExprListExp * expr_list_exp = isSgExprListExp(expr);
-        if (expr_list_exp != NULL) {
-            // FIXME get the type right...
-            base_init = SageBuilder::buildAggregateInitializer_nfi(expr_list_exp, NULL);
-        }
-        else {
-            base_init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
-        }
-        ROSE_ASSERT(base_init != NULL);
-        applySourceRange(base_init, designated_init_expr->getInit()->getSourceRange());
-    }
-
-
-/* Pei-Hung (06/10/2022) revision to handle Initializer in test2013_37.c
- *  After calling getSyntacticForm from InitListExpr, the type and multidimensional array hierarchy is missing.
- *  This version can construct the array structure but need additional support to grab the type structure from 
- *  parent AST node, such as VarDecl.
- */
-
-    auto designatorSize = designated_init_expr->size();
-
-    for (auto it=designatorSize; it > 0; it--) {
-        expr_list_exp = SageBuilder::buildExprListExp_nfi();
-        SgExpression * expr = NULL;
-        clang::DesignatedInitExpr::Designator * D = designated_init_expr->getDesignator(it-1);
-        if (D->isFieldDesignator()) {
-            // In LLVM 20, getField() was renamed to getFieldDecl()
-            SgSymbol * symbol = GetSymbolFromSymbolTable(D->getFieldDecl());
-            SgVariableSymbol * var_sym = isSgVariableSymbol(symbol);
-            ROSE_ASSERT(var_sym != NULL);
-            expr = SageBuilder::buildVarRefExp_nfi(var_sym);
-        }
-        else if (D->isArrayDesignator()) {
-            SgNode * tmp_expr = NULL;
-            if(clang::ConstantExpr::classof(designated_init_expr->getArrayIndex(*D)))
-            {
-               clang::FullExpr* fullExpr = (clang::FullExpr*) designated_init_expr->getArrayIndex(*D);
-               clang::IntegerLiteral* integerLiteral = (clang::IntegerLiteral*) fullExpr->getSubExpr();
-               tmp_expr = SageBuilder::buildUnsignedLongVal((unsigned long) integerLiteral->getValue().getSExtValue());
-            }
-            else
-            {
-               tmp_expr = Traverse(designated_init_expr->getArrayIndex(*D));
-            }
-            expr = isSgExpression(tmp_expr);
-            ROSE_ASSERT(expr != NULL);
-
-        }
-        else if (D->isArrayRangeDesignator()) {
-            ROSE_ASSERT(!"I don't believe range designator initializer are supported by ROSE...");    
-        }
-        else ROSE_ABORT();
-
-        ROSE_ASSERT(expr != NULL);
-
-        applySourceRange(expr, D->getSourceRange());
-        expr->set_parent(expr_list_exp);
-        expr_list_exp->append_expression(expr);
-        if(it > 1)
-        {
-            SgDesignatedInitializer * design_init = new SgDesignatedInitializer(expr_list_exp, base_init);
-            applySourceRange(design_init, designated_init_expr->getDesignatorsSourceRange());
-            expr_list_exp->set_parent(design_init);
-            base_init->set_parent(design_init);
-            SgExprListExp* aggListExp = SageBuilder::buildExprListExp_nfi();
-            design_init->set_parent(aggListExp);
-            aggListExp->append_expression(design_init);
-            SgAggregateInitializer* newAggInit = SageBuilder::buildAggregateInitializer_nfi(aggListExp, NULL);
-            expr_list_exp = SageBuilder::buildExprListExp_nfi(); 
-            base_init = newAggInit; 
-        }
-
-    }
-
-    applySourceRange(expr_list_exp, designated_init_expr->getDesignatorsSourceRange());
-    designated_init = new SgDesignatedInitializer(expr_list_exp, base_init);
-    expr_list_exp->set_parent(base_init);
-    base_init->set_parent(designated_init);
-
-    *node = designated_init;
-
-    return VisitExpr(designated_init_expr, node);
-
-// Pei-Hung (06/10/2022) keep the original implementation which has the array information stored in the list
-/*
-    for (auto it=0; it < designatorSize; it++) {
-        SgExpression * expr = NULL;
-        clang::DesignatedInitExpr::Designator * D = designated_init_expr->getDesignator(it);
-        if (D->isFieldDesignator()) {
-            SgSymbol * symbol = GetSymbolFromSymbolTable(D->getField());
-            SgVariableSymbol * var_sym = isSgVariableSymbol(symbol);
-            ROSE_ASSERT(var_sym != NULL);
-            expr = SageBuilder::buildVarRefExp_nfi(var_sym);
-            applySourceRange(expr, D->getSourceRange());
-        }
-        else if (D->isArrayDesignator()) {
-            SgNode * tmp_expr = NULL;
-            if(clang::ConstantExpr::classof(designated_init_expr->getArrayIndex(*D)))
-            {
-               clang::FullExpr* fullExpr = (clang::FullExpr*) designated_init_expr->getArrayIndex(*D);
-               clang::IntegerLiteral* integerLiteral = (clang::IntegerLiteral*) fullExpr->getSubExpr();
-               tmp_expr = SageBuilder::buildUnsignedLongVal((unsigned long) integerLiteral->getValue().getSExtValue());
-std::cerr << "idx:" << integerLiteral->getValue().getSExtValue() << std::endl;
-            }
-            else
-            {
-               tmp_expr = Traverse(designated_init_expr->getArrayIndex(*D));
-            }
-            expr = isSgExpression(tmp_expr);
-            ROSE_ASSERT(expr != NULL);
-        }
-        else if (D->isArrayRangeDesignator()) {
-            ROSE_ASSERT(!"I don't believe range designator initializer are supported by ROSE...");    
-        }
-        else ROSE_ABORT();
-
-        ROSE_ASSERT(expr != NULL);
-
-        expr->set_parent(expr_list_exp);
-        expr_list_exp->append_expression(expr);
-    }
-
-    applySourceRange(expr_list_exp, designated_init_expr->getDesignatorsSourceRange());
-
-    SgDesignatedInitializer * design_init = new SgDesignatedInitializer(expr_list_exp, init);
-    expr_list_exp->set_parent(design_init);
-    init->set_parent(design_init);
-
-    *node = design_init;
-
-    return VisitExpr(designated_init_expr, node);
-*/
-}
-
-bool ClangToSageTranslator::VisitDesignatedInitUpdateExpr(clang::DesignatedInitUpdateExpr * designated_init_update, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitDesignatedInitUpdateExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(designated_init_update, node) && res;
-}
-
-bool ClangToSageTranslator::VisitExpressionTraitExpr(clang::ExpressionTraitExpr * expression_trait_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitExpressionTraitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(expression_trait_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitExtVectorElementExpr(clang::ExtVectorElementExpr * ext_vector_element_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitExtVectorElementExpr" << std::endl;
-#endif
-
-    SgNode * tmp_base = Traverse(ext_vector_element_expr->getBase());
-    SgExpression * base = isSgExpression(tmp_base);
-#if DEBUG_VISIT_STMT
-    // if (base) std::cerr << "DEBUG: VisitExtVectorElementExpr base node type: " << base->class_name() << std::endl;
-    // else std::cerr << "DEBUG: VisitExtVectorElementExpr base node is NULL" << std::endl;
-#endif
-    ROSE_ASSERT(base != NULL);
-
-    SgType * type = buildTypeFromQualifiedType(ext_vector_element_expr->getType());
-
-    clang::IdentifierInfo & ident_info = ext_vector_element_expr->getAccessor();
-    std::string ident = ident_info.getName().str();
-
-    SgScopeStatement * scope = SageBuilder::ScopeStack.front();
-    SgGlobal * global = isSgGlobal(scope);
-    ROSE_ASSERT(global != NULL);
-
-  // Build Manually a SgVarRefExp to have the same Accessor (text version) TODO ExtVectorAccessor and ExtVectorType
-    SgInitializedName * init_name = SageBuilder::buildInitializedName(ident, SageBuilder::buildVoidType(), NULL);
-    setCompilerGeneratedFileInfo(init_name);
-    init_name->set_scope(global);
-    SgVariableSymbol * var_symbol = new SgVariableSymbol(init_name);
-    SgVarRefExp * pseudo_field = new SgVarRefExp(var_symbol);
-    setCompilerGeneratedFileInfo(pseudo_field, true);
-    init_name->set_parent(pseudo_field);
-
-    SgExpression * res = NULL;
-    if (ext_vector_element_expr->isArrow())
-        res = SageBuilder::buildArrowExp(base, pseudo_field);
-    else
-        res = SageBuilder::buildDotExp(base, pseudo_field);
-
-    ROSE_ASSERT(res != NULL);
-
-    *node = res;
-
-   return VisitExpr(ext_vector_element_expr, node);
-}
-
-bool ClangToSageTranslator::VisitFixedPointLiteral(clang::FixedPointLiteral * fixed_point_literal, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitFixedPointLiteral" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(fixed_point_literal, node) && res;
-}
-
-bool ClangToSageTranslator::VisitFloatingLiteral(clang::FloatingLiteral * floating_literal, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitFloatingLiteral" << std::endl;
-#endif
-
-    unsigned int precision =  llvm::APFloat::semanticsPrecision(floating_literal->getValue().getSemantics());
-    if (precision == 24) {
-        // 32-bit float
-        *node = SageBuilder::buildFloatVal(floating_literal->getValue().convertToFloat());
-    } else if (precision == 53) {
-        // 64-bit double
-        *node = SageBuilder::buildDoubleVal(floating_literal->getValue().convertToDouble());
-    } else if (precision == 64 || precision == 113) {
-        // 80-bit or 128-bit long double - use double as approximation
-        *node = SageBuilder::buildLongDoubleVal(floating_literal->getValue().convertToDouble());
-    } else if (precision == 11) {
-        // 16-bit half precision - use float
-        *node = SageBuilder::buildFloatVal(floating_literal->getValue().convertToFloat());
-    } else {
-        // Fallback for other sizes - use double
-        std::cerr << "Warning: Unsupported float precision " << precision << ", using double" << std::endl;
-        *node = SageBuilder::buildDoubleVal(floating_literal->getValue().convertToDouble());
-    }
-
-    return VisitExpr(floating_literal, node);
-}
-
-bool ClangToSageTranslator::VisitFullExpr(clang::FullExpr * full_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitFullExpr" << std::endl;
-#endif
-    bool res = true;
-
-    SgNode * tmp_expr = Traverse(full_expr->getSubExpr());
-    SgExpression * expr = isSgExpression(tmp_expr);
-
- // printf ("In VisitFullExpr(): built: expr = %p = %s \n",expr,expr->class_name().c_str());
-
-    *node = expr;
-
-    // TODO
-
-    return VisitExpr(full_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitConstantExpr(clang::ConstantExpr * constant_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitConstantExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitFullExpr(constant_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitExprWithCleanups(clang::ExprWithCleanups * expr_with_cleanups, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitExprWithCleanups" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitFullExpr(expr_with_cleanups, node) && res;
-}
-
-bool ClangToSageTranslator::VisitFunctionParmPackExpr(clang::FunctionParmPackExpr * function_parm_pack_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitFunctionParmPackExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(function_parm_pack_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitGenericSelectionExpr(clang::GenericSelectionExpr * generic_Selection_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitGenericSelectionExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(generic_Selection_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitGNUNullExpr(clang::GNUNullExpr * gnu_null_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitGNUNullExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: GNUNullExpr is GNU's __null extension, which represents a null pointer constant
-    // It has type long (or long long on 64-bit) but behaves as a null pointer
-    // Create an integer literal with value 0, VisitExpr will handle the type
-    *node = SageBuilder::buildIntVal(0);
-
-    return VisitExpr(gnu_null_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitImaginaryLiteral(clang::ImaginaryLiteral * imaginary_literal, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitImaginaryLiteral" << std::endl;
-#endif
-
-    SgNode * tmp_imag_val = Traverse(imaginary_literal->getSubExpr());
-    SgValueExp * imag_val = isSgValueExp(tmp_imag_val);
-    ROSE_ASSERT(imag_val != NULL);
-
-    SgComplexVal * comp_val = new SgComplexVal(NULL, imag_val, imag_val->get_type(), "");
-
-    *node = comp_val;
-
-    return VisitExpr(imaginary_literal, node);
-}
-
-bool ClangToSageTranslator::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr * implicit_value_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitImplicitValueInitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(implicit_value_init_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitInitListExpr(clang::InitListExpr * init_list_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitInitListExpr" << std::endl;
-#endif
-
-    // We use the syntactic version of the initializer if it exists
-    if (init_list_expr->getSyntacticForm() != NULL) return VisitInitListExpr(init_list_expr->getSyntacticForm(), node);
-
-    SgExprListExp * expr_list_expr = SageBuilder::buildExprListExp_nfi();
-
-    clang::InitListExpr::iterator it;
-    for (it = init_list_expr->begin(); it != init_list_expr->end(); it++) {
-        SgNode * tmp_expr = Traverse(*it);
-        SgExpression * expr = isSgExpression(tmp_expr);
-        ROSE_ASSERT(expr != NULL);
-
-        // Pei-Hung (05/13/2022) the expr can another InitListExpr
-        SgExprListExp * child_expr_list_expr = isSgExprListExp(expr);
-        SgInitializer * init = NULL;
-        if (child_expr_list_expr != NULL)
-        {
-            SgType * type = expr->get_type();
-            init = SageBuilder::buildAggregateInitializer(child_expr_list_expr, type);
-        }
-
-        if (init != NULL)
-        {
-            applySourceRange(init, (*it)->getSourceRange());
-            expr_list_expr->append_expression(init);
-        }
-        else
-            expr_list_expr->append_expression(expr);
-    }
-
-    *node = expr_list_expr;
-
-    return VisitExpr(init_list_expr, node);
-}
-
-bool ClangToSageTranslator::VisitIntegerLiteral(clang::IntegerLiteral * integer_literal, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitIntegerLiteral" << std::endl;
-#endif
-
-    *node = SageBuilder::buildIntVal(integer_literal->getValue().getSExtValue());
-
-    return VisitExpr(integer_literal, node);
-}
-
-bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr * lambda_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitLambdaExpr" << std::endl;
-#endif
-    bool res = true;
-
-    auto detach_declaration_from_scope = [](SgDeclarationStatement* decl) -> SgScopeStatement* {
-        if (decl == NULL) {
-            return NULL;
-        }
-
-        SgScopeStatement* original_scope = decl->get_scope();
-
-        // Remove any symbol that was registered for this declaration in the enclosing scope.
-        if (SgSymbol* associated_symbol = decl->search_for_symbol_from_symbol_table()) {
-            if (SgScopeStatement* symbol_scope = associated_symbol->get_scope()) {
-                symbol_scope->remove_symbol(associated_symbol);
-            }
-        }
-
-        if (original_scope != NULL) {
-            SageInterface::removeStatement(decl, false);
-            decl->set_parent(NULL);
-        }
-
-        return original_scope;
-    };
-
-    // Get the lambda class (closure type) from Clang
-    const clang::CXXRecordDecl* clang_lambda_class = lambda_expr->getLambdaClass();
-
-    // Get the call operator (operator()) from Clang
-    const clang::CXXMethodDecl* clang_call_operator = lambda_expr->getCallOperator();
-
-    // Convert Clang lambda class to ROSE class declaration
-    SgClassDeclaration* lambda_closure_class = NULL;
-    SgScopeStatement* lambda_closure_lexical_scope = NULL;
-    if (clang_lambda_class != NULL) {
-        SgNode* tmp_class = Traverse(const_cast<clang::CXXRecordDecl*>(clang_lambda_class));
-        lambda_closure_class = isSgClassDeclaration(tmp_class);
-
-        // Remove from enclosing scope using SageInterface so symbols/scopes stay consistent
-        lambda_closure_lexical_scope = detach_declaration_from_scope(lambda_closure_class);
-
-        // Preserve a valid scope so downstream lookups don't see NULL after detachment.
-        if (lambda_closure_class != NULL && lambda_closure_lexical_scope != NULL) {
-            lambda_closure_class->set_scope(lambda_closure_lexical_scope);
-            if (SgClassDefinition* class_def = lambda_closure_class->get_definition()) {
-                class_def->set_scope(lambda_closure_lexical_scope);
-            }
-        }
-    }
-
-    // Convert Clang call operator to ROSE function declaration
-    SgFunctionDeclaration* lambda_function = NULL;
-    SgScopeStatement* lambda_function_scope = NULL;
-    if (clang_call_operator != NULL) {
-        SgNode* tmp_func = Traverse(const_cast<clang::CXXMethodDecl*>(clang_call_operator));
-        lambda_function = isSgFunctionDeclaration(tmp_func);
-
-        lambda_function_scope = detach_declaration_from_scope(lambda_function);
-
-        // Restore the scope pointer for operator() so later queries succeed.
-        if (lambda_function != NULL) {
-            if (lambda_function_scope != NULL) {
-                lambda_function->set_scope(lambda_function_scope);
-            } else if (lambda_closure_class != NULL && lambda_closure_class->get_definition() != NULL) {
-                lambda_function->set_scope(lambda_closure_class->get_definition());
-            }
-        }
-    }
-
-    SgLambdaCaptureList* lambda_capture_list = SageBuilder::buildLambdaCaptureList();
-    unsigned total_captures = lambda_expr->capture_size();
-    unsigned capture_index = 0;
-    for (auto capture_it = lambda_expr->capture_begin(); capture_it != lambda_expr->capture_end(); ++capture_it, ++capture_index) {
-        const clang::LambdaCapture& capture = *capture_it;
-        SgExpression* capture_expression = NULL;
-        bool handled_capture = false;
-
-        if (capture.capturesThis()) {
-            capture_expression = SageBuilder::buildThisExp(NULL);
-            handled_capture = true;
-        } else if (capture.capturesVariable()) {
-            clang::ValueDecl* captured_val = capture.getCapturedVar();
-            clang::VarDecl* captured_var = llvm::dyn_cast_or_null<clang::VarDecl>(captured_val);
-            if (captured_var != NULL) {
-                // Look up the existing symbol instead of traversing again (avoids duplicate decls)
-                SgSymbol* captured_symbol = GetSymbolFromSymbolTable(captured_var);
-                if (captured_symbol == NULL) {
-                    clang::VarDecl* canonical_decl = captured_var->getCanonicalDecl();
-                    if (canonical_decl != captured_var) {
-                        captured_symbol = GetSymbolFromSymbolTable(canonical_decl);
-                    }
-                }
-
-                if (SgVariableSymbol* var_symbol = isSgVariableSymbol(captured_symbol)) {
-                    capture_expression = SageBuilder::buildVarRefExp(var_symbol);
-                    handled_capture = true;
-                } else if (captured_var->isInitCapture()) {
-                    // Create a dangling var ref for init-captures (symbol not in current scope yet)
-                    SgName capture_name(captured_var->getNameAsString());
-                    capture_expression = SageBuilder::buildVarRefExp(capture_name);
-                    handled_capture = true;
-                }
-            }
-        } else if (capture.capturesVLAType()) {
-            // VLA captures are represented on the closure type; nothing to emit in capture list.
-            continue;
-        }
-
-        if (!handled_capture || capture_expression == NULL) {
-            continue;
-        }
-
-        bool is_init_capture = lambda_expr->isInitCapture(&capture);
-        clang::LambdaCaptureKind capture_kind = capture.getCaptureKind();
-        bool capture_by_reference = (capture_kind == clang::LCK_ByRef || capture_kind == clang::LCK_This);
-
-        SgLambdaCapture* sg_capture = SageBuilder::buildLambdaCapture(capture_expression, NULL, NULL);
-        sg_capture->set_capture_by_reference(capture_by_reference);
-        sg_capture->set_implicit(capture.isImplicit());
-        sg_capture->set_pack_expansion(capture.isPackExpansion());
-        if (is_init_capture && capture_index < total_captures) {
-            clang::Expr* clang_init_expr = lambda_expr->capture_init_begin()[capture_index];
-            if (clang_init_expr != NULL) {
-                SgNode* init_node = Traverse(clang_init_expr);
-                if (SgExpression* init_expr = isSgExpression(init_node)) {
-                    sg_capture->set_source_closure_variable(init_expr);
-                    init_expr->set_parent(sg_capture);
-                }
-            }
-        }
-
-        lambda_capture_list->get_capture_list().push_back(sg_capture);
-        sg_capture->set_parent(lambda_capture_list);
-    }
-
-    SgLambdaExp* built_lambda = SageBuilder::buildLambdaExp(lambda_capture_list, lambda_closure_class, lambda_function);
-    ROSE_ASSERT(built_lambda != NULL);
-
-    clang::LambdaCaptureDefault capture_default = lambda_expr->getCaptureDefault();
-    bool has_default_capture = (capture_default != clang::LCD_None);
-    built_lambda->set_capture_default(has_default_capture);
-    built_lambda->set_default_is_by_reference(capture_default == clang::LCD_ByRef);
-
-    *node = built_lambda;
-
-    return VisitExpr(lambda_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitMaterializeTemporaryExpr(clang::MaterializeTemporaryExpr * materialize_temporary_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMaterializeTemporaryExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // MaterializeTemporaryExpr creates a temporary object from a prvalue
-    // For now, just traverse the temporary expression itself
-    // The temporary materialization is implicit in C++ and doesn't need explicit AST representation in ROSE
-    *node = Traverse(materialize_temporary_expr->getSubExpr());
-
-    return VisitExpr(materialize_temporary_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr * member_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMemberExpr" << std::endl;
-#endif
-
-    bool res = true;
-
-    SgNode * tmp_base = Traverse(member_expr->getBase());
-    SgExpression * base = isSgExpression(tmp_base);
-    if (base == NULL) {
-        // std::cerr << "DEBUG: VisitMemberExpr base is NULL! Base stmt class: " << member_expr->getBase()->getStmtClassName() << std::endl;
-    } else {
-        // std::cerr << "DEBUG: VisitMemberExpr base type: " << base->class_name() << std::endl;
-    }
-    ROSE_ASSERT(base != NULL);
-
-    SgSymbol * sym = GetSymbolFromSymbolTable(member_expr->getMemberDecl());
-
-    SgVariableSymbol * var_sym  = isSgVariableSymbol(sym);
-    SgMemberFunctionSymbol * func_sym = isSgMemberFunctionSymbol(sym);
-    SgFunctionSymbol * plain_func_sym = isSgFunctionSymbol(sym); // Regular function symbol (not member)
-    SgClassSymbol * class_sym  = isSgClassSymbol(sym);
-
-    SgExpression * sg_member_expr = NULL;
-
-    bool successful_cast = var_sym || func_sym || plain_func_sym || class_sym;
-    if (sym != NULL && !successful_cast) {
-        std::cerr << "Runtime error: Unknown type of symbol for a member reference." << std::endl;
-        std::cerr << "    sym->class_name() = " << sym->class_name()  << std::endl;
-        res = false;
-    }
-    else if (var_sym != NULL) {
-        sg_member_expr = SageBuilder::buildVarRefExp(var_sym);
-    }
-    else if (func_sym != NULL) { // C++ member function
-        sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(func_sym, false, false); // FIXME 2nd and 3rd params ?
-    }
-    else if (plain_func_sym != NULL) { // Regular function treated as member (e.g., static member or inherited)
-        sg_member_expr = SageBuilder::buildFunctionRefExp(plain_func_sym);
-    }
-    else if (class_sym != NULL) {
-        SgClassDeclaration* classDecl = class_sym->get_declaration();
-        SgClassDeclaration* classDefDecl = isSgClassDeclaration(classDecl->get_definition());
-        SgType* classType = classDecl->get_type();
-//        if(classDecl->get_isUnNamed())
-        {
-          SgName varName(generate_name_for_variable(member_expr));
-          std::cerr << "build varName:" << varName << std::endl;
-          SgVariableDeclaration * var_decl = SageBuilder::buildVariableDeclaration(varName, classType, NULL,SageBuilder::topScopeStack());
-          var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
-          var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(true);
-          var_decl->set_parent(SageBuilder::topScopeStack());
-
-          sg_member_expr = SageBuilder::buildVarRefExp(var_decl);
-        }
-    }
-    else if (sym == NULL) {
-        // Symbol not found - check if member declaration has already been traversed
-        // to avoid infinite recursion during template member access
-        SgNode* tmp_member = NULL;
-        clang::ValueDecl* member_decl = member_expr->getMemberDecl();
-
-        // First check if already in translation map
-        if (llvm::isa<clang::Decl>(member_decl)) {
-            std::map<clang::Decl*, SgNode*>::iterator it_decl = p_decl_translation_map.find((clang::Decl*)member_decl);
-            if (it_decl != p_decl_translation_map.end()) {
-                tmp_member = it_decl->second;
-            }
-        }
-
-        // If not in map, traverse it (but this might fail for template members)
-        if (tmp_member == NULL) {
-            tmp_member = Traverse(member_decl);
-        }
-
-#if DEBUG_VISIT_STMT
-        if (tmp_member != NULL) {
-            // std::cerr << "DEBUG VisitMemberExpr: Got/traversed member, node type: " << tmp_member->class_name() << std::endl;
-        } else {
-            // std::cerr << "DEBUG VisitMemberExpr: Member not available (NULL)" << std::endl;
-        }
-#endif
-        if (tmp_member != NULL) {
-            // CLANG FRONTEND FIX: Extract symbol from the traversed member declaration.
-            //
-            // WHY: After successfully traversing the member's declaration above, we need to
-            // get its symbol. However, calling GetSymbolFromSymbolTable again here would
-            // create infinite recursion when template members reference each other.
-            //
-            // SOLUTION: Set sym=NULL to skip the GetSymbolFromSymbolTable call below
-            // (around line 4290), and instead extract the symbol directly from the
-            // already-constructed SAGE node (tmp_member).
-            //
-            // This breaks the cycle: GetSymbolFromSymbolTable → VisitMemberExpr →
-            // Traverse(member) → GetSymbolFromSymbolTable (AVOIDED by sym=NULL)
-            //
-            sym = NULL;  // Skip GetSymbolFromSymbolTable below; extract from tmp_member instead
-
-            // Extract symbol directly from the traversed node
-            if (isSgVariableDeclaration(tmp_member)) {
-                SgInitializedName* init_name = SageInterface::getFirstInitializedName(isSgVariableDeclaration(tmp_member));
-                if (init_name) {
-                    sym = init_name->search_for_symbol_from_symbol_table();
-                }
-            } else if (isSgFunctionDeclaration(tmp_member)) {
-                SgFunctionDeclaration* func_decl = isSgFunctionDeclaration(tmp_member);
-                SgScopeStatement* decl_scope = func_decl->get_scope();
-                if (decl_scope) {
-                    // Use type-aware lookup to handle overloaded functions correctly
-                    SgFunctionType* func_type = func_decl->get_type();
-                    sym = decl_scope->lookup_function_symbol(func_decl->get_name(), func_type);
-                }
-            }
-            if (isSgVariableSymbol(sym)) {
-                sg_member_expr = SageBuilder::buildVarRefExp(isSgVariableSymbol(sym));
-            } else if (isSgMemberFunctionSymbol(sym)) {
-                sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(isSgMemberFunctionSymbol(sym), false, false);
-            } else if (isSgFunctionSymbol(sym)) {
-                // ROOT CAUSE FIX: Handle plain SgFunctionSymbol (not member function symbol)
-                // This happens when VisitFunctionDecl creates a regular function declaration
-                sg_member_expr = SageBuilder::buildFunctionRefExp(isSgFunctionSymbol(sym));
-            } else if (isSgInitializedName(tmp_member)) {
-                // Create a temporary symbol if we got an initialized name
-                SgVariableSymbol* temp_sym = new SgVariableSymbol(isSgInitializedName(tmp_member));
-                sg_member_expr = SageBuilder::buildVarRefExp(temp_sym);
-            }
-            // ROOT CAUSE FIX: Handle SgMemberFunctionDeclaration from VisitCXXMethodDecl
-            else if (sym == NULL && isSgMemberFunctionDeclaration(tmp_member) != NULL) {
-                SgMemberFunctionDeclaration* member_func_decl = isSgMemberFunctionDeclaration(tmp_member);
-                // Try to find existing symbol in the class scope
-                SgScopeStatement* decl_scope = member_func_decl->get_scope();
-                if (decl_scope != NULL) {
-                    // Use type-aware lookup to handle overloaded member functions correctly
-                    SgFunctionType* func_type = member_func_decl->get_type();
-                    sym = decl_scope->lookup_function_symbol(member_func_decl->get_name(), func_type);
-                }
-                // If still not found, create new member function symbol
-                if (sym == NULL) {
-                    SgMemberFunctionSymbol* new_func_sym = new SgMemberFunctionSymbol(member_func_decl);
-                    new_func_sym->set_parent(member_func_decl);
-                    if (decl_scope != NULL) {
-                        decl_scope->insert_symbol(member_func_decl->get_name(), new_func_sym);
-                    }
-                    sym = new_func_sym;
-                }
-                if (isSgMemberFunctionSymbol(sym)) {
-                    sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(isSgMemberFunctionSymbol(sym), false, false);
-                }
-            }
-            // Also handle regular function declarations that might be static members
-            else if (sym == NULL && isSgFunctionDeclaration(tmp_member) != NULL) {
-                SgFunctionDeclaration* func_decl = isSgFunctionDeclaration(tmp_member);
-                // Try to find existing symbol
-                SgScopeStatement* decl_scope = func_decl->get_scope();
-                if (decl_scope != NULL) {
-                    // Use type-aware lookup to handle overloaded functions correctly
-                    SgFunctionType* func_type = func_decl->get_type();
-                    sym = decl_scope->lookup_function_symbol(func_decl->get_name(), func_type);
-                }
-                // If not found, create new function symbol
-                if (sym == NULL) {
-                    SgFunctionSymbol* new_func_sym = new SgFunctionSymbol(func_decl);
-                    new_func_sym->set_parent(func_decl);
-                    if (decl_scope != NULL) {
-                        decl_scope->insert_symbol(func_decl->get_name(), new_func_sym);
-                    }
-                    sym = new_func_sym;
-                }
-                if (isSgMemberFunctionSymbol(sym)) {
-                    sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(isSgMemberFunctionSymbol(sym), false, false);
-                } else if (isSgFunctionSymbol(sym)) {
-                    sg_member_expr = SageBuilder::buildFunctionRefExp(isSgFunctionSymbol(sym));
-                }
-            }
-        }
-
-        // If still NULL, create a placeholder
-        if (sg_member_expr == NULL) {
-            std::string member_name = member_expr->getMemberNameInfo().getAsString();
-            clang::ValueDecl* member_decl = member_expr->getMemberDecl();
-            if (member_decl) {
-                std::cerr << "Warning: Cannot resolve " << member_decl->getDeclKindName()
-                          << " member '" << member_name << "'";
-                if (tmp_member != NULL) {
-                    std::cerr << " (traversed to " << tmp_member->class_name() << ")";
-                } else {
-                    std::cerr << " (traverse returned NULL)";
-                }
-                std::cerr << ", using placeholder" << std::endl;
-            } else {
-                std::cerr << "Warning: Cannot resolve member '" << member_name << "', using placeholder" << std::endl;
-            }
-            SgType* unknown_type = SageBuilder::buildOpaqueType(member_name + "_type", getGlobalScope());
-            SgInitializedName* placeholder_var = SageBuilder::buildInitializedName(member_name, unknown_type);
-            placeholder_var->get_file_info()->setCompilerGenerated();
-            SgScopeStatement* scope = SageBuilder::topScopeStack();
-            placeholder_var->set_scope(scope);
-            placeholder_var->set_parent(scope);
-            SgVariableSymbol* placeholder_sym = new SgVariableSymbol(placeholder_var);
-            sg_member_expr = SageBuilder::buildVarRefExp(placeholder_sym);
-        }
-    }
-
-    ROSE_ASSERT(sg_member_expr != NULL);
-
-    // TODO (C++) member_expr->getQualifier() : for 'a->Base::foo'
-
-    if (member_expr->isArrow())
-        *node = SageBuilder::buildArrowExp(base, sg_member_expr);
-    else
-        *node = SageBuilder::buildDotExp(base, sg_member_expr);
-
-    return VisitExpr(member_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitMSPropertyRefExpr(clang::MSPropertyRefExpr * ms_property_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMSPropertyRefExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(ms_property_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitMSPropertySubscriptExpr(clang::MSPropertySubscriptExpr * ms_property_subscript_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitMSPropertySubscriptExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(ms_property_subscript_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitNoInitExpr(clang::NoInitExpr * no_init_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitNoInitExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(no_init_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOffsetOfExpr(clang::OffsetOfExpr * offset_of_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOffsetOfExpr" << std::endl;
-#endif
-    bool res = true;
-
-    SgNodePtrList nodePtrList;
-
-    SgType* type = buildTypeFromQualifiedType(offset_of_expr->getTypeSourceInfo()->getType());
-
-    nodePtrList.push_back(type);
-
-    SgExpression* topExp = nullptr;
- 
-    for (unsigned i = 0, n = offset_of_expr->getNumComponents(); i < n; ++i) {
-        clang::OffsetOfNode ON = offset_of_expr->getComponent(i);
-          
-        switch(ON.getKind()) {
-           case clang::OffsetOfNode::Array: {
-               // Array node
-               SgExpression* arrayIdx = isSgExpression(Traverse(offset_of_expr->getIndexExpr(ON.getArrayExprIndex())));
-               SgPntrArrRefExp* pntrArrRefExp = SageBuilder::buildPntrArrRefExp(topExp,arrayIdx);
-               topExp = isSgExpression(pntrArrRefExp);
-               break;
-           }
-           case clang::OffsetOfNode::Field:{
-               // OffsetOfNode still uses getField(), not getFieldDecl()
-               SgNode* fieldNode = Traverse(ON.getField());
-               SgName fieldName(ON.getFieldName()->getName().str());
-               SgVarRefExp* varExp = SageBuilder::buildVarRefExp(fieldName);
-               if(topExp == nullptr)
-               {
-                 topExp = isSgExpression(varExp);
-               }
-               else
-               {
-                 SgDotExp* dotExp = SageBuilder::buildDotExp(topExp, varExp);
-                 topExp = isSgExpression(dotExp);
-               }
-               break;
-           }
-           // TODO
-           case clang::OffsetOfNode::Identifier:{
-               SgName fieldName(ON.getFieldName()->getName().str());
-               SgVarRefExp* varExp = SageBuilder::buildVarRefExp(fieldName);
-               break;
-           }
-           // TODO
-           case clang::OffsetOfNode::Base:
-               break;
-        }
-    }
-    nodePtrList.push_back(topExp);
-
-    SgTypeTraitBuiltinOperator* typeTraitBuiltinOperator = SageBuilder::buildTypeTraitBuiltinOperator("__builtin_offsetof", nodePtrList);
-
-    *node = typeTraitBuiltinOperator;
-
-    return VisitExpr(offset_of_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOMPArraySectionExpr(clang::ArraySectionExpr * omp_array_section_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOMPArraySectionExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(omp_array_section_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOpaqueValueExpr(clang::OpaqueValueExpr * opaque_value_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOpaqueValueExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: OpaqueValueExpr is a Clang internal node representing a value
-    // that appears multiple times in the AST but should only be evaluated once.
-    // It's used for desugaring constructs like the conditional operator and range-based for.
-    // We just traverse the source expression and return it.
-
-    clang::Expr* source_expr = opaque_value_expr->getSourceExpr();
-    if (source_expr) {
-        *node = Traverse(source_expr);
-    } else {
-        // No source expression - OpaqueValueExpr is used as a placeholder
-        // Create a null expression placeholder for ROSE
-        // This happens in range-based for loops and other desugared constructs
-        *node = SageBuilder::buildNullExpression();
-    }
-
-    return VisitExpr(opaque_value_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitOverloadExpr(clang::OverloadExpr * overload_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitOverloadExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // TODO
-
-    return VisitExpr(overload_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitUnresolvedLookupExpr(clang::UnresolvedLookupExpr * unresolved_lookup_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitUnresolvedLookupExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // UnresolvedLookupExpr represents a reference to a name that couldn't be resolved during parsing
-    // (e.g., template-dependent function names like std::iota)
-    // Extract the name and create a variable reference expression as an approximation
-
-    std::string function_name;
-    if (unresolved_lookup_expr->hasExplicitTemplateArgs()) {
-        // Template function with explicit template arguments
-        function_name = unresolved_lookup_expr->getName().getAsString();
-    } else {
-        // Regular function name
-        function_name = unresolved_lookup_expr->getName().getAsString();
-    }
-
-    // Check for qualified names (e.g., std::iota)
-    if (unresolved_lookup_expr->getQualifier() != NULL) {
-        std::string qualifier_str;
-        llvm::raw_string_ostream qualifier_stream(qualifier_str);
-        unresolved_lookup_expr->getQualifier()->print(qualifier_stream, clang::PrintingPolicy(clang::LangOptions()));
-        function_name = qualifier_stream.str() + function_name;
-    }
-
-    // Create a variable reference expression with the function name
-    // This will unparse as the function name, which is what we want
-    SgName sg_name(function_name);
-    *node = SageBuilder::buildVarRefExp(sg_name, SageBuilder::topScopeStack());
-
-    // Set source position
-    SgExpression* expr = isSgExpression(*node);
-    if (expr != NULL) {
-        applySourceRange(expr, unresolved_lookup_expr->getSourceRange());
-    }
-
-    return VisitOverloadExpr(unresolved_lookup_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitUnresolvedMemberExpr(clang::UnresolvedMemberExpr * unresolved_member_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitUnresolvedMemberExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: UnresolvedMemberExpr represents a member access expression where the member
-    // couldn't be resolved at parse time (typically in template-dependent code)
-    // Example: template<typename T> void foo(T t) { t.bar(); }  // 'bar' is unresolved
-
-    // Get the member name
-    std::string member_name = unresolved_member_expr->getMemberName().getAsString();
-
-    // Determine a scope we can safely use for placeholder expressions
-    SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-    if (current_scope == NULL) {
-        current_scope = getGlobalScope();
-    }
-
-    // Handle the base expression (the object/pointer being accessed)
-    SgExpression* base_expr = NULL;
-    if (!unresolved_member_expr->isImplicitAccess()) {
-        if (clang::Expr* base = unresolved_member_expr->getBase()) {
-            SgNode* tmp_base = Traverse(base);
-            base_expr = isSgExpression(tmp_base);
-        }
-    }
-
-    // If no base (implicit 'this' access or translation failure), build a placeholder
-    if (base_expr == NULL) {
-        base_expr = SageBuilder::buildOpaqueVarRefExp("this", current_scope);
-        if (SgLocatedNode* located_base = isSgLocatedNode(base_expr)) {
-            located_base->get_file_info()->setCompilerGenerated();
-        }
-    }
-
-    // Create a placeholder expression for the member name without requiring a resolved symbol
-    SgVarRefExp* member_ref = SageBuilder::buildOpaqueVarRefExp(member_name, current_scope);
-    if (member_ref != NULL) {
-        member_ref->get_file_info()->setCompilerGenerated();
-    }
-
-    // Determine if it's arrow (->) or dot (.) access
-    if (unresolved_member_expr->isArrow()) {
-        *node = SageBuilder::buildArrowExp(base_expr, member_ref);
-    } else {
-        *node = SageBuilder::buildDotExp(base_expr, member_ref);
-    }
-
-    if (SgExpression* expr = isSgExpression(*node)) {
-        applySourceRange(expr, unresolved_member_expr->getSourceRange());
-    }
-
-    return VisitOverloadExpr(unresolved_member_expr, node) && res;
-}
-
-bool ClangToSageTranslator::VisitPackExpansionExpr(clang::PackExpansionExpr * pack_expansion_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitPackExpansionExpr" << std::endl;
-#endif
-    bool res = true;
-
-    // ROOT CAUSE FIX: Pack expansion expressions (e.g., f(args...) where args is a pack)
-    // Traverse the pattern expression (the expression before the ...)
-    clang::Expr* pattern = pack_expansion_expr->getPattern();
-    if (pattern != NULL) {
-        SgNode* tmp_node = Traverse(pattern);
-        SgExpression* pattern_expr = isSgExpression(tmp_node);
-        if (pattern_expr != NULL) {
-            *node = pattern_expr;
-            return VisitExpr(pack_expansion_expr, node) && res;
-        }
-    }
-
-    // Fallback if pattern can't be traversed
+  } else {
+    // No constructor available, create a null expression
     *node = SageBuilder::buildNullExpression();
+  }
 
-    return VisitExpr(pack_expansion_expr, node) && res;
+  return VisitExpr(cxx_construct_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitParenExpr(clang::ParenExpr * paren_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXTemporaryObjectExpr(
+    clang::CXXTemporaryObjectExpr *cxx_temporary_object_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitParenExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXTemporaryObjectExpr"
+            << std::endl;
 #endif
+  bool res = true;
 
-    bool res = true;
+  // TODO
 
-    SgNode * tmp_subexpr = Traverse(paren_expr->getSubExpr());
-    SgExpression * subexpr = isSgExpression(tmp_subexpr);
-    if (tmp_subexpr != NULL && subexpr == NULL) {
-        std::cerr << "Runtime error: tmp_subexpr != NULL && subexpr == NULL" << std::endl;
-        res = false;
-    }
-
-    // bypass ParenExpr, their is nothing equivalent in SageIII
-    *node = subexpr;
-
-    return VisitExpr(paren_expr, node) && res;
+  return VisitCXXConstructExpr(cxx_temporary_object_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitParenListExpr(clang::ParenListExpr * paran_list_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXDefaultArgExpr(
+    clang::CXXDefaultArgExpr *cxx_default_arg_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitParenListExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXDefaultArgExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: ParenListExpr represents a parenthesized list of expressions
-    // like in aggregate initialization: Point p(1, 2);
-    // Build an expression list to represent the paren list
+  // CXXDefaultArgExpr represents use of a default argument in a function call
+  // Traverse to the actual default expression
+  if (cxx_default_arg_expr->getExpr() != nullptr) {
+    *node = Traverse(cxx_default_arg_expr->getExpr());
+  } else {
+    // No expression available, use null expression as placeholder
+    *node = SageBuilder::buildNullExpression();
+  }
 
-    unsigned num_exprs = paran_list_expr->getNumExprs();
+  return VisitExpr(cxx_default_arg_expr, node) && res;
+}
 
-    if (num_exprs == 1) {
-        // Single expression - just unwrap the parentheses and return the expression directly
-        *node = Traverse(paran_list_expr->getExpr(0));
+bool ClangToSageTranslator::VisitCXXDefaultInitExpr(
+    clang::CXXDefaultInitExpr *cxx_default_init_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXDefaultInitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cxx_default_init_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXDeleteExpr(
+    clang::CXXDeleteExpr *cxx_delete_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXDeleteExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: CXXDeleteExpr represents the C++ delete operator
+  // Examples: delete ptr; or delete[] array;
+
+  // Get the expression being deleted
+  SgNode *tmp_arg = Traverse(cxx_delete_expr->getArgument());
+  SgExpression *arg = isSgExpression(tmp_arg);
+
+  if (arg == NULL) {
+    // If we can't get the argument, create a null expression as placeholder
+    arg = SageBuilder::buildNullExpression();
+  }
+
+  // Check if this is array delete (delete[]) or single object delete (delete)
+  bool is_array = cxx_delete_expr->isArrayForm();
+
+  // Build the delete expression
+  *node = SageBuilder::buildDeleteExp(arg, is_array, false, NULL);
+
+  return VisitExpr(cxx_delete_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXDependentScopeMemberExpr(
+    clang::CXXDependentScopeMemberExpr *cxx_dependent_scope_member_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXDependentScopeMemberExpr"
+            << std::endl;
+#endif
+  // std::cerr << "DEBUG: VisitCXXDependentScopeMemberExpr. Member: " <<
+  // cxx_dependent_scope_member_expr->getMember().getAsString() << std::endl;
+  bool res = true;
+
+  // CXXDependentScopeMemberExpr represents member access on a
+  // template-dependent type (e.g., obj.begin(), obj->data()) Extract the base
+  // expression and member name to create proper member access
+
+  SgExpression *base_expr = NULL;
+  if (cxx_dependent_scope_member_expr->getBase() != NULL) {
+    // Traverse the base expression
+    clang::Expr *base =
+        const_cast<clang::Expr *>(cxx_dependent_scope_member_expr->getBase());
+    // std::cerr << "DEBUG: Base Stmt Class: " << base->getStmtClassName() <<
+    // std::endl;
+    SgNode *tmp_base = Traverse(base);
+    base_expr = isSgExpression(tmp_base);
+    // if (base_expr) std::cerr << "DEBUG: VisitCXXDependentScopeMemberExpr base
+    // node type: " << base_expr->class_name() << std::endl; else std::cerr <<
+    // "DEBUG: VisitCXXDependentScopeMemberExpr base node is NULL" << std::endl;
+  }
+
+  // Get the member name
+  std::string member_name =
+      cxx_dependent_scope_member_expr->getMember().getAsString();
+
+  if (base_expr != NULL) {
+    SgVarRefExp *member_ref = SageBuilder::buildDanglingVarRefExp(
+        SgName(member_name), SageBuilder::topScopeStack());
+    // Create an arrow or dot expression depending on the operator used
+    if (cxx_dependent_scope_member_expr->isArrow()) {
+      // Use arrow expression (obj->member)
+      *node = SageBuilder::buildArrowExp(base_expr, member_ref);
     } else {
-        // Multiple expressions - build an ExprListExp
-        SgExprListExp* expr_list = SageBuilder::buildExprListExp();
-        for (unsigned i = 0; i < num_exprs; i++) {
-            SgNode* tmp_expr = Traverse(paran_list_expr->getExpr(i));
-            SgExpression* expr = isSgExpression(tmp_expr);
-            if (expr != NULL) {
-                expr_list->append_expression(expr);
-            } else if (tmp_expr != NULL) {
-                std::cerr << "Warning: ParenListExpr element " << i << " is not an expression" << std::endl;
-                res = false;
-            }
-        }
-        *node = expr_list;
+      // Use dot expression (obj.member)
+      *node = SageBuilder::buildDotExp(base_expr, member_ref);
     }
+  } else {
+    // If we can't get the base expression, use a simple variable reference
+    *node = SageBuilder::buildDanglingVarRefExp(SgName(member_name),
+                                                SageBuilder::topScopeStack());
+  }
 
-    return VisitExpr(paran_list_expr, node) && res;
+  // Set source position
+  SgExpression *expr = isSgExpression(*node);
+  if (expr != NULL) {
+    applySourceRange(expr, cxx_dependent_scope_member_expr->getSourceRange());
+  }
+
+  return VisitExpr(cxx_dependent_scope_member_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitPredefinedExpr(clang::PredefinedExpr * predefined_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitCXXFoldExpr(clang::CXXFoldExpr *cxx_fold_expr,
+                                             SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitPredefinedExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitCXXFoldExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // CXXFoldExpr represents C++17 fold expressions like (... && args)
+  // These are template-dependent, use placeholder for now
+  *node = SageBuilder::buildNullExpression();
+
+  return VisitExpr(cxx_fold_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXInheritedCtorInitExpr(
+    clang::CXXInheritedCtorInitExpr *cxx_inherited_ctor_init_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXInheritedCtorInitExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cxx_inherited_ctor_init_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXNewExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: Implement new expression support
+  // Get the allocated type
+  SgType *allocated_type =
+      buildTypeFromQualifiedType(cxx_new_expr->getAllocatedType());
+
+  // Handle array size if this is array new
+  SgExpression *array_size = NULL;
+  if (cxx_new_expr->isArray()) {
+    if (clang::Expr *size_expr =
+            cxx_new_expr->getArraySize().value_or(nullptr)) {
+      SgNode *tmp_size = Traverse(size_expr);
+      array_size = isSgExpression(tmp_size);
+    }
+  }
+
+  // Handle initializer (constructor call)
+  SgConstructorInitializer *ctor_init = NULL;
+  if (cxx_new_expr->hasInitializer()) {
+    clang::Expr *initializer = cxx_new_expr->getInitializer();
+    if (initializer != NULL) {
+      SgNode *tmp_init = Traverse(initializer);
+      // The initializer might be a CXXConstructExpr or other expression
+      ctor_init = isSgConstructorInitializer(tmp_init);
+    }
+  }
+
+  // Build the expression list for array new (if any)
+  SgExprListExp *array_expr_list = NULL;
+  if (array_size != NULL) {
+    array_expr_list = SageBuilder::buildExprListExp(array_size);
+  }
+
+  // Build the new expression
+  // buildNewExp(type, exprListExp, constInit, expr, val, funcDecl)
+  SgNewExp *new_exp =
+      SageBuilder::buildNewExp(allocated_type,  // type
+                               array_expr_list, // exprListExp (array size list)
+                               ctor_init, // constInit (constructor initializer)
+                               NULL,      // expr (placement new expression)
+                               0,   // val (need_global_specifier as short)
+                               NULL // funcDecl (operator new function)
+      );
+
+  *node = new_exp;
+
+  return VisitExpr(cxx_new_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXNoexceptExpr(
+    clang::CXXNoexceptExpr *cxx_noexcept_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXNoexceptExpr" << std::endl;
+#endif
+  bool res = true;
+
+  if (cxx_noexcept_expr->isValueDependent()) {
+    // Value-dependent noexcept results can't be evaluated until instantiation
+    // Create a placeholder expression so translation can proceed
+    *node = SageBuilder::buildNullExpression();
+    if (SgExpression *expr = isSgExpression(*node)) {
+      expr->get_file_info()->setCompilerGenerated();
+    }
+  } else {
+    // noexcept operator evaluates at compile-time whether an expression can
+    // throw
+    bool can_throw = cxx_noexcept_expr->getValue();
+    *node = SageBuilder::buildBoolValExp(can_throw);
+  }
+
+  if (SgExpression *expr = isSgExpression(*node)) {
+    applySourceRange(expr, cxx_noexcept_expr->getSourceRange());
+  }
+
+  return VisitExpr(cxx_noexcept_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXNullPtrLiteralExpr(
+    clang::CXXNullPtrLiteralExpr *cxx_null_ptr_literal_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXNullPtrLiteralExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: CXXNullPtrLiteralExpr represents C++11's nullptr literal
+  // nullptr is a null pointer constant of type std::nullptr_t
+  // In SAGE, we represent it with SgNullptrValExp
+
+  // Get the type (should be std::nullptr_t)
+  SgType *nullptr_type =
+      buildTypeFromQualifiedType(cxx_null_ptr_literal_expr->getType());
+
+  if (nullptr_type == NULL) {
+    // Fallback: if type conversion fails, use void pointer type
+    nullptr_type = SageBuilder::buildPointerType(SageBuilder::buildVoidType());
+  }
+
+  // Create the nullptr value expression
+  *node = SageBuilder::buildNullptrValExp();
+
+  return VisitExpr(cxx_null_ptr_literal_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(
+    clang::CXXPseudoDestructorExpr *cxx_pseudo_destructor_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXPseudoDestructorExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: CXXPseudoDestructorExpr represents a call to a destructor
+  // on a non-class type Example: ptr->~T() where T is a primitive type (used in
+  // templates) Get the destroyed type
+  clang::QualType destroyed_type =
+      cxx_pseudo_destructor_expr->getDestroyedType();
+  SgType *sg_type = buildTypeFromQualifiedType(destroyed_type);
+  ROSE_ASSERT(sg_type != NULL);
+
+  // Create source location info
+  Sg_File_Info *file_info =
+      Sg_File_Info::generateDefaultFileInfoForTransformationNode();
+  ROSE_ASSERT(file_info != NULL);
+
+  // Create the pseudo destructor reference expression
+  SgPseudoDestructorRefExp *pseudo_dtor =
+      new SgPseudoDestructorRefExp(file_info, sg_type);
+  ROSE_ASSERT(pseudo_dtor != NULL);
+
+  // Call post_construction_initialization which sets up the member function
+  // type
+  pseudo_dtor->post_construction_initialization();
+
+  *node = pseudo_dtor;
+
+  return VisitExpr(cxx_pseudo_destructor_expr, node) && res;
+}
+
+// bool
+// ClangToSageTranslator::VisitCXXRewrittenBinaryOperator(clang::CXXRewrittenBinaryOperator
+// * cxx_rewrite_binary_operator, SgNode ** node) { #if DEBUG_VISIT_STMT
+//     std::cerr << "ClangToSageTranslator::VisitCXXRewrittenBinaryOperator" <<
+//     std::endl;
+// #endif
+//     bool res = true;
+//
+//     // TODO
+//
+//     return VisitExpr(cxx_rewrite_binary_operator, node) && res;
+// }
+
+bool ClangToSageTranslator::VisitCXXScalarValueInitExpr(
+    clang::CXXScalarValueInitExpr *cxx_scalar_value_init_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXScalarValueInitExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: CXXScalarValueInitExpr represents value initialization of
+  // scalar types Examples: int(), char(), double*() - all initialize to
+  // zero/null This is equivalent to a cast expression with default
+  // initialization
+
+  // Get the type being initialized
+  SgType *type =
+      buildTypeFromQualifiedType(cxx_scalar_value_init_expr->getType());
+
+  if (type == NULL) {
+    type = SageBuilder::buildVoidType();
+  }
+
+  // Create a cast expression with a null operand to represent the default
+  // initialization The cast will produce the zero-initialized value of the
+  // target type
+  *node = SageBuilder::buildCastExp(SageBuilder::buildIntVal(0), type);
+
+  return VisitExpr(cxx_scalar_value_init_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXStdInitializerListExpr(
+    clang::CXXStdInitializerListExpr *cxx_std_initializer_list_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXStdInitializerListExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cxx_std_initializer_list_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXThisExpr(clang::CXXThisExpr *cxx_this_expr,
+                                             SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXThisExpr" << std::endl;
+#endif
+  bool res = true;
+
+  SgSymbol *this_symbol = findEnclosingThisSymbol(SageBuilder::topScopeStack());
+  if (this_symbol == NULL) {
+    const clang::Type *this_type_ptr =
+        cxx_this_expr->getType().getTypePtrOrNull();
+    const clang::PointerType *pointer_type =
+        this_type_ptr != NULL ? this_type_ptr->getAs<clang::PointerType>()
+                              : NULL;
+    const clang::CXXRecordDecl *record_decl = NULL;
+    if (pointer_type != NULL) {
+      record_decl = pointer_type->getPointeeType()->getAsCXXRecordDecl();
+    }
+
+    if (record_decl != NULL) {
+      const clang::CXXRecordDecl *canonical_decl =
+          record_decl->getCanonicalDecl();
+      auto it = p_decl_translation_map.find(
+          const_cast<clang::CXXRecordDecl *>(canonical_decl));
+      if (it == p_decl_translation_map.end()) {
+        it = p_decl_translation_map.find(
+            const_cast<clang::CXXRecordDecl *>(record_decl));
+      }
+
+      SgClassDeclaration *class_decl = NULL;
+      if (it != p_decl_translation_map.end()) {
+        class_decl = isSgClassDeclaration(it->second);
+      } else {
+        SgNode *tmp_class =
+            Traverse(const_cast<clang::CXXRecordDecl *>(canonical_decl));
+        class_decl = isSgClassDeclaration(tmp_class);
+      }
+
+      if (class_decl != NULL && class_decl->get_scope() != NULL) {
+        SgScopeStatement *decl_scope = class_decl->get_scope();
+        SgClassSymbol *class_sym =
+            decl_scope->lookup_class_symbol(class_decl->get_name());
+        if (class_sym == NULL) {
+          class_sym = new SgClassSymbol(class_decl);
+          decl_scope->insert_symbol(class_decl->get_name(), class_sym);
+        }
+        this_symbol = class_sym;
+      }
+    }
+  }
+
+  ROSE_ASSERT(this_symbol != NULL);
+
+  SgThisExp *this_exp = SageBuilder::buildThisExp_nfi(this_symbol);
+  *node = this_exp;
+
+  return VisitExpr(cxx_this_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXThrowExpr(
+    clang::CXXThrowExpr *cxx_throw_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXThrowExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: CXXThrowExpr represents C++ throw expressions
+  // Can be either "throw expr;" or bare "throw;" (rethrow)
+  SgExpression *throw_operand = NULL;
+  SgThrowOp::e_throw_kind throw_kind;
+
+  // Check if this is a rethrow (bare "throw;") or throw with expression
+  clang::Expr *sub_expr = cxx_throw_expr->getSubExpr();
+  if (sub_expr != NULL) {
+    // Regular throw with an expression
+    SgNode *tmp_expr = Traverse(sub_expr);
+    throw_operand = isSgExpression(tmp_expr);
+    if (throw_operand == NULL) {
+      std::cerr << "Error: Failed to convert throw operand expression"
+                << std::endl;
+      return false;
+    }
+    throw_kind = SgThrowOp::throw_expression;
+  } else {
+    // Rethrow (bare "throw;")
+    throw_kind = SgThrowOp::rethrow;
+  }
+
+  // Build the throw operation
+  SgThrowOp *throw_op = SageBuilder::buildThrowOp(throw_operand, throw_kind);
+  ROSE_ASSERT(throw_op != NULL);
+
+  *node = throw_op;
+
+  return VisitExpr(cxx_throw_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXTypeidExpr(
+    clang::CXXTypeidExpr *cxx_typeid_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXTypeidExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cxx_typeid_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXUnresolvedConstructExpr(
+    clang::CXXUnresolvedConstructExpr *cxx_unresolved_construct_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXUnresolvedConstructExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: Template-dependent constructor calls (e.g., T(args) where T
+  // is a template parameter) Build a proper constructor call expression instead
+  // of using null placeholder
+
+  // Get the type being constructed (may be a dependent type)
+  SgType *type = buildTypeFromQualifiedType(
+      cxx_unresolved_construct_expr->getTypeAsWritten());
+
+  // Build expression list for constructor arguments
+  SgExprListExp *args = SageBuilder::buildExprListExp_nfi();
+  for (unsigned i = 0; i < cxx_unresolved_construct_expr->getNumArgs(); i++) {
+    SgNode *tmp_expr = Traverse(cxx_unresolved_construct_expr->getArg(i));
+    SgExpression *arg = isSgExpression(tmp_expr);
+    if (arg != NULL) {
+      args->append_expression(arg);
+    }
+  }
+
+  // Build constructor initializer for the unresolved construct
+  SgConstructorInitializer *ctor_init =
+      SageBuilder::buildConstructorInitializer_nfi(
+          NULL, // declaration will be NULL for unresolved/dependent
+                // constructors
+          args, type,
+          false, // need_name
+          false, // need_qualifier
+          false, // need_parenthesis_after_name
+          true // associated_class_unknown - set to true for template-dependent
+               // types
+      );
+
+  *node = ctor_init;
+
+  return VisitExpr(cxx_unresolved_construct_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitCXXUuidofExpr(
+    clang::CXXUuidofExpr *cxx_uuidof_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitCXXUuidofExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(cxx_uuidof_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
+                                             SgNode **node) {
+  // std::cerr << "DEBUG: ClangToSageTranslator::VisitDeclRefExpr" << std::endl;
+  if (clang::NamedDecl *nd =
+          llvm::dyn_cast<clang::NamedDecl>(decl_ref_expr->getDecl())) {
+    // std::cerr << "DEBUG: DeclRefExpr to " << nd->getNameAsString() << " kind:
+    // " << nd->getDeclKindName() << std::endl;
+  }
+
+  if (clang::NonTypeTemplateParmDecl *non_type_param =
+          llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(
+              decl_ref_expr->getDecl())) {
+    SgDeclarationStatement *owning_template = NULL;
+    if (clang::DeclContext *ctx = non_type_param->getDeclContext()) {
+      if (clang::TemplateDecl *template_ctx =
+              llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
+        auto it = p_decl_translation_map.find(template_ctx);
+        if (it != p_decl_translation_map.end()) {
+          owning_template = isSgDeclarationStatement(it->second);
+        }
+      }
+    }
+
+    unsigned position = non_type_param->getIndex();
+    SgTemplateParameter *sg_param =
+        translateTemplateParameter(non_type_param, owning_template, position);
+
+    if (sg_param != NULL) {
+      SgTemplateParameterVal *param_val =
+          SageBuilder::buildTemplateParameterVal(non_type_param->getIndex());
+      param_val->set_valueString(non_type_param->getNameAsString());
+      if (sg_param->get_type() != NULL) {
+        param_val->set_valueType(sg_param->get_type());
+      }
+      applySourceRange(param_val, decl_ref_expr->getSourceRange());
+      *node = param_val;
+      return true;
+    }
+  }
+
+  bool res = true;
+
+  // SgNode * tmp_node = Traverse(decl_ref_expr->getDecl());
+  // DONE: Do not use Traverse(...) as the declaration can not be complete
+  // (recursive functions)
+  //       Instead use SymbolTable from ROSE as the symbol should be ready
+  //       (cannot have a reference before the declaration)
+  // FIXME: This fix will not work for C++ (methods/fields can be use before
+  // they are declared...)
+  // FIXME: I feel like it could work now, we will see ....
+
+  SgSymbol *sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+
+  if (sym == NULL) {
+    SgNode *tmp_decl = Traverse(decl_ref_expr->getDecl());
+
+    // DQ (11/29/2020): Added assertion.
+    ROSE_ASSERT(tmp_decl != NULL);
+
+#if DEBUG_VISIT_STMT
+    printf("tmp_decl = %p = %s \n", tmp_decl, tmp_decl->class_name().c_str());
+#endif
+    SgInitializedName *initializedName = isSgInitializedName(tmp_decl);
+#if DEBUG_VISIT_STMT
+    if (initializedName != NULL) {
+      printf("Found SgInitializedName: initializedName->get_name() = %s \n",
+             initializedName->get_name().str());
+    }
 #endif
 
-    // FIXME It's get tricky here: PredefinedExpr represent compiler generateed variables
-    //    I choose to attach those variables on demand in the function definition scope 
+    if (tmp_decl != NULL) {
+      sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+    }
+
+    // FIXME hack Traverse have added the symbol but we cannot find it
+    // (probably: problem with type and function lookup)
+
+    if (sym == NULL && isSgFunctionDeclaration(tmp_decl) != NULL) {
+      sym = new SgFunctionSymbol(isSgFunctionDeclaration(tmp_decl));
+      sym->set_parent(tmp_decl);
+    }
+    // ROOT CAUSE FIX: Handle SgVariableDeclaration from VisitVarDecl
+    // Extract the InitializedName and create symbol if needed
+    if (sym == NULL && isSgVariableDeclaration(tmp_decl) != NULL) {
+      SgVariableDeclaration *var_decl_result =
+          isSgVariableDeclaration(tmp_decl);
+      if (var_decl_result->get_variables().size() > 0) {
+        SgInitializedName *init_name = var_decl_result->get_variables()[0];
+        if (init_name != NULL) {
+          // Try to get existing symbol first
+          SgScopeStatement *init_scope = init_name->get_scope();
+          if (init_scope != NULL) {
+            sym = init_scope->lookup_variable_symbol(init_name->get_name());
+          }
+          // If still not found, create new symbol
+          if (sym == NULL) {
+            sym = new SgVariableSymbol(init_name);
+            sym->set_parent(init_name);
+            if (init_scope != NULL) {
+              init_scope->insert_symbol(init_name->get_name(), sym);
+            }
+          }
+        }
+      }
+    }
+    // Pei-Hung (04/07/2022) sym can be NULL in the case for C99 VLA
+    if (sym == NULL && isSgInitializedName(tmp_decl) != NULL) {
+      sym = new SgVariableSymbol(isSgInitializedName(tmp_decl));
+      sym->set_parent(tmp_decl);
+      SageBuilder::topScopeStack()->insert_symbol(
+          isSgInitializedName(tmp_decl)->get_name(), sym);
+    }
+  }
+
+  if (sym != NULL) {
+    // Not else if it was NULL we have try to traverse it....
+    SgVariableSymbol *var_sym = isSgVariableSymbol(sym);
+    SgFunctionSymbol *func_sym = isSgFunctionSymbol(sym);
+    SgEnumFieldSymbol *enum_sym = isSgEnumFieldSymbol(sym);
+
+    if (var_sym != NULL) {
+      *node = SageBuilder::buildVarRefExp(var_sym);
+    } else {
+      if (func_sym != NULL) {
+        SgFunctionSymbol *ref_func_sym = func_sym;
+
+        if (decl_ref_expr->hasExplicitTemplateArgs()) {
+          clang::TemplateArgumentListInfo arg_info;
+          decl_ref_expr->copyTemplateArgumentsInto(arg_info);
+
+          // Mark arguments as explicitly specified so the unparser keeps
+          // them
+          SgTemplateArgumentPtrList template_args =
+              buildTemplateArguments(arg_info, true);
+
+          SgScopeStatement *func_scope = func_sym->get_scope();
+          if (func_scope == NULL) {
+            func_scope = SageBuilder::topScopeStack();
+          }
+
+          SgFunctionType *func_type = isSgFunctionType(func_sym->get_type());
+          SgType *ret_type =
+              func_type != NULL ? func_type->get_return_type() : NULL;
+          if (ret_type == NULL) {
+            ret_type = SageBuilder::buildUnknownType();
+          }
+
+          SgFunctionParameterList *param_list = NULL;
+          if (func_type != NULL && func_type->get_argument_list() != NULL) {
+            param_list = SageBuilder::buildFunctionParameterList_nfi(
+                func_type->get_argument_list());
+          } else {
+            param_list = SageBuilder::buildFunctionParameterList_nfi();
+          }
+
+          SgTemplateInstantiationFunctionDecl *inst_decl =
+              isSgTemplateInstantiationFunctionDecl(
+                  SageBuilder::buildNondefiningFunctionDeclaration(
+                      func_sym->get_name(), ret_type, param_list, func_scope,
+                      /*decoratorList=*/NULL,
+                      /*buildTemplateInstantiation=*/true, &template_args,
+                      SgStorageModifier::e_default,
+                      /*forceFreeFunctionScope=*/false));
+
+          if (inst_decl != NULL) {
+            inst_decl->set_template_argument_list_is_explicit(true);
+            inst_decl->get_templateArguments() = template_args;
+
+            SgFunctionDeclaration *base_decl =
+                isSgFunctionDeclaration(func_sym->get_declaration());
+            if (base_decl != NULL) {
+              if (SgTemplateFunctionDeclaration *tmpl_decl =
+                      isSgTemplateFunctionDeclaration(base_decl)) {
+                inst_decl->set_templateDeclaration(tmpl_decl);
+                inst_decl->set_templateName(tmpl_decl->get_name());
+              } else if (SgTemplateFunctionDeclaration *first_nondef =
+                             isSgTemplateFunctionDeclaration(
+                                 base_decl
+                                     ->get_firstNondefiningDeclaration())) {
+                inst_decl->set_templateDeclaration(first_nondef);
+                inst_decl->set_templateName(first_nondef->get_name());
+              }
+            }
+
+            if (inst_decl->get_templateDeclaration() == NULL) {
+              if (clang::FunctionDecl *clang_func =
+                      llvm::dyn_cast<clang::FunctionDecl>(
+                          decl_ref_expr->getDecl())) {
+                clang::FunctionTemplateDecl *primary_template =
+                    clang_func->getPrimaryTemplate();
+                if (primary_template == NULL) {
+                  primary_template = clang_func->getDescribedFunctionTemplate();
+                }
+
+                if (primary_template != NULL) {
+                  SgNode *tmpl_node = Traverse(primary_template);
+                  if (SgTemplateFunctionDeclaration *tmpl_decl =
+                          isSgTemplateFunctionDeclaration(tmpl_node)) {
+                    inst_decl->set_templateDeclaration(tmpl_decl);
+                    inst_decl->set_templateName(tmpl_decl->get_name());
+                  }
+                }
+              }
+            }
+
+            SgFunctionSymbol *inst_sym =
+                isSgFunctionSymbol(inst_decl->get_symbol_from_symbol_table());
+            if (inst_sym == NULL && func_scope != NULL && func_type != NULL) {
+              inst_sym = func_scope->lookup_function_symbol(
+                  func_sym->get_name(), func_type);
+            }
+            if (inst_sym != NULL) {
+              ref_func_sym = inst_sym;
+            }
+          }
+        }
+
+        *node = SageBuilder::buildFunctionRefExp(ref_func_sym);
+
+        // ROOT CAUSE FIX: Set qualified name prefix (namespace) from
+        // Clang declaration This preserves namespace information (e.g.,
+        // std::) even when scope is global
+        SgFunctionRefExp *func_ref = isSgFunctionRefExp(*node);
+        if (func_ref != NULL) {
+          clang::FunctionDecl *func_decl =
+              llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl());
+          if (func_decl != NULL) {
+            std::string qualified_name = func_decl->getQualifiedNameAsString();
+            std::string simple_name = func_decl->getNameAsString();
+            // Extract namespace prefix by removing simple name from
+            // qualified name
+            if (qualified_name.length() > simple_name.length() &&
+                qualified_name.substr(qualified_name.length() -
+                                      simple_name.length()) == simple_name) {
+              // Remove the simple name and the trailing ::
+              std::string namespace_prefix = qualified_name.substr(
+                  0, qualified_name.length() - simple_name.length());
+              if (namespace_prefix.length() >= 2 &&
+                  namespace_prefix.substr(namespace_prefix.length() - 2) ==
+                      "::") {
+                namespace_prefix =
+                    namespace_prefix.substr(0, namespace_prefix.length() - 2);
+              }
+              if (!namespace_prefix.empty()) {
+                // Add to global qualified name map so unparser can
+                // retrieve it
+                SgNode::get_globalQualifiedNameMapForNames()[func_ref] =
+                    namespace_prefix + "::";
+              }
+            }
+          }
+        }
+      } else {
+        if (enum_sym != NULL) {
+          // ROOT CAUSE FIX: Get enum declaration from the type instead of
+          // parent The Clang frontend may not set parent pointers
+          // correctly for enum constants But the type is always set
+          // correctly to an SgEnumType
+          SgInitializedName *init_name = enum_sym->get_declaration();
+          SgEnumDeclaration *enum_decl = NULL;
+
+          if (init_name != NULL && init_name->get_type() != NULL) {
+            SgEnumType *enum_type = isSgEnumType(init_name->get_type());
+            if (enum_type != NULL) {
+              enum_decl = isSgEnumDeclaration(enum_type->get_declaration());
+            }
+          }
+
+          // Fallback: try getting from parent if type method didn't work
+          if (enum_decl == NULL && init_name != NULL) {
+            enum_decl = isSgEnumDeclaration(init_name->get_parent());
+          }
+
+          ROSE_ASSERT(enum_decl != NULL);
+          SgName name = enum_sym->get_name();
+          *node = SageBuilder::buildEnumVal_nfi(0, enum_decl, name);
+        } else {
+          if (sym != NULL) {
+            std::cerr << "Runtime error: Unknown type of symbol for a "
+                         "declaration reference."
+                      << std::endl;
+            std::cerr << "    sym->class_name() = " << sym->class_name()
+                      << std::endl;
+            ROSE_ABORT();
+          }
+        }
+      }
+    }
+  } else {
+    // ROOT CAUSE FIX: Handle template-dependent and unresolved declarations
+    clang::Decl *clang_decl = decl_ref_expr->getDecl();
+    std::string decl_name = "unresolved_symbol";
+
+    // Get declaration name and type info for better handling
+    if (clang_decl && clang::isa<clang::NamedDecl>(clang_decl)) {
+      clang::NamedDecl *named_decl = clang::cast<clang::NamedDecl>(clang_decl);
+      decl_name = named_decl->getNameAsString();
+
+      // Log what type of declaration couldn't be resolved
+      std::cerr << "Warning: Cannot resolve symbol for "
+                << clang_decl->getDeclKindName() << " '" << decl_name
+                << "', using placeholder" << std::endl;
+    } else {
+      std::cerr << "Warning: Cannot resolve symbol for declaration reference, "
+                   "using placeholder"
+                << std::endl;
+    }
+
+    *node = SageBuilder::buildDanglingVarRefExp(SgName(decl_name),
+                                                SageBuilder::topScopeStack());
+  }
+
+  return VisitExpr(decl_ref_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitDependentCoawaitExpr(
+    clang::DependentCoawaitExpr *dependent_coawait_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDependentCoawaitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(dependent_coawait_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitDependentScopeDeclRefExpr(
+    clang::DependentScopeDeclRefExpr *dependent_scope_decl_ref_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDependentScopeDeclRefExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // DependentScopeDeclRefExpr represents a reference to a declaration that
+  // depends on template parameters (e.g., variable references like 'x' or 'y'
+  // in template-dependent contexts) Extract the name and create a variable
+  // reference expression
+
+  std::string decl_name =
+      dependent_scope_decl_ref_expr->getDeclName().getAsString();
+
+  // Check for qualified names (e.g., namespace::var)
+  if (dependent_scope_decl_ref_expr->getQualifier() != NULL) {
+    std::string qualifier_str;
+    llvm::raw_string_ostream qualifier_stream(qualifier_str);
+    dependent_scope_decl_ref_expr->getQualifier()->print(
+        qualifier_stream, clang::PrintingPolicy(clang::LangOptions()));
+    decl_name = qualifier_stream.str() + decl_name;
+  }
+
+  // Create a variable reference expression
+  // NOTE: Using topScopeStack() may not correctly resolve variables in nested
+  // scopes since dependent scope information isn't always available at this
+  // stage. Ideally, the variable lookup should search upward through parent
+  // scopes, but for template-dependent contexts, complete scope information may
+  // not be available until instantiation time.
+  SgName sg_name(decl_name);
+  *node = SageBuilder::buildVarRefExp(sg_name, SageBuilder::topScopeStack());
+
+  // Set source position
+  SgExpression *expr = isSgExpression(*node);
+  if (expr != NULL) {
+    applySourceRange(expr, dependent_scope_decl_ref_expr->getSourceRange());
+  }
+
+  return VisitExpr(dependent_scope_decl_ref_expr, node) && res;
+}
+
+// bool
+// ClangToSageTranslator::VisitDependentScopeDeclRefExpr(clang::DependentScopeDeclRefExpr
+// * dependent_scope_decl_ref_expr);
+
+bool ClangToSageTranslator::VisitDesignatedInitExpr(
+    clang::DesignatedInitExpr *designated_init_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDesignatedInitExpr" << std::endl;
+#endif
+
+  SgInitializer *base_init = NULL;
+  SgDesignatedInitializer *designated_init = NULL;
+  SgExprListExp *expr_list_exp = NULL;
+  {
+    SgNode *tmp_expr = Traverse(designated_init_expr->getInit());
+    SgExpression *expr = isSgExpression(tmp_expr);
+    ROSE_ASSERT(expr != NULL);
+    SgExprListExp *expr_list_exp = isSgExprListExp(expr);
+    if (expr_list_exp != NULL) {
+      // FIXME get the type right...
+      base_init =
+          SageBuilder::buildAggregateInitializer_nfi(expr_list_exp, NULL);
+    } else {
+      base_init =
+          SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
+    }
+    ROSE_ASSERT(base_init != NULL);
+    applySourceRange(base_init,
+                     designated_init_expr->getInit()->getSourceRange());
+  }
+
+  /* Pei-Hung (06/10/2022) revision to handle Initializer in test2013_37.c
+   *  After calling getSyntacticForm from InitListExpr, the type and
+   * multidimensional array hierarchy is missing. This version can construct the
+   * array structure but need additional support to grab the type structure from
+   *  parent AST node, such as VarDecl.
+   */
+
+  auto designatorSize = designated_init_expr->size();
+
+  for (auto it = designatorSize; it > 0; it--) {
+    expr_list_exp = SageBuilder::buildExprListExp_nfi();
+    SgExpression *expr = NULL;
+    clang::DesignatedInitExpr::Designator *D =
+        designated_init_expr->getDesignator(it - 1);
+    if (D->isFieldDesignator()) {
+      // In LLVM 20, getField() was renamed to getFieldDecl()
+      SgSymbol *symbol = GetSymbolFromSymbolTable(D->getFieldDecl());
+      SgVariableSymbol *var_sym = isSgVariableSymbol(symbol);
+      ROSE_ASSERT(var_sym != NULL);
+      expr = SageBuilder::buildVarRefExp_nfi(var_sym);
+    } else if (D->isArrayDesignator()) {
+      SgNode *tmp_expr = NULL;
+      if (clang::ConstantExpr::classof(
+              designated_init_expr->getArrayIndex(*D))) {
+        clang::FullExpr *fullExpr =
+            (clang::FullExpr *)designated_init_expr->getArrayIndex(*D);
+        clang::IntegerLiteral *integerLiteral =
+            (clang::IntegerLiteral *)fullExpr->getSubExpr();
+        tmp_expr = SageBuilder::buildUnsignedLongVal(
+            (unsigned long)integerLiteral->getValue().getSExtValue());
+      } else {
+        tmp_expr = Traverse(designated_init_expr->getArrayIndex(*D));
+      }
+      expr = isSgExpression(tmp_expr);
+      ROSE_ASSERT(expr != NULL);
+
+    } else if (D->isArrayRangeDesignator()) {
+      ROSE_ASSERT(!"I don't believe range designator initializer are supported "
+                   "by ROSE...");
+    } else
+      ROSE_ABORT();
+
+    ROSE_ASSERT(expr != NULL);
+
+    applySourceRange(expr, D->getSourceRange());
+    expr->set_parent(expr_list_exp);
+    expr_list_exp->append_expression(expr);
+    if (it > 1) {
+      SgDesignatedInitializer *design_init =
+          new SgDesignatedInitializer(expr_list_exp, base_init);
+      applySourceRange(design_init,
+                       designated_init_expr->getDesignatorsSourceRange());
+      expr_list_exp->set_parent(design_init);
+      base_init->set_parent(design_init);
+      SgExprListExp *aggListExp = SageBuilder::buildExprListExp_nfi();
+      design_init->set_parent(aggListExp);
+      aggListExp->append_expression(design_init);
+      SgAggregateInitializer *newAggInit =
+          SageBuilder::buildAggregateInitializer_nfi(aggListExp, NULL);
+      expr_list_exp = SageBuilder::buildExprListExp_nfi();
+      base_init = newAggInit;
+    }
+  }
+
+  applySourceRange(expr_list_exp,
+                   designated_init_expr->getDesignatorsSourceRange());
+  designated_init = new SgDesignatedInitializer(expr_list_exp, base_init);
+  expr_list_exp->set_parent(base_init);
+  base_init->set_parent(designated_init);
+
+  *node = designated_init;
+
+  return VisitExpr(designated_init_expr, node);
+
+  // Pei-Hung (06/10/2022) keep the original implementation which has the array
+  // information stored in the list
+  /*
+      for (auto it=0; it < designatorSize; it++) {
+          SgExpression * expr = NULL;
+          clang::DesignatedInitExpr::Designator * D =
+  designated_init_expr->getDesignator(it); if (D->isFieldDesignator()) {
+              SgSymbol * symbol = GetSymbolFromSymbolTable(D->getField());
+              SgVariableSymbol * var_sym = isSgVariableSymbol(symbol);
+              ROSE_ASSERT(var_sym != NULL);
+              expr = SageBuilder::buildVarRefExp_nfi(var_sym);
+              applySourceRange(expr, D->getSourceRange());
+          }
+          else if (D->isArrayDesignator()) {
+              SgNode * tmp_expr = NULL;
+              if(clang::ConstantExpr::classof(designated_init_expr->getArrayIndex(*D)))
+              {
+                 clang::FullExpr* fullExpr = (clang::FullExpr*)
+  designated_init_expr->getArrayIndex(*D); clang::IntegerLiteral* integerLiteral
+  = (clang::IntegerLiteral*) fullExpr->getSubExpr(); tmp_expr =
+  SageBuilder::buildUnsignedLongVal((unsigned long)
+  integerLiteral->getValue().getSExtValue()); std::cerr << "idx:" <<
+  integerLiteral->getValue().getSExtValue() << std::endl;
+              }
+              else
+              {
+                 tmp_expr = Traverse(designated_init_expr->getArrayIndex(*D));
+              }
+              expr = isSgExpression(tmp_expr);
+              ROSE_ASSERT(expr != NULL);
+          }
+          else if (D->isArrayRangeDesignator()) {
+              ROSE_ASSERT(!"I don't believe range designator initializer are
+  supported by ROSE...");
+          }
+          else ROSE_ABORT();
+
+          ROSE_ASSERT(expr != NULL);
+
+          expr->set_parent(expr_list_exp);
+          expr_list_exp->append_expression(expr);
+      }
+
+      applySourceRange(expr_list_exp,
+  designated_init_expr->getDesignatorsSourceRange());
+
+      SgDesignatedInitializer * design_init = new
+  SgDesignatedInitializer(expr_list_exp, init);
+      expr_list_exp->set_parent(design_init);
+      init->set_parent(design_init);
+
+      *node = design_init;
+
+      return VisitExpr(designated_init_expr, node);
+  */
+}
+
+bool ClangToSageTranslator::VisitDesignatedInitUpdateExpr(
+    clang::DesignatedInitUpdateExpr *designated_init_update, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitDesignatedInitUpdateExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(designated_init_update, node) && res;
+}
+
+bool ClangToSageTranslator::VisitExpressionTraitExpr(
+    clang::ExpressionTraitExpr *expression_trait_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitExpressionTraitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(expression_trait_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitExtVectorElementExpr(
+    clang::ExtVectorElementExpr *ext_vector_element_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitExtVectorElementExpr" << std::endl;
+#endif
+
+  SgNode *tmp_base = Traverse(ext_vector_element_expr->getBase());
+  SgExpression *base = isSgExpression(tmp_base);
+#if DEBUG_VISIT_STMT
+  // if (base) std::cerr << "DEBUG: VisitExtVectorElementExpr base node type: "
+  // << base->class_name() << std::endl; else std::cerr << "DEBUG:
+  // VisitExtVectorElementExpr base node is NULL" << std::endl;
+#endif
+  ROSE_ASSERT(base != NULL);
+
+  SgType *type = buildTypeFromQualifiedType(ext_vector_element_expr->getType());
+
+  clang::IdentifierInfo &ident_info = ext_vector_element_expr->getAccessor();
+  std::string ident = ident_info.getName().str();
+
+  SgScopeStatement *scope = SageBuilder::ScopeStack.front();
+  SgGlobal *global = isSgGlobal(scope);
+  ROSE_ASSERT(global != NULL);
+
+  // Build Manually a SgVarRefExp to have the same Accessor (text version) TODO
+  // ExtVectorAccessor and ExtVectorType
+  SgInitializedName *init_name = SageBuilder::buildInitializedName(
+      ident, SageBuilder::buildVoidType(), NULL);
+  setCompilerGeneratedFileInfo(init_name);
+  init_name->set_scope(global);
+  SgVariableSymbol *var_symbol = new SgVariableSymbol(init_name);
+  SgVarRefExp *pseudo_field = new SgVarRefExp(var_symbol);
+  setCompilerGeneratedFileInfo(pseudo_field, true);
+  init_name->set_parent(pseudo_field);
+
+  SgExpression *res = NULL;
+  if (ext_vector_element_expr->isArrow())
+    res = SageBuilder::buildArrowExp(base, pseudo_field);
+  else
+    res = SageBuilder::buildDotExp(base, pseudo_field);
+
+  ROSE_ASSERT(res != NULL);
+
+  *node = res;
+
+  return VisitExpr(ext_vector_element_expr, node);
+}
+
+bool ClangToSageTranslator::VisitFixedPointLiteral(
+    clang::FixedPointLiteral *fixed_point_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitFixedPointLiteral" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(fixed_point_literal, node) && res;
+}
+
+bool ClangToSageTranslator::VisitFloatingLiteral(
+    clang::FloatingLiteral *floating_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitFloatingLiteral" << std::endl;
+#endif
+
+  unsigned int precision = llvm::APFloat::semanticsPrecision(
+      floating_literal->getValue().getSemantics());
+  if (precision == 24) {
+    // 32-bit float
+    *node = SageBuilder::buildFloatVal(
+        floating_literal->getValue().convertToFloat());
+  } else if (precision == 53) {
+    // 64-bit double
+    *node = SageBuilder::buildDoubleVal(
+        floating_literal->getValue().convertToDouble());
+  } else if (precision == 64 || precision == 113) {
+    // 80-bit or 128-bit long double - use double as approximation
+    *node = SageBuilder::buildLongDoubleVal(
+        floating_literal->getValue().convertToDouble());
+  } else if (precision == 11) {
+    // 16-bit half precision - use float
+    *node = SageBuilder::buildFloatVal(
+        floating_literal->getValue().convertToFloat());
+  } else {
+    // Fallback for other sizes - use double
+    std::cerr << "Warning: Unsupported float precision " << precision
+              << ", using double" << std::endl;
+    *node = SageBuilder::buildDoubleVal(
+        floating_literal->getValue().convertToDouble());
+  }
+
+  return VisitExpr(floating_literal, node);
+}
+
+bool ClangToSageTranslator::VisitFullExpr(clang::FullExpr *full_expr,
+                                          SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitFullExpr" << std::endl;
+#endif
+  bool res = true;
+
+  SgNode *tmp_expr = Traverse(full_expr->getSubExpr());
+  SgExpression *expr = isSgExpression(tmp_expr);
+
+  // printf ("In VisitFullExpr(): built: expr = %p = %s
+  // \n",expr,expr->class_name().c_str());
+
+  *node = expr;
+
+  // TODO
+
+  return VisitExpr(full_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitConstantExpr(
+    clang::ConstantExpr *constant_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitConstantExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitFullExpr(constant_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitExprWithCleanups(
+    clang::ExprWithCleanups *expr_with_cleanups, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitExprWithCleanups" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitFullExpr(expr_with_cleanups, node) && res;
+}
+
+bool ClangToSageTranslator::VisitFunctionParmPackExpr(
+    clang::FunctionParmPackExpr *function_parm_pack_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitFunctionParmPackExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(function_parm_pack_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitGenericSelectionExpr(
+    clang::GenericSelectionExpr *generic_Selection_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitGenericSelectionExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(generic_Selection_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitGNUNullExpr(clang::GNUNullExpr *gnu_null_expr,
+                                             SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitGNUNullExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: GNUNullExpr is GNU's __null extension, which represents a
+  // null pointer constant It has type long (or long long on 64-bit) but behaves
+  // as a null pointer Create an integer literal with value 0, VisitExpr will
+  // handle the type
+  *node = SageBuilder::buildIntVal(0);
+
+  return VisitExpr(gnu_null_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitImaginaryLiteral(
+    clang::ImaginaryLiteral *imaginary_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitImaginaryLiteral" << std::endl;
+#endif
+
+  SgNode *tmp_imag_val = Traverse(imaginary_literal->getSubExpr());
+  SgValueExp *imag_val = isSgValueExp(tmp_imag_val);
+  ROSE_ASSERT(imag_val != NULL);
+
+  SgComplexVal *comp_val =
+      new SgComplexVal(NULL, imag_val, imag_val->get_type(), "");
+
+  *node = comp_val;
+
+  return VisitExpr(imaginary_literal, node);
+}
+
+bool ClangToSageTranslator::VisitImplicitValueInitExpr(
+    clang::ImplicitValueInitExpr *implicit_value_init_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitImplicitValueInitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(implicit_value_init_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitInitListExpr(
+    clang::InitListExpr *init_list_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitInitListExpr" << std::endl;
+#endif
+
+  // We use the syntactic version of the initializer if it exists
+  if (init_list_expr->getSyntacticForm() != NULL)
+    return VisitInitListExpr(init_list_expr->getSyntacticForm(), node);
+
+  SgExprListExp *expr_list_expr = SageBuilder::buildExprListExp_nfi();
+
+  clang::InitListExpr::iterator it;
+  for (it = init_list_expr->begin(); it != init_list_expr->end(); it++) {
+    SgNode *tmp_expr = Traverse(*it);
+    SgExpression *expr = isSgExpression(tmp_expr);
+    ROSE_ASSERT(expr != NULL);
+
+    // Pei-Hung (05/13/2022) the expr can another InitListExpr
+    SgExprListExp *child_expr_list_expr = isSgExprListExp(expr);
+    SgInitializer *init = NULL;
+    if (child_expr_list_expr != NULL) {
+      SgType *type = expr->get_type();
+      init = SageBuilder::buildAggregateInitializer(child_expr_list_expr, type);
+    }
+
+    if (init != NULL) {
+      applySourceRange(init, (*it)->getSourceRange());
+      expr_list_expr->append_expression(init);
+    } else
+      expr_list_expr->append_expression(expr);
+  }
+
+  *node = expr_list_expr;
+
+  return VisitExpr(init_list_expr, node);
+}
+
+bool ClangToSageTranslator::VisitIntegerLiteral(
+    clang::IntegerLiteral *integer_literal, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitIntegerLiteral" << std::endl;
+#endif
+
+  *node = SageBuilder::buildIntVal(integer_literal->getValue().getSExtValue());
+
+  return VisitExpr(integer_literal, node);
+}
+
+bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitLambdaExpr" << std::endl;
+#endif
+  bool res = true;
+
+  auto detach_declaration_from_scope =
+      [](SgDeclarationStatement *decl) -> SgScopeStatement * {
+    if (decl == NULL) {
+      return NULL;
+    }
+
+    SgScopeStatement *original_scope = decl->get_scope();
+
+    // Remove any symbol that was registered for this declaration in the
+    // enclosing scope.
+    if (SgSymbol *associated_symbol =
+            decl->search_for_symbol_from_symbol_table()) {
+      if (SgScopeStatement *symbol_scope = associated_symbol->get_scope()) {
+        symbol_scope->remove_symbol(associated_symbol);
+      }
+    }
+
+    if (original_scope != NULL) {
+      SageInterface::removeStatement(decl, false);
+      decl->set_parent(NULL);
+    }
+
+    return original_scope;
+  };
+
+  // Get the lambda class (closure type) from Clang
+  const clang::CXXRecordDecl *clang_lambda_class =
+      lambda_expr->getLambdaClass();
+
+  // Get the call operator (operator()) from Clang
+  const clang::CXXMethodDecl *clang_call_operator =
+      lambda_expr->getCallOperator();
+
+  // Convert Clang lambda class to ROSE class declaration
+  SgClassDeclaration *lambda_closure_class = NULL;
+  SgScopeStatement *lambda_closure_lexical_scope = NULL;
+  if (clang_lambda_class != NULL) {
+    SgNode *tmp_class =
+        Traverse(const_cast<clang::CXXRecordDecl *>(clang_lambda_class));
+    lambda_closure_class = isSgClassDeclaration(tmp_class);
+
+    // Remove from enclosing scope using SageInterface so symbols/scopes stay
+    // consistent
+    lambda_closure_lexical_scope =
+        detach_declaration_from_scope(lambda_closure_class);
+
+    // Preserve a valid scope so downstream lookups don't see NULL after
+    // detachment.
+    if (lambda_closure_class != NULL && lambda_closure_lexical_scope != NULL) {
+      lambda_closure_class->set_scope(lambda_closure_lexical_scope);
+      if (SgClassDefinition *class_def =
+              lambda_closure_class->get_definition()) {
+        class_def->set_scope(lambda_closure_lexical_scope);
+      }
+    }
+  }
+
+  // Convert Clang call operator to ROSE function declaration
+  SgFunctionDeclaration *lambda_function = NULL;
+  SgScopeStatement *lambda_function_scope = NULL;
+  if (clang_call_operator != NULL) {
+    SgNode *tmp_func =
+        Traverse(const_cast<clang::CXXMethodDecl *>(clang_call_operator));
+    lambda_function = isSgFunctionDeclaration(tmp_func);
+
+    lambda_function_scope = detach_declaration_from_scope(lambda_function);
+
+    // Restore the scope pointer for operator() so later queries succeed.
+    if (lambda_function != NULL) {
+      if (lambda_function_scope != NULL) {
+        lambda_function->set_scope(lambda_function_scope);
+      } else if (lambda_closure_class != NULL &&
+                 lambda_closure_class->get_definition() != NULL) {
+        lambda_function->set_scope(lambda_closure_class->get_definition());
+      }
+    }
+  }
+
+  SgLambdaCaptureList *lambda_capture_list =
+      SageBuilder::buildLambdaCaptureList();
+  unsigned total_captures = lambda_expr->capture_size();
+  unsigned capture_index = 0;
+  for (auto capture_it = lambda_expr->capture_begin();
+       capture_it != lambda_expr->capture_end();
+       ++capture_it, ++capture_index) {
+    const clang::LambdaCapture &capture = *capture_it;
+    SgExpression *capture_expression = NULL;
+    bool handled_capture = false;
+
+    if (capture.capturesThis()) {
+      SgSymbol *this_symbol =
+          findEnclosingThisSymbol(SageBuilder::topScopeStack());
+      ROSE_ASSERT(this_symbol != NULL);
+      capture_expression = SageBuilder::buildThisExp_nfi(this_symbol);
+      handled_capture = true;
+    } else if (capture.capturesVariable()) {
+      clang::ValueDecl *captured_val = capture.getCapturedVar();
+      clang::VarDecl *captured_var =
+          llvm::dyn_cast_or_null<clang::VarDecl>(captured_val);
+      if (captured_var != NULL) {
+        // Look up the existing symbol instead of traversing again (avoids
+        // duplicate decls)
+        SgSymbol *captured_symbol = GetSymbolFromSymbolTable(captured_var);
+        if (captured_symbol == NULL) {
+          clang::VarDecl *canonical_decl = captured_var->getCanonicalDecl();
+          if (canonical_decl != captured_var) {
+            captured_symbol = GetSymbolFromSymbolTable(canonical_decl);
+          }
+        }
+
+        if (SgVariableSymbol *var_symbol =
+                isSgVariableSymbol(captured_symbol)) {
+          capture_expression = SageBuilder::buildVarRefExp(var_symbol);
+          handled_capture = true;
+        } else if (captured_var->isInitCapture()) {
+          // Create a dangling var ref for init-captures (symbol not in current
+          // scope yet)
+          SgName capture_name(captured_var->getNameAsString());
+          capture_expression = SageBuilder::buildDanglingVarRefExp(
+              capture_name, SageBuilder::topScopeStack());
+          handled_capture = true;
+        }
+      }
+    } else if (capture.capturesVLAType()) {
+      // VLA captures are represented on the closure type; nothing to emit in
+      // capture list.
+      continue;
+    }
+
+    if (!handled_capture || capture_expression == NULL) {
+      continue;
+    }
+
+    bool is_init_capture = lambda_expr->isInitCapture(&capture);
+    clang::LambdaCaptureKind capture_kind = capture.getCaptureKind();
+    bool capture_by_reference =
+        (capture_kind == clang::LCK_ByRef || capture_kind == clang::LCK_This);
+
+    SgLambdaCapture *sg_capture =
+        SageBuilder::buildLambdaCapture(capture_expression, NULL, NULL);
+    sg_capture->set_capture_by_reference(capture_by_reference);
+    sg_capture->set_implicit(capture.isImplicit());
+    sg_capture->set_pack_expansion(capture.isPackExpansion());
+    if (is_init_capture && capture_index < total_captures) {
+      clang::Expr *clang_init_expr =
+          lambda_expr->capture_init_begin()[capture_index];
+      if (clang_init_expr != NULL) {
+        SgNode *init_node = Traverse(clang_init_expr);
+        if (SgExpression *init_expr = isSgExpression(init_node)) {
+          sg_capture->set_source_closure_variable(init_expr);
+          init_expr->set_parent(sg_capture);
+        }
+      }
+    }
+
+    lambda_capture_list->get_capture_list().push_back(sg_capture);
+    sg_capture->set_parent(lambda_capture_list);
+  }
+
+  SgLambdaExp *built_lambda = SageBuilder::buildLambdaExp(
+      lambda_capture_list, lambda_closure_class, lambda_function);
+  ROSE_ASSERT(built_lambda != NULL);
+
+  clang::LambdaCaptureDefault capture_default =
+      lambda_expr->getCaptureDefault();
+  bool has_default_capture = (capture_default != clang::LCD_None);
+  built_lambda->set_capture_default(has_default_capture);
+  built_lambda->set_default_is_by_reference(capture_default ==
+                                            clang::LCD_ByRef);
+
+  *node = built_lambda;
+
+  return VisitExpr(lambda_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitMaterializeTemporaryExpr(
+    clang::MaterializeTemporaryExpr *materialize_temporary_expr,
+    SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitMaterializeTemporaryExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // MaterializeTemporaryExpr creates a temporary object from a prvalue
+  // For now, just traverse the temporary expression itself
+  // The temporary materialization is implicit in C++ and doesn't need explicit
+  // AST representation in ROSE
+  *node = Traverse(materialize_temporary_expr->getSubExpr());
+
+  return VisitExpr(materialize_temporary_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitMemberExpr" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgNode *tmp_base = Traverse(member_expr->getBase());
+  SgExpression *base = isSgExpression(tmp_base);
+  if (base == NULL) {
+    // std::cerr << "DEBUG: VisitMemberExpr base is NULL! Base stmt class: " <<
+    // member_expr->getBase()->getStmtClassName() << std::endl;
+  } else {
+    // std::cerr << "DEBUG: VisitMemberExpr base type: " << base->class_name()
+    // << std::endl;
+  }
+  ROSE_ASSERT(base != NULL);
+
+  SgSymbol *sym = GetSymbolFromSymbolTable(member_expr->getMemberDecl());
+
+  SgVariableSymbol *var_sym = isSgVariableSymbol(sym);
+  SgMemberFunctionSymbol *func_sym = isSgMemberFunctionSymbol(sym);
+  SgFunctionSymbol *plain_func_sym =
+      isSgFunctionSymbol(sym); // Regular function symbol (not member)
+  SgClassSymbol *class_sym = isSgClassSymbol(sym);
+
+  SgExpression *sg_member_expr = NULL;
+
+  bool successful_cast = var_sym || func_sym || plain_func_sym || class_sym;
+  if (sym != NULL && !successful_cast) {
+    std::cerr << "Runtime error: Unknown type of symbol for a member reference."
+              << std::endl;
+    std::cerr << "    sym->class_name() = " << sym->class_name() << std::endl;
+    res = false;
+  } else if (var_sym != NULL) {
+    sg_member_expr = SageBuilder::buildVarRefExp(var_sym);
+  } else if (func_sym != NULL) { // C++ member function
+    sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
+        func_sym, false, false);       // FIXME 2nd and 3rd params ?
+  } else if (plain_func_sym != NULL) { // Regular function treated as member
+                                       // (e.g., static member or inherited)
+    sg_member_expr = SageBuilder::buildFunctionRefExp(plain_func_sym);
+  } else if (class_sym != NULL) {
+    SgClassDeclaration *classDecl = class_sym->get_declaration();
+    SgClassDeclaration *classDefDecl =
+        isSgClassDeclaration(classDecl->get_definition());
+    SgType *classType = classDecl->get_type();
+    //        if(classDecl->get_isUnNamed())
+    {
+      SgName varName(generate_name_for_variable(member_expr));
+      std::cerr << "build varName:" << varName << std::endl;
+      SgVariableDeclaration *var_decl = SageBuilder::buildVariableDeclaration(
+          varName, classType, NULL, SageBuilder::topScopeStack());
+      var_decl->set_baseTypeDefiningDeclaration(classDefDecl);
+      var_decl->set_variableDeclarationContainsBaseTypeDefiningDeclaration(
+          true);
+      var_decl->set_parent(SageBuilder::topScopeStack());
+
+      sg_member_expr = SageBuilder::buildVarRefExp(var_decl);
+    }
+  } else if (sym == NULL) {
+    // Symbol not found - check if member declaration has already been traversed
+    // to avoid infinite recursion during template member access
+    SgNode *tmp_member = NULL;
+    clang::ValueDecl *member_decl = member_expr->getMemberDecl();
+
+    // First check if already in translation map
+    if (llvm::isa<clang::Decl>(member_decl)) {
+      std::map<clang::Decl *, SgNode *>::iterator it_decl =
+          p_decl_translation_map.find((clang::Decl *)member_decl);
+      if (it_decl != p_decl_translation_map.end()) {
+        tmp_member = it_decl->second;
+      }
+    }
+
+    // If not in map, traverse it (but this might fail for template members)
+    if (tmp_member == NULL) {
+      tmp_member = Traverse(member_decl);
+    }
+
+#if DEBUG_VISIT_STMT
+    if (tmp_member != NULL) {
+      // std::cerr << "DEBUG VisitMemberExpr: Got/traversed member, node type: "
+      // << tmp_member->class_name() << std::endl;
+    } else {
+      // std::cerr << "DEBUG VisitMemberExpr: Member not available (NULL)" <<
+      // std::endl;
+    }
+#endif
+    if (tmp_member != NULL) {
+      // CLANG FRONTEND FIX: Extract symbol from the traversed member
+      // declaration.
+      //
+      // WHY: After successfully traversing the member's declaration above, we
+      // need to get its symbol. However, calling GetSymbolFromSymbolTable again
+      // here would create infinite recursion when template members reference
+      // each other.
+      //
+      // SOLUTION: Set sym=NULL to skip the GetSymbolFromSymbolTable call below
+      // (around line 4290), and instead extract the symbol directly from the
+      // already-constructed SAGE node (tmp_member).
+      //
+      // This breaks the cycle: GetSymbolFromSymbolTable → VisitMemberExpr →
+      // Traverse(member) → GetSymbolFromSymbolTable (AVOIDED by sym=NULL)
+      //
+      sym = NULL; // Skip GetSymbolFromSymbolTable below; extract from
+                  // tmp_member instead
+
+      // Extract symbol directly from the traversed node
+      if (isSgVariableDeclaration(tmp_member)) {
+        SgInitializedName *init_name = SageInterface::getFirstInitializedName(
+            isSgVariableDeclaration(tmp_member));
+        if (init_name) {
+          sym = init_name->search_for_symbol_from_symbol_table();
+        }
+      } else if (isSgFunctionDeclaration(tmp_member)) {
+        SgFunctionDeclaration *func_decl = isSgFunctionDeclaration(tmp_member);
+        SgScopeStatement *decl_scope = func_decl->get_scope();
+        if (decl_scope) {
+          // Use type-aware lookup to handle overloaded functions correctly
+          SgFunctionType *func_type = func_decl->get_type();
+          sym = decl_scope->lookup_function_symbol(func_decl->get_name(),
+                                                   func_type);
+        }
+      }
+      if (isSgVariableSymbol(sym)) {
+        sg_member_expr = SageBuilder::buildVarRefExp(isSgVariableSymbol(sym));
+      } else if (isSgMemberFunctionSymbol(sym)) {
+        sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
+            isSgMemberFunctionSymbol(sym), false, false);
+      } else if (isSgFunctionSymbol(sym)) {
+        // ROOT CAUSE FIX: Handle plain SgFunctionSymbol (not member function
+        // symbol) This happens when VisitFunctionDecl creates a regular
+        // function declaration
+        sg_member_expr =
+            SageBuilder::buildFunctionRefExp(isSgFunctionSymbol(sym));
+      } else if (isSgInitializedName(tmp_member)) {
+        // Create a temporary symbol if we got an initialized name
+        SgVariableSymbol *temp_sym =
+            new SgVariableSymbol(isSgInitializedName(tmp_member));
+        sg_member_expr = SageBuilder::buildVarRefExp(temp_sym);
+      }
+      // ROOT CAUSE FIX: Handle SgMemberFunctionDeclaration from
+      // VisitCXXMethodDecl
+      else if (sym == NULL &&
+               isSgMemberFunctionDeclaration(tmp_member) != NULL) {
+        SgMemberFunctionDeclaration *member_func_decl =
+            isSgMemberFunctionDeclaration(tmp_member);
+        // Try to find existing symbol in the class scope
+        SgScopeStatement *decl_scope = member_func_decl->get_scope();
+        if (decl_scope != NULL) {
+          // Use type-aware lookup to handle overloaded member functions
+          // correctly
+          SgFunctionType *func_type = member_func_decl->get_type();
+          sym = decl_scope->lookup_function_symbol(member_func_decl->get_name(),
+                                                   func_type);
+        }
+        // If still not found, create new member function symbol
+        if (sym == NULL) {
+          SgMemberFunctionSymbol *new_func_sym =
+              new SgMemberFunctionSymbol(member_func_decl);
+          new_func_sym->set_parent(member_func_decl);
+          if (decl_scope != NULL) {
+            decl_scope->insert_symbol(member_func_decl->get_name(),
+                                      new_func_sym);
+          }
+          sym = new_func_sym;
+        }
+        if (isSgMemberFunctionSymbol(sym)) {
+          sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
+              isSgMemberFunctionSymbol(sym), false, false);
+        }
+      }
+      // Also handle regular function declarations that might be static members
+      else if (sym == NULL && isSgFunctionDeclaration(tmp_member) != NULL) {
+        SgFunctionDeclaration *func_decl = isSgFunctionDeclaration(tmp_member);
+        // Try to find existing symbol
+        SgScopeStatement *decl_scope = func_decl->get_scope();
+        if (decl_scope != NULL) {
+          // Use type-aware lookup to handle overloaded functions correctly
+          SgFunctionType *func_type = func_decl->get_type();
+          sym = decl_scope->lookup_function_symbol(func_decl->get_name(),
+                                                   func_type);
+        }
+        // If not found, create new function symbol
+        if (sym == NULL) {
+          SgFunctionSymbol *new_func_sym = new SgFunctionSymbol(func_decl);
+          new_func_sym->set_parent(func_decl);
+          if (decl_scope != NULL) {
+            decl_scope->insert_symbol(func_decl->get_name(), new_func_sym);
+          }
+          sym = new_func_sym;
+        }
+        if (isSgMemberFunctionSymbol(sym)) {
+          sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
+              isSgMemberFunctionSymbol(sym), false, false);
+        } else if (isSgFunctionSymbol(sym)) {
+          sg_member_expr =
+              SageBuilder::buildFunctionRefExp(isSgFunctionSymbol(sym));
+        }
+      }
+    }
+
+    // If still NULL, create a placeholder
+    if (sg_member_expr == NULL) {
+      std::string member_name = member_expr->getMemberNameInfo().getAsString();
+      clang::ValueDecl *member_decl = member_expr->getMemberDecl();
+      if (member_decl) {
+        std::cerr << "Warning: Cannot resolve "
+                  << member_decl->getDeclKindName() << " member '"
+                  << member_name << "'";
+        if (tmp_member != NULL) {
+          std::cerr << " (traversed to " << tmp_member->class_name() << ")";
+        } else {
+          std::cerr << " (traverse returned NULL)";
+        }
+        std::cerr << ", using placeholder" << std::endl;
+      } else {
+        std::cerr << "Warning: Cannot resolve member '" << member_name
+                  << "', using placeholder" << std::endl;
+      }
+      sg_member_expr = SageBuilder::buildDanglingVarRefExp(
+          SgName(member_name), SageBuilder::topScopeStack());
+    }
+  }
+
+  ROSE_ASSERT(sg_member_expr != NULL);
+
+  // TODO (C++) member_expr->getQualifier() : for 'a->Base::foo'
+
+  if (member_expr->isArrow())
+    *node = SageBuilder::buildArrowExp(base, sg_member_expr);
+  else
+    *node = SageBuilder::buildDotExp(base, sg_member_expr);
+
+  return VisitExpr(member_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitMSPropertyRefExpr(
+    clang::MSPropertyRefExpr *ms_property_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitMSPropertyRefExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(ms_property_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitMSPropertySubscriptExpr(
+    clang::MSPropertySubscriptExpr *ms_property_subscript_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitMSPropertySubscriptExpr"
+            << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(ms_property_subscript_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitNoInitExpr(clang::NoInitExpr *no_init_expr,
+                                            SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitNoInitExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(no_init_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitOffsetOfExpr(
+    clang::OffsetOfExpr *offset_of_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitOffsetOfExpr" << std::endl;
+#endif
+  bool res = true;
+
+  SgNodePtrList nodePtrList;
+
+  SgType *type = buildTypeFromQualifiedType(
+      offset_of_expr->getTypeSourceInfo()->getType());
+
+  nodePtrList.push_back(type);
+
+  SgExpression *topExp = nullptr;
+
+  for (unsigned i = 0, n = offset_of_expr->getNumComponents(); i < n; ++i) {
+    clang::OffsetOfNode ON = offset_of_expr->getComponent(i);
+
+    switch (ON.getKind()) {
+    case clang::OffsetOfNode::Array: {
+      // Array node
+      SgExpression *arrayIdx = isSgExpression(
+          Traverse(offset_of_expr->getIndexExpr(ON.getArrayExprIndex())));
+      SgPntrArrRefExp *pntrArrRefExp =
+          SageBuilder::buildPntrArrRefExp(topExp, arrayIdx);
+      topExp = isSgExpression(pntrArrRefExp);
+      break;
+    }
+    case clang::OffsetOfNode::Field: {
+      // OffsetOfNode still uses getField(), not getFieldDecl()
+      SgNode *fieldNode = Traverse(ON.getField());
+      SgName fieldName(ON.getFieldName()->getName().str());
+      SgVarRefExp *varExp = SageBuilder::buildDanglingVarRefExp(
+          fieldName, SageBuilder::topScopeStack());
+      if (topExp == nullptr) {
+        topExp = isSgExpression(varExp);
+      } else {
+        SgDotExp *dotExp = SageBuilder::buildDotExp(topExp, varExp);
+        topExp = isSgExpression(dotExp);
+      }
+      break;
+    }
+    // TODO
+    case clang::OffsetOfNode::Identifier: {
+      SgName fieldName(ON.getFieldName()->getName().str());
+      SgVarRefExp *varExp = SageBuilder::buildDanglingVarRefExp(
+          fieldName, SageBuilder::topScopeStack());
+      break;
+    }
+    // TODO
+    case clang::OffsetOfNode::Base:
+      break;
+    }
+  }
+  nodePtrList.push_back(topExp);
+
+  SgTypeTraitBuiltinOperator *typeTraitBuiltinOperator =
+      SageBuilder::buildTypeTraitBuiltinOperator("__builtin_offsetof",
+                                                 nodePtrList);
+
+  *node = typeTraitBuiltinOperator;
+
+  return VisitExpr(offset_of_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitOMPArraySectionExpr(
+    clang::ArraySectionExpr *omp_array_section_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitOMPArraySectionExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(omp_array_section_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitOpaqueValueExpr(
+    clang::OpaqueValueExpr *opaque_value_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitOpaqueValueExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: OpaqueValueExpr is a Clang internal node representing a
+  // value that appears multiple times in the AST but should only be evaluated
+  // once. It's used for desugaring constructs like the conditional operator and
+  // range-based for. We just traverse the source expression and return it.
+
+  clang::Expr *source_expr = opaque_value_expr->getSourceExpr();
+  if (source_expr) {
+    *node = Traverse(source_expr);
+  } else {
+    // No source expression - OpaqueValueExpr is used as a placeholder
+    // Create a null expression placeholder for ROSE
+    // This happens in range-based for loops and other desugared constructs
+    *node = SageBuilder::buildNullExpression();
+  }
+
+  return VisitExpr(opaque_value_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitOverloadExpr(
+    clang::OverloadExpr *overload_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitOverloadExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // TODO
+
+  return VisitExpr(overload_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitUnresolvedLookupExpr(
+    clang::UnresolvedLookupExpr *unresolved_lookup_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitUnresolvedLookupExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // UnresolvedLookupExpr represents a reference to a name that couldn't be
+  // resolved during parsing (e.g., template-dependent function names like
+  // std::iota) Extract the name and create a variable reference expression as
+  // an approximation
+
+  std::string function_name;
+  if (unresolved_lookup_expr->hasExplicitTemplateArgs()) {
+    // Template function with explicit template arguments
+    function_name = unresolved_lookup_expr->getName().getAsString();
+  } else {
+    // Regular function name
+    function_name = unresolved_lookup_expr->getName().getAsString();
+  }
+
+  // Check for qualified names (e.g., std::iota)
+  if (unresolved_lookup_expr->getQualifier() != NULL) {
+    std::string qualifier_str;
+    llvm::raw_string_ostream qualifier_stream(qualifier_str);
+    unresolved_lookup_expr->getQualifier()->print(
+        qualifier_stream, clang::PrintingPolicy(clang::LangOptions()));
+    function_name = qualifier_stream.str() + function_name;
+  }
+
+  // Create a variable reference expression with the function name
+  // This will unparse as the function name, which is what we want
+  SgName sg_name(function_name);
+  *node = SageBuilder::buildDanglingVarRefExp(sg_name,
+                                              SageBuilder::topScopeStack());
+
+  // Set source position
+  SgExpression *expr = isSgExpression(*node);
+  if (expr != NULL) {
+    applySourceRange(expr, unresolved_lookup_expr->getSourceRange());
+  }
+
+  return VisitOverloadExpr(unresolved_lookup_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitUnresolvedMemberExpr(
+    clang::UnresolvedMemberExpr *unresolved_member_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitUnresolvedMemberExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: UnresolvedMemberExpr represents a member access expression
+  // where the member couldn't be resolved at parse time (typically in
+  // template-dependent code) Example: template<typename T> void foo(T t) {
+  // t.bar(); }  // 'bar' is unresolved
+
+  // Get the member name
+  std::string member_name =
+      unresolved_member_expr->getMemberName().getAsString();
+
+  // Determine a scope we can safely use for placeholder expressions
+  SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+  if (current_scope == NULL) {
+    current_scope = getGlobalScope();
+  }
+
+  // Handle the base expression (the object/pointer being accessed)
+  SgExpression *base_expr = NULL;
+  if (!unresolved_member_expr->isImplicitAccess()) {
+    if (clang::Expr *base = unresolved_member_expr->getBase()) {
+      SgNode *tmp_base = Traverse(base);
+      base_expr = isSgExpression(tmp_base);
+    }
+  }
+
+  // If no base (implicit 'this' access or translation failure), build a
+  // placeholder
+  if (base_expr == NULL) {
+    base_expr = SageBuilder::buildOpaqueVarRefExp("this", current_scope);
+    if (SgLocatedNode *located_base = isSgLocatedNode(base_expr)) {
+      located_base->get_file_info()->setCompilerGenerated();
+    }
+  }
+
+  // Create a placeholder expression for the member name without requiring a
+  // resolved symbol
+  SgVarRefExp *member_ref =
+      SageBuilder::buildOpaqueVarRefExp(member_name, current_scope);
+  if (member_ref != NULL) {
+    member_ref->get_file_info()->setCompilerGenerated();
+  }
+
+  // Determine if it's arrow (->) or dot (.) access
+  if (unresolved_member_expr->isArrow()) {
+    *node = SageBuilder::buildArrowExp(base_expr, member_ref);
+  } else {
+    *node = SageBuilder::buildDotExp(base_expr, member_ref);
+  }
+
+  if (SgExpression *expr = isSgExpression(*node)) {
+    applySourceRange(expr, unresolved_member_expr->getSourceRange());
+  }
+
+  return VisitOverloadExpr(unresolved_member_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitPackExpansionExpr(
+    clang::PackExpansionExpr *pack_expansion_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitPackExpansionExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: Pack expansion expressions (e.g., f(args...) where args is
+  // a pack) Traverse the pattern expression (the expression before the ...)
+  clang::Expr *pattern = pack_expansion_expr->getPattern();
+  if (pattern != NULL) {
+    SgNode *tmp_node = Traverse(pattern);
+    SgExpression *pattern_expr = isSgExpression(tmp_node);
+    if (pattern_expr != NULL) {
+      *node = pattern_expr;
+      return VisitExpr(pack_expansion_expr, node) && res;
+    }
+  }
+
+  // Fallback if pattern can't be traversed
+  *node = SageBuilder::buildNullExpression();
+
+  return VisitExpr(pack_expansion_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitParenExpr(clang::ParenExpr *paren_expr,
+                                           SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitParenExpr" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgNode *tmp_subexpr = Traverse(paren_expr->getSubExpr());
+  SgExpression *subexpr = isSgExpression(tmp_subexpr);
+  if (tmp_subexpr != NULL && subexpr == NULL) {
+    std::cerr << "Runtime error: tmp_subexpr != NULL && subexpr == NULL"
+              << std::endl;
+    res = false;
+  }
+
+  // bypass ParenExpr, their is nothing equivalent in SageIII
+  *node = subexpr;
+
+  return VisitExpr(paren_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitParenListExpr(
+    clang::ParenListExpr *paran_list_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitParenListExpr" << std::endl;
+#endif
+  bool res = true;
+
+  // ROOT CAUSE FIX: ParenListExpr represents a parenthesized list of
+  // expressions like in aggregate initialization: Point p(1, 2); Build an
+  // expression list to represent the paren list
+
+  unsigned num_exprs = paran_list_expr->getNumExprs();
+
+  if (num_exprs == 1) {
+    // Single expression - just unwrap the parentheses and return the expression
+    // directly
+    *node = Traverse(paran_list_expr->getExpr(0));
+  } else {
+    // Multiple expressions - build an ExprListExp
+    SgExprListExp *expr_list = SageBuilder::buildExprListExp();
+    for (unsigned i = 0; i < num_exprs; i++) {
+      SgNode *tmp_expr = Traverse(paran_list_expr->getExpr(i));
+      SgExpression *expr = isSgExpression(tmp_expr);
+      if (expr != NULL) {
+        expr_list->append_expression(expr);
+      } else if (tmp_expr != NULL) {
+        std::cerr << "Warning: ParenListExpr element " << i
+                  << " is not an expression" << std::endl;
+        res = false;
+      }
+    }
+    *node = expr_list;
+  }
+
+  return VisitExpr(paran_list_expr, node) && res;
+}
+
+bool ClangToSageTranslator::VisitPredefinedExpr(
+    clang::PredefinedExpr *predefined_expr, SgNode **node) {
+#if DEBUG_VISIT_STMT
+  std::cerr << "ClangToSageTranslator::VisitPredefinedExpr" << std::endl;
+#endif
+
+  // FIXME It's get tricky here: PredefinedExpr represent compiler generateed
+  // variables
+  //    I choose to attach those variables on demand in the function definition
+  //    scope
 
   // Traverse the scope's stack to find the last function definition:
 
-    SgFunctionDefinition * func_def = NULL;
-    std::list<SgScopeStatement *>::reverse_iterator it = SageBuilder::ScopeStack.rbegin();
-    while (it != SageBuilder::ScopeStack.rend() && func_def == NULL) {
-        func_def = isSgFunctionDefinition(*it);
-        it++;
-    }
-    ROSE_ASSERT(func_def != NULL);
+  SgFunctionDefinition *func_def = NULL;
+  std::list<SgScopeStatement *>::reverse_iterator it =
+      SageBuilder::ScopeStack.rbegin();
+  while (it != SageBuilder::ScopeStack.rend() && func_def == NULL) {
+    func_def = isSgFunctionDefinition(*it);
+    it++;
+  }
+  ROSE_ASSERT(func_def != NULL);
 
   // Determine the name of the variable
 
-    SgName name;
+  SgName name;
 
- // (01/29/2020) Pei-Hung: change to getIndentKind.  And this list is incomplete for Clang 9
-    // In LLVM 20, enum is PredefinedIdentKind with values Func, Function, etc.
-    switch (predefined_expr->getIdentKind()) {
-        case clang::PredefinedIdentKind::Func:
-        case clang::PredefinedIdentKind::FuncDName:
-        case clang::PredefinedIdentKind::FuncSig:
-        case clang::PredefinedIdentKind::LFuncSig:
-            name = "__func__";
-            break;
-        case clang::PredefinedIdentKind::Function:
-        case clang::PredefinedIdentKind::LFunction:
-            name = "__FUNCTION__";
-            break;
-        case clang::PredefinedIdentKind::PrettyFunction:
-        case clang::PredefinedIdentKind::PrettyFunctionNoVirtual:
-            name = "__PRETTY_FUNCTION__";
-            break;
-        default:
-            name = "__func__";
-            break;
-    }
+  // (01/29/2020) Pei-Hung: change to getIndentKind.  And this list is
+  // incomplete for Clang 9 In LLVM 20, enum is PredefinedIdentKind with values
+  // Func, Function, etc.
+  switch (predefined_expr->getIdentKind()) {
+  case clang::PredefinedIdentKind::Func:
+  case clang::PredefinedIdentKind::FuncDName:
+  case clang::PredefinedIdentKind::FuncSig:
+  case clang::PredefinedIdentKind::LFuncSig:
+    name = "__func__";
+    break;
+  case clang::PredefinedIdentKind::Function:
+  case clang::PredefinedIdentKind::LFunction:
+    name = "__FUNCTION__";
+    break;
+  case clang::PredefinedIdentKind::PrettyFunction:
+  case clang::PredefinedIdentKind::PrettyFunctionNoVirtual:
+    name = "__PRETTY_FUNCTION__";
+    break;
+  default:
+    name = "__func__";
+    break;
+  }
 
   // Retrieve the associate symbol if it exists
 
-    SgVariableSymbol * symbol = func_def->lookup_variable_symbol(name);
+  SgVariableSymbol *symbol = func_def->lookup_variable_symbol(name);
 
-  // Else, build a compiler generated initialized name for this variable in the function defintion scope.
+  // Else, build a compiler generated initialized name for this variable in the
+  // function defintion scope.
 
-    if (symbol == NULL) {
-        SgInitializedName * init_name = SageBuilder::buildInitializedName_nfi(name, SageBuilder::buildPointerType(SageBuilder::buildCharType()), NULL);
+  if (symbol == NULL) {
+    SgInitializedName *init_name = SageBuilder::buildInitializedName_nfi(
+        name, SageBuilder::buildPointerType(SageBuilder::buildCharType()),
+        NULL);
 
-        init_name->set_parent(func_def);
-        init_name->set_scope(func_def);
+    init_name->set_parent(func_def);
+    init_name->set_scope(func_def);
 
-        Sg_File_Info * start_fi = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-        start_fi->setCompilerGenerated();
-        init_name->set_startOfConstruct(start_fi);
+    Sg_File_Info *start_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    start_fi->setCompilerGenerated();
+    init_name->set_startOfConstruct(start_fi);
 
-        Sg_File_Info * end_fi   = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-        end_fi->setCompilerGenerated();
-        init_name->set_endOfConstruct(end_fi);
+    Sg_File_Info *end_fi =
+        Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+    end_fi->setCompilerGenerated();
+    init_name->set_endOfConstruct(end_fi);
 
-        symbol = new SgVariableSymbol(init_name);
+    symbol = new SgVariableSymbol(init_name);
 
-        func_def->insert_symbol(name, symbol);
-    }
-    ROSE_ASSERT(symbol != NULL);
+    func_def->insert_symbol(name, symbol);
+  }
+  ROSE_ASSERT(symbol != NULL);
 
   // Finally build the variable reference
 
-    *node = SageBuilder::buildVarRefExp_nfi(symbol);
+  *node = SageBuilder::buildVarRefExp_nfi(symbol);
 
-    return VisitExpr(predefined_expr, node);
+  return VisitExpr(predefined_expr, node);
 }
 
-bool ClangToSageTranslator::VisitPseudoObjectExpr(clang::PseudoObjectExpr * pseudo_object_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitPseudoObjectExpr(
+    clang::PseudoObjectExpr *pseudo_object_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitPseudoObjectExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitPseudoObjectExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(pseudo_object_expr, node) && res;
+  return VisitExpr(pseudo_object_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitShuffleVectorExpr(clang::ShuffleVectorExpr * shuffle_vector_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitShuffleVectorExpr(
+    clang::ShuffleVectorExpr *shuffle_vector_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitShuffleVectorExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitShuffleVectorExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(shuffle_vector_expr, node) && res;
+  return VisitExpr(shuffle_vector_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSizeOfPackExpr(clang::SizeOfPackExpr * size_of_pack_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSizeOfPackExpr(
+    clang::SizeOfPackExpr *size_of_pack_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSizeOfPackExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSizeOfPackExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: sizeof...(Args) returns the compile-time count of pack elements
-    // However, for template-dependent packs, the size isn't known until instantiation
+  // ROOT CAUSE FIX: sizeof...(Args) returns the compile-time count of pack
+  // elements However, for template-dependent packs, the size isn't known until
+  // instantiation
 
-    if (!size_of_pack_expr->isValueDependent()) {
-        // Non-dependent: get the pack length and create an integer literal
-        unsigned pack_length = size_of_pack_expr->getPackLength();
-        *node = SageBuilder::buildUnsignedIntVal(pack_length);
-    } else {
-        // Value-dependent: create an opaque expression placeholder
-        // The actual size will be determined at template instantiation time
-        *node = SageBuilder::buildOpaqueVarRefExp("__sizeof_pack_dependent", getGlobalScope());
-    }
+  if (!size_of_pack_expr->isValueDependent()) {
+    // Non-dependent: get the pack length and create an integer literal
+    unsigned pack_length = size_of_pack_expr->getPackLength();
+    *node = SageBuilder::buildUnsignedIntVal(pack_length);
+  } else {
+    // Value-dependent: create an opaque expression placeholder
+    // The actual size will be determined at template instantiation time
+    *node = SageBuilder::buildOpaqueVarRefExp("__sizeof_pack_dependent",
+                                              getGlobalScope());
+  }
 
-    return VisitExpr(size_of_pack_expr, node) && res;
+  return VisitExpr(size_of_pack_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSourceLocExpr(clang::SourceLocExpr * source_loc_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSourceLocExpr(
+    clang::SourceLocExpr *source_loc_expr, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSourceLocExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSourceLocExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // CLANG FRONTEND FIX: SourceLocExpr represents __builtin_FILE(), __builtin_LINE(),
-    // __builtin_FUNCTION(), __builtin_COLUMN() - compiler builtins that return
-    // source location information at runtime.
-    //
-    // We must preserve correct types:
-    // - __builtin_FILE(), __builtin_FUNCTION(), __builtin_FileName(), __builtin_FuncSig()
-    //   return const char* → SgStringVal
-    // - __builtin_LINE() and __builtin_COLUMN() return unsigned int → SgIntVal
-    //
-    // Current implementation returns placeholder values (empty string "" or 0) since
-    // extracting actual source location info requires SourceManager integration.
+  // CLANG FRONTEND FIX: SourceLocExpr represents __builtin_FILE(),
+  // __builtin_LINE(),
+  // __builtin_FUNCTION(), __builtin_COLUMN() - compiler builtins that return
+  // source location information at runtime.
+  //
+  // We must preserve correct types:
+  // - __builtin_FILE(), __builtin_FUNCTION(), __builtin_FileName(),
+  // __builtin_FuncSig()
+  //   return const char* → SgStringVal
+  // - __builtin_LINE() and __builtin_COLUMN() return unsigned int → SgIntVal
+  //
+  // Current implementation returns placeholder values (empty string "" or 0)
+  // since extracting actual source location info requires SourceManager
+  // integration.
 
-    clang::SourceLocIdentKind kind = source_loc_expr->getIdentKind();
+  clang::SourceLocIdentKind kind = source_loc_expr->getIdentKind();
 
-    switch (kind) {
-        case clang::SourceLocIdentKind::File:
-        case clang::SourceLocIdentKind::FileName:
-        case clang::SourceLocIdentKind::Function:
-        case clang::SourceLocIdentKind::FuncSig:
-            // String-typed builtins: return empty string to preserve type correctness
-            // This allows code like `const char *f = __builtin_FILE();` to unparse correctly
-            *node = SageBuilder::buildStringVal("");
-            break;
+  switch (kind) {
+  case clang::SourceLocIdentKind::File:
+  case clang::SourceLocIdentKind::FileName:
+  case clang::SourceLocIdentKind::Function:
+  case clang::SourceLocIdentKind::FuncSig:
+    // String-typed builtins: return empty string to preserve type correctness
+    // This allows code like `const char *f = __builtin_FILE();` to unparse
+    // correctly
+    *node = SageBuilder::buildStringVal("");
+    break;
 
-        case clang::SourceLocIdentKind::Line:
-        case clang::SourceLocIdentKind::Column:
-            // Integer-typed builtins: return 0 as placeholder
-            *node = SageBuilder::buildIntVal(0);
-            break;
+  case clang::SourceLocIdentKind::Line:
+  case clang::SourceLocIdentKind::Column:
+    // Integer-typed builtins: return 0 as placeholder
+    *node = SageBuilder::buildIntVal(0);
+    break;
 
-        default:
-            // Unknown builtin kind (e.g., SourceLocStruct): default to integer 0
-            *node = SageBuilder::buildIntVal(0);
-            break;
-    }
+  default:
+    // Unknown builtin kind (e.g., SourceLocStruct): default to integer 0
+    *node = SageBuilder::buildIntVal(0);
+    break;
+  }
 
-    return VisitExpr(source_loc_expr, node) && res;
+  return VisitExpr(source_loc_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitStmtExpr(clang::StmtExpr * stmt_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitStmtExpr(clang::StmtExpr *stmt_expr,
+                                          SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitStmtExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitStmtExpr" << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
-    SgNode * tmp_substmt = Traverse(stmt_expr->getSubStmt());
-    SgStatement * substmt = isSgStatement(tmp_substmt);
-    if (tmp_substmt != NULL && substmt == NULL) {
-        std::cerr << "Runtime error: tmp_substmt != NULL && substmt == NULL" << std::endl;
-        res = false;
-    }
+  SgNode *tmp_substmt = Traverse(stmt_expr->getSubStmt());
+  SgStatement *substmt = isSgStatement(tmp_substmt);
+  if (tmp_substmt != NULL && substmt == NULL) {
+    std::cerr << "Runtime error: tmp_substmt != NULL && substmt == NULL"
+              << std::endl;
+    res = false;
+  }
 
-    *node = new SgStatementExpression(substmt);
+  *node = new SgStatementExpression(substmt);
 
-    return VisitExpr(stmt_expr, node) && res;
+  return VisitExpr(stmt_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitStringLiteral(clang::StringLiteral * string_literal, SgNode ** node) {
+bool ClangToSageTranslator::VisitStringLiteral(
+    clang::StringLiteral *string_literal, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitStringLiteral" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitStringLiteral" << std::endl;
 #endif
 
-    // ROOT CAUSE FIX: Check character byte width to handle wide/unicode string literals
-    // getString() only works for regular char strings (width=1)
-    // For wide strings (L"...", u"...", U"..."), we need to use getBytes() instead
-    std::string tmp;
-    unsigned char_byte_width = string_literal->getCharByteWidth();
+  // ROOT CAUSE FIX: Check character byte width to handle wide/unicode string
+  // literals getString() only works for regular char strings (width=1) For wide
+  // strings (L"...", u"...", U"..."), we need to use getBytes() instead
+  std::string tmp;
+  unsigned char_byte_width = string_literal->getCharByteWidth();
 
+  if (char_byte_width == 1) {
+    // Regular char string or UTF-8 string
+    tmp = string_literal->getString().str();
+  } else {
+    // Wide string literal (wchar_t, char16_t, char32_t)
+    // Use getBytes() which returns raw bytes regardless of encoding
+    llvm::StringRef bytes = string_literal->getBytes();
+    tmp = bytes.str();
+  }
+
+  const char *raw_str = tmp.data();
+
+  // Get byte length from Clang instead of searching for '\0'
+  // For wide strings, getBytes() includes embedded NULs between characters
+  // Example: L"AB" becomes {'A',0,'B',0,0,0}, so we can't use '\0' as
+  // terminator
+  unsigned byte_length = string_literal->getByteLength();
+
+  std::string escaped;
+  escaped.reserve(byte_length * 4 + 1);
+  auto appendHexEscape = [&](unsigned char byte) {
+    static const char hex_digits[] = "0123456789ABCDEF";
+    escaped += "\\x";
+    escaped += hex_digits[(byte >> 4) & 0xF];
+    escaped += hex_digits[byte & 0xF];
+  };
+
+  for (unsigned i = 0; i < byte_length; ++i) {
+    unsigned char ch = static_cast<unsigned char>(raw_str[i]);
     if (char_byte_width == 1) {
-        // Regular char string or UTF-8 string
-        tmp = string_literal->getString().str();
+      switch (ch) {
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\0':
+        escaped += "\\0";
+        break;
+      default:
+        escaped.push_back(static_cast<char>(ch));
+        break;
+      }
     } else {
-        // Wide string literal (wchar_t, char16_t, char32_t)
-        // Use getBytes() which returns raw bytes regardless of encoding
-        llvm::StringRef bytes = string_literal->getBytes();
-        tmp = bytes.str();
+      appendHexEscape(ch);
     }
+  }
 
-    const char* raw_str = tmp.data();
+  *node = SageBuilder::buildStringVal(escaped);
 
-    // Get byte length from Clang instead of searching for '\0'
-    // For wide strings, getBytes() includes embedded NULs between characters
-    // Example: L"AB" becomes {'A',0,'B',0,0,0}, so we can't use '\0' as terminator
-    unsigned byte_length = string_literal->getByteLength();
-
-    std::string escaped;
-    escaped.reserve(byte_length * 4 + 1);
-    auto appendHexEscape = [&](unsigned char byte) {
-        static const char hex_digits[] = "0123456789ABCDEF";
-        escaped += "\\x";
-        escaped += hex_digits[(byte >> 4) & 0xF];
-        escaped += hex_digits[byte & 0xF];
-    };
-
-    for (unsigned i = 0; i < byte_length; ++i) {
-        unsigned char ch = static_cast<unsigned char>(raw_str[i]);
-        if (char_byte_width == 1) {
-            switch (ch) {
-                case '\\':
-                    escaped += "\\\\";
-                    break;
-                case '\n':
-                    escaped += "\\n";
-                    break;
-                case '\r':
-                    escaped += "\\r";
-                    break;
-                case '"':
-                    escaped += "\\\"";
-                    break;
-                case '\0':
-                    escaped += "\\0";
-                    break;
-                default:
-                    escaped.push_back(static_cast<char>(ch));
-                    break;
-            }
-        } else {
-            appendHexEscape(ch);
-        }
-    }
-
-    *node = SageBuilder::buildStringVal(escaped);
-
-    return VisitExpr(string_literal, node);
+  return VisitExpr(string_literal, node);
 }
 
-bool ClangToSageTranslator::VisitSubstNonTypeTemplateParmExpr(clang::SubstNonTypeTemplateParmExpr * subst_non_type_template_parm_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSubstNonTypeTemplateParmExpr(
+    clang::SubstNonTypeTemplateParmExpr *subst_non_type_template_parm_expr,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSubstNonTypeTemplateParmExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSubstNonTypeTemplateParmExpr"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // SubstNonTypeTemplateParmExpr represents a non-type template parameter that has been
-    // substituted with its actual value (e.g., N in array<T,N> being replaced with 1024)
-    // Traverse to the replacement expression
-    *node = Traverse(subst_non_type_template_parm_expr->getReplacement());
+  // SubstNonTypeTemplateParmExpr represents a non-type template parameter that
+  // has been substituted with its actual value (e.g., N in array<T,N> being
+  // replaced with 1024) Traverse to the replacement expression
+  *node = Traverse(subst_non_type_template_parm_expr->getReplacement());
 
-    return VisitExpr(subst_non_type_template_parm_expr, node) && res;
+  return VisitExpr(subst_non_type_template_parm_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSubstNonTypeTemplateParmPackExpr(clang::SubstNonTypeTemplateParmPackExpr * subst_non_type_template_parm_pack_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitSubstNonTypeTemplateParmPackExpr(
+    clang::SubstNonTypeTemplateParmPackExpr
+        *subst_non_type_template_parm_pack_expr,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitSubstNonTypeTemplateParmPackExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitSubstNonTypeTemplateParmPackExpr"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO
+  // TODO
 
-    return VisitExpr(subst_non_type_template_parm_pack_expr, node) && res;
+  return VisitExpr(subst_non_type_template_parm_pack_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeTraitExpr(clang::TypeTraitExpr * type_trait, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypeTraitExpr(clang::TypeTraitExpr *type_trait,
+                                               SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitTypeTraitExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTypeTraitExpr" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Type traits (std::is_integral, std::is_same, etc.) evaluate at compile-time
-    // However, template-dependent type traits cannot be evaluated until instantiation
+  // ROOT CAUSE FIX: Type traits (std::is_integral, std::is_same, etc.) evaluate
+  // at compile-time However, template-dependent type traits cannot be evaluated
+  // until instantiation
 
-    if (!type_trait->isValueDependent()) {
-        // Non-dependent: get the compile-time result and create a bool literal
-        bool trait_value = type_trait->getValue();
-        *node = SageBuilder::buildBoolValExp(trait_value);
-    } else {
-        // Value-dependent (template parameter dependent): create an opaque type expression
-        // The actual value will be determined at template instantiation time
-        *node = SageBuilder::buildOpaqueVarRefExp("__type_trait_dependent", getGlobalScope());
-    }
+  if (!type_trait->isValueDependent()) {
+    // Non-dependent: get the compile-time result and create a bool literal
+    bool trait_value = type_trait->getValue();
+    *node = SageBuilder::buildBoolValExp(trait_value);
+  } else {
+    // Value-dependent (template parameter dependent): create an opaque type
+    // expression The actual value will be determined at template instantiation
+    // time
+    *node = SageBuilder::buildOpaqueVarRefExp("__type_trait_dependent",
+                                              getGlobalScope());
+  }
 
-    return VisitExpr(type_trait, node) && res;
+  return VisitExpr(type_trait, node) && res;
 }
-
 
 // TypoExpr was removed in LLVM 20
 /*
-bool ClangToSageTranslator::VisitTypoExpr(clang::TypoExpr * typo_expr, SgNode ** node) {
-#if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitTypoExpr" << std::endl;
-#endif
-    bool res = true;
+bool ClangToSageTranslator::VisitTypoExpr(clang::TypoExpr * typo_expr, SgNode **
+node) { #if DEBUG_VISIT_STMT std::cerr << "ClangToSageTranslator::VisitTypoExpr"
+<< std::endl; #endif bool res = true;
 
     // TODO
 
@@ -5422,262 +6155,283 @@ bool ClangToSageTranslator::VisitTypoExpr(clang::TypoExpr * typo_expr, SgNode **
 }
 */
 
-bool ClangToSageTranslator::VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr * unary_expr_or_type_trait_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitUnaryExprOrTypeTraitExpr(
+    clang::UnaryExprOrTypeTraitExpr *unary_expr_or_type_trait_expr,
+    SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitUnaryExprOrTypeTraitExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUnaryExprOrTypeTraitExpr"
+            << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
-    SgExpression * expr = NULL;
-    SgType * type = NULL;
+  SgExpression *expr = NULL;
+  SgType *type = NULL;
 
-    if (unary_expr_or_type_trait_expr->isArgumentType()) {
-        type = buildTypeFromQualifiedType(unary_expr_or_type_trait_expr->getArgumentType());
+  if (unary_expr_or_type_trait_expr->isArgumentType()) {
+    type = buildTypeFromQualifiedType(
+        unary_expr_or_type_trait_expr->getArgumentType());
+  } else {
+    SgNode *tmp_expr =
+        Traverse(unary_expr_or_type_trait_expr->getArgumentExpr());
+    expr = isSgExpression(tmp_expr);
+
+    if (tmp_expr != NULL && expr == NULL) {
+      std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL"
+                << std::endl;
+      res = false;
     }
-    else {
-        SgNode * tmp_expr = Traverse(unary_expr_or_type_trait_expr->getArgumentExpr());
-        expr = isSgExpression(tmp_expr);
+  }
 
-        if (tmp_expr != NULL && expr == NULL) {
-            std::cerr << "Runtime error: tmp_expr != NULL && expr == NULL" << std::endl;
-            res = false;
+  switch (unary_expr_or_type_trait_expr->getKind()) {
+  case clang::UETT_SizeOf:
+    if (type != NULL) {
+      std::map<SgClassType *, bool>::iterator bool_it =
+          p_class_type_decl_first_see_in_type.find(isSgClassType(type));
+      SgSizeOfOp *sizeofOp = SageBuilder::buildSizeOfOp_nfi(type);
+
+      // Pei-Hung (08/16/22): try to follow VisitTypedefDecl to check if the
+      // classType is first seen
+
+      clang::QualType argumentQualType =
+          unary_expr_or_type_trait_expr->getArgumentType();
+      const clang::Type *argumentType = argumentQualType.getTypePtr();
+      bool isembedded = false;
+      bool iscompleteDefined = false;
+
+      while ((isa<clang::ElaboratedType>(argumentType)) ||
+             (isa<clang::PointerType>(argumentType)) ||
+             (isa<clang::ArrayType>(argumentType))) {
+        if (isa<clang::ElaboratedType>(argumentType)) {
+          argumentQualType =
+              ((clang::ElaboratedType *)argumentType)->getNamedType();
+        } else if (isa<clang::PointerType>(argumentType)) {
+          argumentQualType =
+              ((clang::PointerType *)argumentType)->getPointeeType();
+        } else if (isa<clang::ArrayType>(argumentType)) {
+          argumentQualType =
+              ((clang::ArrayType *)argumentType)->getElementType();
         }
-    }
+        argumentType = argumentQualType.getTypePtr();
+      }
 
-    switch (unary_expr_or_type_trait_expr->getKind()) {
-        case clang::UETT_SizeOf:
-            if (type != NULL) 
-            {
-               std::map<SgClassType *, bool>::iterator bool_it = p_class_type_decl_first_see_in_type.find(isSgClassType(type));
-               SgSizeOfOp* sizeofOp = SageBuilder::buildSizeOfOp_nfi(type);
+      if (isa<clang::RecordType>(argumentType)) {
+        clang::RecordType *argumentRecordType =
+            (clang::RecordType *)argumentType;
+        clang::RecordDecl *recordDeclaration = argumentRecordType->getDecl();
+        isembedded = recordDeclaration->isEmbeddedInDeclarator();
+        iscompleteDefined = recordDeclaration->isCompleteDefinition();
+      }
 
-               //Pei-Hung (08/16/22): try to follow VisitTypedefDecl to check if the classType is first seen 
+      if (isSgClassType(type) && iscompleteDefined) {
+        std::map<SgClassType *, bool>::iterator bool_it =
+            p_class_type_decl_first_see_in_type.find(isSgClassType(type));
+        ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
+        if (bool_it->second) {
+          // Pei-Hung (08/16/22) If it is first seen, the definition should be
+          // unparsed in sizeofOp
+          sizeofOp->set_sizeOfContainsBaseTypeDefiningDeclaration(true);
+          bool_it->second = false;
+        }
+      }
 
-               clang::QualType argumentQualType = unary_expr_or_type_trait_expr->getArgumentType();
-               const clang::Type* argumentType = argumentQualType.getTypePtr();
-               bool isembedded = false;
-               bool iscompleteDefined = false;
+      *node = sizeofOp;
+    } else if (expr != NULL)
+      *node = SageBuilder::buildSizeOfOp_nfi(expr);
+    else
+      res = false;
+    break;
+  case clang::UETT_AlignOf:
+  case clang::UETT_PreferredAlignOf:
+    if (type != NULL) {
+      *node = SageBuilder::buildSizeOfOp_nfi(type);
+      ROSE_ASSERT(FAIL_FIXME ==
+                  0); // difference between AlignOf and PreferredAlignOf is not
+                      // represented in ROSE
+    } else if (expr != NULL)
+      *node = SageBuilder::buildSizeOfOp_nfi(expr);
+    else
+      res = false;
+    break;
+  case clang::UETT_VecStep:
+    ROSE_ASSERT(!"OpenCL - VecStep is not supported!");
+  default:
+    ROSE_ASSERT(!"Unknown clang::UETT_xx");
+  }
 
-               while((isa<clang::ElaboratedType>(argumentType)) || (isa<clang::PointerType>(argumentType)) || (isa<clang::ArrayType>(argumentType)))
-               {
-                  if(isa<clang::ElaboratedType>(argumentType))
-                  {
-                    argumentQualType = ((clang::ElaboratedType *)argumentType)->getNamedType();
-                  }
-                  else if(isa<clang::PointerType>(argumentType))
-                  {
-                    argumentQualType = ((clang::PointerType *)argumentType)->getPointeeType();
-                  }
-                  else if(isa<clang::ArrayType>(argumentType))
-                  {
-                    argumentQualType = ((clang::ArrayType *)argumentType)->getElementType();
-                  }
-                  argumentType = argumentQualType.getTypePtr();
-               }
-
-               if(isa<clang::RecordType>(argumentType))
-               {
-                  clang::RecordType* argumentRecordType = (clang::RecordType*)argumentType;
-                  clang::RecordDecl* recordDeclaration = argumentRecordType->getDecl();
-                  isembedded = recordDeclaration->isEmbeddedInDeclarator();
-                  iscompleteDefined = recordDeclaration->isCompleteDefinition();
-               }
-
-               if (isSgClassType(type) && iscompleteDefined) {
-                   std::map<SgClassType *, bool>::iterator bool_it = p_class_type_decl_first_see_in_type.find(isSgClassType(type));
-                   ROSE_ASSERT(bool_it != p_class_type_decl_first_see_in_type.end());
-                   if (bool_it->second) {
-                       // Pei-Hung (08/16/22) If it is first seen, the definition should be unparsed in sizeofOp
-                       sizeofOp->set_sizeOfContainsBaseTypeDefiningDeclaration(true);
-                       bool_it->second = false;
-                   }
-                 
-               }
-
-               *node = sizeofOp;
-            }
-            else if (expr != NULL) *node = SageBuilder::buildSizeOfOp_nfi(expr);
-            else res = false;
-            break;
-        case clang::UETT_AlignOf:
-        case clang::UETT_PreferredAlignOf:
-            if (type != NULL) {
-              *node = SageBuilder::buildSizeOfOp_nfi(type);
-              ROSE_ASSERT(FAIL_FIXME == 0); // difference between AlignOf and PreferredAlignOf is not represented in ROSE
-            }
-            else if (expr != NULL) *node = SageBuilder::buildSizeOfOp_nfi(expr);
-            else res = false;
-            break;
-        case clang::UETT_VecStep:
-            ROSE_ASSERT(!"OpenCL - VecStep is not supported!");
-        default:
-            ROSE_ASSERT(!"Unknown clang::UETT_xx");
-    }
-
-    return VisitStmt(unary_expr_or_type_trait_expr, node) && res;
+  return VisitStmt(unary_expr_or_type_trait_expr, node) && res;
 }
 
-bool ClangToSageTranslator::VisitUnaryOperator(clang::UnaryOperator * unary_operator, SgNode ** node) {
+bool ClangToSageTranslator::VisitUnaryOperator(
+    clang::UnaryOperator *unary_operator, SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitUnaryOperator" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUnaryOperator" << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
-    SgNode * tmp_subexpr = Traverse(unary_operator->getSubExpr());
-    SgExpression * subexpr = isSgExpression(tmp_subexpr);
-    if (tmp_subexpr != NULL && subexpr == NULL) {
-        std::cerr << "Runtime error: tmp_subexpr != NULL && subexpr == NULL" << std::endl;
-        res = false;
-    }
+  SgNode *tmp_subexpr = Traverse(unary_operator->getSubExpr());
+  SgExpression *subexpr = isSgExpression(tmp_subexpr);
+  if (tmp_subexpr != NULL && subexpr == NULL) {
+    std::cerr << "Runtime error: tmp_subexpr != NULL && subexpr == NULL"
+              << std::endl;
+    res = false;
+  }
 
-    switch (unary_operator->getOpcode()) {
-        case clang::UO_PostInc:
-            *node = SageBuilder::buildPlusPlusOp(subexpr, SgUnaryOp::postfix);
-            break;
-        case clang::UO_PostDec:
-            *node = SageBuilder::buildMinusMinusOp(subexpr, SgUnaryOp::postfix);
-            break;
-        case clang::UO_PreInc:
-            *node = SageBuilder::buildPlusPlusOp(subexpr, SgUnaryOp::prefix);
-            break;
-        case clang::UO_PreDec:
-            *node = SageBuilder::buildMinusMinusOp(subexpr, SgUnaryOp::prefix);
-            break;
-        case clang::UO_AddrOf:
-            *node = SageBuilder::buildAddressOfOp(subexpr);
-            break;
-        case clang::UO_Deref:
-            *node = SageBuilder::buildPointerDerefExp(subexpr);
-            break;
-        case clang::UO_Plus:
-            *node = SageBuilder::buildUnaryAddOp(subexpr);
-            break;
-        case clang::UO_Minus:
-            *node = SageBuilder::buildMinusOp(subexpr);
-            break;
-        // Def. in Clang: UNARY_OPERATION(Not, "~")
-        case clang::UO_Not:
-            *node = SageBuilder::buildBitComplementOp(subexpr);
-            break;
-        // Def. in UNARY_OPERATION(LNot, "!")
-        case clang::UO_LNot:
-            *node = SageBuilder::buildNotOp(subexpr);
-            break;
-        case clang::UO_Real:
-            *node = SageBuilder::buildImagPartOp(subexpr);
-            break;
-        case clang::UO_Imag:
-            *node = SageBuilder::buildRealPartOp(subexpr);
-            break;
-        case clang::UO_Extension:
-            *node = subexpr;
-            break;
-        default:
-            std::cerr << "Runtime error: Unknown unary operator." << std::endl;
-            res = false;
-    }
+  switch (unary_operator->getOpcode()) {
+  case clang::UO_PostInc:
+    *node = SageBuilder::buildPlusPlusOp(subexpr, SgUnaryOp::postfix);
+    break;
+  case clang::UO_PostDec:
+    *node = SageBuilder::buildMinusMinusOp(subexpr, SgUnaryOp::postfix);
+    break;
+  case clang::UO_PreInc:
+    *node = SageBuilder::buildPlusPlusOp(subexpr, SgUnaryOp::prefix);
+    break;
+  case clang::UO_PreDec:
+    *node = SageBuilder::buildMinusMinusOp(subexpr, SgUnaryOp::prefix);
+    break;
+  case clang::UO_AddrOf:
+    *node = SageBuilder::buildAddressOfOp(subexpr);
+    break;
+  case clang::UO_Deref:
+    *node = SageBuilder::buildPointerDerefExp(subexpr);
+    break;
+  case clang::UO_Plus:
+    *node = SageBuilder::buildUnaryAddOp(subexpr);
+    break;
+  case clang::UO_Minus:
+    *node = SageBuilder::buildMinusOp(subexpr);
+    break;
+  // Def. in Clang: UNARY_OPERATION(Not, "~")
+  case clang::UO_Not:
+    *node = SageBuilder::buildBitComplementOp(subexpr);
+    break;
+  // Def. in UNARY_OPERATION(LNot, "!")
+  case clang::UO_LNot:
+    *node = SageBuilder::buildNotOp(subexpr);
+    break;
+  case clang::UO_Real:
+    *node = SageBuilder::buildImagPartOp(subexpr);
+    break;
+  case clang::UO_Imag:
+    *node = SageBuilder::buildRealPartOp(subexpr);
+    break;
+  case clang::UO_Extension:
+    *node = subexpr;
+    break;
+  default:
+    std::cerr << "Runtime error: Unknown unary operator." << std::endl;
+    res = false;
+  }
 
-    return VisitExpr(unary_operator, node) && res;
+  return VisitExpr(unary_operator, node) && res;
 }
 
-bool ClangToSageTranslator::VisitVAArgExpr(clang::VAArgExpr * va_arg_expr, SgNode ** node) {
+bool ClangToSageTranslator::VisitVAArgExpr(clang::VAArgExpr *va_arg_expr,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitVAArgExpr" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitVAArgExpr" << std::endl;
 #endif
 
-    SgNode * tmp_expr = Traverse(va_arg_expr->getSubExpr());
-    SgExpression * expr = isSgExpression(tmp_expr);
-    ROSE_ASSERT(expr != NULL);
+  SgNode *tmp_expr = Traverse(va_arg_expr->getSubExpr());
+  SgExpression *expr = isSgExpression(tmp_expr);
+  ROSE_ASSERT(expr != NULL);
 
-    SgType* type = buildTypeFromQualifiedType(va_arg_expr->getWrittenTypeInfo()->getType());
-    ROSE_ASSERT(type != NULL);
+  SgType *type =
+      buildTypeFromQualifiedType(va_arg_expr->getWrittenTypeInfo()->getType());
+  ROSE_ASSERT(type != NULL);
 
-    *node = SageBuilder::buildVarArgOp_nfi(expr, type);
+  *node = SageBuilder::buildVarArgOp_nfi(expr, type);
 
-    return VisitExpr(va_arg_expr, node);
+  return VisitExpr(va_arg_expr, node);
 }
-bool ClangToSageTranslator::VisitLabelStmt(clang::LabelStmt * label_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitLabelStmt(clang::LabelStmt *label_stmt,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitLabelStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitLabelStmt" << std::endl;
 #endif
 
-    bool res = true;
+  bool res = true;
 
-    SgName name(label_stmt->getName());
+  SgName name(label_stmt->getName());
 
-    *node = SageBuilder::buildLabelStatement_nfi(name, NULL, SageBuilder::topScopeStack());
-    SgLabelStatement * sg_label_stmt = isSgLabelStatement(*node);
+  *node = SageBuilder::buildLabelStatement_nfi(name, NULL,
+                                               SageBuilder::topScopeStack());
+  SgLabelStatement *sg_label_stmt = isSgLabelStatement(*node);
 
-    SgFunctionDefinition * label_scope = NULL;
-    std::list<SgScopeStatement *>::reverse_iterator it = SageBuilder::ScopeStack.rbegin();
-    while (it != SageBuilder::ScopeStack.rend() && label_scope == NULL) {
-        label_scope = isSgFunctionDefinition(*it);
-        it++;
-    }
-    if (label_scope == NULL) {
-         std::cerr << "Runtime error: Cannot find a surrounding function definition for the label statement: \"" << name << "\"." << std::endl;
-         res = false;
-    }
-    else {
-        sg_label_stmt->set_scope(label_scope);
-        SgLabelSymbol* label_sym = new SgLabelSymbol(sg_label_stmt);
-        label_scope->insert_symbol(label_sym->get_name(), label_sym);
-    }
+  SgFunctionDefinition *label_scope = NULL;
+  std::list<SgScopeStatement *>::reverse_iterator it =
+      SageBuilder::ScopeStack.rbegin();
+  while (it != SageBuilder::ScopeStack.rend() && label_scope == NULL) {
+    label_scope = isSgFunctionDefinition(*it);
+    it++;
+  }
+  if (label_scope == NULL) {
+    std::cerr << "Runtime error: Cannot find a surrounding function definition "
+                 "for the label statement: \""
+              << name << "\"." << std::endl;
+    res = false;
+  } else {
+    sg_label_stmt->set_scope(label_scope);
+    SgLabelSymbol *label_sym = new SgLabelSymbol(sg_label_stmt);
+    label_scope->insert_symbol(label_sym->get_name(), label_sym);
+  }
 
-    SgNode * tmp_sub_stmt = Traverse(label_stmt->getSubStmt());
-    SgStatement * sg_sub_stmt = isSgStatement(tmp_sub_stmt);
-    if (sg_sub_stmt == NULL) {
-        SgExpression * sg_sub_expr = isSgExpression(tmp_sub_stmt);
-        ROSE_ASSERT(sg_sub_expr != NULL);
-        sg_sub_stmt = SageBuilder::buildExprStatement(sg_sub_expr);
-    }
+  SgNode *tmp_sub_stmt = Traverse(label_stmt->getSubStmt());
+  SgStatement *sg_sub_stmt = isSgStatement(tmp_sub_stmt);
+  if (sg_sub_stmt == NULL) {
+    SgExpression *sg_sub_expr = isSgExpression(tmp_sub_stmt);
+    ROSE_ASSERT(sg_sub_expr != NULL);
+    sg_sub_stmt = SageBuilder::buildExprStatement(sg_sub_expr);
+  }
 
-    ROSE_ASSERT(sg_sub_stmt != NULL);
-    sg_sub_stmt = wrapStatementWithOpenMPPragmas(label_stmt->getSubStmt(), sg_sub_stmt);
+  ROSE_ASSERT(sg_sub_stmt != NULL);
+  sg_sub_stmt =
+      wrapStatementWithOpenMPPragmas(label_stmt->getSubStmt(), sg_sub_stmt);
 
-    sg_sub_stmt->set_parent(sg_label_stmt);
-    sg_label_stmt->set_statement(sg_sub_stmt);
+  sg_sub_stmt->set_parent(sg_label_stmt);
+  sg_label_stmt->set_statement(sg_sub_stmt);
 
-    return VisitStmt(label_stmt, node) && res;
+  return VisitStmt(label_stmt, node) && res;
 }
 
-bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt * while_stmt, SgNode ** node) {
+bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt *while_stmt,
+                                           SgNode **node) {
 #if DEBUG_VISIT_STMT
-    std::cerr << "ClangToSageTranslator::VisitWhileStmt" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitWhileStmt" << std::endl;
 #endif
 
-    SgNode * tmp_cond = Traverse(while_stmt->getCond());
-    SgExpression * cond = isSgExpression(tmp_cond);
-    ROSE_ASSERT(cond != NULL);
+  SgNode *tmp_cond = Traverse(while_stmt->getCond());
+  SgExpression *cond = isSgExpression(tmp_cond);
+  ROSE_ASSERT(cond != NULL);
 
-    SgStatement * expr_stmt = SageBuilder::buildExprStatement(cond);
+  SgStatement *expr_stmt = SageBuilder::buildExprStatement(cond);
 
-    SgWhileStmt * sg_while_stmt = SageBuilder::buildWhileStmt_nfi(expr_stmt, NULL);
+  SgWhileStmt *sg_while_stmt = SageBuilder::buildWhileStmt_nfi(expr_stmt, NULL);
 
-    cond->set_parent(expr_stmt);
-    expr_stmt->set_parent(sg_while_stmt);
+  cond->set_parent(expr_stmt);
+  expr_stmt->set_parent(sg_while_stmt);
 
-    SageBuilder::pushScopeStack(sg_while_stmt);
+  SageBuilder::pushScopeStack(sg_while_stmt);
 
-    SgNode * tmp_body = Traverse(while_stmt->getBody());
-    SgStatement * body = isSgStatement(tmp_body);
-    SgExpression * expr = isSgExpression(tmp_body);
-    if (expr != NULL) {
-        body =  SageBuilder::buildExprStatement(expr);
-        applySourceRange(body, while_stmt->getBody()->getSourceRange());
-    }
-    ROSE_ASSERT(body != NULL);
-    body = wrapStatementWithOpenMPPragmas(while_stmt->getBody(), body);
+  SgNode *tmp_body = Traverse(while_stmt->getBody());
+  SgStatement *body = isSgStatement(tmp_body);
+  SgExpression *expr = isSgExpression(tmp_body);
+  if (expr != NULL) {
+    body = SageBuilder::buildExprStatement(expr);
+    applySourceRange(body, while_stmt->getBody()->getSourceRange());
+  }
+  ROSE_ASSERT(body != NULL);
+  body = wrapStatementWithOpenMPPragmas(while_stmt->getBody(), body);
 
-    body->set_parent(sg_while_stmt);
+  body->set_parent(sg_while_stmt);
 
-    SageBuilder::popScopeStack();
+  SageBuilder::popScopeStack();
 
-    sg_while_stmt->set_body(body);
+  sg_while_stmt->set_body(body);
 
-    *node = sg_while_stmt;
+  *node = sg_while_stmt;
 
-    return VisitStmt(while_stmt, node);
+  return VisitStmt(while_stmt, node);
 }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -2,875 +2,1006 @@
 #include "sage3basic.h"
 #include "sageInterface.h"
 
-#include <cctype>
 #include "llvm/ADT/SmallString.h"
+#include <cctype>
 
 namespace {
-    // Generate unique name for template declaration with full namespace qualification
-    std::string mangleTemplateName(const clang::TemplateName& tname) {
-        // Get fully qualified name from the underlying TemplateDecl
-        if (clang::TemplateDecl* template_decl = tname.getAsTemplateDecl()) {
-            // Get qualified name from the declaration (includes namespace)
-            std::string result = template_decl->getQualifiedNameAsString();
-            return result;
-        }
+// Generate unique name for template declaration with full namespace
+// qualification
+std::string mangleTemplateName(const clang::TemplateName &tname) {
+  // Get fully qualified name from the underlying TemplateDecl
+  if (clang::TemplateDecl *template_decl = tname.getAsTemplateDecl()) {
+    // Get qualified name from the declaration (includes namespace)
+    std::string result = template_decl->getQualifiedNameAsString();
+    return result;
+  }
 
-        // Fallback: just use the template name without qualification
-        std::string result;
-        llvm::raw_string_ostream stream(result);
-        clang::LangOptions opts;
-        clang::PrintingPolicy policy(opts);
-        tname.print(stream, policy);
-        stream.flush();
-        return result;
-    }
-
-    std::string trimWhitespace(std::string s) {
-      size_t first = 0;
-      while (first < s.size() &&
-             std::isspace(static_cast<unsigned char>(s[first]))) {
-        ++first;
-      }
-      s.erase(0, first);
-
-      while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
-        s.pop_back();
-      }
-      return s;
-    }
-
-    std::string buildTemplateInstantiationName(
-        const std::string &base_name,
-        llvm::ArrayRef<clang::TemplateArgument> args) {
-      if (args.empty())
-        return base_name;
-
-      std::string result = base_name;
-      result += "<";
-      bool first = true;
-      for (const clang::TemplateArgument &arg : args) {
-        if (!first)
-          result += " , ";
-        first = false;
-
-        std::string arg_str;
-        llvm::raw_string_ostream arg_stream(arg_str);
-        arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
-                  true);
-        arg_stream.flush();
-        result += trimWhitespace(arg_str);
-      }
-      result += ">";
-      return result;
-    }
-
-    } // namespace
-
-    // Generate unique name for template instantiation
-    // Note: Must not contain < > characters for ROSE mangling
-    std::string ClangToSageTranslator::getTemplateQualifiedName(
-        SgTemplateClassDeclaration *template_decl) {
-      std::string template_base_name = template_decl->get_name().getString();
-      std::string template_qualified_name = template_base_name;
-
-      SgScopeStatement *decl_scope = template_decl->get_scope();
-      while (decl_scope && !isSgGlobal(decl_scope)) {
-        if (SgNamespaceDefinitionStatement *ns_def =
-                isSgNamespaceDefinitionStatement(decl_scope)) {
-          SgNamespaceDeclarationStatement *ns_decl =
-              ns_def->get_namespaceDeclaration();
-          template_qualified_name =
-              ns_decl->get_name().getString() + "::" + template_qualified_name;
-        } else if (SgClassDefinition *class_def =
-                       isSgClassDefinition(decl_scope)) {
-          SgClassDeclaration *class_decl = class_def->get_declaration();
-          template_qualified_name = class_decl->get_name().getString() +
-                                    "::" + template_qualified_name;
-        }
-        decl_scope = decl_scope->get_scope();
-      }
-      return template_qualified_name;
-    }
-
-    std::string ClangToSageTranslator::mangleTemplateInstantiation(
-        const std::string &template_name,
-        const clang::TemplateSpecializationType *spec_type) {
-      std::string result = template_name + "_";
-      auto args = spec_type->template_arguments();
-      bool first = true;
-      for (const clang::TemplateArgument &arg : args) {
-        if (!first)
-          result += "_";
-        first = false;
-
-        std::string arg_str;
-        llvm::raw_string_ostream arg_stream(arg_str);
-        arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
-                  true);
-        arg_stream.flush();
-
-        // Replace special characters that can't be in mangled names
-        for (char &c : arg_str) {
-          if (c == '<' || c == '>' || c == ',' || c == ' ' || c == ':' ||
-              c == '*' || c == '&') {
-            c = '_';
-          }
-        }
-        result += arg_str;
-      }
-      return result;
-    }
-
-    std::string ClangToSageTranslator::mangleTemplateInstantiation(
-        const std::string &template_name,
-        const clang::TemplateArgumentList &args) {
-      std::string result = template_name + "_";
-      bool first = true;
-      for (unsigned i = 0; i < args.size(); ++i) {
-        const clang::TemplateArgument &arg = args.get(i);
-        if (!first)
-          result += "_";
-        first = false;
-
-        std::string arg_str;
-        llvm::raw_string_ostream arg_stream(arg_str);
-        arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
-                  true);
-        arg_stream.flush();
-
-        for (char &c : arg_str) {
-          if (c == '<' || c == '>' || c == ',' || c == ' ' || c == ':' ||
-              c == '*' || c == '&') {
-            c = '_';
-          }
-        }
-        result += arg_str;
-      }
-      return result;
-    }
-
-    namespace {
-
-    void diagnose_null_scope(SgDeclarationStatement *decl,
-                             const char *context) {
-      if (decl == NULL || decl->get_scope() != NULL)
-        return;
-      MLOG_WARN_C(MLOG_FRONTEND,
-                  "Declaration %s (%p) created with NULL scope in %s\n",
-                  decl->class_name().c_str(), decl, context);
-    }
-    } // anonymous namespace
-
-SgType * ClangToSageTranslator::buildTypeFromQualifiedType(const clang::QualType & qual_type) {
-    SgNode * tmp_type = Traverse(qual_type.getTypePtr());
-    SgType * type = isSgType(tmp_type);
-
-    ROSE_ASSERT(type != NULL); 
-
-    if (qual_type.hasLocalQualifiers()) {
-        SgModifierType * modified_type = new SgModifierType(type);
-        SgTypeModifier & sg_modifer = modified_type->get_typeModifier();
-        clang::Qualifiers qualifier = qual_type.getLocalQualifiers();
-
-        if (qualifier.hasConst()) sg_modifer.get_constVolatileModifier().setConst();
-        if (qualifier.hasVolatile()) sg_modifer.get_constVolatileModifier().setVolatile();
-        if (qualifier.hasRestrict()) sg_modifer.setRestrict();
-        
-        if (qualifier.hasAddressSpace()) {
-            clang::LangAS addrspace = qualifier.getAddressSpace();
-            switch (addrspace) {
-                case clang::LangAS::opencl_global:
-                    sg_modifer.setOpenclGlobal();
-                    break;
-                case clang::LangAS::opencl_local:
-                    sg_modifer.setOpenclLocal();
-                    break;
-                case clang::LangAS::opencl_constant:
-                    sg_modifer.setOpenclConstant();
-                    break;
-                default:
-                    sg_modifer.setAddressSpace();
-                    sg_modifer.set_address_space_value(static_cast<unsigned int>(addrspace));
-            }
-        }
-        modified_type = SgModifierType::insertModifierTypeIntoTypeTable(modified_type);
-
-        return modified_type;
-    }
-    else {
-        return type;
-    }
+  // Fallback: just use the template name without qualification
+  std::string result;
+  llvm::raw_string_ostream stream(result);
+  clang::LangOptions opts;
+  clang::PrintingPolicy policy(opts);
+  tname.print(stream, policy);
+  stream.flush();
+  return result;
 }
 
-SgNode * ClangToSageTranslator::Traverse(const clang::Type * type) {
-    if (type == NULL)
-        return NULL;
+std::string trimWhitespace(std::string s) {
+  size_t first = 0;
+  while (first < s.size() &&
+         std::isspace(static_cast<unsigned char>(s[first]))) {
+    ++first;
+  }
+  s.erase(0, first);
 
-    std::map<const clang::Type *, SgNode *>::iterator it = p_type_translation_map.find(type);
-#if DEBUG_TRAVERSE_TYPE
-    std::cerr << "Traverse Type : " << type << " " << type->getTypeClassName ()<< std::endl;
-#endif
-    if (it != p_type_translation_map.end()) {
-#if DEBUG_TRAVERSE_TYPE
-      std::cerr << " already visited : node = " << it->second << std::endl;
-#endif
-      return it->second;
+  while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
+    s.pop_back();
+  }
+  return s;
+}
+
+std::string
+buildTemplateInstantiationName(const std::string &base_name,
+                               llvm::ArrayRef<clang::TemplateArgument> args) {
+  if (args.empty())
+    return base_name;
+
+  std::string result = base_name;
+  result += "<";
+  bool first = true;
+  for (const clang::TemplateArgument &arg : args) {
+    if (!first)
+      result += " , ";
+    first = false;
+
+    std::string arg_str;
+    llvm::raw_string_ostream arg_stream(arg_str);
+    arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+    arg_stream.flush();
+    result += trimWhitespace(arg_str);
+  }
+  result += ">";
+  return result;
+}
+
+} // namespace
+
+// Generate unique name for template instantiation
+// Note: Must not contain < > characters for ROSE mangling
+std::string ClangToSageTranslator::getTemplateQualifiedName(
+    SgTemplateClassDeclaration *template_decl) {
+  std::string template_base_name = template_decl->get_name().getString();
+  std::string template_qualified_name = template_base_name;
+
+  SgScopeStatement *decl_scope = template_decl->get_scope();
+  while (decl_scope && !isSgGlobal(decl_scope)) {
+    if (SgNamespaceDefinitionStatement *ns_def =
+            isSgNamespaceDefinitionStatement(decl_scope)) {
+      SgNamespaceDeclarationStatement *ns_decl =
+          ns_def->get_namespaceDeclaration();
+      template_qualified_name =
+          ns_decl->get_name().getString() + "::" + template_qualified_name;
+    } else if (SgClassDefinition *class_def = isSgClassDefinition(decl_scope)) {
+      SgClassDeclaration *class_decl = class_def->get_declaration();
+      template_qualified_name =
+          class_decl->get_name().getString() + "::" + template_qualified_name;
     }
+    decl_scope = decl_scope->get_scope();
+  }
+  return template_qualified_name;
+}
 
-    SgNode * result = NULL;
-    bool ret_status = false;
+std::string ClangToSageTranslator::mangleTemplateInstantiation(
+    const std::string &template_name,
+    const clang::TemplateSpecializationType *spec_type) {
+  std::string result = template_name + "_";
+  auto args = spec_type->template_arguments();
+  bool first = true;
+  for (const clang::TemplateArgument &arg : args) {
+    if (!first)
+      result += "_";
+    first = false;
 
-    switch (type->getTypeClass()) {
-        case clang::Type::Decayed:
-            ret_status = VisitDecayedType((clang::DecayedType *)type, &result);
-            break;
-        case clang::Type::ConstantArray:
-            ret_status = VisitConstantArrayType((clang::ConstantArrayType *)type, &result);
-            break;
-        case clang::Type::DependentSizedArray:
-            ret_status = VisitDependentSizedArrayType((clang::DependentSizedArrayType *)type, &result);
-            break;
-       case clang::Type::IncompleteArray:
-            ret_status = VisitIncompleteArrayType((clang::IncompleteArrayType *)type, &result);
-            break;
-        case clang::Type::VariableArray:
-            ret_status = VisitVariableArrayType((clang::VariableArrayType *)type, &result);
-            break;
-        case clang::Type::Atomic:
-            ret_status = VisitAtomicType((clang::AtomicType *)type, &result);
-            break;
-        case clang::Type::Attributed:
-            ret_status = VisitAttributedType((clang::AttributedType *)type, &result);
-            break;
-        case clang::Type::BlockPointer:
-            ret_status = VisitBlockPointerType((clang::BlockPointerType *)type, &result);
-            break;
-        case clang::Type::Builtin:
-            ret_status = VisitBuiltinType((clang::BuiltinType *)type, &result);
-            break;
-        case clang::Type::Complex:
-            ret_status = VisitComplexType((clang::ComplexType *)type, &result);
-            break;
-        case clang::Type::Decltype:
-            ret_status = VisitDecltypeType((clang::DecltypeType *)type, &result);
-            break;
-     // case clang::Type::DependentDecltype:
-     //     ret_status = VisitDependentDecltypeType((clang::DependentDecltypeType *)type, &result);
-     //     break;
-        case clang::Type::Auto:
-            ret_status = VisitAutoType((clang::AutoType *)type, &result);
-            break;
-        case clang::Type::DeducedTemplateSpecialization:
-            ret_status = VisitDeducedTemplateSpecializationType((clang::DeducedTemplateSpecializationType *)type, &result);
-            break;
-        case clang::Type::DependentSizedExtVector:
-            ret_status = VisitDependentSizedExtVectorType((clang::DependentSizedExtVectorType *)type, &result);
-            break;
-        case clang::Type::DependentVector:
-            ret_status = VisitDependentVectorType((clang::DependentVectorType *)type, &result);
-            break;
-        case clang::Type::FunctionNoProto:
-            ret_status = VisitFunctionNoProtoType((clang::FunctionNoProtoType *)type, &result);
-            break;
-        case clang::Type::FunctionProto:
-            ret_status = VisitFunctionProtoType((clang::FunctionProtoType *)type, &result);
-            break;
-        case clang::Type::InjectedClassName:
-            ret_status = VisitInjectedClassNameType((clang::InjectedClassNameType *)type, &result);
-            break;
-     // case clang::Type::LocInfo:
-     //     ret_status = VisitLocInfoType((clang::LocInfoType *)type, &result);
-     //     break;
-        case clang::Type::MacroQualified:
-            ret_status = VisitMacroQualifiedType((clang::MacroQualifiedType *)type, &result);
-            break;
-        case clang::Type::MemberPointer:
-            ret_status = VisitMemberPointerType((clang::MemberPointerType *)type, &result);
-            break;
-        case clang::Type::PackExpansion:
-            ret_status = VisitPackExpansionType((clang::PackExpansionType *)type, &result);
-            break;
-        case clang::Type::Paren:
-            ret_status = VisitParenType((clang::ParenType *)type, &result);
-            break;
-        case clang::Type::Pipe:
-            ret_status = VisitPipeType((clang::PipeType *)type, &result);
-            break;
-        case clang::Type::Pointer:
-            ret_status = VisitPointerType((clang::PointerType *)type, &result);
-            break;
-        case clang::Type::LValueReference:
-            ret_status = VisitLValueReferenceType((clang::LValueReferenceType *)type, &result);
-            break;
-        case clang::Type::RValueReference:
-            ret_status = VisitRValueReferenceType((clang::RValueReferenceType *)type, &result);
-            break;
-        case clang::Type::SubstTemplateTypeParmPack:
-            ret_status = VisitSubstTemplateTypeParmPackType((clang::SubstTemplateTypeParmPackType *)type, &result);
-            break;
-        case clang::Type::SubstTemplateTypeParm:
-            ret_status = VisitSubstTemplateTypeParmType((clang::SubstTemplateTypeParmType *)type, &result);
-            break;
-        case clang::Type::Enum:
-            ret_status = VisitEnumType((clang::EnumType *)type, &result);
-            break;
-        case clang::Type::Record:
-            ret_status = VisitRecordType((clang::RecordType *)type, &result);
-            break;
-        case clang::Type::TemplateSpecialization:
-            ret_status = VisitTemplateSpecializationType((clang::TemplateSpecializationType *)type, &result);
-            break;
-        case clang::Type::TemplateTypeParm:
-            ret_status = VisitTemplateTypeParmType((clang::TemplateTypeParmType *)type, &result);
-            break;
-        case clang::Type::Typedef:
-            ret_status = VisitTypedefType((clang::TypedefType *)type, &result);
-            break;
-        case clang::Type::TypeOfExpr:
-            ret_status = VisitTypeOfExprType((clang::TypeOfExprType *)type, &result);
-            break;
+    std::string arg_str;
+    llvm::raw_string_ostream arg_stream(arg_str);
+    arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+    arg_stream.flush();
+
+    // Replace special characters that can't be in mangled names
+    for (char &c : arg_str) {
+      if (c == '<' || c == '>' || c == ',' || c == ' ' || c == ':' ||
+          c == '*' || c == '&') {
+        c = '_';
+      }
+    }
+    result += arg_str;
+  }
+  return result;
+}
+
+std::string ClangToSageTranslator::mangleTemplateInstantiation(
+    const std::string &template_name, const clang::TemplateArgumentList &args) {
+  std::string result = template_name + "_";
+  bool first = true;
+  for (unsigned i = 0; i < args.size(); ++i) {
+    const clang::TemplateArgument &arg = args.get(i);
+    if (!first)
+      result += "_";
+    first = false;
+
+    std::string arg_str;
+    llvm::raw_string_ostream arg_stream(arg_str);
+    arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+    arg_stream.flush();
+
+    for (char &c : arg_str) {
+      if (c == '<' || c == '>' || c == ',' || c == ' ' || c == ':' ||
+          c == '*' || c == '&') {
+        c = '_';
+      }
+    }
+    result += arg_str;
+  }
+  return result;
+}
+
+namespace {
+
+void diagnose_null_scope(SgDeclarationStatement *decl, const char *context) {
+  if (decl == NULL || decl->get_scope() != NULL)
+    return;
+  MLOG_WARN_C(MLOG_FRONTEND,
+              "Declaration %s (%p) created with NULL scope in %s\n",
+              decl->class_name().c_str(), decl, context);
+}
+} // anonymous namespace
+
+SgType *ClangToSageTranslator::buildTypeFromQualifiedType(
+    const clang::QualType &qual_type) {
+  SgNode *tmp_type = Traverse(qual_type.getTypePtr());
+  SgType *type = isSgType(tmp_type);
+
+  ROSE_ASSERT(type != NULL);
+
+  if (qual_type.hasLocalQualifiers()) {
+    SgModifierType *modified_type = new SgModifierType(type);
+    SgTypeModifier &sg_modifer = modified_type->get_typeModifier();
+    clang::Qualifiers qualifier = qual_type.getLocalQualifiers();
+
+    if (qualifier.hasConst())
+      sg_modifer.get_constVolatileModifier().setConst();
+    if (qualifier.hasVolatile())
+      sg_modifer.get_constVolatileModifier().setVolatile();
+    if (qualifier.hasRestrict())
+      sg_modifer.setRestrict();
+
+    if (qualifier.hasAddressSpace()) {
+      clang::LangAS addrspace = qualifier.getAddressSpace();
+      switch (addrspace) {
+      case clang::LangAS::opencl_global:
+        sg_modifer.setOpenclGlobal();
+        break;
+      case clang::LangAS::opencl_local:
+        sg_modifer.setOpenclLocal();
+        break;
+      case clang::LangAS::opencl_constant:
+        sg_modifer.setOpenclConstant();
+        break;
+      default:
+        sg_modifer.setAddressSpace();
+        sg_modifer.set_address_space_value(
+            static_cast<unsigned int>(addrspace));
+      }
+    }
+    modified_type =
+        SgModifierType::insertModifierTypeIntoTypeTable(modified_type);
+
+    return modified_type;
+  } else {
+    return type;
+  }
+}
+
+SgNode *ClangToSageTranslator::Traverse(const clang::Type *type) {
+  if (type == NULL)
+    return NULL;
+
+  std::map<const clang::Type *, SgNode *>::iterator it =
+      p_type_translation_map.find(type);
+#if DEBUG_TRAVERSE_TYPE
+  std::cerr << "Traverse Type : " << type << " " << type->getTypeClassName()
+            << std::endl;
+#endif
+  if (it != p_type_translation_map.end()) {
+#if DEBUG_TRAVERSE_TYPE
+    std::cerr << " already visited : node = " << it->second << std::endl;
+#endif
+    return it->second;
+  }
+
+  SgNode *result = NULL;
+  bool ret_status = false;
+
+  switch (type->getTypeClass()) {
+  case clang::Type::Decayed:
+    ret_status = VisitDecayedType((clang::DecayedType *)type, &result);
+    break;
+  case clang::Type::ConstantArray:
+    ret_status =
+        VisitConstantArrayType((clang::ConstantArrayType *)type, &result);
+    break;
+  case clang::Type::DependentSizedArray:
+    ret_status = VisitDependentSizedArrayType(
+        (clang::DependentSizedArrayType *)type, &result);
+    break;
+  case clang::Type::IncompleteArray:
+    ret_status =
+        VisitIncompleteArrayType((clang::IncompleteArrayType *)type, &result);
+    break;
+  case clang::Type::VariableArray:
+    ret_status =
+        VisitVariableArrayType((clang::VariableArrayType *)type, &result);
+    break;
+  case clang::Type::Atomic:
+    ret_status = VisitAtomicType((clang::AtomicType *)type, &result);
+    break;
+  case clang::Type::Attributed:
+    ret_status = VisitAttributedType((clang::AttributedType *)type, &result);
+    break;
+  case clang::Type::BlockPointer:
+    ret_status =
+        VisitBlockPointerType((clang::BlockPointerType *)type, &result);
+    break;
+  case clang::Type::Builtin:
+    ret_status = VisitBuiltinType((clang::BuiltinType *)type, &result);
+    break;
+  case clang::Type::Complex:
+    ret_status = VisitComplexType((clang::ComplexType *)type, &result);
+    break;
+  case clang::Type::Decltype:
+    ret_status = VisitDecltypeType((clang::DecltypeType *)type, &result);
+    break;
+    // case clang::Type::DependentDecltype:
+    //     ret_status = VisitDependentDecltypeType((clang::DependentDecltypeType
+    //     *)type, &result); break;
+  case clang::Type::Auto:
+    ret_status = VisitAutoType((clang::AutoType *)type, &result);
+    break;
+  case clang::Type::DeducedTemplateSpecialization:
+    ret_status = VisitDeducedTemplateSpecializationType(
+        (clang::DeducedTemplateSpecializationType *)type, &result);
+    break;
+  case clang::Type::DependentSizedExtVector:
+    ret_status = VisitDependentSizedExtVectorType(
+        (clang::DependentSizedExtVectorType *)type, &result);
+    break;
+  case clang::Type::DependentVector:
+    ret_status =
+        VisitDependentVectorType((clang::DependentVectorType *)type, &result);
+    break;
+  case clang::Type::FunctionNoProto:
+    ret_status =
+        VisitFunctionNoProtoType((clang::FunctionNoProtoType *)type, &result);
+    break;
+  case clang::Type::FunctionProto:
+    ret_status =
+        VisitFunctionProtoType((clang::FunctionProtoType *)type, &result);
+    break;
+  case clang::Type::InjectedClassName:
+    ret_status = VisitInjectedClassNameType(
+        (clang::InjectedClassNameType *)type, &result);
+    break;
+    // case clang::Type::LocInfo:
+    //     ret_status = VisitLocInfoType((clang::LocInfoType *)type, &result);
+    //     break;
+  case clang::Type::MacroQualified:
+    ret_status =
+        VisitMacroQualifiedType((clang::MacroQualifiedType *)type, &result);
+    break;
+  case clang::Type::MemberPointer:
+    ret_status =
+        VisitMemberPointerType((clang::MemberPointerType *)type, &result);
+    break;
+  case clang::Type::PackExpansion:
+    ret_status =
+        VisitPackExpansionType((clang::PackExpansionType *)type, &result);
+    break;
+  case clang::Type::Paren:
+    ret_status = VisitParenType((clang::ParenType *)type, &result);
+    break;
+  case clang::Type::Pipe:
+    ret_status = VisitPipeType((clang::PipeType *)type, &result);
+    break;
+  case clang::Type::Pointer:
+    ret_status = VisitPointerType((clang::PointerType *)type, &result);
+    break;
+  case clang::Type::LValueReference:
+    ret_status =
+        VisitLValueReferenceType((clang::LValueReferenceType *)type, &result);
+    break;
+  case clang::Type::RValueReference:
+    ret_status =
+        VisitRValueReferenceType((clang::RValueReferenceType *)type, &result);
+    break;
+  case clang::Type::SubstTemplateTypeParmPack:
+    ret_status = VisitSubstTemplateTypeParmPackType(
+        (clang::SubstTemplateTypeParmPackType *)type, &result);
+    break;
+  case clang::Type::SubstTemplateTypeParm:
+    ret_status = VisitSubstTemplateTypeParmType(
+        (clang::SubstTemplateTypeParmType *)type, &result);
+    break;
+  case clang::Type::Enum:
+    ret_status = VisitEnumType((clang::EnumType *)type, &result);
+    break;
+  case clang::Type::Record:
+    ret_status = VisitRecordType((clang::RecordType *)type, &result);
+    break;
+  case clang::Type::TemplateSpecialization:
+    ret_status = VisitTemplateSpecializationType(
+        (clang::TemplateSpecializationType *)type, &result);
+    break;
+  case clang::Type::TemplateTypeParm:
+    ret_status =
+        VisitTemplateTypeParmType((clang::TemplateTypeParmType *)type, &result);
+    break;
+  case clang::Type::Typedef:
+    ret_status = VisitTypedefType((clang::TypedefType *)type, &result);
+    break;
+  case clang::Type::TypeOfExpr:
+    ret_status = VisitTypeOfExprType((clang::TypeOfExprType *)type, &result);
+    break;
     //  case clang::Type::DependentTypeOfExpr:
-    //      ret_status = VisitDependentTypeOfExprType((clang::DependentTypeOfExprType *)type, &result);
-    //      break;
-        case clang::Type::TypeOf:
-            ret_status = VisitTypeOfType((clang::TypeOfType *)type, &result);
-            break;
-        case clang::Type::DependentName:
-            ret_status = VisitDependentNameType((clang::DependentNameType *)type, &result);
-            break;
-        case clang::Type::DependentTemplateSpecialization:
-            ret_status = VisitDependentTemplateSpecializationType((clang::DependentTemplateSpecializationType *)type, &result);
-            break;
-        case clang::Type::Elaborated:
-            ret_status = VisitElaboratedType((clang::ElaboratedType *)type, &result);
-            break;
-        case clang::Type::UnaryTransform:
-            ret_status = VisitUnaryTransformType((clang::UnaryTransformType *)type, &result);
-            break;
-        case clang::Type::UnresolvedUsing:
-            ret_status = VisitUnresolvedUsingType((clang::UnresolvedUsingType *)type, &result);
-            break;
-        case clang::Type::Vector:
-            ret_status = VisitVectorType((clang::VectorType *)type, &result);
-            break;
-        case clang::Type::ExtVector:
-            ret_status = VisitExtVectorType((clang::ExtVectorType *)type, &result);
-            break;
-        case clang::Type::Using:
-            ret_status = VisitUsingType((clang::UsingType *)type, &result);
-            break;
+    //      ret_status =
+    //      VisitDependentTypeOfExprType((clang::DependentTypeOfExprType *)type,
+    //      &result); break;
+  case clang::Type::TypeOf:
+    ret_status = VisitTypeOfType((clang::TypeOfType *)type, &result);
+    break;
+  case clang::Type::DependentName:
+    ret_status =
+        VisitDependentNameType((clang::DependentNameType *)type, &result);
+    break;
+  case clang::Type::DependentTemplateSpecialization:
+    ret_status = VisitDependentTemplateSpecializationType(
+        (clang::DependentTemplateSpecializationType *)type, &result);
+    break;
+  case clang::Type::Elaborated:
+    ret_status = VisitElaboratedType((clang::ElaboratedType *)type, &result);
+    break;
+  case clang::Type::UnaryTransform:
+    ret_status =
+        VisitUnaryTransformType((clang::UnaryTransformType *)type, &result);
+    break;
+  case clang::Type::UnresolvedUsing:
+    ret_status =
+        VisitUnresolvedUsingType((clang::UnresolvedUsingType *)type, &result);
+    break;
+  case clang::Type::Vector:
+    ret_status = VisitVectorType((clang::VectorType *)type, &result);
+    break;
+  case clang::Type::ExtVector:
+    ret_status = VisitExtVectorType((clang::ExtVectorType *)type, &result);
+    break;
+  case clang::Type::Using:
+    ret_status = VisitUsingType((clang::UsingType *)type, &result);
+    break;
 
-        default:
-            std::cerr << "Warning: Unhandled clang::Type '" << type->getTypeClassName() << "'. Using opaque type." << std::endl;
-            ret_status = true;
-            break;
-    }
+  default:
+    std::cerr << "Warning: Unhandled clang::Type '" << type->getTypeClassName()
+              << "'. Using opaque type." << std::endl;
+    ret_status = true;
+    break;
+  }
 
-    if (result == NULL) {
-        result = SageBuilder::buildUnknownType();
-    }
+  if (result == NULL) {
+    result = SageBuilder::buildUnknownType();
+  }
 
-    p_type_translation_map.insert(std::pair<const clang::Type *, SgNode *>(type, result));
+  p_type_translation_map.insert(
+      std::pair<const clang::Type *, SgNode *>(type, result));
 
 #if DEBUG_TRAVERSE_TYPE
-    std::cerr << "Traverse(clang::Type : " << type << " ";
-    std::cerr << " visit done : node = " << result << std::endl;
+  std::cerr << "Traverse(clang::Type : " << type << " ";
+  std::cerr << " visit done : node = " << result << std::endl;
 #endif
-    return result;
+  return result;
 }
 
 /***************/
 /* Visit Types */
 /***************/
 
-bool ClangToSageTranslator::VisitType(clang::Type * type, SgNode ** node) {
+bool ClangToSageTranslator::VisitType(clang::Type *type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitType" << std::endl;
 #endif
 
-    if (*node == NULL) {
-        std::cerr << "Runtime error: No Sage node associated with the type: " << type->getTypeClassName() << std::endl;
-        return false;
-    }
-/*
-    std::cerr << "Dump type " << type->getTypeClassName() << "(" << type << "): ";
-    type->dump();
-    std::cerr << std::endl;
-*/
-    // TODO
+  if (*node == NULL) {
+    std::cerr << "Runtime error: No Sage node associated with the type: "
+              << type->getTypeClassName() << std::endl;
+    return false;
+  }
+  /*
+      std::cerr << "Dump type " << type->getTypeClassName() << "(" << type <<
+     "): "; type->dump(); std::cerr << std::endl;
+  */
+  // TODO
 
-    return true;
+  return true;
 }
 
-bool ClangToSageTranslator::VisitAdjustedType(clang::AdjustedType * adjusted_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitAdjustedType(
+    clang::AdjustedType *adjusted_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitAdjustedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAdjustedType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(adjusted_type, node) && res;
+  return VisitType(adjusted_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDecayedType(clang::DecayedType * decayed_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDecayedType(clang::DecayedType *decayed_type,
+                                             SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDecayedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDecayedType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-//    SgType * decayType = buildTypeFromQualifiedType(decayed_type->getDecayedType ());
-    SgType * pointeeType = buildTypeFromQualifiedType(decayed_type->getPointeeType ());
+  //    SgType * decayType =
+  //    buildTypeFromQualifiedType(decayed_type->getDecayedType ());
+  SgType *pointeeType =
+      buildTypeFromQualifiedType(decayed_type->getPointeeType());
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-//    *node = pointeeType;
-// Pei-Hung (04/08/2022) Building SgArrayyType to represent the DecayedType in Clang,
-// in order to match the type of ParmVarDecl  in FunctionProtoType
-// Might need to check the case when the pointeeType is a functionType
-    if(decayed_type->getPointeeType()->getTypeClass() == clang::Type::VariableArray ||
-       decayed_type->getPointeeType()->getTypeClass() == clang::Type::ConstantArray ||
-       decayed_type->getPointeeType()->getTypeClass() == clang::Type::DependentSizedArray ||
-       decayed_type->getPointeeType()->getTypeClass() == clang::Type::IncompleteArray 
-       )
-      *node = SageBuilder::buildArrayType(pointeeType);
-    else 
-      *node = pointeeType;
+  //    *node = pointeeType;
+  // Pei-Hung (04/08/2022) Building SgArrayyType to represent the DecayedType in
+  // Clang, in order to match the type of ParmVarDecl  in FunctionProtoType
+  // Might need to check the case when the pointeeType is a functionType
+  if (decayed_type->getPointeeType()->getTypeClass() ==
+          clang::Type::VariableArray ||
+      decayed_type->getPointeeType()->getTypeClass() ==
+          clang::Type::ConstantArray ||
+      decayed_type->getPointeeType()->getTypeClass() ==
+          clang::Type::DependentSizedArray ||
+      decayed_type->getPointeeType()->getTypeClass() ==
+          clang::Type::IncompleteArray)
+    *node = SageBuilder::buildArrayType(pointeeType);
+  else
+    *node = pointeeType;
 
-    return VisitAdjustedType(decayed_type, node) && res;
+  return VisitAdjustedType(decayed_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitArrayType(clang::ArrayType * array_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitArrayType(clang::ArrayType *array_type,
+                                           SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitArrayType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitArrayType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Array type handling is implemented in child visitor functions
-    // (ConstantArrayType, VariableArrayType, DependentSizedArrayType, IncompleteArrayType)
-    // which set *node before calling this base function
-    // ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  // Array type handling is implemented in child visitor functions
+  // (ConstantArrayType, VariableArrayType, DependentSizedArrayType,
+  // IncompleteArrayType) which set *node before calling this base function
+  // ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
- // DQ (11/28/2020): Added assertion.
-    ROSE_ASSERT(*node != NULL);
+  // DQ (11/28/2020): Added assertion.
+  ROSE_ASSERT(*node != NULL);
 
-    return VisitType(array_type, node) && res;
+  return VisitType(array_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitConstantArrayType(clang::ConstantArrayType * constant_array_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitConstantArrayType(
+    clang::ConstantArrayType *constant_array_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitConstantArrayType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitConstantArrayType" << std::endl;
 #endif
 
-    SgType * type = buildTypeFromQualifiedType(constant_array_type->getElementType());
+  SgType *type =
+      buildTypeFromQualifiedType(constant_array_type->getElementType());
 
-    // TODO clang::ArrayType::ArraySizeModifier
+  // TODO clang::ArrayType::ArraySizeModifier
 
-    SgExpression * expr = SageBuilder::buildIntVal(constant_array_type->getSize().getSExtValue());
+  SgExpression *expr =
+      SageBuilder::buildIntVal(constant_array_type->getSize().getSExtValue());
 
-    *node = SageBuilder::buildArrayType(type, expr);
+  *node = SageBuilder::buildArrayType(type, expr);
 
-    return VisitArrayType(constant_array_type, node);
+  return VisitArrayType(constant_array_type, node);
 }
 
-bool ClangToSageTranslator::VisitDependentSizedArrayType(clang::DependentSizedArrayType * dependent_sized_array_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentSizedArrayType(
+    clang::DependentSizedArrayType *dependent_sized_array_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDependentSizedArrayType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDependentSizedArrayType"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Template-dependent array sizes (e.g., T arr[N] where N is a template parameter)
-    // Create a placeholder array type with unknown size
-    // ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  SgType *type =
+      buildTypeFromQualifiedType(dependent_sized_array_type->getElementType());
 
-    SgType * type = buildTypeFromQualifiedType(dependent_sized_array_type->getElementType());
-
-    // Use buildArrayType without size expression to represent dependent-sized array
+  clang::Expr *size_expr = dependent_sized_array_type->getSizeExpr();
+  if (size_expr != NULL) {
+    SgNode *tmp_expr = Traverse(size_expr);
+    SgExpression *array_size = isSgExpression(tmp_expr);
+    ROSE_ASSERT(array_size != NULL);
+    *node = SageBuilder::buildArrayType(type, array_size);
+  } else {
+    // Size may be deduced from an initializer; represent as unknown-size array.
     *node = SageBuilder::buildArrayType(type);
+  }
 
-    return VisitArrayType(dependent_sized_array_type, node) && res;
+  return VisitArrayType(dependent_sized_array_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitIncompleteArrayType(clang::IncompleteArrayType * incomplete_array_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitIncompleteArrayType(
+    clang::IncompleteArrayType *incomplete_array_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitIncompleteArrayType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitIncompleteArrayType" << std::endl;
 #endif
 
-    SgType * type = buildTypeFromQualifiedType(incomplete_array_type->getElementType());
+  SgType *type =
+      buildTypeFromQualifiedType(incomplete_array_type->getElementType());
 
-    // In LLVM 20, ArraySizeModifier moved from ArrayType:: to clang:: namespace
+  // In LLVM 20, ArraySizeModifier moved from ArrayType:: to clang:: namespace
 
-    clang::ArraySizeModifier sizeModifier = incomplete_array_type->getSizeModifier();
+  clang::ArraySizeModifier sizeModifier =
+      incomplete_array_type->getSizeModifier();
 
-    if(sizeModifier == clang::ArraySizeModifier::Star)
-    {
-      SgExprListExp* exprListExp = SageBuilder::buildExprListExp(SageBuilder::buildNullExpression());
-      *node = SageBuilder::buildArrayType(type, exprListExp);
+  if (sizeModifier == clang::ArraySizeModifier::Star) {
+    SgExprListExp *exprListExp =
+        SageBuilder::buildExprListExp(SageBuilder::buildNullExpression());
+    *node = SageBuilder::buildArrayType(type, exprListExp);
+  } else if (sizeModifier == clang::ArraySizeModifier::Static) {
+    // TODO check how to handle Static
+    *node = SageBuilder::buildArrayType(type);
+  } else // clang::ArraySizeModifier::Normal
+  {
+    *node = SageBuilder::buildArrayType(type);
+  }
+
+  // DQ (11/28/2020): Added assertion.
+  // ROSE_ASSERT(*node != NULL);
+
+  return VisitArrayType(incomplete_array_type, node);
+}
+
+bool ClangToSageTranslator::VisitVariableArrayType(
+    clang::VariableArrayType *variable_array_type, SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitVariableArrayType" << std::endl;
+#endif
+  bool res = true;
+
+  SgType *type =
+      buildTypeFromQualifiedType(variable_array_type->getElementType());
+
+  SgNode *tmp_expr = Traverse(variable_array_type->getSizeExpr());
+  SgExpression *array_size = isSgExpression(tmp_expr);
+
+  SgArrayType *arrayType = SageBuilder::buildArrayType(type, array_size);
+  arrayType->set_is_variable_length_array(true);
+  *node = arrayType;
+
+  // DQ (11/28/2020): Added assertion.
+  ROSE_ASSERT(*node != NULL);
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitArrayType(variable_array_type, node) && res;
+}
+
+bool ClangToSageTranslator::VisitAtomicType(clang::AtomicType *atomic_type,
+                                            SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitAtomicType" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitType(atomic_type, node) && res;
+}
+
+bool ClangToSageTranslator::VisitAttributedType(
+    clang::AttributedType *attributed_type, SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitAttributedType" << std::endl;
+#endif
+
+  SgType *type = buildTypeFromQualifiedType(attributed_type->getModifiedType());
+
+  SgModifierType *modified_type = SgModifierType::createType(type);
+  SgTypeModifier &sg_modifer = modified_type->get_typeModifier();
+
+  //(01/29/2020) Pei-Hung needs to revisit this part.
+  /*
+      switch (attributed_type->getAttrKind()) {
+          case clang::AttributedType::attr_noreturn:
+     sg_modifer.setGnuAttributeNoReturn();      break; case
+     clang::AttributedType::attr_cdecl: sg_modifer.setGnuAttributeCdecl();
+     break; case clang::AttributedType::attr_stdcall:
+     sg_modifer.setGnuAttributeStdcall();       break;
+
+          case clang::AttributedType::attr_address_space:
+              std::cerr << "Unsupported attribute attr_address_space" <<
+     std::endl; ROSE_ASSERT(false); case clang::AttributedType::attr_regparm:
+              std::cerr << "Unsupported attribute attr_regparm" << std::endl;
+     ROSE_ASSERT(false); case clang::AttributedType::attr_vector_size: std::cerr
+     << "Unsupported attribute attr_vector_size" << std::endl;
+     ROSE_ASSERT(false); case clang::AttributedType::attr_neon_vector_type:
+              std::cerr << "Unsupported attribute attr_neon_vector_type" <<
+     std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_neon_polyvector_type: std::cerr << "Unsupported
+     attribute attr_neon_polyvector_type" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_objc_gc: std::cerr << "Unsupported attribute
+     attr_objc_gc" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_objc_ownership: std::cerr << "Unsupported
+     attribute attr_objc_ownership" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_pcs: std::cerr << "Unsupported attribute
+     attr_pcs" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_fastcall: std::cerr << "Unsupported attribute
+     attr_fastcall" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_thiscall: std::cerr << "Unsupported attribute
+     attr_thiscall" << std::endl; ROSE_ASSERT(false); case
+     clang::AttributedType::attr_pascal: std::cerr << "Unsupported attribute
+     attr_pascal" << std::endl; ROSE_ASSERT(false); default: std::cerr <<
+     "Unknown attribute" << std::endl; ROSE_ASSERT(false);
+      }
+  */
+  *node = SgModifierType::insertModifierTypeIntoTypeTable(modified_type);
+  ;
+
+  return VisitType(attributed_type, node);
+}
+
+bool ClangToSageTranslator::VisitBlockPointerType(
+    clang::BlockPointerType *block_pointer_type, SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitBlockPointerType" << std::endl;
+#endif
+  bool res = true;
+
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+
+  return VisitType(block_pointer_type, node) && res;
+}
+
+bool ClangToSageTranslator::VisitBuiltinType(clang::BuiltinType *builtin_type,
+                                             SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitBuiltinType" << std::endl;
+#endif
+
+  switch (builtin_type->getKind()) {
+  case clang::BuiltinType::Void:
+    *node = SageBuilder::buildVoidType();
+    break;
+  case clang::BuiltinType::Bool:
+    *node = SageBuilder::buildBoolType();
+    break;
+  case clang::BuiltinType::Short:
+    *node = SageBuilder::buildShortType();
+    break;
+  case clang::BuiltinType::Int:
+    *node = SageBuilder::buildIntType();
+    break;
+  case clang::BuiltinType::Long:
+    *node = SageBuilder::buildLongType();
+    break;
+  case clang::BuiltinType::LongLong:
+    *node = SageBuilder::buildLongLongType();
+    break;
+  case clang::BuiltinType::Float:
+    *node = SageBuilder::buildFloatType();
+    break;
+  case clang::BuiltinType::Double:
+    *node = SageBuilder::buildDoubleType();
+    break;
+  case clang::BuiltinType::LongDouble:
+    *node = SageBuilder::buildLongDoubleType();
+    break;
+
+  case clang::BuiltinType::Char_S:
+    *node = SageBuilder::buildCharType();
+    break;
+
+  case clang::BuiltinType::UInt:
+    *node = SageBuilder::buildUnsignedIntType();
+    break;
+  case clang::BuiltinType::UChar:
+    *node = SageBuilder::buildUnsignedCharType();
+    break;
+  case clang::BuiltinType::SChar:
+    *node = SageBuilder::buildSignedCharType();
+    break;
+  case clang::BuiltinType::UShort:
+    *node = SageBuilder::buildUnsignedShortType();
+    break;
+  case clang::BuiltinType::ULong:
+    *node = SageBuilder::buildUnsignedLongType();
+    break;
+  case clang::BuiltinType::ULongLong:
+    *node = SageBuilder::buildUnsignedLongLongType();
+    break;
+    /*
+            case clang::BuiltinType::NullPtr:    *node = SageBuilder::build();
+       break;
+    */
+  // TODO ROSE type ?
+  case clang::BuiltinType::UInt128:
+    *node = SageBuilder::buildUnsignedLongLongType();
+    break;
+  case clang::BuiltinType::Int128:
+    *node = SageBuilder::buildLongLongType();
+    break;
+
+  // Wide character and Unicode types - use wchar for wide chars, int/long for
+  // char16/32
+  case clang::BuiltinType::Char_U:
+    *node = SageBuilder::buildUnsignedCharType();
+    break;
+  case clang::BuiltinType::WChar_U:
+    *node = SageBuilder::buildWcharType();
+    break;
+  case clang::BuiltinType::WChar_S:
+    *node = SageBuilder::buildWcharType();
+    break;
+  case clang::BuiltinType::Char16:
+    *node = SageBuilder::buildUnsignedShortType();
+    break; // char16_t is typically 16-bit
+  case clang::BuiltinType::Char32:
+    *node = SageBuilder::buildUnsignedIntType();
+    break; // char32_t is typically 32-bit
+
+  case clang::BuiltinType::ObjCId:
+  case clang::BuiltinType::ObjCClass:
+  case clang::BuiltinType::ObjCSel:
+  case clang::BuiltinType::Dependent:
+  case clang::BuiltinType::Overload:
+  case clang::BuiltinType::BoundMember:
+  case clang::BuiltinType::UnknownAny:
+  default: {
+    // Fallback for unknown builtin types (e.g., ARM SVE types, vendor
+    // extensions)
+    std::string type_name =
+        builtin_type->getName(p_compiler_instance->getLangOpts()).str();
+    // Using fallback type for unknown builtin (suppressed)
+
+    // Check if scope stack is initialized before building opaque type
+    SgScopeStatement *scope = SageBuilder::topScopeStack();
+    if (scope != nullptr) {
+      // Build opaque type if we have a valid scope
+      *node = SageBuilder::buildOpaqueType(type_name, scope);
+    } else {
+      // Fall back to int type if scope not yet initialized (early header
+      // processing) Scope not initialized, using int type (suppressed)
+      *node = SageBuilder::buildIntType();
     }
-    else if(sizeModifier == clang::ArraySizeModifier::Static)
-    {
-      // TODO check how to handle Static
-      *node = SageBuilder::buildArrayType(type);
-    }
-    else  // clang::ArraySizeModifier::Normal
-    {
-      *node = SageBuilder::buildArrayType(type);
-    }
+    break;
+  }
+  }
 
-
-
- // DQ (11/28/2020): Added assertion.
- // ROSE_ASSERT(*node != NULL);
-
-    return VisitArrayType(incomplete_array_type, node);
+  return VisitType(builtin_type, node);
 }
 
-bool ClangToSageTranslator::VisitVariableArrayType(clang::VariableArrayType * variable_array_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitComplexType(clang::ComplexType *complex_type,
+                                             SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitVariableArrayType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitComplexType" << std::endl;
 #endif
-    bool res = true;
 
-    SgType * type = buildTypeFromQualifiedType(variable_array_type->getElementType());
+  bool res = true;
 
-    SgNode* tmp_expr = Traverse(variable_array_type->getSizeExpr());
-    SgExpression* array_size = isSgExpression(tmp_expr);
+  SgType *type = buildTypeFromQualifiedType(complex_type->getElementType());
 
-    SgArrayType* arrayType = SageBuilder::buildArrayType(type,array_size);
-    arrayType->set_is_variable_length_array(true);
-    *node = arrayType;
+  *node = SageBuilder::buildComplexType(type);
 
- // DQ (11/28/2020): Added assertion.
-    ROSE_ASSERT(*node != NULL);
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
-
-    return VisitArrayType(variable_array_type, node) && res;
+  return VisitType(complex_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAtomicType(clang::AtomicType * atomic_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDecltypeType(
+    clang::DecltypeType *decltype_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitAtomicType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDecltypeType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  // TODO: Full support for decltype not yet implemented
+  // decltype(expr) deduces the type of an expression
+  // For now, use a generic unknown type scoped to global scope to avoid
+  // ROSE-1378
+  *node = SageBuilder::buildOpaqueType("decltype", getGlobalScope());
 
-    return VisitType(atomic_type, node) && res;
+  return VisitType(decltype_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAttributedType(clang::AttributedType * attributed_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentDecltypeType(
+    clang::DependentDecltypeType *dependent_decltype_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitAttributedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDependentDecltypeType" << std::endl;
 #endif
+  bool res = true;
 
-    SgType * type = buildTypeFromQualifiedType(attributed_type->getModifiedType());
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    SgModifierType * modified_type = SgModifierType::createType(type);
-    SgTypeModifier & sg_modifer = modified_type->get_typeModifier();
-
-//(01/29/2020) Pei-Hung needs to revisit this part.
-/*
-    switch (attributed_type->getAttrKind()) {
-        case clang::AttributedType::attr_noreturn:             sg_modifer.setGnuAttributeNoReturn();      break;
-        case clang::AttributedType::attr_cdecl:                sg_modifer.setGnuAttributeCdecl();         break;
-        case clang::AttributedType::attr_stdcall:              sg_modifer.setGnuAttributeStdcall();       break;
-
-        case clang::AttributedType::attr_address_space:
-            std::cerr << "Unsupported attribute attr_address_space" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_regparm:
-            std::cerr << "Unsupported attribute attr_regparm" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_vector_size:
-            std::cerr << "Unsupported attribute attr_vector_size" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_neon_vector_type:
-            std::cerr << "Unsupported attribute attr_neon_vector_type" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_neon_polyvector_type:
-            std::cerr << "Unsupported attribute attr_neon_polyvector_type" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_objc_gc:
-            std::cerr << "Unsupported attribute attr_objc_gc" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_objc_ownership:
-            std::cerr << "Unsupported attribute attr_objc_ownership" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_pcs:
-            std::cerr << "Unsupported attribute attr_pcs" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_fastcall:
-            std::cerr << "Unsupported attribute attr_fastcall" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_thiscall:
-            std::cerr << "Unsupported attribute attr_thiscall" << std::endl; ROSE_ASSERT(false);
-        case clang::AttributedType::attr_pascal:
-            std::cerr << "Unsupported attribute attr_pascal" << std::endl; ROSE_ASSERT(false);
-        default:
-            std::cerr << "Unknown attribute" << std::endl; ROSE_ASSERT(false);
-    } 
-*/
-    *node = SgModifierType::insertModifierTypeIntoTypeTable(modified_type);;
-
-    return VisitType(attributed_type, node);
+  return VisitDecltypeType(dependent_decltype_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBlockPointerType(clang::BlockPointerType * block_pointer_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDeducedType(clang::DeducedType *deduced_type,
+                                             SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitBlockPointerType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDeducedType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(block_pointer_type, node) && res;
+  return VisitType(deduced_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitBuiltinType(clang::BuiltinType * builtin_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitAutoType(clang::AutoType *auto_type,
+                                          SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitBuiltinType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitAutoType" << std::endl;
 #endif
+  bool res = true;
 
-    switch (builtin_type->getKind()) {
-        case clang::BuiltinType::Void:       *node = SageBuilder::buildVoidType();             break;
-        case clang::BuiltinType::Bool:       *node = SageBuilder::buildBoolType();             break;
-        case clang::BuiltinType::Short:      *node = SageBuilder::buildShortType();            break;
-        case clang::BuiltinType::Int:        *node = SageBuilder::buildIntType();              break;
-        case clang::BuiltinType::Long:       *node = SageBuilder::buildLongType();             break;
-        case clang::BuiltinType::LongLong:   *node = SageBuilder::buildLongLongType();         break;
-        case clang::BuiltinType::Float:      *node = SageBuilder::buildFloatType();            break;
-        case clang::BuiltinType::Double:     *node = SageBuilder::buildDoubleType();           break;
-        case clang::BuiltinType::LongDouble: *node = SageBuilder::buildLongDoubleType();       break;
+  // TODO: Full support for auto type deduction not yet implemented
+  // auto keyword (C++11) allows type to be deduced from initializer
+  // For now, use a generic unknown type scoped to global scope
+  *node = SageBuilder::buildOpaqueType("auto", getGlobalScope());
 
-        case clang::BuiltinType::Char_S:     *node = SageBuilder::buildCharType();             break;
-
-        case clang::BuiltinType::UInt:       *node = SageBuilder::buildUnsignedIntType();      break;
-        case clang::BuiltinType::UChar:      *node = SageBuilder::buildUnsignedCharType();     break;
-        case clang::BuiltinType::SChar:      *node = SageBuilder::buildSignedCharType();       break;
-        case clang::BuiltinType::UShort:     *node = SageBuilder::buildUnsignedShortType();    break;
-        case clang::BuiltinType::ULong:      *node = SageBuilder::buildUnsignedLongType();     break;
-        case clang::BuiltinType::ULongLong:  *node = SageBuilder::buildUnsignedLongLongType(); break;
-/*
-        case clang::BuiltinType::NullPtr:    *node = SageBuilder::build(); break;
-*/
-        // TODO ROSE type ?
-        case clang::BuiltinType::UInt128:    *node = SageBuilder::buildUnsignedLongLongType(); break;
-        case clang::BuiltinType::Int128:     *node = SageBuilder::buildLongLongType();         break;
- 
-        // Wide character and Unicode types - use wchar for wide chars, int/long for char16/32
-        case clang::BuiltinType::Char_U:    *node = SageBuilder::buildUnsignedCharType();   break;
-        case clang::BuiltinType::WChar_U:   *node = SageBuilder::buildWcharType();          break;
-        case clang::BuiltinType::WChar_S:   *node = SageBuilder::buildWcharType();          break;
-        case clang::BuiltinType::Char16:    *node = SageBuilder::buildUnsignedShortType();  break; // char16_t is typically 16-bit
-        case clang::BuiltinType::Char32:    *node = SageBuilder::buildUnsignedIntType();    break; // char32_t is typically 32-bit
-
-
-        case clang::BuiltinType::ObjCId:
-        case clang::BuiltinType::ObjCClass:
-        case clang::BuiltinType::ObjCSel:
-        case clang::BuiltinType::Dependent:
-        case clang::BuiltinType::Overload:
-        case clang::BuiltinType::BoundMember:
-        case clang::BuiltinType::UnknownAny:
-        default: {
-            // Fallback for unknown builtin types (e.g., ARM SVE types, vendor extensions)
-            std::string type_name = builtin_type->getName(p_compiler_instance->getLangOpts()).str();
-            // Using fallback type for unknown builtin (suppressed)
-
-            // Check if scope stack is initialized before building opaque type
-            SgScopeStatement* scope = SageBuilder::topScopeStack();
-            if (scope != nullptr) {
-                // Build opaque type if we have a valid scope
-                *node = SageBuilder::buildOpaqueType(type_name, scope);
-            } else {
-                // Fall back to int type if scope not yet initialized (early header processing)
-                // Scope not initialized, using int type (suppressed)
-                *node = SageBuilder::buildIntType();
-            }
-            break;
-        }
-    }
-
-    return VisitType(builtin_type, node);
+  return VisitDeducedType(auto_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitComplexType(clang::ComplexType * complex_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDeducedTemplateSpecializationType(
+    clang::DeducedTemplateSpecializationType
+        *deduced_template_specialization_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitComplexType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDeducedTemplateSpecializationType"
+            << std::endl;
 #endif
+  bool res = true;
 
-    bool res = true;
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    SgType * type = buildTypeFromQualifiedType(complex_type->getElementType());
-
-    *node = SageBuilder::buildComplexType(type);
-
-    return VisitType(complex_type, node) && res;
+  return VisitDeducedType(deduced_template_specialization_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDecltypeType(clang::DecltypeType * decltype_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentAddressSpaceType(
+    clang::DependentAddressSpaceType *dependent_address_space_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDecltypeType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitDependentAddressSpaceType"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO: Full support for decltype not yet implemented
-    // decltype(expr) deduces the type of an expression
-    // For now, use a generic unknown type scoped to global scope to avoid ROSE-1378
-    *node = SageBuilder::buildOpaqueType("decltype", getGlobalScope());
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(decltype_type, node) && res;
+  return VisitType(dependent_address_space_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDependentDecltypeType(clang::DependentDecltypeType * dependent_decltype_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentSizedExtVectorType(
+    clang::DependentSizedExtVectorType *dependent_sized_ext_vector_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDependentDecltypeType" << std::endl;
+  std::cerr << "ClangToSageTranslator::DependentSizedExtVectorType"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitDecltypeType(dependent_decltype_type, node) && res;
+  return VisitType(dependent_sized_ext_vector_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDeducedType(clang::DeducedType * deduced_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentVectorType(
+    clang::DependentVectorType *dependent_vector_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDeducedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::DependentVectorType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(deduced_type, node) && res;
+  return VisitType(dependent_vector_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitAutoType(clang::AutoType * auto_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitFunctionType(
+    clang::FunctionType *function_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitAutoType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFunctionType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO: Full support for auto type deduction not yet implemented
-    // auto keyword (C++11) allows type to be deduced from initializer
-    // For now, use a generic unknown type scoped to global scope
-    *node = SageBuilder::buildOpaqueType("auto", getGlobalScope());
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitDeducedType(auto_type, node) && res;
+  return VisitType(function_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDeducedTemplateSpecializationType(clang::DeducedTemplateSpecializationType * deduced_template_specialization_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitFunctionNoProtoType(
+    clang::FunctionNoProtoType *function_no_proto_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDeducedTemplateSpecializationType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFunctionNoProtoType" << std::endl;
 #endif
-    bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  bool res = true;
 
-    return VisitDeducedType(deduced_template_specialization_type, node) && res;
+  SgFunctionParameterTypeList *param_type_list =
+      new SgFunctionParameterTypeList();
+
+  SgType *ret_type =
+      buildTypeFromQualifiedType(function_no_proto_type->getReturnType());
+
+  *node = SageBuilder::buildFunctionType(ret_type, param_type_list);
+
+  return VisitType(function_no_proto_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDependentAddressSpaceType(clang::DependentAddressSpaceType * dependent_address_space_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitFunctionProtoType(
+    clang::FunctionProtoType *function_proto_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitDependentAddressSpaceType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitFunctionProtoType" << std::endl;
 #endif
-    bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  bool res = true;
+  SgFunctionParameterTypeList *param_type_list =
+      new SgFunctionParameterTypeList();
+  for (unsigned i = 0; i < function_proto_type->getNumParams(); i++) {
+#if DEBUG_VISIT_TYPE
+    std::cerr << "funcProtoType: " << i << " th param" << std::endl;
+#endif
+    SgType *param_type =
+        buildTypeFromQualifiedType(function_proto_type->getParamType(i));
 
-    return VisitType(dependent_address_space_type, node) && res;
+    param_type_list->append_argument(param_type);
+  }
+
+  if (function_proto_type->isVariadic()) {
+    param_type_list->append_argument(SgTypeEllipse::createType());
+  }
+
+  SgType *ret_type =
+      buildTypeFromQualifiedType(function_proto_type->getReturnType());
+
+  SgFunctionType *func_type =
+      SageBuilder::buildFunctionType(ret_type, param_type_list);
+  if (function_proto_type->isVariadic())
+    func_type->set_has_ellipses(1);
+
+  *node = func_type;
+
+  return VisitType(function_proto_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDependentSizedExtVectorType(clang::DependentSizedExtVectorType * dependent_sized_ext_vector_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitInjectedClassNameType(
+    clang::InjectedClassNameType *injected_class_name_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::DependentSizedExtVectorType" << std::endl;
+  std::cerr << "ClangToSageTranslator::InjectedClassNameType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  // InjectedClassName represents a class referring to itself within its own
+  // definition (e.g., in member functions) Desugar to get the actual
+  // instantiated type
+  *node = Traverse(
+      injected_class_name_type->getInjectedSpecializationType().getTypePtr());
 
-    return VisitType(dependent_sized_ext_vector_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitDependentVectorType(clang::DependentVectorType * dependent_vector_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::DependentVectorType" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
-
-    return VisitType(dependent_vector_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitFunctionType(clang::FunctionType * function_type, SgNode ** node)  {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitFunctionType" << std::endl;
-#endif
-    bool res = true;
-
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
-
-    return VisitType(function_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitFunctionNoProtoType(clang::FunctionNoProtoType * function_no_proto_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitFunctionNoProtoType" << std::endl;
-#endif
-
-    bool res = true;
-
-    SgFunctionParameterTypeList * param_type_list = new SgFunctionParameterTypeList();
-
-    SgType * ret_type = buildTypeFromQualifiedType(function_no_proto_type->getReturnType()); 
-
-    *node = SageBuilder::buildFunctionType(ret_type, param_type_list);
-
-    return VisitType(function_no_proto_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitFunctionProtoType(clang::FunctionProtoType * function_proto_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitFunctionProtoType" << std::endl;
-#endif
-
-    bool res = true;
-    SgFunctionParameterTypeList * param_type_list = new SgFunctionParameterTypeList();
-    for (unsigned i = 0; i < function_proto_type->getNumParams(); i++) {
-#if DEBUG_VISIT_TYPE
-        std::cerr << "funcProtoType: " << i << " th param" << std::endl;
-#endif
-        SgType * param_type = buildTypeFromQualifiedType(function_proto_type->getParamType(i));
-
-        param_type_list->append_argument(param_type);
-    }
-
-    if (function_proto_type->isVariadic()) {
-        param_type_list->append_argument(SgTypeEllipse::createType());
-    }
-
-    SgType * ret_type = buildTypeFromQualifiedType(function_proto_type->getReturnType());
-
-    SgFunctionType * func_type = SageBuilder::buildFunctionType(ret_type, param_type_list);
-    if (function_proto_type->isVariadic()) func_type->set_has_ellipses(1);
-
-    *node = func_type;
-
-    return VisitType(function_proto_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitInjectedClassNameType(clang::InjectedClassNameType * injected_class_name_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::InjectedClassNameType" << std::endl;
-#endif
-    bool res = true;
-
-    // InjectedClassName represents a class referring to itself within its own definition (e.g., in member functions)
-    // Desugar to get the actual instantiated type
-    *node = Traverse(injected_class_name_type->getInjectedSpecializationType().getTypePtr());
-
-    return VisitType(injected_class_name_type, node) && res;
+  return VisitType(injected_class_name_type, node) && res;
 }
 
 // LocInfoType was removed in LLVM 20
 /*
-bool ClangToSageTranslator::VisitLocInfoType(clang::LocInfoType * loc_info_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::LocInfoType" << std::endl;
-#endif
-    bool res = true;
+bool ClangToSageTranslator::VisitLocInfoType(clang::LocInfoType * loc_info_type,
+SgNode ** node) { #if DEBUG_VISIT_TYPE std::cerr <<
+"ClangToSageTranslator::LocInfoType" << std::endl; #endif bool res = true;
 
     ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
@@ -878,497 +1009,528 @@ bool ClangToSageTranslator::VisitLocInfoType(clang::LocInfoType * loc_info_type,
 }
 */
 
-bool ClangToSageTranslator::VisitMacroQualifiedType(clang::MacroQualifiedType * macro_qualified_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitMacroQualifiedType(
+    clang::MacroQualifiedType *macro_qualified_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::MacroQualifiedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::MacroQualifiedType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(macro_qualified_type, node) && res;
+  return VisitType(macro_qualified_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitMemberPointerType(clang::MemberPointerType * member_pointer_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitMemberPointerType(
+    clang::MemberPointerType *member_pointer_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::MemberPointerType" << std::endl;
+  std::cerr << "ClangToSageTranslator::MemberPointerType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // TODO: Full support for member pointers not yet implemented
-    // Member pointers (e.g., int Class::*) point to class members
-    // For now, use a generic unknown type scoped to global scope
-    *node = SageBuilder::buildOpaqueType("member_pointer", getGlobalScope());
+  // TODO: Full support for member pointers not yet implemented
+  // Member pointers (e.g., int Class::*) point to class members
+  // For now, use a generic unknown type scoped to global scope
+  *node = SageBuilder::buildOpaqueType("member_pointer", getGlobalScope());
 
-    return VisitType(member_pointer_type, node) && res;
+  return VisitType(member_pointer_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitPackExpansionType(clang::PackExpansionType * pack_expansion_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitPackExpansionType(
+    clang::PackExpansionType *pack_expansion_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::PackExpansionType" << std::endl;
+  std::cerr << "ClangToSageTranslator::PackExpansionType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: Pack expansion types (e.g., Args... in variadic templates)
-    // represent template parameter packs that are expanded
-    // Try to get the pattern type (the type being expanded)
-    clang::QualType pattern = pack_expansion_type->getPattern();
-    SgType* pattern_type = buildTypeFromQualifiedType(pattern);
+  // ROOT CAUSE FIX: Pack expansion types (e.g., Args... in variadic templates)
+  // represent template parameter packs that are expanded
+  // Try to get the pattern type (the type being expanded)
+  clang::QualType pattern = pack_expansion_type->getPattern();
+  SgType *pattern_type = buildTypeFromQualifiedType(pattern);
 
-    if (pattern_type != NULL) {
-      if (SgTemplateType *template_type = isSgTemplateType(pattern_type)) {
-        template_type->set_packed(true);
-      }
-        // Use the pattern type directly - the pack expansion is handled at a higher level
-        *node = pattern_type;
-    } else {
-        // Fallback: use opaque type if pattern translation fails
-        *node = SageBuilder::buildOpaqueType("pack_expansion", getGlobalScope());
+  if (pattern_type != NULL) {
+    if (SgTemplateType *template_type = isSgTemplateType(pattern_type)) {
+      template_type->set_packed(true);
     }
+    // Use the pattern type directly - the pack expansion is handled at a higher
+    // level
+    *node = pattern_type;
+  } else {
+    // Fallback: use opaque type if pattern translation fails
+    *node = SageBuilder::buildOpaqueType("pack_expansion", getGlobalScope());
+  }
 
-    return VisitType(pack_expansion_type, node) && res;
+  return VisitType(pack_expansion_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitParenType(clang::ParenType * paren_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitParenType(clang::ParenType *paren_type,
+                                           SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitParenType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitParenType" << std::endl;
 #endif
 
-    *node = buildTypeFromQualifiedType(paren_type->getInnerType());
+  *node = buildTypeFromQualifiedType(paren_type->getInnerType());
 
-    return VisitType(paren_type, node);
+  return VisitType(paren_type, node);
 }
 
-bool ClangToSageTranslator::VisitPipeType(clang::PipeType * pipe_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitPipeType(clang::PipeType *pipe_type,
+                                          SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::PipeType" << std::endl;
+  std::cerr << "ClangToSageTranslator::PipeType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(pipe_type, node) && res;
+  return VisitType(pipe_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitPointerType(clang::PointerType * pointer_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitPointerType(clang::PointerType *pointer_type,
+                                             SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitPointerType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitPointerType" << std::endl;
 #endif
 
-    SgType * type = buildTypeFromQualifiedType(pointer_type->getPointeeType());
+  SgType *type = buildTypeFromQualifiedType(pointer_type->getPointeeType());
 
-    *node = SageBuilder::buildPointerType(type);
+  *node = SageBuilder::buildPointerType(type);
 
-    return VisitType(pointer_type, node);
+  return VisitType(pointer_type, node);
 }
 
-bool ClangToSageTranslator::VisitReferenceType(clang::ReferenceType * reference_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitReferenceType(
+    clang::ReferenceType *reference_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::ReferenceType" << std::endl;
+  std::cerr << "ClangToSageTranslator::ReferenceType" << std::endl;
 #endif
 
-    SgType * pointee_type = buildTypeFromQualifiedType(reference_type->getPointeeType());
-    if (pointee_type == nullptr) {
-        return false;
-    }
+  SgType *pointee_type =
+      buildTypeFromQualifiedType(reference_type->getPointeeType());
+  if (pointee_type == nullptr) {
+    return false;
+  }
 
-    if (clang::isa<clang::RValueReferenceType>(reference_type)) {
-        *node = SageBuilder::buildRvalueReferenceType(pointee_type);
-    } else {
-        *node = SageBuilder::buildReferenceType(pointee_type);
-    }
+  if (clang::isa<clang::RValueReferenceType>(reference_type)) {
+    *node = SageBuilder::buildRvalueReferenceType(pointee_type);
+  } else {
+    *node = SageBuilder::buildReferenceType(pointee_type);
+  }
 
-    return VisitType(reference_type, node);
+  return VisitType(reference_type, node);
 }
 
-bool ClangToSageTranslator::VisitLValueReferenceType(clang::LValueReferenceType * lvalue_reference_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitLValueReferenceType(
+    clang::LValueReferenceType *lvalue_reference_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::LValueReferenceType" << std::endl;
+  std::cerr << "ClangToSageTranslator::LValueReferenceType" << std::endl;
 #endif
-    return VisitReferenceType(lvalue_reference_type, node);
+  return VisitReferenceType(lvalue_reference_type, node);
 }
 
-bool ClangToSageTranslator::VisitRValueReferenceType(clang::RValueReferenceType * rvalue_reference_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitRValueReferenceType(
+    clang::RValueReferenceType *rvalue_reference_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::RValueReferenceType" << std::endl;
+  std::cerr << "ClangToSageTranslator::RValueReferenceType" << std::endl;
 #endif
-    return VisitReferenceType(rvalue_reference_type, node);
+  return VisitReferenceType(rvalue_reference_type, node);
 }
 
-bool ClangToSageTranslator::VisitSubstTemplateTypeParmPackType(clang::SubstTemplateTypeParmPackType * subst_template_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitSubstTemplateTypeParmPackType(
+    clang::SubstTemplateTypeParmPackType *subst_template_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::SubstTemplateTypeParmPackType" << std::endl;
+  std::cerr << "ClangToSageTranslator::SubstTemplateTypeParmPackType"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(subst_template_type, node) && res;
+  return VisitType(subst_template_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitSubstTemplateTypeParmType(clang::SubstTemplateTypeParmType * subst_template_type_parm_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitSubstTemplateTypeParmType(
+    clang::SubstTemplateTypeParmType *subst_template_type_parm_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::SubstTemplateTypeParmType" << std::endl;
+  std::cerr << "ClangToSageTranslator::SubstTemplateTypeParmType" << std::endl;
 #endif
 
-    // SubstTemplateTypeParmType represents a type where a template parameter has been
-    // substituted with a concrete type. We simply traverse to the replacement type.
-    clang::QualType replacement_type = subst_template_type_parm_type->getReplacementType();
-    *node = Traverse(replacement_type.getTypePtr());
+  // SubstTemplateTypeParmType represents a type where a template parameter has
+  // been substituted with a concrete type. We simply traverse to the
+  // replacement type.
+  clang::QualType replacement_type =
+      subst_template_type_parm_type->getReplacementType();
+  *node = Traverse(replacement_type.getTypePtr());
 
-    return VisitType(subst_template_type_parm_type, node);
+  return VisitType(subst_template_type_parm_type, node);
 }
 
-bool ClangToSageTranslator::VisitTagType(clang::TagType * tag_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitTagType(clang::TagType *tag_type,
+                                         SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitTagType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTagType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(tag_type, node) && res;
+  return VisitType(tag_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitEnumType(clang::EnumType * enum_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitEnumType(clang::EnumType *enum_type,
+                                          SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitEnumType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitEnumType" << std::endl;
 #endif
 
-    SgSymbol * sym = GetSymbolFromSymbolTable(enum_type->getDecl());
+  SgSymbol *sym = GetSymbolFromSymbolTable(enum_type->getDecl());
 
-    SgEnumSymbol * enum_sym = isSgEnumSymbol(sym);
+  SgEnumSymbol *enum_sym = isSgEnumSymbol(sym);
 
+  if (enum_sym == NULL) {
+    SgNode *tmp_decl = Traverse(enum_type->getDecl());
+    SgEnumDeclaration *sg_decl = isSgEnumDeclaration(tmp_decl);
+
+    ROSE_ASSERT(sg_decl != NULL);
+    *node = sg_decl->get_type();
+  } else {
+    *node = enum_sym->get_type();
+  }
+
+  if (isSgEnumType(*node) != NULL) {
     if (enum_sym == NULL) {
-        SgNode * tmp_decl = Traverse(enum_type->getDecl());
-        SgEnumDeclaration * sg_decl = isSgEnumDeclaration(tmp_decl);
+      p_enum_type_decl_first_see_in_type.insert(
+          std::pair<SgEnumType *, bool>(isSgEnumType(*node), true));
+    } else
+      p_enum_type_decl_first_see_in_type.insert(
+          std::pair<SgEnumType *, bool>(isSgEnumType(*node), false));
+  }
 
-        ROSE_ASSERT(sg_decl != NULL);
-        *node = sg_decl->get_type();
-    }
-    else {
-        *node = enum_sym->get_type();
-    }
-
-    if (isSgEnumType(*node) != NULL) {
-        if (enum_sym == NULL) {
-            p_enum_type_decl_first_see_in_type.insert(std::pair<SgEnumType *, bool>(isSgEnumType(*node), true));
-        }
-        else
-            p_enum_type_decl_first_see_in_type.insert(std::pair<SgEnumType *, bool>(isSgEnumType(*node), false));
-    }
-
-    return VisitType(enum_type, node);
+  return VisitType(enum_type, node);
 }
 
-bool ClangToSageTranslator::VisitRecordType(clang::RecordType * record_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitRecordType(clang::RecordType *record_type,
+                                            SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitRecordType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitRecordType" << std::endl;
 #endif
 
-    SgSymbol * sym = GetSymbolFromSymbolTable(record_type->getDecl());
+  SgSymbol *sym = GetSymbolFromSymbolTable(record_type->getDecl());
 
-    SgClassSymbol * class_sym = isSgClassSymbol(sym);
+  SgClassSymbol *class_sym = isSgClassSymbol(sym);
 
-    if (class_sym == NULL) {
-        clang::RecordDecl *record_decl = record_type->getDecl();
-        SgNode * tmp_decl = Traverse(record_decl);
-        SgClassDeclaration * sg_decl = isSgClassDeclaration(tmp_decl);
+  if (class_sym == NULL) {
+    clang::RecordDecl *record_decl = record_type->getDecl();
+    SgNode *tmp_decl = Traverse(record_decl);
+    SgClassDeclaration *sg_decl = isSgClassDeclaration(tmp_decl);
 
-        if (sg_decl != NULL) {
-            // Ensure firstNondefiningDeclaration is set before calling get_type()
-            // which internally calls createType() and asserts on this pointer
-            if (sg_decl->get_firstNondefiningDeclaration() == NULL) {
-                // For template specializations and forward declarations without separate non-defining decl
-                // use the declaration itself as the first non-defining declaration
-                sg_decl->set_firstNondefiningDeclaration(sg_decl);
-            }
-            *node = sg_decl->get_type();
-        } else {
-            std::string qualified_name = record_decl->getQualifiedNameAsString();
-            if (qualified_name.empty()) {
-                qualified_name = "__anonymous_record";
-            }
-            // std::isalnum expects values representable as unsigned char; cast to avoid UB for negative char.
-            for (char &ch : qualified_name) {
-                if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) {
-                    ch = '_';
-                }
-            }
-            SgScopeStatement *scope = SageBuilder::topScopeStack();
-            if (scope == NULL) {
-                scope = p_global_scope;
-            }
-            *node = SageBuilder::buildOpaqueType(qualified_name, scope);
+    if (sg_decl != NULL) {
+      // Ensure firstNondefiningDeclaration is set before calling get_type()
+      // which internally calls createType() and asserts on this pointer
+      if (sg_decl->get_firstNondefiningDeclaration() == NULL) {
+        // For template specializations and forward declarations without
+        // separate non-defining decl use the declaration itself as the first
+        // non-defining declaration
+        sg_decl->set_firstNondefiningDeclaration(sg_decl);
+      }
+      *node = sg_decl->get_type();
+    } else {
+      std::string qualified_name = record_decl->getQualifiedNameAsString();
+      if (qualified_name.empty()) {
+        qualified_name = "__anonymous_record";
+      }
+      // std::isalnum expects values representable as unsigned char; cast to
+      // avoid UB for negative char.
+      for (char &ch : qualified_name) {
+        if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) {
+          ch = '_';
         }
+      }
+      SgScopeStatement *scope = SageBuilder::topScopeStack();
+      if (scope == NULL) {
+        scope = p_global_scope;
+      }
+      *node = SageBuilder::buildOpaqueType(qualified_name, scope);
     }
-    else {
-        *node = class_sym->get_type();
-    }
+  } else {
+    *node = class_sym->get_type();
+  }
 
-    // After translating the declaration, the symbol should now exist; refresh the lookup
+  // After translating the declaration, the symbol should now exist; refresh the
+  // lookup
+  if (class_sym == NULL) {
+    class_sym =
+        isSgClassSymbol(GetSymbolFromSymbolTable(record_type->getDecl()));
+  }
+
+  if (isSgClassType(*node) != NULL) {
     if (class_sym == NULL) {
-        class_sym = isSgClassSymbol(GetSymbolFromSymbolTable(record_type->getDecl()));
-    }
+      p_class_type_decl_first_see_in_type.insert(
+          std::pair<SgClassType *, bool>(isSgClassType(*node), true));
+      isSgNamedType(*node)->set_autonomous_declaration(true);
+    } else
+      p_class_type_decl_first_see_in_type.insert(
+          std::pair<SgClassType *, bool>(isSgClassType(*node), false));
+  }
 
-    if (isSgClassType(*node) != NULL) {
-        if (class_sym == NULL) {
-            p_class_type_decl_first_see_in_type.insert(std::pair<SgClassType *, bool>(isSgClassType(*node), true));
-            isSgNamedType(*node)->set_autonomous_declaration(true);
-        }
-        else
-            p_class_type_decl_first_see_in_type.insert(std::pair<SgClassType *, bool>(isSgClassType(*node), false));
-    }
-
-    return VisitType(record_type, node);
+  return VisitType(record_type, node);
 }
 
 // Build template parameters by inferring from instantiation arguments
-SgTemplateParameterPtrList*
-ClangToSageTranslator::buildTemplateParameters(
-    const clang::TemplateSpecializationType* clang_type) {
+SgTemplateParameterPtrList *ClangToSageTranslator::buildTemplateParameters(
+    const clang::TemplateSpecializationType *clang_type) {
 
-    // For Clang frontend, we don't have access to the original template parameter
-    // declarations since they're in standard library headers. We need to infer
-    // parameters from the instantiation arguments.
+  // For Clang frontend, we don't have access to the original template parameter
+  // declarations since they're in standard library headers. We need to infer
+  // parameters from the instantiation arguments.
 
-    SgTemplateParameterPtrList* param_list = new SgTemplateParameterPtrList();
+  SgTemplateParameterPtrList *param_list = new SgTemplateParameterPtrList();
 
-    auto args = clang_type->template_arguments();
-    int param_position = 0;
+  auto args = clang_type->template_arguments();
+  int param_position = 0;
 
-    for (const clang::TemplateArgument& arg : args) {
-        SgType* param_type = nullptr;
-        SgTemplateParameter::template_parameter_enum param_kind;
+  for (const clang::TemplateArgument &arg : args) {
+    SgType *param_type = nullptr;
+    SgTemplateParameter::template_parameter_enum param_kind;
 
-        switch (arg.getKind()) {
-            case clang::TemplateArgument::Type:
-                // Type parameter (e.g., typename T)
-                param_kind = SgTemplateParameter::type_parameter;
-                param_type = SageBuilder::buildTemplateType(
-                    SgName("T" + std::to_string(param_position)));
-                break;
+    switch (arg.getKind()) {
+    case clang::TemplateArgument::Type:
+      // Type parameter (e.g., typename T)
+      param_kind = SgTemplateParameter::type_parameter;
+      param_type = SageBuilder::buildTemplateType(
+          SgName("T" + std::to_string(param_position)));
+      break;
 
-            case clang::TemplateArgument::Integral:
-                // Non-type parameter (e.g., size_t N)
-                param_kind = SgTemplateParameter::nontype_parameter;
-                param_type = buildTypeFromQualifiedType(arg.getIntegralType());
-                break;
+    case clang::TemplateArgument::Integral:
+      // Non-type parameter (e.g., size_t N)
+      param_kind = SgTemplateParameter::nontype_parameter;
+      param_type = buildTypeFromQualifiedType(arg.getIntegralType());
+      break;
 
-            case clang::TemplateArgument::Template: {
-                // Template template parameter
-                param_kind = SgTemplateParameter::template_parameter;
-                std::string param_name = "Template" + std::to_string(param_position);
-                SgTemplateType* ttype = SageBuilder::buildTemplateType(SgName(param_name));
+    case clang::TemplateArgument::Template: {
+      // Template template parameter
+      param_kind = SgTemplateParameter::template_parameter;
+      std::string param_name = "Template" + std::to_string(param_position);
+      SgTemplateType *ttype =
+          SageBuilder::buildTemplateType(SgName(param_name));
 
-                // Create SgNonrealDecl
-                SgScopeStatement* current_scope = SageBuilder::topScopeStack();
-                ROSE_ASSERT(current_scope != NULL);
-                SgDeclarationScope *decl_scope =
-                    isSgDeclarationScope(current_scope);
-                if (decl_scope == NULL) {
-                  decl_scope = SageBuilder::buildDeclarationScope();
-                  decl_scope->set_parent(current_scope);
-                }
+      // Create SgNonrealDecl
+      SgScopeStatement *current_scope = SageBuilder::topScopeStack();
+      ROSE_ASSERT(current_scope != NULL);
+      SgDeclarationScope *decl_scope = isSgDeclarationScope(current_scope);
+      if (decl_scope == NULL) {
+        decl_scope = SageBuilder::buildDeclarationScope();
+        decl_scope->set_parent(current_scope);
+      }
 
-                SgNonrealDecl* nrdecl = SageBuilder::buildNonrealDecl(SgName(param_name), decl_scope);
-                diagnose_null_scope(nrdecl, "TemplateTemplateArgument");
-                // nrdecl->set_type(ttype); // Removed: SgNonrealDecl expects SgNonrealType
+      SgNonrealDecl *nrdecl =
+          SageBuilder::buildNonrealDecl(SgName(param_name), decl_scope);
+      diagnose_null_scope(nrdecl, "TemplateTemplateArgument");
+      // nrdecl->set_type(ttype); // Removed: SgNonrealDecl expects
+      // SgNonrealType
 
-                // Translate inner parameters
-                clang::TemplateName tname = arg.getAsTemplate();
-                clang::TemplateDecl* tdecl = tname.getAsTemplateDecl();
+      // Translate inner parameters
+      clang::TemplateName tname = arg.getAsTemplate();
+      clang::TemplateDecl *tdecl = tname.getAsTemplateDecl();
 
-                if (tdecl) {
-                    SgTemplateParameterPtrList* inner_params = translateTemplateParameterList(tdecl->getTemplateParameters(), nrdecl);
-                    if (inner_params) {
-                        nrdecl->get_tpl_params() = *inner_params;
-                        delete inner_params;
-                    }
-                }
-
-                SgTemplateParameter* param = SageBuilder::buildTemplateParameter(SgTemplateParameter::template_parameter, ttype);
-                param->set_templateDeclaration(nrdecl);
-
-                param_list->push_back(param);
-                param_position++;
-                continue;
-            }
-
-            case clang::TemplateArgument::Pack:
-                // Parameter pack (e.g., typename ... Args)
-                // We infer it as a type parameter pack
-                param_kind = SgTemplateParameter::type_parameter;
-                param_type = SageBuilder::buildTemplateType(
-                    SgName("... Args" + std::to_string(param_position)));
-                break;
-
-            case clang::TemplateArgument::Expression:
-                // Expression argument (e.g., sizeof(T))
-                // We infer it as a non-type parameter
-                param_kind = SgTemplateParameter::nontype_parameter;
-                if (clang::Expr* expr = arg.getAsExpr()) {
-                    param_type = buildTypeFromQualifiedType(expr->getType());
-                } else {
-                    // Fallback if expression is null (shouldn't happen for Expression kind)
-                    param_type = SageBuilder::buildIntType();
-                }
-                break;
-
-            case clang::TemplateArgument::Declaration: {
-                // Non-type parameter (e.g., void (*F)())
-                param_kind = SgTemplateParameter::nontype_parameter;
-                clang::ValueDecl* decl = arg.getAsDecl();
-                if (decl) {
-                    param_type = buildTypeFromQualifiedType(decl->getType());
-                } else {
-                    // Should not happen for Declaration kind
-                    param_type = SageBuilder::buildVoidType(); 
-                }
-                break;
-            }
-
-            case clang::TemplateArgument::NullPtr:
-                // Non-type parameter (e.g., nullptr)
-                param_kind = SgTemplateParameter::nontype_parameter;
-                param_type = buildTypeFromQualifiedType(arg.getNullPtrType());
-                break;
-
-            default:
-                std::cerr << "Warning: Unsupported template parameter kind: "
-                          << arg.getKind() << " (Pack=" << clang::TemplateArgument::Pack 
-                          << ", Expression=" << clang::TemplateArgument::Expression
-                          << ", Template=" << clang::TemplateArgument::Template
-                          << ", Integral=" << clang::TemplateArgument::Integral
-                          << ", Type=" << clang::TemplateArgument::Type
-                          << ", Declaration=" << clang::TemplateArgument::Declaration
-                          << ", NullPtr=" << clang::TemplateArgument::NullPtr
-                          << ", Null=" << clang::TemplateArgument::Null
-                          << ")" << std::endl;
-                continue;
+      if (tdecl) {
+        SgTemplateParameterPtrList *inner_params =
+            translateTemplateParameterList(tdecl->getTemplateParameters(),
+                                           nrdecl);
+        if (inner_params) {
+          nrdecl->get_tpl_params() = *inner_params;
+          delete inner_params;
         }
+      }
 
+      SgTemplateParameter *param = SageBuilder::buildTemplateParameter(
+          SgTemplateParameter::template_parameter, ttype);
+      param->set_templateDeclaration(nrdecl);
 
-        SgTemplateParameter* param = SageBuilder::buildTemplateParameter(
-            param_kind, param_type);
-        if (param) {
-            param_list->push_back(param);
-        }
-        param_position++;
+      param_list->push_back(param);
+      param_position++;
+      continue;
     }
 
-    return param_list;
+    case clang::TemplateArgument::Pack:
+      // Parameter pack (e.g., typename ... Args)
+      // We infer it as a type parameter pack
+      param_kind = SgTemplateParameter::type_parameter;
+      param_type = SageBuilder::buildTemplateType(
+          SgName("... Args" + std::to_string(param_position)));
+      break;
+
+    case clang::TemplateArgument::Expression:
+      // Expression argument (e.g., sizeof(T))
+      // We infer it as a non-type parameter
+      param_kind = SgTemplateParameter::nontype_parameter;
+      if (clang::Expr *expr = arg.getAsExpr()) {
+        param_type = buildTypeFromQualifiedType(expr->getType());
+      } else {
+        // Fallback if expression is null (shouldn't happen for Expression kind)
+        param_type = SageBuilder::buildIntType();
+      }
+      break;
+
+    case clang::TemplateArgument::Declaration: {
+      // Non-type parameter (e.g., void (*F)())
+      param_kind = SgTemplateParameter::nontype_parameter;
+      clang::ValueDecl *decl = arg.getAsDecl();
+      if (decl) {
+        param_type = buildTypeFromQualifiedType(decl->getType());
+      } else {
+        // Should not happen for Declaration kind
+        param_type = SageBuilder::buildVoidType();
+      }
+      break;
+    }
+
+    case clang::TemplateArgument::NullPtr:
+      // Non-type parameter (e.g., nullptr)
+      param_kind = SgTemplateParameter::nontype_parameter;
+      param_type = buildTypeFromQualifiedType(arg.getNullPtrType());
+      break;
+
+    default:
+      std::cerr << "Warning: Unsupported template parameter kind: "
+                << arg.getKind() << " (Pack=" << clang::TemplateArgument::Pack
+                << ", Expression=" << clang::TemplateArgument::Expression
+                << ", Template=" << clang::TemplateArgument::Template
+                << ", Integral=" << clang::TemplateArgument::Integral
+                << ", Type=" << clang::TemplateArgument::Type
+                << ", Declaration=" << clang::TemplateArgument::Declaration
+                << ", NullPtr=" << clang::TemplateArgument::NullPtr
+                << ", Null=" << clang::TemplateArgument::Null << ")"
+                << std::endl;
+      continue;
+    }
+
+    SgTemplateParameter *param =
+        SageBuilder::buildTemplateParameter(param_kind, param_type);
+    if (param) {
+      param_list->push_back(param);
+    }
+    param_position++;
+  }
+
+  return param_list;
 }
 
-SgTemplateClassDeclaration*
+SgTemplateClassDeclaration *
 ClangToSageTranslator::getOrCreateTemplateDeclaration(
-    const std::string& template_name,
-    const clang::TemplateSpecializationType* clang_type) {
+    const std::string &template_name,
+    const clang::TemplateSpecializationType *clang_type) {
 
-    // Check cache first
-    auto it = p_template_decl_cache.find(template_name);
-    if (it != p_template_decl_cache.end()) {
-        return it->second;
+  // Check cache first
+  auto it = p_template_decl_cache.find(template_name);
+  if (it != p_template_decl_cache.end()) {
+    return it->second;
+  }
+
+  // Extract just the base name (e.g., "array" from "std::array")
+  size_t last_colon = template_name.find_last_of(':');
+  std::string base_name = (last_colon != std::string::npos)
+                              ? template_name.substr(last_colon + 1)
+                              : template_name;
+
+  // Resolve scope (handle namespaces like std::)
+  SgScopeStatement *scope = getGlobalScope();
+  if (last_colon != std::string::npos) {
+    size_t pos = 0;
+    while (pos < last_colon) {
+      size_t next_colon = template_name.find("::", pos);
+      if (next_colon == std::string::npos || next_colon > last_colon) {
+        break;
+      }
+      std::string ns_name = template_name.substr(pos, next_colon - pos);
+
+      // Find or create namespace
+      SgNamespaceSymbol *ns_sym =
+          scope->lookup_namespace_symbol(SgName(ns_name));
+      if (ns_sym) {
+        scope = ns_sym->get_declaration()->get_definition();
+      } else {
+        SgNamespaceDeclarationStatement *ns_decl =
+            SageBuilder::buildNamespaceDeclaration(SgName(ns_name), scope);
+        scope = ns_decl->get_definition();
+      }
+
+      pos = next_colon + 2;
     }
+  }
 
-    // Extract just the base name (e.g., "array" from "std::array")
-    size_t last_colon = template_name.find_last_of(':');
-    std::string base_name = (last_colon != std::string::npos)
-                            ? template_name.substr(last_colon + 1)
-                            : template_name;
+  // Build template parameters
+  SgTemplateParameterPtrList *params = buildTemplateParameters(clang_type);
 
-    // Resolve scope (handle namespaces like std::)
-    SgScopeStatement* scope = getGlobalScope();
-    if (last_colon != std::string::npos) {
-        size_t pos = 0;
-        while (pos < last_colon) {
-            size_t next_colon = template_name.find("::", pos);
-            if (next_colon == std::string::npos || next_colon > last_colon) {
-                break;
-            }
-            std::string ns_name = template_name.substr(pos, next_colon - pos);
-            
-            // Find or create namespace
-            SgNamespaceSymbol* ns_sym = scope->lookup_namespace_symbol(SgName(ns_name));
-            if (ns_sym) {
-                scope = ns_sym->get_declaration()->get_definition();
-            } else {
-                SgNamespaceDeclarationStatement* ns_decl = 
-                    SageBuilder::buildNamespaceDeclaration(SgName(ns_name), scope);
-                scope = ns_decl->get_definition();
-            }
-            
-            pos = next_colon + 2;
-        }
-    }
+  // Create empty template argument list for primary template
+  SgTemplateArgumentPtrList *empty_args = new SgTemplateArgumentPtrList();
 
-    // Build template parameters
-    SgTemplateParameterPtrList* params = buildTemplateParameters(clang_type);
+  // Create template class declaration
+  SgTemplateClassDeclaration *template_decl =
+      SageBuilder::buildNondefiningTemplateClassDeclaration_nfi(
+          SgName(base_name),
+          SgClassDeclaration::e_class, // Assume class (could be struct)
+          scope, params,
+          empty_args // No specialization arguments for primary template
+      );
 
-    // Create empty template argument list for primary template
-    SgTemplateArgumentPtrList* empty_args = new SgTemplateArgumentPtrList();
+  // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
+  // crash (ua test).
+  template_decl->set_firstNondefiningDeclaration(template_decl);
 
-    // Create template class declaration
-    SgTemplateClassDeclaration* template_decl =
-        SageBuilder::buildNondefiningTemplateClassDeclaration_nfi(
-            SgName(base_name),
-            SgClassDeclaration::e_class,  // Assume class (could be struct)
-            scope,
-            params,
-            empty_args  // No specialization arguments for primary template
-        );
+  // Mark as compiler generated and forward declaration
+  template_decl->setForward();
+  template_decl->set_isUnNamed(false);
+  template_decl->get_file_info()->setCompilerGenerated();
+  template_decl->get_file_info()->unsetOutputInCodeGeneration();
 
-    // REX FIX: Ensure firstNondefiningDeclaration is set to avoid unparser
-    // crash (ua test).
-    template_decl->set_firstNondefiningDeclaration(template_decl);
+  // Insert into scope symbol table if not already present
+  if (!scope->lookup_class_symbol(SgName(base_name))) {
+    SgClassSymbol *template_symbol = new SgClassSymbol(template_decl);
+    scope->insert_symbol(SgName(base_name), template_symbol);
+  }
 
-    // Mark as compiler generated and forward declaration
-    template_decl->setForward();
-    template_decl->set_isUnNamed(false);
-    template_decl->get_file_info()->setCompilerGenerated();
-    template_decl->get_file_info()->unsetOutputInCodeGeneration();
+  // Cache it
+  p_template_decl_cache[template_name] = template_decl;
 
-    // Insert into scope symbol table if not already present
-    if (!scope->lookup_class_symbol(SgName(base_name))) {
-        SgClassSymbol* template_symbol = new SgClassSymbol(template_decl);
-        scope->insert_symbol(SgName(base_name), template_symbol);
-    }
-
-    // Cache it
-    p_template_decl_cache[template_name] = template_decl;
-
-    return template_decl;
+  return template_decl;
 }
 
 namespace {
-// Build a literal expression from an APSInt while preserving sign and (as text) width.
-SgExpression* buildIntegralTemplateArgExpr(const llvm::APSInt& value, SgType* int_type) {
-    const bool is_signed = value.isSigned();
-    const unsigned bitwidth = value.getBitWidth();
+// Build a literal expression from an APSInt while preserving sign and (as text)
+// width.
+SgExpression *buildIntegralTemplateArgExpr(const llvm::APSInt &value,
+                                           SgType *int_type) {
+  const bool is_signed = value.isSigned();
+  const unsigned bitwidth = value.getBitWidth();
 
-    SgExpression* expr = NULL;
-    if (is_signed) {
-        // Use the widest native builder we have; valueString keeps the full precision.
-        long long v = (bitwidth <= 63) ? value.getSExtValue() : 0;
-        expr = SageBuilder::buildLongLongIntVal(v);
-    } else {
-        unsigned long long v = (bitwidth <= 64) ? value.getZExtValue() : 0;
-        expr = SageBuilder::buildUnsignedLongLongIntVal(v);
+  SgExpression *expr = NULL;
+  if (is_signed) {
+    // Use the widest native builder we have; valueString keeps the full
+    // precision.
+    long long v = (bitwidth <= 63) ? value.getSExtValue() : 0;
+    expr = SageBuilder::buildLongLongIntVal(v);
+  } else {
+    unsigned long long v = (bitwidth <= 64) ? value.getZExtValue() : 0;
+    expr = SageBuilder::buildUnsignedLongLongIntVal(v);
+  }
+
+  if (expr != NULL) {
+    llvm::SmallString<64> buf;
+    value.toString(buf, 10, value.isSigned());
+    std::string text(buf.begin(), buf.end());
+
+    if (SgLongLongIntVal *ll = isSgLongLongIntVal(expr)) {
+      ll->set_valueString(text);
+    } else if (SgUnsignedLongLongIntVal *ull =
+                   isSgUnsignedLongLongIntVal(expr)) {
+      ull->set_valueString(text);
     }
+  }
 
-    if (expr != NULL) {
-        llvm::SmallString<64> buf;
-        value.toString(buf, 10, value.isSigned());
-        std::string text(buf.begin(), buf.end());
-
-        if (SgLongLongIntVal* ll = isSgLongLongIntVal(expr)) {
-            ll->set_valueString(text);
-        } else if (SgUnsignedLongLongIntVal* ull = isSgUnsignedLongLongIntVal(expr)) {
-            ull->set_valueString(text);
-        }
-    }
-
-    return expr;
+  return expr;
 }
 } // namespace
 
@@ -1391,9 +1553,12 @@ SgTemplateArgument *ClangToSageTranslator::translateTemplateArgument(
 
     SgExpression *value_expr = buildIntegralTemplateArgExpr(value, int_type);
 
-    sg_arg =
-        new SgTemplateArgument(SgTemplateArgument::nontype_argument, value_expr,
-                               int_type, nullptr, nullptr, explicitlySpecified);
+    sg_arg = new SgTemplateArgument(SgTemplateArgument::nontype_argument,
+                                    false /*isArrayBoundUnknownType*/, int_type,
+                                    value_expr, nullptr, explicitlySpecified);
+    if (value_expr != nullptr) {
+      value_expr->set_parent(sg_arg);
+    }
     break;
   }
 
@@ -1480,367 +1645,404 @@ SgTemplateArgumentPtrList ClangToSageTranslator::buildTemplateArguments(
   return arg_list;
 }
 
-SgTemplateInstantiationDecl*
+SgTemplateInstantiationDecl *
 ClangToSageTranslator::getOrCreateTemplateInstantiation(
-    SgTemplateClassDeclaration* template_decl,
-    const clang::TemplateSpecializationType* clang_type) {
+    SgTemplateClassDeclaration *template_decl,
+    const clang::TemplateSpecializationType *clang_type) {
 
-    // Extract both base name and qualified name for the template
-    std::string template_base_name = template_decl->get_name().getString();
+  // Extract both base name and qualified name for the template
+  std::string template_base_name = template_decl->get_name().getString();
 
-    // ROOT CAUSE FIX: Check if template declaration has namespace qualification stored
-    // Use qualified name (e.g., "std::array") for instantiation name instead of just base name
-    std::string template_qualified_name =
-        getTemplateQualifiedName(template_decl);
+  // ROOT CAUSE FIX: Check if template declaration has namespace qualification
+  // stored Use qualified name (e.g., "std::array") for instantiation name
+  // instead of just base name
+  std::string template_qualified_name = getTemplateQualifiedName(template_decl);
 
-    // Use qualified name in cache key to avoid namespace collisions
-    // Example: "std::array<int>" and "my_ns::array<int>" must have different cache keys
-    // Otherwise they would both mangle to "array_int" and collide
-    std::string inst_name_full = mangleTemplateInstantiation(template_qualified_name, clang_type);
-    std::string inst_display_name = buildTemplateInstantiationName(
-        template_base_name, clang_type->template_arguments());
+  // Use qualified name in cache key to avoid namespace collisions
+  // Example: "std::array<int>" and "my_ns::array<int>" must have different
+  // cache keys Otherwise they would both mangle to "array_int" and collide
+  std::string inst_name_full =
+      mangleTemplateInstantiation(template_qualified_name, clang_type);
+  std::string inst_display_name = buildTemplateInstantiationName(
+      template_base_name, clang_type->template_arguments());
 
-    // Check cache
-    auto it = p_template_inst_cache.find(inst_name_full);
-    if (it != p_template_inst_cache.end()) {
-      SgTemplateInstantiationDecl *inst_decl = it->second;
-      if (inst_decl != nullptr) {
-        if (inst_decl->get_templateArguments().empty()) {
-          inst_decl->get_templateArguments() =
-              buildTemplateArguments(clang_type);
-        }
-        for (SgTemplateArgument *arg : inst_decl->get_templateArguments()) {
-          if (arg != nullptr) {
-            arg->set_parent(inst_decl);
-          }
+  // Check cache
+  auto it = p_template_inst_cache.find(inst_name_full);
+  if (it != p_template_inst_cache.end()) {
+    SgTemplateInstantiationDecl *inst_decl = it->second;
+    if (inst_decl != nullptr) {
+      if (inst_decl->get_templateArguments().empty()) {
+        inst_decl->get_templateArguments() = buildTemplateArguments(clang_type);
+      }
+      for (SgTemplateArgument *arg : inst_decl->get_templateArguments()) {
+        if (arg != nullptr) {
+          arg->set_parent(inst_decl);
         }
       }
-      return inst_decl;
     }
-
-    // Build template arguments
-    SgTemplateArgumentPtrList args = buildTemplateArguments(clang_type);
-
-    // Create class type first (will be set on instantiation)
-    SgClassType* class_type = nullptr;
-
-    // Create template instantiation declaration with all parameters
-    // ROOT CAUSE FIX: Use qualified name (e.g., "std::array") not just base name ("array")
-    // This ensures the unparser outputs the correct namespace qualification
-    SgTemplateInstantiationDecl *inst_decl = new SgTemplateInstantiationDecl(
-        SgName(inst_display_name), SgClassDeclaration::e_class,
-        class_type, // type (initially nullptr, will be set)
-        nullptr,    // definition
-        template_decl, args);
-
-    inst_decl->get_templateArguments() = args;
-    for (SgTemplateArgument *arg : inst_decl->get_templateArguments()) {
-      if (arg != nullptr) {
-        arg->set_parent(inst_decl);
-      }
-    }
-
-    // Set file info and mark as compiler generated
-    // Create synthetic file info since this is a compiler-generated node
-    Sg_File_Info* file_info = Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
-    inst_decl->set_file_info(file_info);
-    inst_decl->setForward();
-    inst_decl->set_definingDeclaration(nullptr);
-    inst_decl->set_firstNondefiningDeclaration(inst_decl);
-
-    if (inst_name_full.find("__conditional") != std::string::npos ||
-        inst_name_full.find("conditional") != std::string::npos) {
-      std::cerr << "DEBUG: getOrCreateTemplateInstantiation created: "
-                << inst_name_full << " at " << inst_decl << " firstNondef: "
-                << inst_decl->get_firstNondefiningDeclaration() << std::endl;
-    }
-
-    // REX FIX: Always require global qualification for template instantiations
-    // This ensures that the unparser prints "::" (e.g. "::std::vector" or "::tuple")
-    // which prevents ambiguity when global templates are shadowed.
-    inst_decl->set_global_qualification_required(true);
-
-    if (inst_decl->get_templateDeclaration() == NULL) {
-        std::cerr << "CRITICAL ERROR: inst_decl->get_templateDeclaration() is NULL immediately after creation! Setting it explicitly." << std::endl;
-        inst_decl->set_templateDeclaration(template_decl);
-    }
-
-    // FIX P1: Handle nested namespaces correctly (e.g., "std::chrono::duration")
-    // Split the qualified name by "::" and create/find nested namespace scopes
-    SgScopeStatement* inst_scope = getGlobalScope();
-
-    // Split qualified name into components
-    std::vector<std::string> components;
-    size_t start = 0;
-    size_t colon_pos = template_qualified_name.find("::");
-    while (colon_pos != std::string::npos) {
-        components.push_back(template_qualified_name.substr(start, colon_pos - start));
-        start = colon_pos + 2;  // Skip "::"
-        colon_pos = template_qualified_name.find("::", start);
-    }
-    components.push_back(template_qualified_name.substr(start));  // Last component (class name)
-
-    // Iterate through all namespace components (all except the last, which is the class name)
-    // For "std::chrono::duration", iterate through ["std", "chrono"], not "duration"
-    for (size_t i = 0; i + 1 < components.size(); ++i) {
-        const std::string& ns_name = components[i];
-
-        // Find or create namespace in current scope
-        SgNamespaceDefinitionStatement* ns_def = nullptr;
-        SgDeclarationStatementPtrList& decls = inst_scope->getDeclarationList();
-        for (SgDeclarationStatement* decl : decls) {
-            if (SgNamespaceDeclarationStatement* ns_decl = isSgNamespaceDeclarationStatement(decl)) {
-                if (ns_decl->get_name().getString() == ns_name) {
-                    ns_def = ns_decl->get_definition();
-                    break;
-                }
-            }
-        }
-
-        if (ns_def == nullptr) {
-            // Create namespace in current scope
-            // buildNamespaceDeclaration automatically inserts the declaration into inst_scope
-            SgNamespaceDeclarationStatement* ns_decl =
-                SageBuilder::buildNamespaceDeclaration(SgName(ns_name), inst_scope);
-            ns_decl->get_file_info()->setCompilerGenerated();
-            ns_def = ns_decl->get_definition();
-            ns_def->get_file_info()->setCompilerGenerated();
-        }
-
-        // Move into nested namespace for next iteration
-        inst_scope = ns_def;
-    }
-
-    inst_decl->set_scope(inst_scope);
-
-    // CRITICAL: Set template name before creating type
-    // get_mangled_name() requires this to be set and will assert if it's null
-    // Use ONLY base name for templateName (e.g., "array" not "std::array")
-    // The qualified name is in the declaration name above
-    // NameQualificationTraversal will add the necessary qualification (e.g. "std::")
-    inst_decl->set_templateName(SgName(template_base_name));
-
-    // Create class type pointing to this instantiation
-    class_type = SgClassType::createType(inst_decl);
-    inst_decl->set_type(class_type);
-
-    // Create symbol and insert into symbol table
-    // ROOT CAUSE FIX: Insert symbol into the same scope as the declaration (inst_scope)
-    // not getGlobalScope(). This fixes ROSETTA warnings:
-    // "SgScopeStatement::insert_symbol(): class_declaration->get_scope() != this"
-    // The declaration's scope (set on line 1322) must match the scope where we insert the symbol.
-    // Use full mangled name for symbol table to avoid conflicts
-    SgClassSymbol* class_symbol = new SgClassSymbol(inst_decl);
-    inst_scope->insert_symbol(SgName(inst_name_full), class_symbol);
-
-    // Cache it with full name
-    p_template_inst_cache[inst_name_full] = inst_decl;
-
     return inst_decl;
-}
+  }
 
-bool ClangToSageTranslator::VisitTemplateSpecializationType(clang::TemplateSpecializationType * template_specialization_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::TemplateSpecializationType" << std::endl;
-#endif
+  // Build template arguments
+  SgTemplateArgumentPtrList args = buildTemplateArguments(clang_type);
 
-    // Don't desugar or use canonical type for template specializations
-    // We want to create proper SgTemplateInstantiationDecl nodes with template arguments
-    // Desugaring would lose the template argument information
+  // Create class type first (will be set on instantiation)
+  SgClassType *class_type = nullptr;
 
-    // REX FIX: Handle dependent template specializations as opaque types
-    // This avoids creating broken SgTemplateInstantiationDecl nodes for types like T::rebind<int>
-    // which cause unparsing issues (e.g., "T__rebind_int_")
-    if (template_specialization_type->isDependentType()) {
-        clang::PrintingPolicy policy = p_compiler_instance->getASTContext().getPrintingPolicy();
-        
-        // Check if the template is a template parameter (e.g. C in UsePack<C, Args...>)
-        // If so, do NOT use fully qualified name, as it would produce UsePack::C
-        bool is_template_param = false;
-        clang::TemplateName tname = template_specialization_type->getTemplateName();
-        if (clang::TemplateDecl* decl = tname.getAsTemplateDecl()) {
-            if (clang::isa<clang::TemplateTemplateParmDecl>(decl)) {
-                is_template_param = true;
-            }
+  // Create template instantiation declaration with all parameters
+  // ROOT CAUSE FIX: Use qualified name (e.g., "std::array") not just base name
+  // ("array") This ensures the unparser outputs the correct namespace
+  // qualification
+  SgTemplateInstantiationDecl *inst_decl = new SgTemplateInstantiationDecl(
+      SgName(inst_display_name), SgClassDeclaration::e_class,
+      class_type, // type (initially nullptr, will be set)
+      nullptr,    // definition
+      template_decl, args);
+
+  inst_decl->get_templateArguments() = args;
+  for (SgTemplateArgument *arg : inst_decl->get_templateArguments()) {
+    if (arg != nullptr) {
+      arg->set_parent(inst_decl);
+    }
+  }
+
+  // Set file info and mark as compiler generated
+  // Create synthetic file info since this is a compiler-generated node
+  Sg_File_Info *file_info =
+      Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode();
+  inst_decl->set_file_info(file_info);
+  inst_decl->setForward();
+  inst_decl->set_definingDeclaration(nullptr);
+  inst_decl->set_firstNondefiningDeclaration(inst_decl);
+
+  if (inst_name_full.find("__conditional") != std::string::npos ||
+      inst_name_full.find("conditional") != std::string::npos) {
+    std::cerr << "DEBUG: getOrCreateTemplateInstantiation created: "
+              << inst_name_full << " at " << inst_decl << " firstNondef: "
+              << inst_decl->get_firstNondefiningDeclaration() << std::endl;
+  }
+
+  // REX FIX: Always require global qualification for template instantiations
+  // This ensures that the unparser prints "::" (e.g. "::std::vector" or
+  // "::tuple") which prevents ambiguity when global templates are shadowed.
+  inst_decl->set_global_qualification_required(true);
+
+  if (inst_decl->get_templateDeclaration() == NULL) {
+    std::cerr << "CRITICAL ERROR: inst_decl->get_templateDeclaration() is NULL "
+                 "immediately after creation! Setting it explicitly."
+              << std::endl;
+    inst_decl->set_templateDeclaration(template_decl);
+  }
+
+  // FIX P1: Handle nested namespaces correctly (e.g., "std::chrono::duration")
+  // Split the qualified name by "::" and create/find nested namespace scopes
+  SgScopeStatement *inst_scope = getGlobalScope();
+
+  // Split qualified name into components
+  std::vector<std::string> components;
+  size_t start = 0;
+  size_t colon_pos = template_qualified_name.find("::");
+  while (colon_pos != std::string::npos) {
+    components.push_back(
+        template_qualified_name.substr(start, colon_pos - start));
+    start = colon_pos + 2; // Skip "::"
+    colon_pos = template_qualified_name.find("::", start);
+  }
+  components.push_back(
+      template_qualified_name.substr(start)); // Last component (class name)
+
+  // Iterate through all namespace components (all except the last, which is the
+  // class name) For "std::chrono::duration", iterate through ["std", "chrono"],
+  // not "duration"
+  for (size_t i = 0; i + 1 < components.size(); ++i) {
+    const std::string &ns_name = components[i];
+
+    // Find or create namespace in current scope
+    SgNamespaceDefinitionStatement *ns_def = nullptr;
+    SgDeclarationStatementPtrList &decls = inst_scope->getDeclarationList();
+    for (SgDeclarationStatement *decl : decls) {
+      if (SgNamespaceDeclarationStatement *ns_decl =
+              isSgNamespaceDeclarationStatement(decl)) {
+        if (ns_decl->get_name().getString() == ns_name) {
+          ns_def = ns_decl->get_definition();
+          break;
         }
-        
-        if (!is_template_param) {
-            policy.FullyQualifiedName = true;
-        }
-        policy.SuppressScope = false;
-        
-        std::string type_name = clang::QualType(template_specialization_type, 0).getAsString(policy);
-        
-        // Strip leading "::" if present to avoid double qualification by unparser
-        if (type_name.size() >= 2 && type_name.substr(0, 2) == "::") {
-            type_name = type_name.substr(2);
-        }
-
-        *node = SageBuilder::buildOpaqueType(type_name, getGlobalScope());
-        return VisitType(template_specialization_type, node);
+      }
     }
 
-    // Extract template name
+    if (ns_def == nullptr) {
+      // Create namespace in current scope
+      // buildNamespaceDeclaration automatically inserts the declaration into
+      // inst_scope
+      SgNamespaceDeclarationStatement *ns_decl =
+          SageBuilder::buildNamespaceDeclaration(SgName(ns_name), inst_scope);
+      ns_decl->get_file_info()->setCompilerGenerated();
+      ns_def = ns_decl->get_definition();
+      ns_def->get_file_info()->setCompilerGenerated();
+    }
+
+    // Move into nested namespace for next iteration
+    inst_scope = ns_def;
+  }
+
+  inst_decl->set_scope(inst_scope);
+
+  // CRITICAL: Set template name before creating type
+  // get_mangled_name() requires this to be set and will assert if it's null
+  // Use ONLY base name for templateName (e.g., "array" not "std::array")
+  // The qualified name is in the declaration name above
+  // NameQualificationTraversal will add the necessary qualification (e.g.
+  // "std::")
+  inst_decl->set_templateName(SgName(template_base_name));
+
+  // Create class type pointing to this instantiation
+  class_type = SgClassType::createType(inst_decl);
+  inst_decl->set_type(class_type);
+
+  // Create symbol and insert into symbol table
+  // ROOT CAUSE FIX: Insert symbol into the same scope as the declaration
+  // (inst_scope) not getGlobalScope(). This fixes ROSETTA warnings:
+  // "SgScopeStatement::insert_symbol(): class_declaration->get_scope() != this"
+  // The declaration's scope (set on line 1322) must match the scope where we
+  // insert the symbol. Use full mangled name for symbol table to avoid
+  // conflicts
+  SgClassSymbol *class_symbol = new SgClassSymbol(inst_decl);
+  inst_scope->insert_symbol(SgName(inst_name_full), class_symbol);
+
+  // Cache it with full name
+  p_template_inst_cache[inst_name_full] = inst_decl;
+
+  return inst_decl;
+}
+
+bool ClangToSageTranslator::VisitTemplateSpecializationType(
+    clang::TemplateSpecializationType *template_specialization_type,
+    SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::TemplateSpecializationType" << std::endl;
+#endif
+
+  // Don't desugar or use canonical type for template specializations
+  // We want to create proper SgTemplateInstantiationDecl nodes with template
+  // arguments Desugaring would lose the template argument information
+
+  // REX FIX: Handle dependent template specializations as opaque types
+  // This avoids creating broken SgTemplateInstantiationDecl nodes for types
+  // like T::rebind<int> which cause unparsing issues (e.g., "T__rebind_int_")
+  if (template_specialization_type->isDependentType()) {
+    clang::PrintingPolicy policy =
+        p_compiler_instance->getASTContext().getPrintingPolicy();
+
+    // Check if the template is a template parameter (e.g. C in UsePack<C,
+    // Args...>) If so, do NOT use fully qualified name, as it would produce
+    // UsePack::C
+    bool is_template_param = false;
     clang::TemplateName tname = template_specialization_type->getTemplateName();
-    std::string template_name = mangleTemplateName(tname);
-
-    // DEBUG: // std::cerr << "DEBUG VisitTemplateSpecializationType: template_name = '" << template_name << "'" << std::endl;
-
-    // Get or create template class declaration
-    SgTemplateClassDeclaration* template_decl = NULL;
-    
-    clang::TemplateDecl* clang_template_decl = tname.getAsTemplateDecl();
-    if (clang_template_decl) {
-        // std::cerr << "DEBUG: Found clang_template_decl for " << template_name << std::endl;
-        SgNode* tmp_node = Traverse(clang_template_decl);
-        template_decl = isSgTemplateClassDeclaration(tmp_node);
-        if (template_decl) {
-             // std::cerr << "DEBUG: Found existing SgTemplateClassDeclaration for " << template_name << std::endl;
-        } else {
-             // std::cerr << "DEBUG: Traverse returned NULL or non-template for " << template_name << std::endl;
-        }
-    } else {
-        // std::cerr << "DEBUG: No clang_template_decl for " << template_name << std::endl;
+    if (clang::TemplateDecl *decl = tname.getAsTemplateDecl()) {
+      if (clang::isa<clang::TemplateTemplateParmDecl>(decl)) {
+        is_template_param = true;
+      }
     }
 
-    if (template_decl == NULL) {
-        // std::cerr << "DEBUG: Creating new template declaration for " << template_name << std::endl;
-        template_decl = getOrCreateTemplateDeclaration(template_name, template_specialization_type);
+    if (!is_template_param) {
+      policy.FullyQualifiedName = true;
     }
-    
-    if (template_decl == NULL) {
-        std::cerr << "CRITICAL ERROR: template_decl is NULL for " << template_name << std::endl;
+    policy.SuppressScope = false;
+
+    std::string type_name =
+        clang::QualType(template_specialization_type, 0).getAsString(policy);
+
+    // Strip leading "::" if present to avoid double qualification by unparser
+    if (type_name.size() >= 2 && type_name.substr(0, 2) == "::") {
+      type_name = type_name.substr(2);
     }
 
-    // Get or create template instantiation
-    SgTemplateInstantiationDecl* inst_decl =
-        getOrCreateTemplateInstantiation(template_decl, template_specialization_type);
-
-    // Return the class type
-    *node = inst_decl->get_type();
-    ROSE_ASSERT(*node != nullptr);
-
+    *node = SageBuilder::buildOpaqueType(type_name, getGlobalScope());
     return VisitType(template_specialization_type, node);
-}
+  }
 
-bool ClangToSageTranslator::VisitTemplateTypeParmType(clang::TemplateTypeParmType * template_type_parm_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitTemplateTypeParmType" << std::endl;
-#endif
-    bool res = true;
+  // Extract template name
+  clang::TemplateName tname = template_specialization_type->getTemplateName();
+  std::string template_name = mangleTemplateName(tname);
 
-    // CLANG FRONTEND FIX: Proper template type parameter support
-    // Get the template parameter declaration to extract the name
-    const clang::TemplateTypeParmDecl* param_decl = template_type_parm_type->getDecl();
-    std::string param_name;
+  // DEBUG: // std::cerr << "DEBUG VisitTemplateSpecializationType:
+  // template_name = '" << template_name << "'" << std::endl;
 
-    if (param_decl && param_decl->getDeclName().isIdentifier()) {
-        // Use the actual template parameter name (e.g., "T")
-        param_name = param_decl->getNameAsString();
+  // Get or create template class declaration
+  SgTemplateClassDeclaration *template_decl = NULL;
+
+  clang::TemplateDecl *clang_template_decl = tname.getAsTemplateDecl();
+  if (clang_template_decl) {
+    // std::cerr << "DEBUG: Found clang_template_decl for " << template_name <<
+    // std::endl;
+    SgNode *tmp_node = Traverse(clang_template_decl);
+    template_decl = isSgTemplateClassDeclaration(tmp_node);
+    if (template_decl) {
+      // std::cerr << "DEBUG: Found existing SgTemplateClassDeclaration for " <<
+      // template_name << std::endl;
     } else {
-        // Fallback to a generic name if we can't get the actual name
-        param_name = "template_type_param";
+      // std::cerr << "DEBUG: Traverse returned NULL or non-template for " <<
+      // template_name << std::endl;
+    }
+  } else {
+    // std::cerr << "DEBUG: No clang_template_decl for " << template_name <<
+    // std::endl;
+  }
+
+  if (template_decl == NULL) {
+    // std::cerr << "DEBUG: Creating new template declaration for " <<
+    // template_name << std::endl;
+    template_decl = getOrCreateTemplateDeclaration(
+        template_name, template_specialization_type);
+  }
+
+  if (template_decl == NULL) {
+    std::cerr << "CRITICAL ERROR: template_decl is NULL for " << template_name
+              << std::endl;
+  }
+
+  // Get or create template instantiation
+  SgTemplateInstantiationDecl *inst_decl = getOrCreateTemplateInstantiation(
+      template_decl, template_specialization_type);
+
+  // Return the class type
+  *node = inst_decl->get_type();
+  ROSE_ASSERT(*node != nullptr);
+
+  return VisitType(template_specialization_type, node);
+}
+
+bool ClangToSageTranslator::VisitTemplateTypeParmType(
+    clang::TemplateTypeParmType *template_type_parm_type, SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitTemplateTypeParmType" << std::endl;
+#endif
+  bool res = true;
+
+  // CLANG FRONTEND FIX: Proper template type parameter support
+  // Get the template parameter declaration to extract the name
+  const clang::TemplateTypeParmDecl *param_decl =
+      template_type_parm_type->getDecl();
+  std::string param_name;
+
+  if (param_decl && param_decl->getDeclName().isIdentifier()) {
+    // Use the actual template parameter name (e.g., "T")
+    param_name = param_decl->getNameAsString();
+  } else {
+    // Fallback to a generic name if we can't get the actual name
+    param_name = "template_type_param";
+  }
+
+  // Create a proper template type with the actual parameter name
+  *node = SageBuilder::buildTemplateType(SgName(param_name));
+
+  return VisitType(template_type_parm_type, node) && res;
+}
+
+bool ClangToSageTranslator::VisitTypedefType(clang::TypedefType *typedef_type,
+                                             SgNode **node) {
+#if DEBUG_VISIT_TYPE
+  std::cerr << "ClangToSageTranslator::VisitTypedefType" << std::endl;
+#endif
+
+  bool res = true;
+
+  SgSymbol *sym = GetSymbolFromSymbolTable(typedef_type->getDecl());
+  SgTypedefSymbol *tdef_sym = isSgTypedefSymbol(sym);
+
+  if (tdef_sym == NULL) {
+    // Some typedefs (especially template-dependent ones) may not have symbols
+    // yet Use unknown type as fallback - this is acceptable for incomplete C++
+    // support Cannot find a typedef symbol for the TypedefType, using unknown
+    // type
+    if (SgProject::get_verbose() > 0) {
+      std::cerr << "CFE: Missing typedef symbol for '"
+                << typedef_type->getDecl()->getNameAsString() << "'"
+                << std::endl;
     }
 
-    // Create a proper template type with the actual parameter name
-    *node = SageBuilder::buildTemplateType(SgName(param_name));
-
-    return VisitType(template_type_parm_type, node) && res;
-}
-
-bool ClangToSageTranslator::VisitTypedefType(clang::TypedefType * typedef_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitTypedefType" << std::endl;
-#endif
-
-    bool res = true;
-
-    SgSymbol * sym = GetSymbolFromSymbolTable(typedef_type->getDecl());
-    SgTypedefSymbol * tdef_sym = isSgTypedefSymbol(sym);
-
-    if (tdef_sym == NULL) {
-        // Some typedefs (especially template-dependent ones) may not have symbols yet
-        // Use unknown type as fallback - this is acceptable for incomplete C++ support
-        // Cannot find a typedef symbol for the TypedefType, using unknown type
-        if (SgProject::get_verbose() > 0) {
-            std::cerr << "CFE: Missing typedef symbol for '" << typedef_type->getDecl()->getNameAsString() << "'"
-                      << std::endl;
-        }
-
-        // Try to translate the typedef declaration on demand so the symbol becomes available.
-        // This handles cases where a typedef type is referenced before its declaration is processed.
-        auto it = p_decl_translation_map.find(typedef_type->getDecl());
-        if (it == p_decl_translation_map.end()) {
-            Traverse(const_cast<clang::TypedefNameDecl *>(typedef_type->getDecl()));
-            sym = GetSymbolFromSymbolTable(typedef_type->getDecl());
-            tdef_sym = isSgTypedefSymbol(sym);
-        }
+    // Try to translate the typedef declaration on demand so the symbol becomes
+    // available. This handles cases where a typedef type is referenced before
+    // its declaration is processed.
+    auto it = p_decl_translation_map.find(typedef_type->getDecl());
+    if (it == p_decl_translation_map.end()) {
+      Traverse(const_cast<clang::TypedefNameDecl *>(typedef_type->getDecl()));
+      sym = GetSymbolFromSymbolTable(typedef_type->getDecl());
+      tdef_sym = isSgTypedefSymbol(sym);
     }
+  }
 
-    *node = (tdef_sym != NULL) ? tdef_sym->get_type()
-                               : SageBuilder::buildUnknownType();
+  *node = (tdef_sym != NULL) ? tdef_sym->get_type()
+                             : SageBuilder::buildUnknownType();
 
-   return VisitType(typedef_type, node) && res;
+  return VisitType(typedef_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeOfExprType(clang::TypeOfExprType * type_of_expr_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypeOfExprType(
+    clang::TypeOfExprType *type_of_expr_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::TypeOfExprType" << std::endl;
+  std::cerr << "ClangToSageTranslator::TypeOfExprType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    SgNode* tmp_expr = Traverse(type_of_expr_type->getUnderlyingExpr());
+  SgNode *tmp_expr = Traverse(type_of_expr_type->getUnderlyingExpr());
 
- // printf ("In VisitTypeOfExprType(): tmp_expr = %p = %s \n",tmp_expr,tmp_expr->class_name().c_str());
+  // printf ("In VisitTypeOfExprType(): tmp_expr = %p = %s
+  // \n",tmp_expr,tmp_expr->class_name().c_str());
 
-    SgExpression* expr = isSgExpression(tmp_expr);
-    SgType* type = SageBuilder::buildTypeOfType(expr,NULL);
+  SgExpression *expr = isSgExpression(tmp_expr);
+  SgType *type = SageBuilder::buildTypeOfType(expr, NULL);
 
-    *node = type;
+  *node = type;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(type_of_expr_type, node) && res;
+  return VisitType(type_of_expr_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDependentTypeOfExprType(clang::DependentTypeOfExprType * dependent_type_of_expr_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentTypeOfExprType(
+    clang::DependentTypeOfExprType *dependent_type_of_expr_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::DependentTypeOfExprType" << std::endl;
+  std::cerr << "ClangToSageTranslator::DependentTypeOfExprType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitTypeOfExprType(dependent_type_of_expr_type, node) && res;
+  return VisitTypeOfExprType(dependent_type_of_expr_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeOfType(clang::TypeOfType * type_of_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypeOfType(clang::TypeOfType *type_of_type,
+                                            SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::TypeOfType" << std::endl;
+  std::cerr << "ClangToSageTranslator::TypeOfType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // In LLVM 20, getUnderlyingType() was renamed to getUnmodifiedType()
-    SgType* underlyinigType = buildTypeFromQualifiedType(type_of_type->getUnmodifiedType());
+  // In LLVM 20, getUnderlyingType() was renamed to getUnmodifiedType()
+  SgType *underlyinigType =
+      buildTypeFromQualifiedType(type_of_type->getUnmodifiedType());
 
-    SgType* type = SageBuilder::buildTypeOfType(NULL,underlyinigType);
+  SgType *type = SageBuilder::buildTypeOfType(NULL, underlyinigType);
 
-    *node = type;
+  *node = type;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME 
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(type_of_type, node) && res;
+  return VisitType(type_of_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitTypeWithKeyword(clang::TypeWithKeyword * type_with_keyword, SgNode ** node) {
+bool ClangToSageTranslator::VisitTypeWithKeyword(
+    clang::TypeWithKeyword *type_with_keyword, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitTypeWithKeyword" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitTypeWithKeyword" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
-    return VisitType(type_with_keyword, node) && res;
+  return VisitType(type_with_keyword, node) && res;
 }
 
 bool ClangToSageTranslator::VisitDependentNameType(
@@ -1875,150 +2077,166 @@ bool ClangToSageTranslator::VisitDependentNameType(
   return VisitTypeWithKeyword(dependent_name_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitDependentTemplateSpecializationType(clang::DependentTemplateSpecializationType * dependent_template_specialization_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitDependentTemplateSpecializationType(
+    clang::DependentTemplateSpecializationType
+        *dependent_template_specialization_type,
+    SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::DependentTemplateSpecializationType" << std::endl;
+  std::cerr << "ClangToSageTranslator::DependentTemplateSpecializationType"
+            << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // REX: Build a meaningful name for dependent template specializations
-    // Extract the template name and arguments even though they're dependent
-    std::string type_name;
+  // REX: Build a meaningful name for dependent template specializations
+  // Extract the template name and arguments even though they're dependent
+  std::string type_name;
 
-    // Get the qualifier (e.g., "std" in "std::array")
-    if (dependent_template_specialization_type->getQualifier() != NULL) {
-        llvm::raw_string_ostream qualifier_stream(type_name);
-        dependent_template_specialization_type->getQualifier()->print(qualifier_stream,
-                                                                       clang::PrintingPolicy(clang::LangOptions()));
-        qualifier_stream.flush();
+  // Get the qualifier (e.g., "std" in "std::array")
+  if (dependent_template_specialization_type->getQualifier() != NULL) {
+    llvm::raw_string_ostream qualifier_stream(type_name);
+    dependent_template_specialization_type->getQualifier()->print(
+        qualifier_stream, clang::PrintingPolicy(clang::LangOptions()));
+    qualifier_stream.flush();
+  }
+
+  // Get the template name (e.g., "array")
+  // Note: getIdentifier() returns nullptr for operator/literal templates like
+  // T::template operator+<U> In those cases, fall back to a generic name
+  if (dependent_template_specialization_type->getIdentifier() != NULL) {
+    type_name += dependent_template_specialization_type->getIdentifier()
+                     ->getName()
+                     .str();
+  } else {
+    // Handle operator or literal template names
+    type_name += "dependent_template_specialization";
+  }
+
+  // Build template arguments string
+  // In LLVM 20, use template_arguments() iterator instead of
+  // getNumArgs()/getArg()
+  auto template_args =
+      dependent_template_specialization_type->template_arguments();
+  if (!template_args.empty()) {
+    type_name += "<";
+    bool first = true;
+    for (const clang::TemplateArgument &arg : template_args) {
+      if (!first)
+        type_name += ", ";
+      first = false;
+      std::string arg_str;
+      llvm::raw_string_ostream arg_stream(arg_str);
+      arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
+                /*IncludeType=*/true);
+      arg_stream.flush();
+      type_name += arg_str;
     }
+    type_name += ">";
+  }
 
-    // Get the template name (e.g., "array")
-    // Note: getIdentifier() returns nullptr for operator/literal templates like T::template operator+<U>
-    // In those cases, fall back to a generic name
-    if (dependent_template_specialization_type->getIdentifier() != NULL) {
-        type_name += dependent_template_specialization_type->getIdentifier()->getName().str();
-    } else {
-        // Handle operator or literal template names
-        type_name += "dependent_template_specialization";
+  // Sanitize the type name for use as a C++ identifier
+  // Replace invalid characters (::, <, >, comma, space, *, &) with underscores
+  // This produces a valid typedef name instead of using raw template syntax
+  // REX FIX: Do NOT sanitize! We want the raw template syntax for unparsing.
+  std::string sanitized_name = type_name;
+  /*
+  for (size_t i = 0; i < sanitized_name.length(); ++i) {
+      char c = sanitized_name[i];
+      if (c == ':' || c == '<' || c == '>' || c == ',' || c == ' ' ||
+          c == '*' || c == '&' || c == '(' || c == ')') {
+          sanitized_name[i] = '_';
+      }
+  }
+  */
+
+  // Create a proper template type with the raw name
+  // Note: buildOpaqueType creates SgClassType in global scope, which unparser
+  // qualifies with :: SgTemplateType unparses as just the name, avoiding
+  // unwanted qualification. REX FIX: Prepend "typename " and insert "template "
+  // for dependent types
+  std::string final_name = sanitized_name;
+
+  // Insert "template " after the last "::" if it exists
+  size_t last_colon = final_name.find_last_of(':');
+  if (last_colon != std::string::npos && last_colon + 1 < final_name.length()) {
+    // Check if it's already there (unlikely)
+    if (final_name.find("template ", last_colon + 1) != last_colon + 1) {
+      final_name.insert(last_colon + 1, "template ");
     }
+  }
 
-    // Build template arguments string
-    // In LLVM 20, use template_arguments() iterator instead of getNumArgs()/getArg()
-    auto template_args = dependent_template_specialization_type->template_arguments();
-    if (!template_args.empty()) {
-        type_name += "<";
-        bool first = true;
-        for (const clang::TemplateArgument &arg : template_args) {
-            if (!first) type_name += ", ";
-            first = false;
-            std::string arg_str;
-            llvm::raw_string_ostream arg_stream(arg_str);
-            arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, /*IncludeType=*/true);
-            arg_stream.flush();
-            type_name += arg_str;
-        }
-        type_name += ">";
-    }
+  final_name = "typename " + final_name;
+  *node = SageBuilder::buildTemplateType(SgName(final_name));
 
-    // Sanitize the type name for use as a C++ identifier
-    // Replace invalid characters (::, <, >, comma, space, *, &) with underscores
-    // This produces a valid typedef name instead of using raw template syntax
-    // REX FIX: Do NOT sanitize! We want the raw template syntax for unparsing.
-    std::string sanitized_name = type_name;
-    /*
-    for (size_t i = 0; i < sanitized_name.length(); ++i) {
-        char c = sanitized_name[i];
-        if (c == ':' || c == '<' || c == '>' || c == ',' || c == ' ' ||
-            c == '*' || c == '&' || c == '(' || c == ')') {
-            sanitized_name[i] = '_';
-        }
-    }
-    */
-
-    // Create a proper template type with the raw name
-    // Note: buildOpaqueType creates SgClassType in global scope, which unparser qualifies with ::
-    // SgTemplateType unparses as just the name, avoiding unwanted qualification.
-    // REX FIX: Prepend "typename " and insert "template " for dependent types
-    std::string final_name = sanitized_name;
-    
-    // Insert "template " after the last "::" if it exists
-    size_t last_colon = final_name.find_last_of(':');
-    if (last_colon != std::string::npos && last_colon + 1 < final_name.length()) {
-        // Check if it's already there (unlikely)
-        if (final_name.find("template ", last_colon + 1) != last_colon + 1) {
-             final_name.insert(last_colon + 1, "template ");
-        }
-    }
-    
-    final_name = "typename " + final_name;
-    *node = SageBuilder::buildTemplateType(SgName(final_name));
-
-    return VisitTypeWithKeyword(dependent_template_specialization_type, node) && res;
+  return VisitTypeWithKeyword(dependent_template_specialization_type, node) &&
+         res;
 }
 
-bool ClangToSageTranslator::VisitElaboratedType(clang::ElaboratedType * elaborated_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitElaboratedType(
+    clang::ElaboratedType *elaborated_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitElaboratedType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitElaboratedType" << std::endl;
 #endif
 
-    SgType * type = buildTypeFromQualifiedType(elaborated_type->getNamedType());
+  SgType *type = buildTypeFromQualifiedType(elaborated_type->getNamedType());
 
-    // CLANG FRONTEND NOTE: ElaboratedType contains namespace qualifiers (e.g., "std::" in "std::string")
-    // and struct/class/enum keywords that provide "sugar" for the type reference.
-    //
-    // WARNING: Do NOT mutate the underlying SgTypedefDeclaration or other type declarations!
-    // The same declaration is shared by all uses, so modifying it causes corruption:
-    //   1st use: "string" → "std::string"
-    //   2nd use: "std::string" → "std::std::string"
-    //   3rd use: "std::std::string" → "std::std::std::string"
-    //
-    // TODO: ROSE needs a proper way to represent elaborated types with qualifiers.
-    // Possible solutions:
-    //   - Create SgQualifiedNameType or similar wrapper
-    //   - Store qualifier info as attributes on the type
-    //   - Handle qualification during unparsing only
-    //
-    // For now, we just desugar to the named type (same as EDG frontend behavior).
+  // CLANG FRONTEND NOTE: ElaboratedType contains namespace qualifiers (e.g.,
+  // "std::" in "std::string") and struct/class/enum keywords that provide
+  // "sugar" for the type reference.
+  //
+  // WARNING: Do NOT mutate the underlying SgTypedefDeclaration or other type
+  // declarations! The same declaration is shared by all uses, so modifying it
+  // causes corruption:
+  //   1st use: "string" → "std::string"
+  //   2nd use: "std::string" → "std::std::string"
+  //   3rd use: "std::std::string" → "std::std::std::string"
+  //
+  // TODO: ROSE needs a proper way to represent elaborated types with
+  // qualifiers. Possible solutions:
+  //   - Create SgQualifiedNameType or similar wrapper
+  //   - Store qualifier info as attributes on the type
+  //   - Handle qualification during unparsing only
+  //
+  // For now, we just desugar to the named type (same as EDG frontend behavior).
 
-    *node = type;
+  *node = type;
 
-    return VisitTypeWithKeyword(elaborated_type, node);
+  return VisitTypeWithKeyword(elaborated_type, node);
 }
 
-bool ClangToSageTranslator::VisitUnaryTransformType(clang::UnaryTransformType * unary_transform_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitUnaryTransformType(
+    clang::UnaryTransformType *unary_transform_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::UnaryTransformType" << std::endl;
+  std::cerr << "ClangToSageTranslator::UnaryTransformType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // UnaryTransformType is sugar that wraps another type (e.g., __underlying_type).
-    // Desugar it so downstream consumers see the real underlying type instead of an
-    // unknown placeholder.
-    clang::QualType underlying = unary_transform_type->desugar();
-    if (underlying.isNull()) {
-        underlying = unary_transform_type->getUnderlyingType();
-    }
-    if (underlying.isNull()) {
-        underlying = unary_transform_type->getBaseType();
-    }
+  // UnaryTransformType is sugar that wraps another type (e.g.,
+  // __underlying_type). Desugar it so downstream consumers see the real
+  // underlying type instead of an unknown placeholder.
+  clang::QualType underlying = unary_transform_type->desugar();
+  if (underlying.isNull()) {
+    underlying = unary_transform_type->getUnderlyingType();
+  }
+  if (underlying.isNull()) {
+    underlying = unary_transform_type->getBaseType();
+  }
 
-    if (underlying.isNull()) {
-        *node = SageBuilder::buildUnknownType();
-    } else {
-        *node = buildTypeFromQualifiedType(underlying);
-    }
+  if (underlying.isNull()) {
+    *node = SageBuilder::buildUnknownType();
+  } else {
+    *node = buildTypeFromQualifiedType(underlying);
+  }
 
-    return VisitType(unary_transform_type, node) && res;
+  return VisitType(unary_transform_type, node) && res;
 }
 
 // DependentUnaryTransformType was removed/renamed in LLVM 20
 /*
-bool ClangToSageTranslator::VisitDependentUnaryTransformType(clang::DependentUnaryTransformType * dependent_unary_transform_type, SgNode ** node) {
-#if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::DependentUnaryTransformType" << std::endl;
-#endif
-    bool res = true;
+bool
+ClangToSageTranslator::VisitDependentUnaryTransformType(clang::DependentUnaryTransformType
+* dependent_unary_transform_type, SgNode ** node) { #if DEBUG_VISIT_TYPE
+    std::cerr << "ClangToSageTranslator::DependentUnaryTransformType" <<
+std::endl; #endif bool res = true;
 
     ROSE_ASSERT(FAIL_FIXME == 0); // FIXME
 
@@ -2026,58 +2244,62 @@ bool ClangToSageTranslator::VisitDependentUnaryTransformType(clang::DependentUna
 }
 */
 
-bool ClangToSageTranslator::VisitUnresolvedUsingType(clang::UnresolvedUsingType * unresolved_using_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitUnresolvedUsingType(
+    clang::UnresolvedUsingType *unresolved_using_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::UnresolvedUsingType" << std::endl;
+  std::cerr << "ClangToSageTranslator::UnresolvedUsingType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // Preserve the type as an unresolved dependent name rather than leaving a null
-    // node (which triggers runtime errors and forces an unknown type later).
-    *node = SageBuilder::buildUnknownType();
+  // Preserve the type as an unresolved dependent name rather than leaving a
+  // null node (which triggers runtime errors and forces an unknown type later).
+  *node = SageBuilder::buildUnknownType();
 
-    return VisitType(unresolved_using_type, node) && res;
+  return VisitType(unresolved_using_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitVectorType(clang::VectorType * vector_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitVectorType(clang::VectorType *vector_type,
+                                            SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitVectorType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitVectorType" << std::endl;
 #endif
 
-    SgType * type = buildTypeFromQualifiedType(vector_type->getElementType());
+  SgType *type = buildTypeFromQualifiedType(vector_type->getElementType());
 
-    SgModifierType * modified_type = new SgModifierType(type);
-    SgTypeModifier & sg_modifer = modified_type->get_typeModifier();
+  SgModifierType *modified_type = new SgModifierType(type);
+  SgTypeModifier &sg_modifer = modified_type->get_typeModifier();
 
-    sg_modifer.setVectorType();
-    sg_modifer.set_vector_size(vector_type->getNumElements());
+  sg_modifer.setVectorType();
+  sg_modifer.set_vector_size(vector_type->getNumElements());
 
-    *node = SgModifierType::insertModifierTypeIntoTypeTable(modified_type);
+  *node = SgModifierType::insertModifierTypeIntoTypeTable(modified_type);
 
-    return VisitType(vector_type, node);
+  return VisitType(vector_type, node);
 }
 
-bool ClangToSageTranslator::VisitExtVectorType(clang::ExtVectorType * ext_vector_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitExtVectorType(
+    clang::ExtVectorType *ext_vector_type, SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitExtVectorType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitExtVectorType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    ROSE_ASSERT(FAIL_FIXME == 0); // FIXME Is it anything to be done here?
+  ROSE_ASSERT(FAIL_FIXME == 0); // FIXME Is it anything to be done here?
 
-    return VisitVectorType(ext_vector_type, node) && res;
+  return VisitVectorType(ext_vector_type, node) && res;
 }
 
-bool ClangToSageTranslator::VisitUsingType(clang::UsingType * using_type, SgNode ** node) {
+bool ClangToSageTranslator::VisitUsingType(clang::UsingType *using_type,
+                                           SgNode **node) {
 #if DEBUG_VISIT_TYPE
-    std::cerr << "ClangToSageTranslator::VisitUsingType" << std::endl;
+  std::cerr << "ClangToSageTranslator::VisitUsingType" << std::endl;
 #endif
-    bool res = true;
+  bool res = true;
 
-    // ROOT CAUSE FIX: UsingType is a type alias from a using declaration
-    // Desugar it to get the underlying type
-    clang::QualType underlying = using_type->desugar();
-    *node = buildTypeFromQualifiedType(underlying);
+  // ROOT CAUSE FIX: UsingType is a type alias from a using declaration
+  // Desugar it to get the underlying type
+  clang::QualType underlying = using_type->desugar();
+  *node = buildTypeFromQualifiedType(underlying);
 
-    return res;
+  return res;
 }

--- a/src/frontend/SageIII/sageInterface/sageBuilder.C
+++ b/src/frontend/SageIII/sageInterface/sageBuilder.C
@@ -8163,6 +8163,60 @@ SageBuilder::buildVarRefExp(const std::string& varName, SgScopeStatement* scope)
 }
 
 SgVarRefExp *
+SageBuilder::buildDanglingVarRefExp(const SgName &name,
+                                    SgScopeStatement *scope /*=NULL*/) {
+  if (scope == NULL)
+    scope = SageBuilder::topScopeStack();
+
+  SgType *unknownType = SgTypeUnknown::createType();
+
+  SgVariableDeclaration *placeholderDecl =
+      new SgVariableDeclaration(name, unknownType, NULL);
+  placeholderDecl->set_firstNondefiningDeclaration(placeholderDecl);
+  placeholderDecl->set_definingDeclaration(placeholderDecl);
+  if (scope != NULL) {
+    placeholderDecl->set_scope(scope);
+    placeholderDecl->set_parent(scope);
+  }
+  placeholderDecl->set_file_info(
+      Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode());
+  if (Sg_File_Info *fi = placeholderDecl->get_file_info()) {
+    fi->setCompilerGenerated();
+    fi->unsetOutputInCodeGeneration();
+  }
+
+  ROSE_ASSERT(!placeholderDecl->get_variables().empty());
+  SgInitializedName *placeholderVar = placeholderDecl->get_variables().front();
+  placeholderVar->set_scope(scope);
+  placeholderVar->set_parent(placeholderDecl);
+  placeholderVar->set_file_info(
+      Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode());
+  if (Sg_File_Info *fi = placeholderVar->get_file_info()) {
+    fi->setCompilerGenerated();
+    fi->unsetOutputInCodeGeneration();
+  }
+  if (SgVariableDefinition *def =
+          isSgVariableDefinition(placeholderVar->get_declptr())) {
+    def->set_parent(placeholderVar);
+    def->set_vardefn(placeholderVar);
+    if (def->get_file_info() == NULL) {
+      def->set_file_info(
+          Sg_File_Info::generateDefaultFileInfoForCompilerGeneratedNode());
+    }
+    if (Sg_File_Info *fi = def->get_file_info()) {
+      fi->setCompilerGenerated();
+      fi->unsetOutputInCodeGeneration();
+    }
+  }
+
+  SgVariableSymbol *placeholderSymbol = new SgVariableSymbol(placeholderVar);
+  placeholderSymbol->set_parent(scope != NULL
+                                    ? static_cast<SgNode *>(scope)
+                                    : static_cast<SgNode *>(placeholderVar));
+  return SageBuilder::buildVarRefExp(placeholderSymbol);
+}
+
+SgVarRefExp *
 SageBuilder::buildVarRefExp(const SgName& name, SgScopeStatement* scope/*=NULL*/)
    {
 #if 0
@@ -8202,23 +8256,9 @@ SageBuilder::buildVarRefExp(const SgName& name, SgScopeStatement* scope/*=NULL*/
           printf ("What type of symbol is this: symbol = %p = %s \n",symbol,symbol->class_name().c_str());
 #endif
           varSymbol = isSgVariableSymbol(symbol);
-        }
-       else
-        {
-       // if not found: put fake init name and symbol here and
-       // waiting for a postProcessing phase to clean it up
-       // two features: no scope and unknown type for initializedName
-          SgInitializedName * name1 = buildInitializedName(name,SgTypeUnknown::createType());
-          name1->set_scope(scope);  // buildInitializedName() does not set scope for various reasons
-          name1->set_parent(scope);
-          varSymbol = new SgVariableSymbol(name1);
-          varSymbol->set_parent(scope);
-
-       // DQ (4/2/2012): Output a warning:
-#if 0
-          printf ("WARNING: In SageBuilder::buildVarRefExp(): symbol not found so we built a SgVariableSymbol = %p (but not put into symbol table) \n",varSymbol);
-#endif
-        }
+     } else {
+       return buildDanglingVarRefExp(name, scope);
+     }
 
      if (varSymbol == NULL)
         {

--- a/src/frontend/SageIII/sageInterface/sageBuilder.h
+++ b/src/frontend/SageIII/sageInterface/sageBuilder.h
@@ -732,6 +732,17 @@ It is possible to build a reference to a variable with known name before the var
 */
 ROSE_DLL_API SgVarRefExp * buildVarRefExp(const SgName& name, SgScopeStatement* scope=NULL);
 
+//! Build a variable reference expression without symbol-table lookup.
+/*!
+ * This creates a compiler-generated placeholder variable declaration (not
+ * attached to any statement list and suppressed from code generation) and
+ * returns a SgVarRefExp referring to it. This is useful for
+ * template-dependent/unresolved names where binding to an existing symbol by
+ * name would be incorrect.
+ */
+ROSE_DLL_API SgVarRefExp *
+buildDanglingVarRefExp(const SgName &name, SgScopeStatement *scope = NULL);
+
 //! Build SgVarRefExp based on a variable's name. It will lookup symbol table internally starting from scope. A variable is unique so type can be inferred.
 ROSE_DLL_API SgVarRefExp * buildVarRefExp(const std::string& varName, SgScopeStatement* scope=NULL);
 

--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -15366,7 +15366,43 @@ void SageInterface::clearUnusedVariableSymbols(SgNode* root /*= NULL */)
             std::cout << "Symbol " << symbolToDelete->get_name().str() << ' ' << symbolToDelete <<
                ' ' << symbolToDelete->get_declaration() <<  " is deleted." << std::endl;
 #endif
-            delete symbolToDelete->get_declaration();
+          SgInitializedName *initNameToDelete =
+              symbolToDelete->get_declaration();
+
+          // When the placeholder is built via
+          // SageBuilder::buildDanglingVarRefExp, it may include a
+          // compiler-generated SgVariableDeclaration and its
+          // SgVariableDefinition. Deleting only the SgInitializedName would
+          // leave behind dangling statements in the memory pool that fail AST
+          // consistency checks (e.g., SgStatement::get_scope()).
+          if (initNameToDelete != NULL) {
+            if (SgVariableDefinition *varDef =
+                    isSgVariableDefinition(initNameToDelete->get_declptr())) {
+              delete varDef;
+              initNameToDelete->set_declptr(NULL);
+            }
+
+            SgVariableDeclaration *parentVarDecl =
+                isSgVariableDeclaration(initNameToDelete->get_parent());
+            if (parentVarDecl != NULL) {
+              SgInitializedNamePtrList &vars = parentVarDecl->get_variables();
+              vars.erase(
+                  std::remove(vars.begin(), vars.end(), initNameToDelete),
+                  vars.end());
+
+              // Delete the placeholder declaration if it was created only to
+              // anchor a dangling reference.
+              if (vars.empty() && parentVarDecl->get_file_info() != NULL &&
+                  parentVarDecl->get_file_info()->isCompilerGenerated() &&
+                  parentVarDecl->get_file_info()->isOutputInCodeGeneration() ==
+                      false) {
+                delete parentVarDecl;
+              }
+            }
+
+            delete initNameToDelete;
+          }
+
             delete symbolToDelete;
         }
     }

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -82,3 +82,14 @@ add_test(
     -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue89_alias.cpp
 )
 set_tests_properties(Cxx_tests_rex_test2025_issue89_type_alias_template_args PROPERTIES LABELS Cxx_tests)
+
+add_test(
+  NAME Cxx_tests_rex_test2025_issue90_array_dim_template_param
+  COMMAND sh -c "\"$@\" && grep \"data\\[N\\]\" rose_rex_test2025_issue90_array_dim.cpp | grep -v \"//\" && ${CMAKE_CXX_COMPILER} -std=c++17 -c rose_rex_test2025_issue90_array_dim.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue90_array_dim.cpp
+)
+set_tests_properties(Cxx_tests_rex_test2025_issue90_array_dim_template_param PROPERTIES LABELS Cxx_tests)

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -13,6 +13,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   rex_test2025_variadic_template_params.cpp
   rex_test2025_issue88.cpp
   rex_test2025_issue89_alias.cpp
+  rex_test2025_issue90_array_dim.cpp
   rex_test2025_issue107_chrono.cpp
   rex_test2025_issue107_redundant.cpp
   rex_test2025_issue107_enable_if.cpp

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue90_array_dim.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue90_array_dim.cpp
@@ -1,0 +1,14 @@
+// REX Issue #90: Array dimension expressions using non-type template parameters
+// must be preserved (e.g., T data[N] must not become T data[]).
+
+template <typename T, int N> struct Container {
+  T data[N];
+
+  void push(T val) { data[0] = val; }
+};
+
+int main() {
+  Container<int, 10> c;
+  c.push(5);
+  return 0;
+}


### PR DESCRIPTION
## Fix issue #90: preserve array dimensions using non-type template parameters

### Problem
In template code like:

```cpp
template <typename T, int N> struct Container { T data[N]; };
```

REX/ROSE was dropping the dependent array bound during Clang→Sage translation, causing the unparsed output to become `data[]` (or otherwise lose `N`). This breaks round-trip correctness and downstream compilation.

### Root cause
- `clang::DependentSizedArrayType` was translated as an **unknown-size** `SgArrayType` (no index expression), even when Clang provides a size expression.
- Template-dependent/unresolved names were sometimes forced through name-based symbol lookup, which can bind incorrectly (or fail) in dependent contexts.

### What this PR changes
- **CFE type translation:** preserve the bound for `clang::DependentSizedArrayType` by traversing `getSizeExpr()` and building `SgArrayType(base, sizeExpr)` when available; only use unknown-size arrays when Clang genuinely has no size expression.
- **Shared builder refactor:** add `SageBuilder::buildDanglingVarRefExp` and route `SageBuilder::buildVarRefExp(name, scope)` “symbol-not-found” behavior through it. This builds a compiler-generated, non-emitted placeholder anchor without doing symbol-table lookup by name.
- **AST cleanup correctness:** extend `SageInterface::clearUnusedVariableSymbols` so placeholders created by `buildDanglingVarRefExp` are deleted consistently (incl. the associated `SgVariableDeclaration`/`SgVariableDefinition`), preventing orphaned statements in the memory pool.
- **CFE usage:** replace ad-hoc placeholder var-ref construction in the Clang frontend with `SageBuilder::buildDanglingVarRefExp` where appropriate.

### Tests
- Add new nonsmoke compile test:
  - `tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue90_array_dim.cpp`
- Add new CTest that:
  1. Runs the translator on the test.
  2. Greps the generated output for `data[N]`.
  3. Compiles `rose_rex_test2025_issue90_array_dim.cpp` with `-std=c++17`.
- Add the test to the **required-to-pass** set:
  - `tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake`

### Verification
- `ctest -R rex -j32 --output-on-failure`
- `ctest -R '^astInterface_' -j32 --output-on-failure`

### Notes / follow-ups
- Follow-up design issue (not implemented here): representing dependent/unresolved name references as `SgNonrealRefExp` instead of placeholder `SgVarRefExp` (tracked in https://github.com/ouankou/rex/issues/115).

### Additional changes included in this branch
- `.gemini/config.yaml`
- `scripts/install-pre-push-ci-tests-hook.sh` now builds before running tests
