### PR TITLE
[Issue 94] Fix template argument comma spacing

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -1100,8 +1100,14 @@ Unparse_ExprStmt::unparseTemplateArgumentList(const SgTemplateArgumentPtrList & 
      ROSE_ASSERT(ninfo.isTypeFirstPart()  == false);
      ROSE_ASSERT(ninfo.isTypeSecondPart() == false);
 
-  // DQ (2/10/2019): Make a copy to support removing the start_of_pack_expansion_argument which has been complicccated to deal with in unparsing.
-  // const SgTemplateArgumentPtrList templateArgListPtr = input_templateArgListPtr;
+     // Unparse types in template argument lists without introducing trailing
+     // spaces that would lead to output like "T , U" instead of "T, U".
+     ninfo.set_inTemplateList();
+
+     // DQ (2/10/2019): Make a copy to support removing the
+     // start_of_pack_expansion_argument which has been complicccated to deal
+     // with in unparsing. const SgTemplateArgumentPtrList templateArgListPtr =
+     // input_templateArgListPtr;
      SgTemplateArgumentPtrList templateArgListPtr;
      SgTemplateArgumentPtrList::const_iterator copy_iter = input_templateArgListPtr.begin();
 
@@ -1393,7 +1399,7 @@ Unparse_ExprStmt::unparseTemplateArgumentList(const SgTemplateArgumentPtrList & 
                if (true)
                   {
                  // unp->u_exprStmt->curprint(" /* output comma: part 1 */ ");
-                    unp->u_exprStmt->curprint(" , ");
+                 unp->u_exprStmt->curprint(", ");
                   }
                  else
                   {

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -834,7 +834,15 @@ Unparse_Type::unparseType(SgType* type, SgUnparse_Info& info)
        // This is the code that was always used before the addition of type names generated from where name qualification of subtypes are required.
           switch (type->variant())
              {
-               case T_UNKNOWN:            curprint ( get_type_name(type) + " ");          break;
+          case T_UNKNOWN: {
+            curprint(get_type_name(type));
+            if (!(info.inTemplateList() == true &&
+                  info.isTypeFirstPart() == false &&
+                  info.isTypeSecondPart() == false)) {
+              curprint(" ");
+            }
+            break;
+          }
                case T_CHAR:
                case T_SIGNED_CHAR:
                case T_UNSIGNED_CHAR:
@@ -884,7 +892,12 @@ Unparse_Type::unparseType(SgType* type, SgUnparse_Info& info)
                        }
                       else
                        {
-                         curprint ( get_type_name(type) + " ");
+                         curprint(get_type_name(type));
+                         if (!(info.inTemplateList() == true &&
+                               info.isTypeFirstPart() == false &&
+                               info.isTypeSecondPart() == false)) {
+                           curprint(" ");
+                         }
                        }
                     break;
                   }

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -48,6 +48,18 @@ set_tests_properties(Cxx_tests_rex_test2025_issue93_static_assert_order_unparse
   PROPERTIES LABELS Cxx_tests
 )
 
+# Issue 94: Template argument lists must not introduce a space before commas.
+add_test(
+  NAME Cxx_tests_rex_test2025_issue94_template_arg_spacing_unparse
+  COMMAND sh -c "\"$@\" && grep -F \"Container<int, 10>\" rose_rex_test2025_issue94_template_arg_spacing.cpp && ! grep -E \"Container<int[[:space:]]+,\" rose_rex_test2025_issue94_template_arg_spacing.cpp && ${CMAKE_CXX_COMPILER} -std=c++17 -c rose_rex_test2025_issue94_template_arg_spacing.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue94_template_arg_spacing.cpp
+)
+set_tests_properties(Cxx_tests_rex_test2025_issue94_template_arg_spacing_unparse PROPERTIES LABELS Cxx_tests)
+
 # Verify explicit template arguments are preserved in calls
 add_test(
   NAME Cxx_tests_rex_test2025_template_call_explicit_args

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -18,6 +18,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   rex_test2025_issue91_decl_chain.cpp
   rex_test2025_issue92_redundant_sym.cpp
   rex_test2025_issue93_static_assert_order.cpp
+  rex_test2025_issue94_template_arg_spacing.cpp
   rex_test2025_issue107_chrono.cpp
   rex_test2025_issue107_redundant.cpp
   rex_test2025_issue107_enable_if.cpp

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue94_template_arg_spacing.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue94_template_arg_spacing.cpp
@@ -1,0 +1,9 @@
+template <typename T, int N> struct Container {
+  T data[N];
+};
+
+int main() {
+  Container<int, 10> c;
+  (void)c;
+  return 0;
+}


### PR DESCRIPTION
## Summary
Fixes incorrect whitespace before commas in unparsed C++ template argument lists.

Example (before): `Container<int , 10>`

Example (after):  `Container<int, 10>`

Fixes #94

## Root Cause
Template argument list unparsing emitted the separator as `" , "` (space before comma), and builtin types were always unparsed with a trailing space. In combination this produced outputs like `int  ,` inside template argument lists.

## Fix
- Unparse template argument separators as `", "` (no leading space).
- Mark the `SgUnparse_Info` as `inTemplateList` while unparsing template arguments.
- Suppress the trailing space after builtin types when they are emitted as a complete template argument (i.e., not first/second-part type output) so delimiters like `,` are not preceded by whitespace.

## Tests
- Added `tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue94_template_arg_spacing.cpp`.
- Registered it in `tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake`.
- Added a CTest that verifies the unparsed output contains `Container<int, 10>` and rejects `Container<int ,`.

## Validation
- `ctest --test-dir build -R issue94 -j32 --output-on-failure`
- `ctest --test-dir build -R rex -j32 --output-on-failure`
- `ctest --test-dir build -R "^astInterface_" -j32 --output-on-failure`
