### PR TITLE
Fix issue59 leftovers: remove unparser qualification stripping

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
@@ -11607,6 +11607,8 @@ Unparse_ExprStmt::unparseTypeDefStmt(SgStatement* stmt, SgUnparse_Info& info)
           curprint(" = ");
 
           SgUnparse_Info ninfo(info);
+          ninfo.set_declstatement_ptr(typedef_stmt);
+          ninfo.set_reference_node_for_qualification(typedef_stmt);
           bool outputTypeDefinition = typedef_stmt->get_typedefBaseTypeContainsDefiningDeclaration();
           if (outputTypeDefinition) {
               ninfo.set_SkipQualifiedNames();

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -12,64 +12,25 @@
 // Interestingly it must be at the top of the list of include files.
 #include "rose_config.h"
 
+#include <cctype>
+
 // DQ (12/31/2005): This is OK if not declared in a header file
 using namespace std;
 
 namespace {
-// Strip a leading global qualifier and, if the name is qualified by the current (or owning)
-// class, strip that class qualification as well (e.g., UsesDependent::rebound -> rebound).
-static std::string strip_redundant_qualification(std::string name, const SgUnparse_Info& info, SgType* type) {
-  // Trim trailing whitespace
-  while (!name.empty() && isspace(name.back())) {
+static std::string trim_whitespace(std::string name) {
+  while (!name.empty() &&
+         std::isspace(static_cast<unsigned char>(name.back()))) {
     name.pop_back();
   }
 
-  // Trim leading whitespace
   size_t first_non_space = 0;
-  while (first_non_space < name.size() && isspace(name[first_non_space])) {
+  while (first_non_space < name.size() &&
+         std::isspace(static_cast<unsigned char>(name[first_non_space]))) {
     ++first_non_space;
   }
   if (first_non_space > 0) {
     name.erase(0, first_non_space);
-  }
-
-  // Only strip explicit global qualification when it is not required by the unparse info.
-  if (info.get_global_qualification_required() == false) {
-    // Remove any leading global qualifiers
-    while (name.size() > 2 && name.compare(0, 2, "::") == 0) {
-      name = name.substr(2);
-    }
-
-    // Drop redundant global qualifiers that appear immediately after delimiters (e.g., "<::std::tuple>")
-    auto is_identifier_char = [](char c) {
-      return isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '>';
-    };
-    for (size_t i = 0; i + 1 < name.size(); /* increment inside */) {
-      if (name[i] == ':' && name[i+1] == ':') {
-        bool preceded_by_identifier = (i > 0) && is_identifier_char(name[i-1]);
-        if (!preceded_by_identifier) {
-          name.erase(i, 2);
-          continue;
-        }
-      }
-      ++i;
-    }
-  }
-
-  // Determine enclosing class from current scope.
-  SgScopeStatement* cur_scope = info.get_current_scope();
-  SgClassDefinition* cur_class = SageInterface::getEnclosingClassDefinition(cur_scope);
-  SgClassDeclaration* cur_decl = NULL;
-
-  if (cur_class != NULL) {
-    cur_decl = cur_class->get_declaration();
-  }
-
-  if (cur_decl != NULL) {
-    std::string prefix = cur_decl->get_name().getString() + "::";
-    if (name.size() > prefix.size() && name.compare(0, prefix.size(), prefix) == 0) {
-      name = name.substr(prefix.size());
-    }
   }
 
   return name;
@@ -795,15 +756,11 @@ Unparse_Type::unparseType(SgType* type, SgUnparse_Info& info)
 #if 0
                printf ("Ouput typeNameString = %s \n",typeNameString.c_str());
 #endif
-               if (info.SkipBaseType() == false)
-                  {
-                     std::string finalName = strip_redundant_qualification(typeNameString, info, type);
-                     curprint(finalName);
-                     curprint(" "); // Restore space stripped by trim
-                   }
-             }
-            else
-             {
+            if (info.SkipBaseType() == false) {
+              curprint(trim_whitespace(typeNameString));
+              curprint(" ");
+            }
+          } else {
             // Sometimes neither is set and this is the trivial case where we want to output the generated type name (see test2011_74.C).
             // if (isSgPointerType(type) != NULL)
                if (info.isTypeFirstPart() == false && info.isTypeSecondPart() == false)
@@ -813,13 +770,11 @@ Unparse_Type::unparseType(SgType* type, SgUnparse_Info& info)
 #endif
                  // DQ (6/18/2013): Added support to skip output of typenames when handling multiple variable declarations in
                  // SgForInitStmt IR nodes and multiple SgInitializedName IR nodes in a single SgVariableDeclaration IR node.
-                     if (info.SkipBaseType() == false)
-                        {
-                          std::string finalName = strip_redundant_qualification(typeNameString, info, type);
-                          curprint(finalName);
-                        }
-                   }
-             }
+                 if (info.SkipBaseType() == false) {
+                   curprint(trim_whitespace(typeNameString));
+                 }
+               }
+          }
         }
        else
         {
@@ -2834,13 +2789,10 @@ Unparse_Type::unparseClassType(SgType* type, SgUnparse_Info& info)
 #endif
                       // DQ (3/29/2019): In reviewing where we are using the get_qualified_name() function, this
                       // might be OK since it is likely only associated with the unparseToString() function.
-                         SgName nameQualifierAndType = class_type->get_qualified_name();
-                      // Strip redundant/global qualification from the generated name (e.g., leading "::std::")
-                         std::string finalName = strip_redundant_qualification(nameQualifierAndType.str(), info, type);
-                         curprint(finalName);
-                       }
-                      else
-                       {
+                         SgName nameQualifierAndType =
+                             class_type->get_qualified_name();
+                         curprint(nameQualifierAndType.str());
+                    } else {
                       // DQ (6/2/2011): Newest support for name qualification...
 #if DEBUG_UNPARSE_CLASS_TYPE
                          printf ("info.get_reference_node_for_qualification() = %p = %s \n",info.get_reference_node_for_qualification(),info.get_reference_node_for_qualification()->class_name().c_str());
@@ -2858,38 +2810,7 @@ Unparse_Type::unparseClassType(SgType* type, SgUnparse_Info& info)
 #if DEBUG_UNPARSE_CLASS_TYPE && 0
                          curprint ( string("\n/* In unparseClassType: nameQualifier (from unp->u_name->generateNameQualifier function) = ") + nameQualifier + " */ \n ");
 #endif
-                         // REX FIX: Strip redundant qualification in unparseClassType
-                         std::string qualStr = nameQualifier.str();
-                         SgName nm = decl->get_name();
-                         
-                         // Debug ALL class names
-                         // printf("DEBUG: unparseClassType nm='%s' qualStr='%s'\n", nm.str(), qualStr.c_str());
-                         
-                         if (nm == "vector") {
-                             SgScopeStatement* scope = decl->get_scope();
-                             std::string scopeName = "unknown";
-                             if (scope) {
-                                 if (isSgGlobal(scope)) scopeName = "Global";
-                                 else if (isSgNamespaceDefinitionStatement(scope)) {
-                                     SgNamespaceDeclarationStatement* nsDecl = isSgNamespaceDefinitionStatement(scope)->get_namespaceDeclaration();
-                                     scopeName = std::string("Namespace: ") + nsDecl->get_name().str();
-                                 } else if (isSgClassDefinition(scope)) {
-                                     scopeName = std::string("Class: ") + isSgClassDefinition(scope)->get_declaration()->get_name().str();
-                                 }
-                             }
-                         // printf("DEBUG: unparseClassType for 'vector'. qualStr='%s'. Scope='%s'\n", qualStr.c_str(), scopeName.c_str());
-                        }
-
-                        // Preserve explicit global qualification when required; otherwise trim redundancies.
-                        if (info.get_global_qualification_required() == false) {
-                          while (qualStr.size() > 2 && qualStr.compare(0,2,"::") == 0) {
-                            qualStr = qualStr.substr(2);
-                          }
-                          if (qualStr == "::") {
-                            qualStr = "";
-                          }
-                        }
-                        curprint(qualStr);
+                         curprint(nameQualifier.str());
 
                          SgTemplateInstantiationDecl* templateInstantiationDeclaration = isSgTemplateInstantiationDecl(decl);
 
@@ -2965,7 +2886,7 @@ Unparse_Type::unparseClassType(SgType* type, SgUnparse_Info& info)
                               printf ("test 1: class type name: nm = %s \n",nm.str());
 #endif
                             }
-                       }
+                    }
                   }
              }
             else
@@ -3758,42 +3679,43 @@ Unparse_Type::unparseTypedefType(SgType* type, SgUnparse_Info& info)
                if (info.get_reference_node_for_qualification() == NULL)
                   {
                  // printf ("WARNING: In unparseTypedefType(): info.get_reference_node_for_qualification() == NULL (assuming this is for unparseToString() \n");
-                    SgName nameQualifierAndType = typedef_type->get_qualified_name();
+                 SgName nameQualifierAndType =
+                     typedef_type->get_qualified_name();
 #if 0
                     printf ("In unparseTypedefType(): Output name nameQualifierAndType = %s \n",nameQualifierAndType.str());
 #endif
                 // DQ (3/29/2019): In reviewing where we are using the get_qualified_name() function, this
                 // might be OK since it is likely only associated with the unparseToString() function.
-                    std::string finalName = strip_redundant_qualification(nameQualifierAndType.str(), info, type);
-                    curprint(finalName);
-                  }
-                 else
-                  {
-                    SgName nameQualifier = unp->u_name->lookup_generated_qualified_name(info.get_reference_node_for_qualification());
+                 curprint(nameQualifierAndType.str());
+               } else {
+                 SgName nameQualifier =
+                     unp->u_name->lookup_generated_qualified_name(
+                         info.get_reference_node_for_qualification());
 
-                    // ROOT CAUSE FIX: If lookup_generated_qualified_name() returns empty (e.g., for system
-                    // header typedefs not in our AST), fall back to get_qualified_name() which is already
-                    // computed and stored on the type. This handles std::string and other system types.
-                    if (nameQualifier.getString().empty()) {
-                        SgName fullName = typedef_type->get_qualified_name();
-                        if (!fullName.getString().empty()) {
-                            curprint(fullName.getString() + " ");
-                            // Skip the normal name output below since we used the full qualified name
-                            return;
-                        }
-                    }
+                 // ROOT CAUSE FIX: If lookup_generated_qualified_name() returns
+                 // empty (e.g., for system header typedefs not in our AST),
+                 // fall back to get_qualified_name() which is already computed
+                 // and stored on the type. This handles std::string and other
+                 // system types.
+                 if (nameQualifier.getString().empty()) {
+                   SgName fullName = typedef_type->get_qualified_name();
+                   if (!fullName.getString().empty()) {
+                     curprint(fullName.getString() + " ");
+                     // Skip the normal name output below since we used the full
+                     // qualified name
+                     return;
+                   }
+                 }
 
-                    std::string qualStr = strip_redundant_qualification(nameQualifier.str(), info, type);
-                    // REX FIX: Prepend empty comment to ensure qualification is not stripped by unparser
-                    if (!qualStr.empty()) curprint("/* */" + qualStr);
+                 curprint(nameQualifier.str());
 
                  // DQ (4/14/2018): This is not the correct way to handle the output of template instantations since this uses the internal name (with unqualified template arguments).
 
 #if 0
                  // DQ (4/15/2018): Original code (which unparsed using the name which would embedd template arguments, but without name qualification).
-                    SgName nm = typedef_type->get_name();
-                    if (nm.getString() != "")
-                       {
+	                         SgName nm = typedef_type->get_name();
+	                        if (nm.getString() != "")
+	                           {
 #if 0
                          printf ("In unparseTypedefType(): Output qualifier of current types to the name = %s \n",nm.str());
 #endif
@@ -3828,12 +3750,11 @@ Unparse_Type::unparseTypedefType(SgType* type, SgUnparse_Info& info)
 #if 0
                               printf ("In unparseTypedefType(): Output qualifier of current types to the name = %s \n",nm.str());
 #endif
-                              std::string nmStr = strip_redundant_qualification(nm.getString(), info, type);
-                              curprint ( nmStr + " ");
-                            }
+                          curprint(nm.getString() + " ");
+                        }
                        }
 #endif
-                  }
+               }
 #endif
 #endif
              }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -1432,6 +1432,7 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
   std::cerr << "ClangToSageTranslator::VisitDecl" << std::endl;
 #endif
   if (*node == NULL) {
+#if DEBUG_VISIT_DECL
     const char *kind_name = decl ? decl->getDeclKindName() : "Unknown";
     std::string loc_string;
     if (decl) {
@@ -1458,6 +1459,7 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
       std::cerr << "Runtime error declaration name: " << nd->getNameAsString()
                 << std::endl;
     }
+#endif
     return false;
   }
 
@@ -3428,26 +3430,13 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
         }
 
         if (sg_decl) {
-          if (SgTemplateClassDeclaration *class_tmpl =
-                  isSgTemplateClassDeclaration(sg_decl)) {
-            SgName qual_name = class_tmpl->get_qualified_name();
-            if (qual_name.getString().find("::") == std::string::npos &&
-                class_tmpl->get_scope()) {
-              if (SgNamespaceDefinitionStatement *ns_def =
-                      isSgNamespaceDefinitionStatement(
-                          class_tmpl->get_scope())) {
-                qual_name =
-                    ns_def->get_namespaceDeclaration()->get_name().getString() +
-                    "::" + class_tmpl->get_name().getString();
-              }
-            }
-            SgType *type = SageBuilder::buildTemplateType(qual_name);
-            sg_arg = new SgTemplateArgument(type, false);
-          } else {
-            sg_arg = new SgTemplateArgument(
-                SgTemplateArgument::template_template_argument, sg_decl);
-            sg_arg->set_templateDeclaration(sg_decl);
-          }
+          sg_arg = new SgTemplateArgument(
+              SgTemplateArgument::template_template_argument,
+              /*isArrayBoundUnknownType=*/false,
+              /*type=*/NULL,
+              /*expression=*/NULL,
+              /*templateDeclaration=*/sg_decl,
+              /*explicitlySpecified=*/false);
         }
       }
       break;
@@ -3531,8 +3520,12 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
               sg_arg = new SgTemplateArgument(type, false);
             } else {
               sg_arg = new SgTemplateArgument(
-                  SgTemplateArgument::template_template_argument, sg_decl);
-              sg_arg->set_templateDeclaration(sg_decl);
+                  SgTemplateArgument::template_template_argument,
+                  /*isArrayBoundUnknownType=*/false,
+                  /*type=*/NULL,
+                  /*expression=*/NULL,
+                  /*templateDeclaration=*/sg_decl,
+                  /*explicitlySpecified=*/false);
             }
           }
         }
@@ -3603,28 +3596,13 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
           }
 
           if (sg_decl) {
-            if (SgTemplateClassDeclaration *class_tmpl =
-                    isSgTemplateClassDeclaration(sg_decl)) {
-              // Reuse logic for name qualification
-              SgName qual_name = class_tmpl->get_qualified_name();
-              if (qual_name.getString().find("::") == std::string::npos &&
-                  class_tmpl->get_scope()) {
-                if (SgNamespaceDefinitionStatement *ns_def =
-                        isSgNamespaceDefinitionStatement(
-                            class_tmpl->get_scope())) {
-                  qual_name = ns_def->get_namespaceDeclaration()
-                                  ->get_name()
-                                  .getString() +
-                              "::" + class_tmpl->get_name().getString();
-                }
-              }
-              SgType *type = SageBuilder::buildTemplateType(qual_name);
-              sg_arg = new SgTemplateArgument(type, false);
-            } else {
-              sg_arg = new SgTemplateArgument(
-                  SgTemplateArgument::template_template_argument, sg_decl);
-              sg_arg->set_templateDeclaration(sg_decl);
-            }
+            sg_arg = new SgTemplateArgument(
+                SgTemplateArgument::template_template_argument,
+                /*isArrayBoundUnknownType=*/false,
+                /*type=*/NULL,
+                /*expression=*/NULL,
+                /*templateDeclaration=*/sg_decl,
+                /*explicitlySpecified=*/false);
           }
         }
         break;

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -1659,25 +1659,13 @@ SgTemplateArgument *ClangToSageTranslator::translateTemplateArgument(
       }
 
       if (sg_decl != nullptr) {
-        if (SgTemplateClassDeclaration *class_tmpl =
-                isSgTemplateClassDeclaration(sg_decl)) {
-          SgName qual_name = class_tmpl->get_qualified_name();
-          if (qual_name.getString().find("::") == std::string::npos &&
-              class_tmpl->get_scope()) {
-            if (SgNamespaceDefinitionStatement *ns_def =
-                    isSgNamespaceDefinitionStatement(class_tmpl->get_scope())) {
-              qual_name =
-                  ns_def->get_namespaceDeclaration()->get_name().getString() +
-                  "::" + class_tmpl->get_name().getString();
-            }
-          }
-          SgType *type = SageBuilder::buildTemplateType(qual_name);
-          sg_arg = new SgTemplateArgument(type, explicitlySpecified);
-        } else {
-          sg_arg = new SgTemplateArgument(
-              SgTemplateArgument::template_template_argument, sg_decl);
-          sg_arg->set_templateDeclaration(sg_decl);
-        }
+        sg_arg = new SgTemplateArgument(
+            SgTemplateArgument::template_template_argument,
+            /*isArrayBoundUnknownType=*/false,
+            /*type=*/nullptr,
+            /*expression=*/nullptr,
+            /*templateDeclaration=*/sg_decl,
+            /*explicitlySpecified=*/explicitlySpecified);
       } else {
         std::cerr << "Warning: Failed to translate template declaration "
                      "for template argument\n";
@@ -1817,11 +1805,6 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
   inst_decl->set_definingDeclaration(nullptr);
   inst_decl->set_firstNondefiningDeclaration(inst_decl);
 
-  // REX FIX: Always require global qualification for template instantiations
-  // This ensures that the unparser prints "::" (e.g. "::std::vector" or
-  // "::tuple") which prevents ambiguity when global templates are shadowed.
-  inst_decl->set_global_qualification_required(true);
-
   if (inst_decl->get_templateDeclaration() == NULL) {
     std::cerr << "CRITICAL ERROR: inst_decl->get_templateDeclaration() is NULL "
                  "immediately after creation! Setting it explicitly."
@@ -1947,12 +1930,7 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
     std::string type_name =
         clang::QualType(template_specialization_type, 0).getAsString(policy);
 
-    // Strip leading "::" if present to avoid double qualification by unparser
-    if (type_name.size() >= 2 && type_name.substr(0, 2) == "::") {
-      type_name = type_name.substr(2);
-    }
-
-    *node = SageBuilder::buildOpaqueType(type_name, getGlobalScope());
+    *node = SageBuilder::buildTemplateType(SgName(type_name));
     return VisitType(template_specialization_type, node);
   }
 
@@ -2167,7 +2145,7 @@ bool ClangToSageTranslator::VisitDependentNameType(
     type_name = "typename " + type_name;
   }
 
-  *node = SageBuilder::buildOpaqueType(type_name, getGlobalScope());
+  *node = SageBuilder::buildTemplateType(SgName(type_name));
 
   return VisitTypeWithKeyword(dependent_name_type, node) && res;
 }

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -91,6 +91,24 @@ set_tests_properties(
   PROPERTIES LABELS Cxx_tests
 )
 
+# Issue 59: Template-template arguments must preserve required global
+# qualification (no string stripping in the unparser).
+add_test(
+  NAME Cxx_tests_rex_test2025_issue59_template_template_arg_global_qual_unparse
+  COMMAND
+    sh -c
+    "\"$@\" && grep -E \"UsePack[[:space:]]*<[[:space:]]*::Lib::Tuple\" rose_rex_test2025_issue59_template_template_arg_global_qual.cpp && ${CMAKE_CXX_COMPILER} -std=c++20 -c rose_rex_test2025_issue59_template_template_arg_global_qual.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue59_template_template_arg_global_qual.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_test2025_issue59_template_template_arg_global_qual_unparse
+  PROPERTIES LABELS Cxx_tests
+)
+
 # Namespace reopenings: keep declarations in their lexical namespace block.
 add_test(
   NAME Cxx_tests_rex_test2025_namespace_reopenings_preserve_blocks_unparse

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -27,6 +27,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   rex_test2025_issue124_system_header_specialization_args.cpp
   rex_test2025_issue125_fixup_child_list_warning.cpp
   rex_test2025_issue126_default_template_args.cpp
+  rex_test2025_issue59_template_template_arg_global_qual.cpp
   rex_test2025_namespace_reopenings_preserve_blocks.cpp
   method-defn-in-tpldecl-0.C
   method-defn-in-tpldecl-1.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue59_template_template_arg_global_qual.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue59_template_template_arg_global_qual.cpp
@@ -1,0 +1,15 @@
+namespace Lib {
+template <class... Ts> struct Tuple {};
+} // namespace Lib
+
+namespace A {
+namespace Lib {
+template <class... Ts> struct Tuple {};
+} // namespace Lib
+
+template <template <class...> class TT, class... Ts> struct UsePack {};
+
+UsePack<::Lib::Tuple, int, double> v{};
+} // namespace A
+
+int main() { return 0; }


### PR DESCRIPTION
## What this fixes
Issue #59 still had two leftover problems that were only being hidden by late-stage string surgery and noisy debug output:

1) **Required global qualification could be lost or mangled** for template/template-template arguments and dependent template spellings.
2) **The unparser was stripping qualification from generated type-name strings** (`strip_redundant_qualification`), which masked IR issues and could silently change meaning (e.g. collapsing `::Lib::Tuple` to `Lib::Tuple` inside a namespace that also defines `Lib`).

This PR removes the unparser workaround and fixes the *root cause* in the Clang frontend/type lowering so the IR carries the correct structure and the unparser can print it directly.

## Root cause
- The Clang frontend was constructing some template arguments/types in ways that pushed qualification into raw strings or into the wrong IR knobs.
  - Template-template arguments were not always represented as `SgTemplateArgument::template_template_argument` with the `templateDeclaration` set.
  - Some dependent template spellings were lowered as global-scope opaque types, which ROSE then (correctly) qualified as global, producing incorrect `::...` behavior downstream.
- The unparser then tried to compensate by stripping global qualifiers and other "redundant" prefixes from the *string form* of a generated qualified type name.

That approach is inherently fragile: it can silently drop required `::` and makes the printed output depend on ad-hoc string heuristics instead of the AST.

## What changed (no hacks)
### Frontend (root-cause fixes)
- `src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp`
  - Translate template-template arguments as `SgTemplateArgument::template_template_argument` with the `templateDeclaration` stored structurally.
  - Stop forcing `set_global_qualification_required(true)` on every template instantiation (global qualification must be represented structurally and decided by the name-qualification machinery, not hard-wired).
  - Lower dependent template specializations / dependent names as `SgTemplateType(SgName(...))` instead of a global-scope opaque type.

- `src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp`
  - Fix `SgTemplateArgument` construction for template-template args (use the correct ctor so the declaration is attached in the right slot).
  - Gate the old "Runtime error: No Sage node..." debug prints behind `DEBUG_VISIT_DECL` to avoid noisy output during normal test runs.

### Unparser (remove workaround)
- `src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C`
  - Remove `strip_redundant_qualification` (no more stripping `::` or class qualifiers from generated strings).
  - Keep only whitespace normalization for generated strings.

- `src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C`
  - Ensure `unparseTypeDefStmt` sets `declstatement_ptr` + `reference_node_for_qualification` for `using` aliases so generated name-qualification lookup is done in the correct context.

## New regression test
- `tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue59_template_template_arg_global_qual.cpp`
  - Creates both `::Lib::Tuple` and `A::Lib::Tuple` and instantiates `UsePack<::Lib::Tuple, ...>` inside `namespace A`.
  - The test asserts the unparsed output preserves the required global qualification (`UsePack< ::Lib::Tuple ...>`).

Wiring:
- Added to `tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake`.
- Added a dedicated unparse/grep check in `tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt`.

## How to verify
- `cmake --build build -j32`
- `ctest --test-dir build -R rex --output-on-failure -j32`
- `ctest --test-dir build -R astInterface --output-on-failure -j32`

Fixes #59
