### PR TITLE
Add regression test for issue64 global :: template qualification

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -109,6 +109,24 @@ set_tests_properties(
   PROPERTIES LABELS Cxx_tests
 )
 
+# Issue 64: Unparser must preserve required global qualification for template
+# instantiations when a global template is shadowed by a nested-scope template.
+add_test(
+  NAME Cxx_tests_rex_test2025_issue64_shadow_template_global_qual_unparse
+  COMMAND
+    sh -c
+    "\"$@\" && ${CMAKE_CXX_COMPILER} -std=c++20 -c rose_rex_test2025_issue64_shadow_template_global_qual.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue64_shadow_template_global_qual.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_test2025_issue64_shadow_template_global_qual_unparse
+  PROPERTIES LABELS Cxx_tests
+)
+
 # Namespace reopenings: keep declarations in their lexical namespace block.
 add_test(
   NAME Cxx_tests_rex_test2025_namespace_reopenings_preserve_blocks_unparse

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -28,6 +28,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   rex_test2025_issue125_fixup_child_list_warning.cpp
   rex_test2025_issue126_default_template_args.cpp
   rex_test2025_issue59_template_template_arg_global_qual.cpp
+  rex_test2025_issue64_shadow_template_global_qual.cpp
   rex_test2025_namespace_reopenings_preserve_blocks.cpp
   method-defn-in-tpldecl-0.C
   method-defn-in-tpldecl-1.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue64_shadow_template_global_qual.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue64_shadow_template_global_qual.cpp
@@ -1,0 +1,19 @@
+template <typename T> struct tuple {
+  char tag[1];
+};
+
+namespace N {
+template <typename T> struct tuple {
+  char tag[2];
+};
+
+struct A {
+  ::tuple<int> t1;
+  tuple<int> t2;
+
+  static_assert(sizeof(t1) == 1);
+  static_assert(sizeof(t2) == 2);
+};
+} // namespace N
+
+int main() { return 0; }


### PR DESCRIPTION
## Summary
Issue #64 originally reported that a leading global qualifier `::` was being silently dropped when unparsing template instantiations, which can change meaning when a global template is shadowed by a nested-scope template.

On current `main`, the original repro no longer reproduces (global `::` is preserved), likely due to recent root-cause cleanups that removed unparser-side `::`/qualification string trimming and fixed qualification to be represented structurally.

This PR adds a regression test so we never reintroduce any `::` trimming behavior.

## What this PR changes
- Adds `rex_test2025_issue64_shadow_template_global_qual.cpp` which defines both a global `tuple<T>` and a shadowing `N::tuple<T>` and verifies the global-qualified member remains global.
- Registers the test in `Cxx_Testcodes.cmake` and adds a compile-the-unparsed-output check in `Cxx_tests/CMakeLists.txt`.

## Verification
- `ctest --test-dir build -R rex --output-on-failure -j32`
- `ctest --test-dir build -R astInterface --output-on-failure -j32`

Refs: #64
