### PR TITLE
Fix duplicate embedded record decls (Issue 66)

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -775,6 +775,17 @@ void ClangToSageTranslator::populateClassDefinition(
       continue;
     }
 
+    // Clang models records/enums declared as part of a declarator
+    // (e.g., `struct Y { ... } field;` or `struct { ... } field;`) as TagDecls
+    // that are "embedded in declarator". These must not be appended as
+    // standalone members; the owning declarator/field will already emit the
+    // embedded definition inline during unparsing.
+    if (clang::TagDecl *tag_decl = llvm::dyn_cast<clang::TagDecl>(inner_decl)) {
+      if (tag_decl->isEmbeddedInDeclarator()) {
+        continue;
+      }
+    }
+
     if (inner_decl->isImplicit()) {
       continue;
     }

--- a/tests/nonsmoke/functional/CompileTests/C_tests/C_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/C_Testcodes.cmake
@@ -6,6 +6,7 @@ set(TESTCODES_REQUIRED_TO_PASS
   constants.c
   gconv_info.c
   math.c
+  rex_test2025_embedded_record_decl.c
   rose-1391-a.c
   rose-1391-b.c
   stdio.c

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2025_embedded_record_decl.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2025_embedded_record_decl.c
@@ -1,0 +1,16 @@
+typedef struct X {
+  struct Y {
+    int dummy;
+  } y;
+
+  struct {
+    int a;
+  } anon;
+} X;
+
+int main(void) {
+  X x;
+  x.y.dummy = 0;
+  x.anon.a = 1;
+  return x.y.dummy + x.anon.a;
+}


### PR DESCRIPTION
Fixes #66.

## Problem
`C_tests_test2012_01` failed when compiling the generated `rose_test2012_01.c` due to duplicated record definitions coming from system headers (e.g. `__pthread_mutex_s`, anonymous structs inside `siginfo_t`).

This was caused by **Clang AST “embedded in declarator” TagDecls** being appended as standalone members in ROSE:

- Clang represents `struct Y { ... } field;` (and anonymous `struct { ... } field;`) with a `clang::TagDecl` where `isEmbeddedInDeclarator()==true`.
- The unparser also emits the embedded definition inline as part of the owning `FieldDecl`/declarator.
- If we additionally append the translated TagDecl as a standalone member, the output becomes:
  - `struct Y { ... };`
  - `struct Y { ... } field;`
  …which duplicates the record and redeclares its fields.

## Root-cause fix (CFE)
`ClangToSageTranslator::populateClassDefinition()` now skips `clang::TagDecl` members where `tagDecl->isEmbeddedInDeclarator()` is true, so embedded record/enum definitions are only emitted inline by the owning declarator and are not duplicated as standalone members.

This matches the existing TU-level logic already used in `VisitTranslationUnitDecl`.

## Tests
- Added `tests/nonsmoke/functional/CompileTests/C_tests/rex_test2025_embedded_record_decl.c`
- Registered it in `tests/nonsmoke/functional/CompileTests/C_tests/C_Testcodes.cmake`

## Verification
- `ctest --test-dir build -R '^C_tests_test2012_01$' --output-on-failure -j32`
- `ctest --test-dir build -R '^C_tests_rex_test2025_embedded_record_decl$' --output-on-failure -j32`
- `ctest --test-dir build -R astInterface --output-on-failure -j32`
- `ctest --test-dir build -R rex --output-on-failure -j32`

All pass.

## Note
`tokenStreamMapping_test2012_01.c` still aborts in token-stream unparsing (`unparseStatementFromTokenStream` scope assertion) and remains a separate token-mapping issue (tracked under #73).
