### PR TITLE
Handle parameter list unique-name generation

### DIFF
--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -2977,6 +2977,39 @@ SageInterface::generateUniqueNameForUseAsIdentifier_support ( SgDeclarationState
                break;
              }
 
+          case V_SgFunctionParameterList:
+             {
+               SgFunctionParameterList* parameterList =
+                   isSgFunctionParameterList(declaration);
+               ROSE_ASSERT(parameterList != NULL);
+
+               SgFunctionDeclaration* functionDeclaration = NULL;
+               if (SgFunctionDeclaration* parentDecl =
+                       isSgFunctionDeclaration(parameterList->get_parent()))
+                  {
+                    functionDeclaration = parentDecl;
+                  }
+               else if (SgFunctionDefinition* functionDef =
+                            isSgFunctionDefinition(parameterList->get_parent()))
+                  {
+                    functionDeclaration = functionDef->get_declaration();
+                  }
+
+               if (functionDeclaration != NULL)
+                  {
+                    string function_name =
+                        generateUniqueNameForUseAsIdentifier_support(
+                            functionDeclaration);
+                    s = function_name + "__params";
+                  }
+               else
+                  {
+                    s = "params";
+                  }
+
+               break;
+             }
+
          case V_SgVariableDefinition:
             {
               SgVariableDefinition* varDef = isSgVariableDefinition(declaration);

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -236,6 +236,21 @@ set_tests_properties(
   PROPERTIES LABELS Cxx_tests
 )
 
+# Issue 149: Parameter lists must not be reported as unsupported declarations.
+add_test(
+  NAME Cxx_tests_rex_test2025_issue149_param_list_unique_name_interface_function_coverage
+  COMMAND
+    $<TARGET_FILE:interfaceFunctionCoverage>
+    -rose:verbose 0 -rose:skipfinalCompileStep
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2025_issue149_param_list_unique_name.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_test2025_issue149_param_list_unique_name_interface_function_coverage
+  PROPERTIES
+    LABELS Cxx_tests
+    FAIL_REGULAR_EXPRESSION "Unsupported declaration = .*SgFunctionParameterList"
+)
+
 # Issue 124: System header template specializations must preserve template args.
 add_test(
   NAME Cxx_tests_rex_test2025_issue124_system_header_specialization_args_unparse

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx_Testcodes.cmake
@@ -34,6 +34,7 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS
   rex_test2025_issue123_std_double_colon.cpp
   rex_test2025_issue146_std_iota_quad_colon.cpp
   rex_test2025_issue146_shadowed_function_template.cpp
+  rex_test2025_issue149_param_list_unique_name.cpp
   rex_test2025_issue124_system_header_specialization_args.cpp
   rex_test2025_issue125_fixup_child_list_warning.cpp
   rex_test2025_issue126_default_template_args.cpp

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue149_param_list_unique_name.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2025_issue149_param_list_unique_name.cpp
@@ -1,0 +1,15 @@
+int foo(int argc, char* argv[]) {
+  return argc + (argv != 0);
+}
+
+int test_moveVariableDeclaration(int j) {
+  int i;
+  for (i = 0; i < 3; ++i) {
+    j += i;
+  }
+  return j;
+}
+
+int main(int argc, char* argv[]) {
+  return foo(argc, argv) + test_moveVariableDeclaration(argc);
+}


### PR DESCRIPTION
## Summary
- add SgFunctionParameterList handling in generateUniqueNameForUseAsIdentifier_support with function-derived naming
- add a C++ regression that exercises parameter list naming and guards against the unsupported-warning regression

## Testing
- cmake --build build -j32
- ctest --test-dir build -R astInterface -j32 --output-on-failure
- ctest --test-dir build -R rex -j32 --output-on-failure
