### PR TITLE
Reduce Doxygen scope to stabilize docs publish

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -12,7 +12,7 @@ GENERATE_RTF           = NO
 GENERATE_DOCSET        = NO
 GENERATE_TREEVIEW      = NO
 
-INPUT                  = src README.md
+INPUT                  = src/Rose src/rose.h src/util README.md
 RECURSIVE              = YES
 FILE_PATTERNS          = *.h *.hh *.hpp *.hxx *.md
 EXCLUDE                = src/frontend/SageIII/ompparser src/frontend/SageIII/accparser src/ROSETTA

--- a/docs/sphinx/developer-notes.md
+++ b/docs/sphinx/developer-notes.md
@@ -35,5 +35,5 @@
 
 ## Scope
 
-- Doxygen is header-only (`*.h*`, plus Markdown), scoped to `src` + `README.md`.
+- Doxygen is header-only (`*.h*`, plus Markdown), scoped to `src/Rose`, `src/rose.h`, `src/util`, and `README.md`.
 - Private/internal members are included; undocumented/local/anon entries are skipped; heavy third-party headers (nlohmann copies) and submodules (ompparser/accparser) are excluded to keep the build manageable.


### PR DESCRIPTION
## Summary
- Narrow Doxygen inputs to the public-facing headers (`src/Rose`, `src/rose.h`, `src/util`, plus `README.md`) so the API tree stays focused and the docs build remains tractable.
- Align developer notes with the new API scope guidance.

## Root Cause
Publish Docs runs were being canceled mid-build after Sphinx started processing thousands of API pages. The oversized Doxygen scope made the Exhale/Sphinx phase too heavy for CI runners, leading to runner shutdowns instead of a clean failure.

## Fix
Reduce the Doxygen input set to the public-facing headers and utilities, which cuts the generated API surface area and brings the Sphinx build back within CI resource limits.

## Testing
- `doxygen docs/Doxyfile`
- `/tmp/rex-docs-venv/bin/python -m sphinx -j 32 -d docs/_build/doctrees -b html docs/sphinx docs/_build/html`
  - Build succeeded locally with warnings from Doxygen/Exhale about duplicate/overloaded functions.
