### PR TITLE
Fix docs publish runner shutdown

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: doxygen docs/Doxyfile
 
       - name: Build Sphinx HTML
-        run: python -m sphinx -j auto -d docs/_build/doctrees -b html docs/sphinx docs/_build/html
+        run: python -m sphinx -d docs/_build/doctrees -b html docs/sphinx docs/_build/html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
- remove the explicit `-j auto` from the Sphinx build step so CI uses the same serial build path as the last successful Publish Docs run

## Root cause evidence
- Last successful Publish Docs run: `20321261731` (head `87da8a6`, 2025-12-18).
- First failure after that: `20470127527` (head `f5776c1`, 2025-12-23). The only workflow change between these SHAs in `.github/workflows/docs-publish.yml` was switching from `SPHINXOPTS="-j auto"` (unused by the direct `python -m sphinx` call) to passing `-j auto` directly on the command line.
- All subsequent failures (`20495909888`, `20735101196`) cancel during “Build Sphinx HTML” with `The runner has received a shutdown signal` while reading sources (~55%).
- No other workflow changes separate the last success from the first failure; the regression is the explicit parallel Sphinx build.

## Fix
- run Sphinx without explicit parallelism in CI (restores the pre-2025-12-23 behavior).

## Testing
- `doxygen docs/Doxyfile`
- `/tmp/rex-docs-venv/bin/python -m sphinx -j 32 -d docs/_build/doctrees -b html docs/sphinx docs/_build/html` (completed locally; Sphinx emits existing warnings and one docutils error about `preproc_only_`, but exits 0 as in CI)
