### PR TITLE
Add IR flags for nonreal qualifiers

### DIFF
--- a/src/ROSETTA/src/statement.C
+++ b/src/ROSETTA/src/statement.C
@@ -2021,6 +2021,9 @@ Grammar::setUpStatements ()
      NonrealDecl.setDataPrototype ("bool","is_class_member","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
      NonrealDecl.setDataPrototype ("bool","is_template_param","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
      NonrealDecl.setDataPrototype ("bool","is_template_template_param","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+     NonrealDecl.setDataPrototype ("bool","has_template_keyword","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+     NonrealDecl.setDataPrototype ("bool","has_global_qualifier","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+     NonrealDecl.setDataPrototype ("bool","suppress_typename","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
      NonrealDecl.setDataPrototype ("bool","is_nonreal_template","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
      NonrealDecl.setDataPrototype ("bool","is_nonreal_function","= false", NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
 

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -4749,17 +4749,10 @@ Unparse_Type::unparseNonrealType(SgType* type, SgUnparse_Info& info, bool is_fir
      SgNonrealDecl * nrdecl = isSgNonrealDecl(nrtype->get_declaration());
      ASSERT_not_null(nrdecl);
 
-     static const char kRexNonrealTemplateKeywordAttr[] =
-         "rex_nonreal_template_keyword";
-     static const char kRexNonrealGlobalQualifierAttr[] =
-         "rex_nonreal_global_qualifier";
-     static const char kRexNonrealNoTypenameAttr[] = "rex_nonreal_no_typename";
      bool has_global_qualifier =
-         is_first_in_nonreal_chain &&
-         nrdecl->getAttribute(kRexNonrealGlobalQualifierAttr) != NULL;
+         is_first_in_nonreal_chain && nrdecl->get_has_global_qualifier();
      bool suppress_typename =
-         is_first_in_nonreal_chain &&
-         nrdecl->getAttribute(kRexNonrealNoTypenameAttr) != NULL;
+         is_first_in_nonreal_chain && nrdecl->get_suppress_typename();
      if (is_first_in_nonreal_chain) {
        if (const SgTemplateArgument *template_arg = isSgTemplateArgument(
                info.get_reference_node_for_qualification())) {
@@ -4813,8 +4806,7 @@ Unparse_Type::unparseNonrealType(SgType* type, SgUnparse_Info& info, bool is_fir
 
      SgTemplateArgumentPtrList & tpl_args = nrdecl->get_tpl_args();
 
-     if (has_nonreal_parent &&
-         nrdecl->getAttribute(kRexNonrealTemplateKeywordAttr) != NULL)
+     if (has_nonreal_parent && nrdecl->get_has_template_keyword())
        curprint("template ");
 
      // output the name of the non-real type

--- a/src/frontend/CxxFrontend/Clang/CMakeLists.txt
+++ b/src/frontend/CxxFrontend/Clang/CMakeLists.txt
@@ -7,7 +7,6 @@ message(STATUS "Configuring Clang frontend...")
 set(CLANG_FRONTEND_SOURCES
   clang-frontend.cpp
   clang-frontend-decl.cpp
-  clang-frontend-nonreal-attrs.cpp
   clang-frontend-stmt.cpp
   clang-frontend-type.cpp
   clang-to-rose-support.cpp

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -376,10 +376,7 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
   if (SgNonrealDecl *member_decl = isSgNonrealDecl(
           member_type ? member_type->get_declaration() : nullptr)) {
     if (!spec_decl->isDependentType()) {
-      if (member_decl->getAttribute(kRexNonrealNoTypenameAttr) == NULL) {
-        member_decl->setAttribute(kRexNonrealNoTypenameAttr,
-                                  new RexNonrealFlagAttribute());
-      }
+      member_decl->set_suppress_typename(true);
     }
   }
   return member_type;

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-nonreal-attrs.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-nonreal-attrs.cpp
@@ -1,5 +1,0 @@
-#include "clang-frontend-private.hpp"
-
-const char kRexNonrealTemplateKeywordAttr[] = "rex_nonreal_template_keyword";
-const char kRexNonrealGlobalQualifierAttr[] = "rex_nonreal_global_qualifier";
-const char kRexNonrealNoTypenameAttr[] = "rex_nonreal_no_typename";

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
@@ -80,25 +80,6 @@
 
 #include "llvm/Frontend/OpenMP/OMPIRBuilder.h"
 
-class RexNonrealFlagAttribute : public AstAttribute {
-public:
-  OwnershipPolicy getOwnershipPolicy() const override {
-    return CONTAINER_OWNERSHIP;
-  }
-
-  AstAttribute *copy() const override { return new RexNonrealFlagAttribute(); }
-
-  std::string attribute_class_name() const override {
-    return "RexNonrealFlagAttribute";
-  }
-
-  std::string toString() override { return ""; }
-};
-
-extern const char kRexNonrealTemplateKeywordAttr[];
-extern const char kRexNonrealGlobalQualifierAttr[];
-extern const char kRexNonrealNoTypenameAttr[];
-
 // DQ (11/27/2020): Turn on/off the debugging information as we visit clang IR nodes.
 #define DEBUG_VISITOR             0
 #define DEBUG_TRAVERSAL           0

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -642,8 +642,7 @@ ClangToSageTranslator::buildNonrealRefExpFromNestedNameSpecifier(
   ROSE_ASSERT(nrdecl != nullptr);
 
   if (terminalHasTemplateKeyword) {
-    nrdecl->setAttribute(kRexNonrealTemplateKeywordAttr,
-                         new RexNonrealFlagAttribute());
+    nrdecl->set_has_template_keyword(true);
   }
 
   SgNonrealSymbol *sym =

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -2242,8 +2242,7 @@ SgNonrealType *ClangToSageTranslator::buildNonrealTypeFromNestedNameSpecifier(
           isSgNonrealDecl(segment_type->get_declaration());
       ROSE_ASSERT(segment_decl != nullptr);
       if (nns->getKind() == clang::NestedNameSpecifier::TypeSpecWithTemplate) {
-        segment_decl->setAttribute(kRexNonrealTemplateKeywordAttr,
-                                   new RexNonrealFlagAttribute());
+        segment_decl->set_has_template_keyword(true);
       }
       current_scope = segment_decl->get_nonreal_decl_scope();
     }
@@ -2260,10 +2259,7 @@ SgNonrealType *ClangToSageTranslator::buildNonrealTypeFromNestedNameSpecifier(
   if (has_global_qualifier) {
     SgNonrealDecl *nrdecl = isSgNonrealDecl(nrtype->get_declaration());
     ROSE_ASSERT(nrdecl != nullptr);
-    if (nrdecl->getAttribute(kRexNonrealGlobalQualifierAttr) == NULL) {
-      nrdecl->setAttribute(kRexNonrealGlobalQualifierAttr,
-                           new RexNonrealFlagAttribute());
-    }
+    nrdecl->set_has_global_qualifier(true);
   }
 
   return nrtype;
@@ -2699,10 +2695,7 @@ bool ClangToSageTranslator::VisitTypedefType(clang::TypedefType *typedef_type,
     if (SgNonrealDecl *member_decl = isSgNonrealDecl(
             member_type ? member_type->get_declaration() : nullptr)) {
       if (!spec_decl->isDependentType()) {
-        if (member_decl->getAttribute(kRexNonrealNoTypenameAttr) == NULL) {
-          member_decl->setAttribute(kRexNonrealNoTypenameAttr,
-                                    new RexNonrealFlagAttribute());
-        }
+        member_decl->set_suppress_typename(true);
       }
     }
     return member_type;
@@ -2888,8 +2881,7 @@ bool ClangToSageTranslator::VisitDependentTemplateSpecializationType(
   if (SgNonrealType *nrtype = isSgNonrealType(*node)) {
     if (SgNonrealDecl *nrdecl = isSgNonrealDecl(nrtype->get_declaration())) {
       if (name_info.has_template_keyword) {
-        nrdecl->setAttribute(kRexNonrealTemplateKeywordAttr,
-                             new RexNonrealFlagAttribute());
+        nrdecl->set_has_template_keyword(true);
       }
     }
   }
@@ -3019,10 +3011,7 @@ bool ClangToSageTranslator::VisitElaboratedType(
         if (SgNonrealType *nrtype = isSgNonrealType(*node)) {
           if (SgNonrealDecl *nrdecl =
                   isSgNonrealDecl(nrtype->get_declaration())) {
-            if (nrdecl->getAttribute(kRexNonrealNoTypenameAttr) == NULL) {
-              nrdecl->setAttribute(kRexNonrealNoTypenameAttr,
-                                   new RexNonrealFlagAttribute());
-            }
+            nrdecl->set_suppress_typename(true);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Implements issue #491 by adding explicit IR fields on `SgNonrealDecl` for `template` keyword presence, leading global qualifier, and `typename` suppression.
- Removes the temporary AstAttribute-based flags and switches the Clang frontend + unparser to use the IR state directly.

## Changes
- Added ROSETTA data members for the three nonreal qualifier flags so accessors/serialization are generated.
- Updated Clang CFE nonreal construction to set these fields when building nested-name-specifier chains, dependent template specializations, and elaborated types.
- Updated `unparseNonrealType` to read the new flags and emit `template`, `::`, and `typename` consistently without attribute lookups.
- Removed `clang-frontend-nonreal-attrs.cpp` and the related attribute plumbing from the CFE build.

## Testing
- `ctest -R "rex_test2025_dependent_template_specialization_type" -j16 --output-on-failure`
- `ctest -R "rex|astInterface" -j16 --output-on-failure`
