### PR TITLE
Fix unparse of standalone operator-> calls

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -2720,9 +2720,10 @@ Unparse_ExprStmt::unparseMFuncRefSupport ( SgExpression* expr, SgUnparse_Info& i
 
   // DQ (10/16/2016): Fix for test2016_84.C and test2016_85.C (simpler code).
      bool uses_operator_syntax = false;
+     SgFunctionCallExp* functionCallExp = NULL;
      if (possibleFunctionCall != NULL)
         {
-          SgFunctionCallExp* functionCallExp = isSgFunctionCallExp(possibleFunctionCall);
+          functionCallExp = isSgFunctionCallExp(possibleFunctionCall);
           if (functionCallExp != NULL)
              {
                uses_operator_syntax  = functionCallExp->get_uses_operator_syntax();
@@ -3780,6 +3781,71 @@ Unparse_ExprStmt::unparseFuncCall(SgExpression* expr, SgUnparse_Info& info)
   // required in places even though we have historically defaulted to the generation of the
   // operator syntax (e.g. "x+y"), see test2013_100.C for an example of where this is required.
      bool uses_operator_syntax = func_call->get_uses_operator_syntax();
+
+     class ScopedOperatorSyntaxSetting
+        {
+          public:
+               ScopedOperatorSyntaxSetting(SgFunctionCallExp* call, bool enable, bool new_value)
+                    : call_(call), old_value_(call->get_uses_operator_syntax()), enabled_(enable)
+                       {
+                         if (enabled_)
+                            {
+                              call_->set_uses_operator_syntax(new_value);
+                            }
+                       }
+               ~ScopedOperatorSyntaxSetting()
+                  {
+                    if (enabled_)
+                       {
+                         call_->set_uses_operator_syntax(old_value_);
+                       }
+                  }
+
+          private:
+               SgFunctionCallExp* call_;
+               bool old_value_;
+               bool enabled_;
+        };
+
+  // Operator-> calls require explicit syntax unless they are the direct base of an arrow expression.
+     bool force_call_syntax = false;
+     if (uses_operator_syntax == true)
+        {
+          SgBinaryOp* binary_op = isSgBinaryOp(func_call->get_function());
+          if (binary_op != NULL &&
+              ((isSgDotExp(binary_op) != NULL) || (isSgArrowExp(binary_op) != NULL)))
+             {
+               SgExpression* rhs = binary_op->get_rhs_operand();
+               SgFunctionSymbol* func_symbol = NULL;
+               if (SgMemberFunctionRefExp* mfunc_ref = isSgMemberFunctionRefExp(rhs))
+                  {
+                    func_symbol = mfunc_ref->get_symbol();
+                  }
+               else if (SgFunctionRefExp* func_ref = isSgFunctionRefExp(rhs))
+                  {
+                    func_symbol = func_ref->get_symbol();
+                  }
+
+               if (func_symbol != NULL)
+                  {
+                    const std::string func_name = func_symbol->get_name().str();
+                    if (func_name == "operator->")
+                       {
+                         SgArrowExp* arrow_parent = isSgArrowExp(func_call->get_parent());
+                         if (arrow_parent == NULL || arrow_parent->get_lhs_operand() != func_call)
+                            {
+                              force_call_syntax = true;
+                            }
+                       }
+                  }
+             }
+        }
+
+     ScopedOperatorSyntaxSetting operator_syntax_guard(func_call, force_call_syntax, false);
+     if (force_call_syntax == true)
+        {
+          uses_operator_syntax = false;
+        }
 
 #if DEBUG_FUNCTION_CALL
      printf ("In Unparse_ExprStmt::unparseFuncCall(): (before test for conversion operator) uses_operator_syntax = %s \n",uses_operator_syntax == true ? "true" : "false");


### PR DESCRIPTION
## Summary
- force explicit call syntax for overloaded `operator->` when the call is not the base of an arrow expression
- preserve operator syntax when the call feeds a `->` chain

## Issue
Fixes #244.

## Testing
- `cmake --build build -j16`
- `ctest --test-dir build/tests/nonsmoke/functional/roseTests/programTransformationTests -R "normalizationTranslator_test2004_47.C|normalizationTranslator_test2005_43.C" -j16 --output-on-failure`
- `ctest --test-dir build -R "rex|astInterface" -j16 --output-on-failure`
- manual:
  - `build/tests/nonsmoke/functional/roseTests/programTransformationTests/extractFunctionArgumentsTest/../../../../../../bin/normalizationTranslator -w -rose:verbose 0 -I/home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/Cxx_tests -I/home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/A++Code -c /home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/Cxx_tests/lulesh.C`
  - `build/tests/nonsmoke/functional/roseTests/programTransformationTests/extractFunctionArgumentsTest/../../../../../../bin/normalizationTranslator -w -rose:verbose 0 -I/home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/Cxx_tests -I/home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/A++Code -c /home/ouankou/Projects/rex-codex/tests/nonsmoke/functional/CompileTests/Cxx_tests/luleshTALC.C`

## Notes
- `astQuery_test3_cxx_grammar` and `Cxx_tests_failing_test2010_02_C`/`Cxx_tests_failing_test2013_09_C`/`Cxx_tests_failing_test2014_65_C`/`Cxx_tests_failing_test2017_99_C` are disabled in this build.
