### PR TITLE
Shrink API search index

### DIFF
--- a/docs/mkdocs-search-exclude.py
+++ b/docs/mkdocs-search-exclude.py
@@ -29,12 +29,10 @@ def on_files(files, config):
         child = urls[i + 1]
         if not child.startswith(url):
             continue
-        if len(child) <= len(url):
-            continue
         if url.endswith("/"):
             has_children.add(url)
         else:
-            if child[len(url)] == "/":
+            if child[len(url):].startswith("/"):
                 has_children.add(url)
 
     setattr(config, "_search_exclude_leaf_urls", set(urls) - has_children)
@@ -110,7 +108,8 @@ def on_post_build(config):
                 temp_path = None
             except OSError as exc:
                 raise OSError(
-                    f"Failed to replace search index file '{path}' with temporary file '{temp_path}'. "
+                    f"Failed to replace search index file '{path}' with temporary file '{temp_path}' "
+                    f"(note: the temporary file may already have been deleted). "
                     f"Original OS error: {exc}"
                 ) from exc
         finally:


### PR DESCRIPTION
## Summary
- Exclude API leaf pages from search indexing and cap per-section text length to keep the search index under GitHub’s 100 MB limit.
- Preserve API search while keeping the rendered content unchanged.

## Details
- `docs/mkdocs-search-exclude.py` now:
  - Builds a leaf-page set and marks them `search: {exclude: true}` so list/container pages remain searchable.
  - Truncates oversized search entries to 100k characters in `search_index.json` after build.

## Evidence
- Local `mkdocs build -f mkdocs-reference.yml` produces `_site/reference/search/search_index.json` at ~68 MB (under the 100 MB limit).

## Testing
- `.venv-docs/bin/mkdocs build -f mkdocs-reference.yml`
