### PR TITLE
Fix copyAST typedef embedding and test output

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -8095,21 +8095,42 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   // for ROSE AST.
   bool isembedded = false;
   bool iscompleteDefined = false;
-  bool hasElaboratedType = false;
+  clang::TagDecl *ownedTagDecl = nullptr;
   bool isOwnedTagDeclADefinition = false;
   bool isDefinitionRequired = false;
   // Definitions embedded in a declarator are not autonomous.
   bool isAutonomousDeclaration = true;
+  auto isEmbeddedInThisTypedef = [&](clang::TagDecl *tag) -> bool {
+    if (!isembedded || tag == nullptr || p_compiler_instance == nullptr) {
+      return isembedded;
+    }
+    clang::SourceManager &sm = p_compiler_instance->getSourceManager();
+    clang::SourceLocation decl_loc = tag->getBeginLoc();
+    clang::SourceRange typedef_range = typedef_decl->getSourceRange();
+    if (!decl_loc.isValid() || !typedef_range.isValid()) {
+      return isembedded;
+    }
+    decl_loc = sm.getFileLoc(decl_loc);
+    clang::SourceLocation range_begin = sm.getFileLoc(typedef_range.getBegin());
+    clang::SourceLocation range_end = sm.getFileLoc(typedef_range.getEnd());
+    if (!decl_loc.isValid() || !range_begin.isValid() || !range_end.isValid()) {
+      return isembedded;
+    }
+    if (sm.isBeforeInTranslationUnit(decl_loc, range_begin) ||
+        sm.isBeforeInTranslationUnit(range_end, decl_loc)) {
+      return false;
+    }
+    return true;
+  };
 
   // Adding check for EaboratedType and PointerType to retrieve base EnumType
   while ((llvm::isa<clang::ElaboratedType>(underlyingType)) ||
          (llvm::isa<clang::PointerType>(underlyingType)) ||
          (llvm::isa<clang::ArrayType>(underlyingType))) {
     if (llvm::isa<clang::ElaboratedType>(underlyingType)) {
-      hasElaboratedType = true;
       underlyingQualType =
           ((clang::ElaboratedType *)underlyingType)->getNamedType();
-      clang::TagDecl *ownedTagDecl =
+      ownedTagDecl =
           ((clang::ElaboratedType *)underlyingType)->getOwnedTagDecl();
       if (ownedTagDecl != nullptr) {
         isOwnedTagDeclADefinition =
@@ -8130,6 +8151,7 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     clang::EnumDecl *enumDeclaration = underlyingEnumType->getDecl();
     isembedded = enumDeclaration->isEmbeddedInDeclarator();
     iscompleteDefined = enumDeclaration->isCompleteDefinition();
+    isembedded = isEmbeddedInThisTypedef(enumDeclaration);
   }
 
   if (llvm::isa<clang::RecordType>(underlyingType)) {
@@ -8138,9 +8160,10 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     clang::RecordDecl *recordDeclaration = underlyingRecordType->getDecl();
     isembedded = recordDeclaration->isEmbeddedInDeclarator();
     iscompleteDefined = recordDeclaration->isCompleteDefinition();
+    isembedded = isEmbeddedInThisTypedef(recordDeclaration);
   }
 
-  if (hasElaboratedType) {
+  if (ownedTagDecl != nullptr) {
     isDefinitionRequired = isOwnedTagDeclADefinition;
   } else {
     isDefinitionRequired = iscompleteDefined;
@@ -8168,7 +8191,9 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     sg_underlyingType = type;
   }
 
-  sg_typedef_decl = SageBuilder::buildTypedefDeclaration_nfi(name, type, scope);
+  bool has_defining_base = isembedded && isDefinitionRequired;
+  sg_typedef_decl = SageBuilder::buildTypedefDeclaration_nfi(name, type, scope,
+                                                             has_defining_base);
   if (SgProject::get_verbose() > 0) {
     if (name == "uint8_t" || name == "uint16_t" || name == "uint32_t" ||
         name == "in_port_t" || name == "in_addr_t") {
@@ -8221,6 +8246,28 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
       // enumDefDecl->set_isAutonomousDeclaration(false);
       sg_typedef_decl->set_declaration(enumDefDecl);
       sg_typedef_decl->set_typedefBaseTypeContainsDefiningDeclaration(true);
+    }
+  }
+
+  if (!has_defining_base) {
+    if (SgClassDeclaration *classDecl =
+            isSgClassDeclaration(sg_typedef_decl->get_declaration())) {
+      if (classDecl->get_definingDeclaration() == classDecl) {
+        SgDeclarationStatement *nondef =
+            classDecl->get_firstNondefiningDeclaration();
+        if (nondef != nullptr && nondef != classDecl) {
+          sg_typedef_decl->set_declaration(nondef);
+        }
+      }
+    } else if (SgEnumDeclaration *enumDecl =
+                   isSgEnumDeclaration(sg_typedef_decl->get_declaration())) {
+      if (enumDecl->get_definingDeclaration() == enumDecl) {
+        SgDeclarationStatement *nondef =
+            enumDecl->get_firstNondefiningDeclaration();
+        if (nondef != nullptr && nondef != enumDecl) {
+          sg_typedef_decl->set_declaration(nondef);
+        }
+      }
     }
   }
 

--- a/tests/nonsmoke/functional/CompileTests/copyAST_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/copyAST_tests/CMakeLists.txt
@@ -191,6 +191,9 @@ endif()
 
 set(ROSE_FLAGS  -rose:verbose 0 )
 
+set(ROSE_TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/rose_output)
+file(MAKE_DIRECTORY ${ROSE_TEST_OUTPUT_DIR})
+
 set(TESTCODE_INCLUDES "")
 
 foreach(testcode ${TESTCODES_REQUIRED_TO_PASS})
@@ -198,6 +201,7 @@ foreach(testcode ${TESTCODES_REQUIRED_TO_PASS})
   add_test(
     NAME copyAST_${basename}
     COMMAND copyExample ${ROSE_FLAGS}
+            -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_${basename}.C
             -c ${CMAKE_CURRENT_SOURCE_DIR}/${testcode})
   set_tests_properties(copyAST_${basename} PROPERTIES LABELS COPYASTTEST)
 endforeach()
@@ -205,6 +209,7 @@ endforeach()
 add_test(
   NAME copyAST_copyLoops
   COMMAND copyLoops ${ROSE_FLAGS}
+          -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_copyLoops_copytest2007_60.C
           -c ${CMAKE_CURRENT_SOURCE_DIR}/copytest2007_60.C
 )
 set_tests_properties(copyAST_copyLoops PROPERTIES LABELS COPYASTTEST)
@@ -212,6 +217,7 @@ set_tests_properties(copyAST_copyLoops PROPERTIES LABELS COPYASTTEST)
 add_test(
   NAME copyAST_copyBlocks
   COMMAND copyBlocks ${ROSE_FLAGS}
+          -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_copyBlocks_copytest2007_63.C
           -c ${CMAKE_CURRENT_SOURCE_DIR}/copytest2007_63.C
 )
 set_tests_properties(copyAST_copyBlocks PROPERTIES LABELS COPYASTTEST)
@@ -219,6 +225,7 @@ set_tests_properties(copyAST_copyBlocks PROPERTIES LABELS COPYASTTEST)
 add_test(
   NAME copyAST_copyFunctionDefinitions
   COMMAND copyFunctionDefinitions ${ROSE_FLAGS}
+          -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_copyFunctionDefinitions_copytest2007_63.C
           -c ${CMAKE_CURRENT_SOURCE_DIR}/copytest2007_63.C
 )
 set_tests_properties(copyAST_copyFunctionDefinitions PROPERTIES LABELS COPYASTTEST)
@@ -229,6 +236,7 @@ foreach(testcode ${EXTRA_TESTCODES_REQUIRED_TO_PASS})
   add_test(
     NAME copyAST_${basename}
     COMMAND copyExample ${ROSE_FLAGS}
+            -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_${basename}.C
             -I${CMAKE_CURRENT_SOURCE_DIR}/../Cxx_tests ${TESTCODE_INCLUDES}
             -c ${CMAKE_CURRENT_SOURCE_DIR}/../Cxx_tests/${testcode})
   set_tests_properties(copyAST_${basename} PROPERTIES LABELS COPYASTTEST)
@@ -239,6 +247,7 @@ foreach(testcode ${_copyast_disabled_extra_tests})
   add_test(
     NAME copyAST_${basename}
     COMMAND copyExample ${ROSE_FLAGS}
+            -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_${basename}.C
             -I${CMAKE_CURRENT_SOURCE_DIR}/../Cxx_tests ${TESTCODE_INCLUDES}
             -c ${CMAKE_CURRENT_SOURCE_DIR}/../Cxx_tests/${testcode})
   set_tests_properties(copyAST_${basename} PROPERTIES DISABLED TRUE LABELS COPYASTTEST)
@@ -276,6 +285,7 @@ foreach(testcode ${_copyast_disabled_tests})
   add_test(
     NAME copyAST_${basename}
     COMMAND copyExample ${ROSE_FLAGS}
+            -rose:output ${ROSE_TEST_OUTPUT_DIR}/rose_${basename}.C
             -c ${CMAKE_CURRENT_SOURCE_DIR}/${testcode})
   set_tests_properties(copyAST_${basename} PROPERTIES DISABLED TRUE LABELS COPYASTTEST)
 endforeach()


### PR DESCRIPTION
## Summary
- Fix Clang typedef handling so only typedefs with truly embedded tag definitions attach defining declarations; avoid recursive typedef/tag ownership loops that crashed copyAST (Issue 216).
- Normalize non-embedded typedefs to reference the first nondefining decl, keeping ROSE symbol invariants intact.
- Route copyAST test output into the build tree via explicit `-rose:output` paths to prevent source tree artifacts.

## Root cause
Typedefs with elaborated or nested tag declarations were treated as embedded definitions without checking that the tag was actually within the typedef's source range. That could attach the defining decl to the typedef even when the typedef only referenced a named type, creating a self-referential copy graph and segfaults in copyAST.

## Testing
- `ctest --test-dir build -R "copyAST_test2003_08|copyAST_test2004_07" -j16 --output-on-failure`
- `ctest --test-dir build -R "rex|astInterface|Query" -j16 --output-on-failure`
