### PR TITLE
Refine binary operator arg checks for member overloads

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -50,6 +50,26 @@ bool isBinaryOperatorName(const string &func_name) {
          func_name == "operator->*" || func_name == "operator->" ||
          func_name == "operator()" || func_name == "operator[]";
 }
+
+bool isMemberOperatorCall(SgFunctionCallExp *func_call,
+                          SgFunctionDeclaration *decl) {
+  if (decl != nullptr) {
+    return isSgMemberFunctionDeclaration(decl) != nullptr;
+  }
+
+  SgExpression *function = func_call->get_function();
+  if (isSgMemberFunctionRefExp(function) != nullptr) {
+    return true;
+  }
+  if (SgDotExp *dot = isSgDotExp(function)) {
+    return isSgMemberFunctionRefExp(dot->get_rhs_operand()) != nullptr;
+  }
+  if (SgArrowExp *arrow = isSgArrowExp(function)) {
+    return isSgMemberFunctionRefExp(arrow->get_rhs_operand()) != nullptr;
+  }
+  return isSgDotStarOp(function) != nullptr ||
+         isSgArrowStarOp(function) != nullptr;
+}
 } // namespace
 
 #ifdef _MSC_VER
@@ -3902,24 +3922,7 @@ void Unparse_ExprStmt::unparseFuncCall(SgExpression *expr,
               ? func_call->get_args()->get_expressions().size()
               : 0;
 
-      bool is_member_operator = false;
-      if (decl != nullptr) {
-        is_member_operator = (isSgMemberFunctionDeclaration(decl) != nullptr);
-      } else {
-        SgExpression *function = func_call->get_function();
-        if (isSgMemberFunctionRefExp(function) != nullptr) {
-          is_member_operator = true;
-        } else if (SgDotExp *dot = isSgDotExp(function)) {
-          is_member_operator =
-              (isSgMemberFunctionRefExp(dot->get_rhs_operand()) != nullptr);
-        } else if (SgArrowExp *arrow = isSgArrowExp(function)) {
-          is_member_operator =
-              (isSgMemberFunctionRefExp(arrow->get_rhs_operand()) != nullptr);
-        } else if (isSgDotStarOp(function) != nullptr ||
-                   isSgArrowStarOp(function) != nullptr) {
-          is_member_operator = true;
-        }
-      }
+      bool is_member_operator = isMemberOperatorCall(func_call, decl);
 
       // Member binary operators have one explicit argument; non-members have
       // two.


### PR DESCRIPTION
## Summary
- extract member-operator detection into a helper to simplify `unparseFuncCall`
- treat pointer-to-member operator calls (`.*`, `->*`) as member operators when validating argument counts
- avoid binary-operator argument validation for `operator()` and `operator[]` so they never unparse as infix
- reuse the associated function declaration for both operator-name and member checks

## Testing
- `cmake --build build -j32`
- `ctest --test-dir build -R "Cxx11_tests_test2018_36|Cxx11_tests_test2018_62|Cxx11_tests_test2018_68|Cxx11_tests_test2018_69|Cxx11_tests_test2018_70|Cxx11_tests_test2019_43|Cxx_tests_test2007_109_C|Cxx_tests_test2007_125_C" --output-on-failure -j32`
- `ctest --test-dir build -R "rex|astInterface|testQuery" --output-on-failure -j32`
