### PR TITLE
Handle pointer-to-member operator calls

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -3905,6 +3905,9 @@ void Unparse_ExprStmt::unparseFuncCall(SgExpression *expr,
       } else if (SgArrowExp *arrow = isSgArrowExp(function)) {
         is_member_operator =
             (isSgMemberFunctionRefExp(arrow->get_rhs_operand()) != nullptr);
+      } else if (isSgDotStarOp(function) != nullptr ||
+                 isSgArrowStarOp(function) != nullptr) {
+        is_member_operator = true;
       }
     }
 


### PR DESCRIPTION
## Summary
- treat `.*` and `->*` operator call expressions as member operators for argument-count validation
- avoid misclassifying pointer-to-member binary operator calls when selecting operator syntax

## Testing
- `cmake --build build -j32`
- `ctest --test-dir build -R "Cxx11_tests_test2018_36|Cxx11_tests_test2018_62|Cxx11_tests_test2018_68|Cxx11_tests_test2018_69|Cxx11_tests_test2018_70|Cxx11_tests_test2019_43|Cxx_tests_test2007_109_C|Cxx_tests_test2007_125_C" --output-on-failure -j32`
- `ctest --test-dir build -R "rex|astInterface|testQuery" --output-on-failure -j32`
