### PR TITLE
Fix Flang FE compile-only propagation (-c)

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/fortran_flang_support.C
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/fortran_flang_support.C
@@ -51,8 +51,6 @@ int experimental_fortran_main(int argc, char *argv[], SgSourceFile *srcFile) {
     }
   }
 
-  std::vector<std::string> arg_storage;
-  std::vector<char *> arg_ptrs;
   bool needs_compile_only = false;
   if (srcFile != nullptr) {
     if (SgProject *project = srcFile->get_project()) {
@@ -70,23 +68,14 @@ int experimental_fortran_main(int argc, char *argv[], SgSourceFile *srcFile) {
       }
     }
     if (!has_compile_only) {
-      arg_storage.reserve(argc + 1);
-      arg_ptrs.reserve(argc + 1);
-      for (int i = 0; i < argc; ++i) {
-        arg_storage.emplace_back(argv[i] != nullptr ? argv[i] : "");
-      }
-      arg_storage.emplace_back("-c");
-      for (auto &arg : arg_storage) {
-        arg_ptrs.push_back(arg.data());
-      }
-      status = flang_external_builder_main(static_cast<int>(arg_ptrs.size()),
-                                           arg_ptrs.data(), srcFile);
-    } else {
-      status = flang_external_builder_main(argc, argv, srcFile);
+      std::cerr << "[FATAL] [ROSE] [frontend] [Fortran] "
+                   "error: Flang frontend requires -c when ROSE is in "
+                   "compile-only mode.\n";
+      ROSE_ABORT();
     }
-  } else {
-    status = flang_external_builder_main(argc, argv, srcFile);
   }
+
+  status = flang_external_builder_main(argc, argv, srcFile);
 
   if (SgProject::get_verbose() > 0) {
     cout << "FINISHED parsing with status " << status << "\n";

--- a/src/frontend/SageIII/sage_support/sage_support.C
+++ b/src/frontend/SageIII/sage_support/sage_support.C
@@ -2671,6 +2671,23 @@ int SgSourceFile::build_Fortran_AST(vector<string> argv,
     flangCommandLine.push_back("-fexternal-builder");
     vector<string> flangArgs = argv;
     SgFile::stripRoseCommandLineOptions(flangArgs);
+    bool needs_compile_only = false;
+    if (SgProject *project = get_project()) {
+      needs_compile_only =
+          project->get_compileOnly() || project->get_skipfinalCompileStep();
+    }
+    if (needs_compile_only) {
+      bool has_compile_only = false;
+      for (const auto &arg : flangArgs) {
+        if (arg == "-c") {
+          has_compile_only = true;
+          break;
+        }
+      }
+      if (!has_compile_only) {
+        flangCommandLine.push_back("-c");
+      }
+    }
 
     std::string source_path = get_sourceFileNameWithPath();
     if (source_path.empty()) {

--- a/tests/nonsmoke/functional/CompileTests/Fortran_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Fortran_tests/CMakeLists.txt
@@ -134,6 +134,13 @@ add_test(
     "$<TARGET_FILE:testTranslator> ${ROSE_FLAGS_STR} -rose:fortran_std=f90 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_include.f90 && awk 'tolower($0) ~ /include/ && $0 ~ /rex_test2026_include\\.inc/ {found=1} END {exit !found}' rose_rex_test2026_include.f90"
 )
 
+add_test(
+  NAME fortran_rex_issue487_compile_only
+  WORKING_DIRECTORY ${_fortran_output_dir}
+  COMMAND ${BASH_EXECUTABLE} -c
+    "rm -f a.out && $<TARGET_FILE:testTranslator> ${ROSE_FLAGS_STR} -rose:fortran_std=f90 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_issue487_compile_only.f90 && test ! -e a.out"
+)
+
 set(_fortran_comment_diff_tests
   test2020_comment_1.f90
   test2020_comment_2.f90

--- a/tests/nonsmoke/functional/CompileTests/Fortran_tests/rex_issue487_compile_only.f90
+++ b/tests/nonsmoke/functional/CompileTests/Fortran_tests/rex_issue487_compile_only.f90
@@ -1,0 +1,6 @@
+program rex_issue487_compile_only
+  implicit none
+  integer :: x
+  x = 1
+  print *, x
+end program rex_issue487_compile_only


### PR DESCRIPTION
# Fix Flang FE compile-only propagation (-c)

Closes: ouankou/rex#487

## Problem

ROSE parses `-c` and records compile-only intent in `SgProject::compileOnly`, and this is propagated into per-file `SgFile::compileOnly`. The C/C++ (Clang) frontend path honors compile-only semantics consistently.

However, the experimental Flang frontend path builds the `f18-parse-demo` driver command line without mapping ROSE’s compile-only intent into Flang driver options. As a result, the Flang driver may still perform a link step, diverging from expected `-c` behavior.

## Root cause

Compile-only intent was not propagated at the command-line construction point for the experimental Flang path, so Flang’s `DriverOptions::compileOnly` could remain unset.

## Fix

- Propagate ROSE compile-only intent into Flang driver argv by injecting `-c` into the `f18-parse-demo` command line when the project is in compile-only mode.
- Remove the late “argv mutation” behavior and instead enforce an invariant in the Flang bridge layer: when ROSE is compile-only, Flang must receive `-c` (otherwise abort).

This keeps compile-only semantics consistent across frontends without any workaround/hack/fallback behavior.

## Tests

- Added `fortran_rex_issue487_compile_only`: runs `testTranslator -c` on a small Fortran input and asserts no `a.out` is produced (no link step).
- Verified the repository pre-push CI-aligned selection (the same suite the pre-push hook runs) passes with this change.

