### PR TITLE
Fix pseudo-dtor destroyed type spelling (ELSATEST t0481)

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -6246,13 +6246,16 @@ bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(
           cxx_pseudo_destructor_expr->getDestroyedTypeInfo()) {
     destroyed_type = buildTypeFromQualifiedType(type_info->getType());
   } else {
-    clang::QualType qual_type = cxx_pseudo_destructor_expr->getDestroyedType();
-    if (!qual_type.isNull()) {
-      destroyed_type = buildTypeFromQualifiedType(qual_type);
-    } else if (const clang::IdentifierInfo *id =
-                   cxx_pseudo_destructor_expr->getDestroyedTypeIdentifier()) {
+    if (const clang::IdentifierInfo *id =
+            cxx_pseudo_destructor_expr->getDestroyedTypeIdentifier()) {
       destroyed_type =
           SageBuilder::buildTemplateType(SgName(id->getName().str()));
+    } else {
+      clang::QualType qual_type =
+          cxx_pseudo_destructor_expr->getDestroyedType();
+      if (!qual_type.isNull()) {
+        destroyed_type = buildTypeFromQualifiedType(qual_type);
+      }
     }
   }
   ROSE_ASSERT(destroyed_type != nullptr);

--- a/tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Failing_Tests.cmake
+++ b/tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Failing_Tests.cmake
@@ -481,7 +481,6 @@ set(START_OF_FAILED_TESTS_USING_ROSE
   t0478.cc
   t0479.cc
   t0480.cc
-  t0481.cc
   t0482.cc
   t0483.cc
   t0484.cc

--- a/tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Testcodes_Disabled.cmake
+++ b/tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Testcodes_Disabled.cmake
@@ -320,7 +320,6 @@ set(TESTCODES_DISABLED
   t0478.cc
   t0479.cc
   t0480.cc
-  t0481.cc
   t0482.cc
   t0483.cc
   t0484.cc

--- a/tests/nonsmoke/functional/CompileTests/Fortran_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Fortran_tests/CMakeLists.txt
@@ -134,11 +134,20 @@ add_test(
     "$<TARGET_FILE:testTranslator> ${ROSE_FLAGS_STR} -rose:fortran_std=f90 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_include.f90 && awk 'tolower($0) ~ /include/ && $0 ~ /rex_test2026_include\\.inc/ {found=1} END {exit !found}' rose_rex_test2026_include.f90"
 )
 
+set(_fortran_issue487_output_dir ${_fortran_output_dir}/rex_issue487_compile_only)
+file(MAKE_DIRECTORY ${_fortran_issue487_output_dir})
+set(ROSE_FLAGS_ISSUE487 -rose:verbose 0 -rose:detect_dangling_pointers 2
+                       -I${CMAKE_CURRENT_SOURCE_DIR}
+                       -I${CMAKE_CURRENT_BINARY_DIR}
+                       -I${_fortran_issue487_output_dir}
+                       -outputdir ${_fortran_issue487_output_dir})
+string(JOIN " " ROSE_FLAGS_ISSUE487_STR ${ROSE_FLAGS_ISSUE487})
+
 add_test(
   NAME fortran_rex_issue487_compile_only
-  WORKING_DIRECTORY ${_fortran_output_dir}
+  WORKING_DIRECTORY ${_fortran_issue487_output_dir}
   COMMAND ${BASH_EXECUTABLE} -c
-    "rm -f a.out && $<TARGET_FILE:testTranslator> ${ROSE_FLAGS_STR} -rose:fortran_std=f90 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_issue487_compile_only.f90 && test ! -e a.out"
+    "rm -f a.out && $<TARGET_FILE:testTranslator> ${ROSE_FLAGS_ISSUE487_STR} -rose:fortran_std=f90 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_issue487_compile_only.f90 && test ! -e a.out"
 )
 
 set(_fortran_comment_diff_tests


### PR DESCRIPTION
## Summary

This PR fixes pseudo-destructor call translation when the destroyed type is a template name spelled **without** template arguments (e.g., `a->~A()` for `A<int>* a`).

Clang represents this as `CXXPseudoDestructorExpr` and may provide only an identifier for the destroyed type (no `TypeSourceInfo`). Previously we would fall back to the semantic destroyed `QualType`, which can carry template arguments and leads the unparser to emit `~A<int>()` (or otherwise lose the original spelling intent). This breaks Elsa testcase `t0481.cc`.

The fix prefers the **source-spelled destroyed type identifier** when present, and only falls back to `QualType` when no identifier is available.

## Changes

- Fix `CXXPseudoDestructorExpr` translation to preserve destroyed-type spelling:
  - `src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp`
- Re-enable Elsa testcase `t0481.cc`:
  - `tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Testcodes_Disabled.cmake`
  - `tests/nonsmoke/functional/CompileTests/ElsaTestCases/ElsaTestCases_Failing_Tests.cmake`
- Make `fortran_rex_issue487_compile_only` robust under parallel CTest runs by giving it its own output/working directory:
  - `tests/nonsmoke/functional/CompileTests/Fortran_tests/CMakeLists.txt`

## Testing

- `ctest -R ELSATEST_t0481_cc -j32 --output-on-failure`
- Pre-push CI selection (matches repo pre-push hook):
  - `ctest -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" -j32 --output-on-failure`

## Notes

No workaround/fallback was added in the unparser or test harness for the C++ case; the fix is in the Clang→Sage translation so the IR captures the correct intended spelling.
