### PR TITLE
CFE: canonicalize implicit template-instantiation redecl mapping

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -17074,6 +17074,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     const bool register_redecl_chain =
         specialization_kind != clang::TSK_ExplicitInstantiationDefinition &&
         specialization_kind != clang::TSK_ExplicitInstantiationDeclaration;
+    const bool register_all_implicit_instantiation_redecls =
+        specialization_kind == clang::TSK_ImplicitInstantiation;
 
     auto register_decl = [&](clang::FunctionDecl *key) {
       if (key == nullptr) {
@@ -17100,6 +17102,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     if (register_redecl_chain) {
       register_decl(clang_decl->getCanonicalDecl());
       register_decl(clang_decl->getFirstDecl());
+    }
+
+    if (register_all_implicit_instantiation_redecls) {
+      for (clang::FunctionDecl *redecl : clang_decl->redecls()) {
+        register_decl(redecl);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
This PR implements the root-cause fix for #202 by canonicalizing Clang declaration-to-ROSE mapping across the full redeclaration chain for **implicit function template instantiations**.

### Fixes
- Closes #202

### Follow-up
- Related follow-up issue: #585

## Problem
`addPrototypesForTemplateInstantiations` could assert on duplicate defining template instantiations. The underlying cause is declaration identity drift in CFE mapping: multiple Clang redeclarations of the same implicit instantiation could resolve to different ROSE declaration objects in later passes.

## Root-cause Fix
In `translateFunctionDeclCommon` (`src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp`), `register_function_translation` now registers **all redeclarations** (`redecls()`) for implicit instantiations (`TSK_ImplicitInstantiation`) into `p_decl_translation_map`, instead of only key/canonical/first.

This keeps implicit instantiation declaration identity stable across redeclaration forms and prevents duplicate defining-instantiation entries downstream.

## Why this is long-term (not workaround)
- Fix is applied at declaration normalization/mapping source in CFE.
- No assertion softening/removal.
- No special casing by file/function name.
- No post-pass string-level filtering.

## What changed
- `src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp`
  - Added `register_all_implicit_instantiation_redecls` condition.
  - Added `for (clang::FunctionDecl *redecl : clang_decl->redecls())` registration path.

## Verification
### Build
```bash
cmake --build build -j16
```

### Issue-specific tests
```bash
ctest --test-dir build -R "ut_test2007_165\.C|ua_test2007_165\.C|Cxx_tests_test2007_165_C" --output-on-failure -j16
```
Passed: 3/3.

### Requested regression sweep
```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j16
```
Passed: 4906/4906.

## Notes
A separate pre-existing callgraph template-instantiation output mismatch is documented in #585 and intentionally not addressed in this PR to keep #202 fix focused and surgical.
