### PR TITLE
fix(ci): use docker/build-push-action@v6 for GHCR push auth

### DIFF
--- a/.github/workflows/weekly-base-images.yml
+++ b/.github/workflows/weekly-base-images.yml
@@ -46,42 +46,32 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push base image (riscv64)
-      run: |
-        set -euo pipefail
-        metadata_file="${RUNNER_TEMP}/riscv64-metadata.json"
-        docker buildx build \
-          --platform linux/riscv64 \
-          --pull \
-          -f ci/docker/rex-riscv64.Dockerfile \
-          --output=type=registry,name="${IMAGE_REPO}",push-by-digest=true \
-          --provenance=false \
-          --metadata-file "${metadata_file}" \
-          .
-        export METADATA_FILE="${metadata_file}"
-        riscv_digest="$(python3 -c 'import json, os; print(json.load(open(os.environ["METADATA_FILE"], "r", encoding="utf-8"))["containerimage.digest"])')"
-        echo "RISCV_DIGEST=${riscv_digest}" >> "${GITHUB_ENV}"
+      id: build-riscv64
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ci/docker/rex-riscv64.Dockerfile
+        platforms: linux/riscv64
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
     - name: Build and push base image (loong64)
-      run: |
-        set -euo pipefail
-        metadata_file="${RUNNER_TEMP}/loong64-metadata.json"
-        docker buildx build \
-          --platform linux/loong64 \
-          --pull \
-          -f ci/docker/rex-loongarch64.Dockerfile \
-          --output=type=registry,name="${IMAGE_REPO}",push-by-digest=true \
-          --provenance=false \
-          --metadata-file "${metadata_file}" \
-          .
-        export METADATA_FILE="${metadata_file}"
-        loong_digest="$(python3 -c 'import json, os; print(json.load(open(os.environ["METADATA_FILE"], "r", encoding="utf-8"))["containerimage.digest"])')"
-        echo "LOONG_DIGEST=${loong_digest}" >> "${GITHUB_ENV}"
+      id: build-loong64
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ci/docker/rex-loongarch64.Dockerfile
+        platforms: linux/loong64
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
     - name: Publish multi-arch manifest (base tag only)
       run: |
         set -euo pipefail
         docker buildx imagetools create \
           -t "${IMAGE_REPO}:${BASE_TAG}" \
-          "${IMAGE_REPO}@${RISCV_DIGEST}" \
-          "${IMAGE_REPO}@${LOONG_DIGEST}"
+          "${IMAGE_REPO}@${{ steps.build-riscv64.outputs.digest }}" \
+          "${IMAGE_REPO}@${{ steps.build-loong64.outputs.digest }}"
         docker buildx imagetools inspect "${IMAGE_REPO}:${BASE_TAG}"


### PR DESCRIPTION
## Summary

Fix the `weekly-base-images` workflow that has been failing consistently with:

```
ERROR: failed to push ghcr.io/ouankou/rex: denied: permission_denied: write_package
```

## Root Cause

The `docker/setup-buildx-action@v3` creates a builder using the **`docker-container` driver**, which runs BuildKit inside a separate Docker container. This container does **not** automatically inherit the Docker CLI credentials set by `docker/login-action@v3`.

When the raw `docker buildx build --output=type=registry` command tries to push, the BuildKit daemon inside the container makes its own auth request to GHCR — but it doesn't have access to the `GITHUB_TOKEN` credentials, resulting in `permission_denied: write_package`.

The workflow's `packages: write` permission and Docker login are both correct — the issue is purely credential forwarding between the Docker CLI and the BuildKit container.

## Fix

Replace the two raw `docker buildx build` shell commands with `docker/build-push-action@v6`, which is the official Docker GitHub Action designed to work seamlessly with `docker/login-action` and `docker/setup-buildx-action`. It automatically forwards authentication config to the BuildKit builder.

### What changed

| Aspect | Before | After |
|---|---|---|
| Build steps | Raw `docker buildx build` shell commands | `docker/build-push-action@v6` action |
| Digest extraction | Manual JSON parsing from metadata files | Action output `steps.*.outputs.digest` |
| Auth forwarding | ❌ Not forwarded to BuildKit container | ✅ Automatic via action |
| Multi-arch manifest | `docker buildx imagetools create` | `docker buildx imagetools create` (unchanged) |

### Behavior preserved

- Each arch (riscv64, loong64) is pushed **by digest only** (no tag)
- The final step assembles both digests into a single **`rex:base`** multi-arch manifest
- No additional tags are created

## Failed runs (all 3 consecutive failures)

| Run ID | Date | Event | Error |
|---|---|---|---|
| 21887346018 | 2026-02-11 | schedule | `permission_denied: write_package` |
| 21657805162 | 2026-02-04 | workflow_dispatch | `permission_denied: write_package` |
| 21652706043 | 2026-02-04 | schedule | `permission_denied: write_package` |

## Additional note

If this is pushing to a **new** GHCR package for the first time, the package itself may also need the repository linked with "Write" access under **Package Settings → Manage Actions access**. This is a one-time GHCR-level configuration.
