### PR TITLE
fix(ci): use type=image output for GHCR push-by-digest

### DIFF
--- a/.github/workflows/weekly-base-images.yml
+++ b/.github/workflows/weekly-base-images.yml
@@ -52,9 +52,10 @@ jobs:
         context: .
         file: ci/docker/rex-riscv64.Dockerfile
         platforms: linux/riscv64
+        tags: ${{ env.IMAGE_REPO }}
         pull: true
         provenance: false
-        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
     - name: Build and push base image (loong64)
       id: build-loong64
@@ -63,9 +64,10 @@ jobs:
         context: .
         file: ci/docker/rex-loongarch64.Dockerfile
         platforms: linux/loong64
+        tags: ${{ env.IMAGE_REPO }}
         pull: true
         provenance: false
-        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
     - name: Publish multi-arch manifest (base tag only)
       run: |


### PR DESCRIPTION
## Summary

Fix `weekly-base-images` workflow push failure — still failing after PR #594 was merged.

## Root Cause

The previous fix switched from raw `docker buildx build` to `docker/build-push-action@v6` but used `type=registry` as the output type. According to the [official Docker multi-platform guide](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners), push-by-digest requires `type=image` with `name-canonical=true` and `push=true`.

The `type=registry` output type does not properly handle GHCR's token exchange for push-by-digest, resulting in `permission_denied: write_package` even though `packages: write` is set and Docker login succeeds.

## Fix

Switch outputs from:
```
type=registry,name=ghcr.io/ouankou/rex,push-by-digest=true
```
to the documented pattern:
```
type=image,push-by-digest=true,name-canonical=true,push=true
```

Also add `tags` input (required by `type=image`) set to `${{ env.IMAGE_REPO }}`.

### Behavior preserved
- Each arch pushed **by digest only** (no tag)
- Final manifest assembled as **`rex:base`** (unchanged)
- No additional tags created

## Reference
- [Docker docs: Distribute build across multiple runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)
- Failed run: 22050894175
