### PR TITLE
Fix sourcePosition abort on SgEmptyDeclaration (issue #204)

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/sourcePosition_tests/statements.C
+++ b/tests/nonsmoke/functional/CompileTests/sourcePosition_tests/statements.C
@@ -118,6 +118,7 @@ nodeColor( SgStatement* statement )
                case V_SgUsingDirectiveStatement:
                case V_SgVariableDeclaration:
                case V_SgVariableDefinition:
+               case V_SgEmptyDeclaration:
                     returnString = "lightred";
                     break;
 
@@ -669,4 +670,3 @@ int main( int argc, char * argv[] )
 
      return backend(project);
    }
-


### PR DESCRIPTION
## Summary
Issue #204 still reproduces on current `main` through the source-position pipeline:
- `copyAST_copytest2007_29` already passes (symbol-table side is already handled).
- `SOURCEPOSITIONTEST_test2001_19.C` aborted in `nodeColor` when encountering `SgEmptyDeclaration`.

This PR applies the missing explicit handling for `SgEmptyDeclaration` in `nodeColor(SgStatement*)`, treating it as a normal declaration-class node (mapped to the declaration color path), instead of falling into the default abort path.

## Root Cause
Clang FE emits `SgEmptyDeclaration` for standalone `;` declarations, but the source-position statement classifier did not include `V_SgEmptyDeclaration` in its declaration switch. That mismatch caused an assertion in the default case.

## Fix
- `tests/nonsmoke/functional/CompileTests/sourcePosition_tests/statements.C`
  - Added explicit `case V_SgEmptyDeclaration` in `nodeColor(SgStatement*)` declaration handling.
  - Semantics: handled as an explicit no-op declaration category, not via fallback/default behavior.

## Validation
### Direct issue repro
- `ctest --test-dir build -R "copyAST_copytest2007_29|SOURCEPOSITIONTEST_test2001_19.C" --output-on-failure -j32`
  - Result: `100% tests passed, 0 tests failed out of 2`

### Requested regression set
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - Result: `100% tests passed, 0 tests failed out of 4919`

### Hook-validated push checks
- Pre-push hooks reran the above filtered set and additional OpenMP checks.
- Additional OpenMP run result: `100% tests passed, 0 tests failed out of 959`

Closes #204.
