### PR TITLE
Fix quote normalization in function-name mangling

### DIFF
--- a/src/frontend/SageIII/manglingSupport.C
+++ b/src/frontend/SageIII/manglingSupport.C
@@ -146,6 +146,8 @@ private:
     replaceAllInString(normalized_, "__ptr__", escaped_literal_prefix_ + "ptr");
     replaceAllInString(normalized_, "__minus__",
                        escaped_literal_prefix_ + "minus");
+    replaceAllInString(normalized_, "__quote__",
+                       escaped_literal_prefix_ + "quote");
   }
 
   void substituteOperatorsWithMarkers() {
@@ -174,6 +176,7 @@ private:
     replaceAllInString(normalized_, "&", "__ref__");
     replaceAllInString(normalized_, "*", "__ptr__");
     replaceAllInString(normalized_, "_-", "__minus__");
+    replaceAllInString(normalized_, "\"", "__quote__");
   }
 
   void restoreOperatorsFromMarkers() {
@@ -197,6 +200,8 @@ private:
     replaceAllInString(normalized_, escaped_literal_prefix_ + "ptr", "__ptr__");
     replaceAllInString(normalized_, escaped_literal_prefix_ + "minus",
                        "__minus__");
+    replaceAllInString(normalized_, escaped_literal_prefix_ + "quote",
+                       "__quote__");
 
     replaceAllInString(normalized_,
                        escaped_literal_prefix_ + escaped_literal_prefix_,
@@ -220,8 +225,9 @@ static string normalizeNameForMangledNameSupport(const string &name) {
   const bool hasTypeDecorators = normalized.find('&') != string::npos ||
                                  normalized.find('*') != string::npos ||
                                  normalized.find("_-") != string::npos;
+  const bool hasLiteralQuotes = normalized.find('"') != string::npos;
   if (!hasTemplateSyntax && !hasScopeSyntax && !hasTemplateSeparators &&
-      !hasTypeDecorators) {
+      !hasTypeDecorators && !hasLiteralQuotes) {
     return normalized;
   }
 
@@ -749,7 +755,7 @@ string mangleFunctionNameToString(const string &s,
   }
   // else, leave name as is.
 
-  return s_mangled;
+  return normalizeNameForMangledNameSupport(s_mangled);
 }
 
 SgName mangleFunctionName(const SgName &n, const SgName &ret_type_name) {


### PR DESCRIPTION
## Summary
Fixes issue #276 by ensuring function-name mangling never leaves raw quote characters from C++11 user-defined literal operators in `mangledName`.

Fixes #276

## Problem
`Cxx11_tests_test2014_50_C` aborted in `AstConsistencyTests` because a mangled function name still contained `"` from a user-defined literal operator name (e.g. `operator "" _w`).

## Root Cause
`mangleFunctionNameToString` could return names containing literal quotes, and the shared mangling normalizer did not treat `"` as a special character to normalize.

## Changes
- Updated `src/frontend/SageIII/manglingSupport.C`:
- Added `" -> __quote__` handling in `ManglingNormalizer::mangleSpecialCharacters`.
- Added escaping/unescaping for existing `__quote__` tokens, consistent with existing `__tas__/__tae__/__scope__` handling.
- Extended `normalizeNameForMangledNameSupport` fast-path checks to normalize names containing quotes.
- Made `mangleFunctionNameToString` return the normalized name so all function/operator-name mangling paths use the same sanitization step.

## Why this is a long-term fix
This is implemented in the shared mangling normalization pipeline (frontend mangling support), not as a per-test or per-function workaround. It prevents quote leakage for literal operator names while keeping existing token-escape semantics consistent across mangling paths.

## Validation
- Reproduced original failure before fix:
- `ctest --test-dir build -j32 --output-on-failure -R Cxx11_tests_test2014_50`
- After fix, reproduction passes:
- `ctest --test-dir build -j32 --output-on-failure -R Cxx11_tests_test2014_50`
- Requested regression slice passes:
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: `100% tests passed, 0 tests failed out of 4919`
- Pre-push hook also re-ran the same 4919-test slice and additional OpenMP/OpenACC suite:
- Result: `100% tests passed, 0 tests failed out of 959`
