### PR TITLE
Refactor OpenMP lowering regressions and add Rodinia CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,10 @@ jobs:
         cd $GITHUB_WORKSPACE
         CTEST_JOBS="$(nproc)"
         ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j"${CTEST_JOBS}"
-        ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests --output-on-failure -j"${CTEST_JOBS}"
+        # Explicitly gate Rodinia-derived OpenMP lowering regressions.
+        ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests -L "OMPLOWERING_RODINIA" --output-on-failure -j"${CTEST_JOBS}"
+        # Run the remaining OpenMP tests without rerunning OMPLOWERING_RODINIA.
+        ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests -LE "OMPLOWERING_RODINIA" --output-on-failure -j"${CTEST_JOBS}"
 
   fortran-only-config:
     strategy:

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -69,6 +69,73 @@ std::string normalizeOperatorFunctionName(std::string name) {
   return name;
 }
 
+static bool canLexTrailingDeclToken(clang::SourceLocation loc,
+                                    clang::SourceManager &sm) {
+  if (!loc.isValid() || loc.isMacroID()) {
+    return false;
+  }
+
+  clang::FileID file_id = sm.getFileID(loc);
+  if (file_id.isInvalid() || file_id != sm.getMainFileID()) {
+    return false;
+  }
+
+  auto buffer = sm.getBufferDataOrNone(file_id);
+  if (!buffer) {
+    return false;
+  }
+
+  unsigned offset = sm.getFileOffset(loc);
+  if (offset >= buffer->size()) {
+    return false;
+  }
+
+  bool invalid = false;
+  (void)sm.getCharacterData(loc, &invalid);
+  return !invalid;
+}
+
+static clang::SourceRange extendDeclSourceRangeWithTrailingSemicolon(
+    clang::SourceRange range, clang::SourceManager &sm,
+    const clang::LangOptions &lang_opts) {
+  if (!range.isValid()) {
+    return range;
+  }
+
+  clang::SourceLocation end = range.getEnd();
+  if (!end.isValid()) {
+    return range;
+  }
+  if (end.isMacroID()) {
+    end = sm.getExpansionLoc(end);
+  }
+  if (!end.isValid()) {
+    return range;
+  }
+
+  if (!canLexTrailingDeclToken(end, sm)) {
+    return range;
+  }
+
+  clang::SourceLocation after_end =
+      clang::Lexer::getLocForEndOfToken(end, 0, sm, lang_opts);
+  if (!after_end.isValid()) {
+    return range;
+  }
+
+  clang::Token tok;
+  if (clang::Lexer::getRawToken(after_end, tok, sm, lang_opts,
+                                /*IgnoreWhiteSpace=*/true)) {
+    return range;
+  }
+  if (!tok.is(clang::tok::semi)) {
+    return range;
+  }
+
+  range.setEnd(tok.getLocation());
+  return range;
+}
+
 } // namespace
 
 static bool symbol_present_in_scope(SgScopeStatement *scope, SgSymbol *sym) {
@@ -5777,6 +5844,11 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
       if (loc.isValid()) {
         range = clang::SourceRange(loc, loc);
       }
+    }
+    if (range.isValid() && p_compiler_instance != nullptr) {
+      range = extendDeclSourceRangeWithTrailingSemicolon(
+          range, p_compiler_instance->getSourceManager(),
+          p_compiler_instance->getLangOpts());
     }
     applySourceRange(*node, range);
   }
@@ -16036,15 +16108,25 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   for (unsigned i = 0; i < function_decl->getNumParams(); i++) {
     clang::ParmVarDecl *param_decl = function_decl->getParamDecl(i);
-    if (funcProtoType != nullptr && function_decl->getParamDecl(i)->getType() !=
-                                        funcProtoType->getParamType(i)) {
+    if (funcProtoType != nullptr) {
+      const clang::QualType declared_param_type = param_decl->getType();
+      const clang::QualType proto_param_type = funcProtoType->getParamType(i);
+      bool differs = false;
+      if (p_compiler_instance != nullptr) {
+        differs = !p_compiler_instance->getASTContext().hasSameType(
+            declared_param_type, proto_param_type);
+      } else {
+        differs = declared_param_type.getCanonicalType() !=
+                  proto_param_type.getCanonicalType();
+      }
+      if (differs) {
 #if DEBUG_VISIT_DECL
-      std::cout << "Func arg type :"
-                << function_decl->getParamDecl(i)->getType().getAsString()
-                << " funcProtoType arg type:"
-                << funcProtoType->getParamType(i).getAsString() << std::endl;
+        std::cout << "Func arg type :" << declared_param_type.getAsString()
+                  << " funcProtoType arg type:"
+                  << proto_param_type.getAsString() << std::endl;
 #endif
-      diffInProtoType = true;
+        diffInProtoType = true;
+      }
     }
     SgNode *tmp_init_name = Traverse(param_decl);
     SgInitializedName *init_name = isSgInitializedName(tmp_init_name);
@@ -19664,15 +19746,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   */
   //  ROSE_ASSERT(GetSymbolFromSymbolTable(function_decl) != nullptr);
 
-  // Pei-Hung (09/27/2022) setup linkage
-  if (function_decl->isExternC()) {
-    sg_function_decl->get_declarationModifier()
-        .get_storageModifier()
-        .setExtern();
-  }
-
-  // Pei-Hung (06/16/22) added "extern" modifier
-  bool hasExternalStorage = function_decl->isLocalExternDecl();
+  // Map only explicit storage-class extern, not plain C language linkage.
+  bool hasExternalStorage =
+      function_decl->isLocalExternDecl() ||
+      function_decl->getStorageClass() == clang::SC_Extern;
   if (hasExternalStorage) {
     sg_function_decl->get_declarationModifier()
         .get_storageModifier()
@@ -21751,7 +21828,19 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
 
     if (!suppress_var) {
       if (loc.isMacroID()) {
-        loc = sm.getSpellingLoc(loc);
+        // Macro-spelled declarations used in source-level macros (e.g. GNU
+        // statement-expressions in main-file macros) should be preserved using
+        // their expansion location. Falling back to spelling location here
+        // would incorrectly suppress declarations that are lexically in the
+        // main file but spelled in headers.
+        clang::SourceLocation expansion_loc = sm.getExpansionLoc(loc);
+        if (expansion_loc.isValid() && sm.isWrittenInMainFile(expansion_loc) &&
+            !sm.isInSystemHeader(expansion_loc) &&
+            !sm.isWrittenInBuiltinFile(expansion_loc)) {
+          loc = expansion_loc;
+        } else {
+          loc = sm.getSpellingLoc(loc);
+        }
       }
       if (!loc.isValid()) {
         suppress_var = true;

--- a/src/frontend/CxxFrontend/Clang/clang-frontend.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend.cpp
@@ -11,6 +11,8 @@
 
 #include <memory>
 
+#include <set>
+
 #include <sstream>
 #include <vector>
 
@@ -837,6 +839,7 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
     const std::string default_openmp_define =
         "_OPENMP=" + std::to_string(OMPVERSION);
     std::string openmp_define;
+
     for (const auto &define_value : openmp_define_list) {
       if (define_value == "_OPENMP") {
         openmp_define = default_openmp_define;
@@ -856,6 +859,7 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
         break;
       }
     }
+
     if (openmp_define.empty()) {
       openmp_define = default_openmp_define;
     }
@@ -1027,13 +1031,7 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   // Avoid staged Clang resource headers that cause include_next loops.
   filter_staged_resource_dirs(sys_dirs_list);
 
-  // If user explicitly provided -D_OPENMP=value on command line, honor it
-  // Otherwise, when -fopenmp is passed to Clang (enable_openmp=true), Clang
-  // will automatically define _OPENMP with the correct version for its OpenMP
-  // runtime. We should NOT override Clang's built-in _OPENMP macro with a
-  // hardcoded value.
-  // Do not pass _OPENMP to the Clang frontend: OpenMP pragmas are handled as
-  // plain text and Clang's omp.h expects OpenMP-enabled parsing semantics.
+  // Build cc1-style argument list for the in-process Clang invocation.
 
   const size_t estimated_argc = 1 + define_list.size() + inc_dirs_list.size() +
                                 (sys_dirs_list.size() * 2) +
@@ -1255,6 +1253,103 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
       cc1_args_storage.emplace_back();
     }
   }
+
+  auto canonical_path = [](const std::string &path) -> std::string {
+    if (path.empty()) {
+      return path;
+    }
+    llvm::SmallString<256> resolved;
+    if (!llvm::sys::fs::real_path(path, resolved)) {
+      return resolved.str().str();
+    }
+    return path;
+  };
+  std::set<std::string> cc1_system_include_dirs;
+  auto record_system_include = [&](const std::string &dir) {
+    if (dir.empty()) {
+      return;
+    }
+    cc1_system_include_dirs.insert(canonical_path(dir));
+  };
+  auto parse_system_include_flag = [&](const std::string &flag,
+                                       std::size_t index) -> bool {
+    auto consume_prefixed = [&](const char *prefix) -> bool {
+      const std::size_t prefix_len = std::strlen(prefix);
+      if (flag.rfind(prefix, 0) != 0 || flag.size() <= prefix_len) {
+        return false;
+      }
+      std::string suffix = flag.substr(prefix_len);
+      if (!suffix.empty() && suffix[0] == '=') {
+        suffix.erase(suffix.begin());
+      }
+      if (!suffix.empty()) {
+        record_system_include(suffix);
+      }
+      return true;
+    };
+
+    if (flag == "-isystem" || flag == "-internal-isystem" ||
+        flag == "-internal-externc-isystem" || flag == "-c-isystem" ||
+        flag == "-cxx-isystem") {
+      if (index + 1 < cc1_args_storage.size()) {
+        record_system_include(cc1_args_storage[index + 1]);
+      }
+      return true;
+    }
+    return consume_prefixed("-isystem") ||
+           consume_prefixed("-internal-isystem") ||
+           consume_prefixed("-internal-externc-isystem") ||
+           consume_prefixed("-c-isystem") || consume_prefixed("-cxx-isystem");
+  };
+  for (std::size_t i = 0; i < cc1_args_storage.size(); ++i) {
+    parse_system_include_flag(cc1_args_storage[i], i);
+  }
+
+  // Clang 21 toolchains on some distros may omit GCC's runtime include
+  // directory from cc1 args, which drops omp.h target API declarations.
+  if (sageFile.get_openmp() && !disable_openmp_via_flag) {
+    std::vector<std::string> omp_runtime_candidates;
+    std::set<std::string> seen_runtime_candidates;
+    auto collect_openmp_include_candidates = [&](const auto &paths) {
+      for (const std::string &base_dir : paths) {
+        if (base_dir.empty()) {
+          continue;
+        }
+        llvm::SmallString<256> include_dir(base_dir);
+        if (!llvm::StringRef(base_dir).ends_with("/include")) {
+          llvm::sys::path::append(include_dir, "include");
+        }
+        if (!llvm::sys::fs::exists(include_dir)) {
+          continue;
+        }
+        llvm::SmallString<256> omp_header(include_dir);
+        llvm::sys::path::append(omp_header, "omp.h");
+        if (!llvm::sys::fs::exists(omp_header)) {
+          continue;
+        }
+        std::string normalized = canonical_path(include_dir.str().str());
+        if (seen_runtime_candidates.insert(normalized).second) {
+          omp_runtime_candidates.push_back(normalized);
+        }
+      }
+    };
+
+    const clang::driver::ToolChain &default_toolchain =
+        compilation->getDefaultToolChain();
+    collect_openmp_include_candidates(default_toolchain.getFilePaths());
+    collect_openmp_include_candidates(default_toolchain.getLibraryPaths());
+
+    for (const std::string &candidate : omp_runtime_candidates) {
+      if (cc1_system_include_dirs.count(candidate) != 0) {
+        continue;
+      }
+      cc1_args_storage.push_back("-internal-isystem");
+      cc1_args_storage.push_back(candidate);
+      cc1_system_include_dirs.insert(candidate);
+      break;
+    }
+  }
+
   std::vector<const char *> cc1_args_cstr;
   cc1_args_cstr.reserve(cc1_args_storage.size());
   for (const auto &arg : cc1_args_storage) {
@@ -1429,16 +1524,13 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
     lang_opts.GNUCVersion = 40201; // GCC 4.2.1 (Clang default)
   }
   if (openmp_ast_mode) {
-    // OpenMP/OpenACC AST-only parsing should tolerate non-standard C code used
-    // in legacy tests (e.g., void main, implicit functions). Keep C++ in
-    // hosted mode so standard headers (iostream, etc.) remain usable.
+    // OpenMP/OpenACC AST-only parsing should preserve the same language
+    // standard selected for normal frontend parsing. Do not force legacy C89
+    // semantics here; users who do not pass -std should get Clang's default.
+    // Keep C++ in hosted mode so standard headers (iostream, etc.) remain
+    // usable.
     if (language == ClangToSageTranslator::C) {
       lang_opts.Freestanding = 1;
-      lang_opts.C99 = 0;
-      lang_opts.C11 = 0;
-      lang_opts.C17 = 0;
-      lang_opts.C23 = 0;
-      lang_opts.GNUMode = 1;
     }
   }
 
@@ -1516,13 +1608,14 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   clang::FileID mainFileID = compiler_instance->getSourceManager().createFileID(
       input_file_entry, clang::SourceLocation(), clang::SrcMgr::C_User);
 
-  // Preserve original spelling for no-backend-compile roundtrip workflows
-  // (e.g., cmp-based translator tests), unless we intentionally rewrite the
-  // in-memory source buffer below.
   if ((language == ClangToSageTranslator::C ||
        language == ClangToSageTranslator::CPLUSPLUS ||
        language == ClangToSageTranslator::CUDA) &&
-      sageFile.get_skipfinalCompileStep() && !openmp_ast_mode) {
+      sageFile.get_skipfinalCompileStep() && !openmp_ast_mode &&
+      !sageFile.get_openmp_lowering()) {
+    // Preserve original spelling for no-backend-compile roundtrip workflows
+    // (e.g., cmp-based translator tests), unless we intentionally rewrite the
+    // in-memory source buffer below.
     sageFile.set_unparse_tokens(true);
   }
 
@@ -1572,6 +1665,7 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   // Register pragma and preprocessor callbacks (OpenMP and includes).
   RoseOpenMPPragmaCallback *omp_callback = nullptr;
   SagePreprocessorRecord *preprocessor_recorder = nullptr;
+  std::unique_ptr<SagePreprocessorRecord> secondary_preprocessor_recorder;
   {
     clang::Preprocessor &PP = compiler_instance->getPreprocessor();
     auto omp_callback_owner = std::make_unique<RoseOpenMPPragmaCallback>(
@@ -1582,8 +1676,14 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
     auto preprocessor_recorder_owner = std::make_unique<SagePreprocessorRecord>(
         &(compiler_instance->getSourceManager()));
     preprocessor_recorder = preprocessor_recorder_owner.get();
-    PP.addPPCallbacks(std::move(preprocessor_recorder_owner));
-    PP.addCommentHandler(preprocessor_recorder);
+    if (!is_secondary_parse) {
+      PP.addPPCallbacks(std::move(preprocessor_recorder_owner));
+      PP.addCommentHandler(preprocessor_recorder);
+    } else {
+      // Secondary parses should not contribute another directive/comment stream
+      // to the already-annotated primary AST.
+      secondary_preprocessor_recorder = std::move(preprocessor_recorder_owner);
+    }
   }
   if (preprocessor_recorder != nullptr && !suppressed_includes.empty()) {
     clang::SourceLocation file_start =
@@ -1929,6 +2029,10 @@ void finishSageAST(ClangToSageTranslator &translator) {
       if (node == nullptr) {
         return nullptr;
       }
+      Sg_File_Info *info = node->get_file_info();
+      if (info != nullptr && info->get_line() > 0) {
+        return info;
+      }
       Sg_File_Info *start = node->get_startOfConstruct();
       if (start != nullptr && start->get_line() > 0) {
         return start;
@@ -2114,6 +2218,76 @@ void finishSageAST(ClangToSageTranslator &translator) {
       }
       return nullptr;
     };
+    auto is_comment_directive = [](const PreprocessingInfo *info) -> bool {
+      if (info == nullptr) {
+        return false;
+      }
+      PreprocessingInfo::DirectiveType type = info->getTypeOfDirective();
+      return type == PreprocessingInfo::C_StyleComment ||
+             type == PreprocessingInfo::CplusplusStyleComment;
+    };
+    auto find_sibling_anchor_after_cursor =
+        [&](SgLocatedNode *anchor, Sg_File_Info *cursor) -> SgLocatedNode * {
+      if (anchor == nullptr || cursor == nullptr) {
+        return nullptr;
+      }
+
+      auto better_anchor = [&](SgLocatedNode *lhs, SgLocatedNode *rhs) -> bool {
+        if (lhs == nullptr) {
+          return false;
+        }
+        if (rhs == nullptr) {
+          return true;
+        }
+        return location_leq(node_start(lhs), node_start(rhs));
+      };
+
+      auto consider = [&](SgLocatedNode *candidate, SgLocatedNode *&best) {
+        if (candidate == nullptr) {
+          return;
+        }
+        Sg_File_Info *candidate_start = node_start(candidate);
+        if (candidate_start == nullptr || candidate_start->get_line() <= 0) {
+          return;
+        }
+        if (!is_same_file(candidate_start, cursor)) {
+          return;
+        }
+        if (!location_leq(cursor, candidate_start)) {
+          return;
+        }
+        if (better_anchor(candidate, best)) {
+          best = candidate;
+        }
+      };
+
+      SgLocatedNode *best = nullptr;
+      SgNode *parent = anchor->get_parent();
+      if (SgBasicBlock *block = isSgBasicBlock(parent)) {
+        for (SgStatement *stmt : block->get_statements()) {
+          consider(isSgLocatedNode(stmt), best);
+        }
+      } else if (SgGlobal *scope = isSgGlobal(parent)) {
+        for (SgDeclarationStatement *decl : scope->get_declarations()) {
+          consider(isSgLocatedNode(decl), best);
+        }
+      } else if (SgNamespaceDefinitionStatement *scope =
+                     isSgNamespaceDefinitionStatement(parent)) {
+        for (SgDeclarationStatement *decl : scope->get_declarations()) {
+          consider(isSgLocatedNode(decl), best);
+        }
+      } else if (SgClassDefinition *scope = isSgClassDefinition(parent)) {
+        for (SgDeclarationStatement *decl : scope->get_members()) {
+          consider(isSgLocatedNode(decl), best);
+        }
+      } else if (SgTemplateClassDefinition *scope =
+                     isSgTemplateClassDefinition(parent)) {
+        for (SgDeclarationStatement *decl : scope->get_members()) {
+          consider(isSgLocatedNode(decl), best);
+        }
+      }
+      return best;
+    };
 
     SgStatement *attach_target = find_last_output_stmt(global_scope);
     SgStatement *first_output_stmt = find_first_output_stmt(global_scope);
@@ -2166,6 +2340,19 @@ void finishSageAST(ClangToSageTranslator &translator) {
       if (entry.second != nullptr) {
         SgLocatedNode *anchor = find_anchor_for_cursor(entry.first);
         if (anchor != nullptr) {
+          if (is_comment_directive(entry.second) && entry.first != nullptr) {
+            Sg_File_Info *anchor_start = node_start(anchor);
+            if (anchor_start != nullptr && anchor_start->get_line() > 0 &&
+                is_same_file(anchor_start, entry.first) &&
+                location_leq(entry.first, anchor_start) &&
+                !location_leq(anchor_start, entry.first)) {
+              if (SgLocatedNode *better_anchor =
+                      find_sibling_anchor_after_cursor(anchor, entry.first)) {
+                anchor = better_anchor;
+              }
+            }
+          }
+
           Sg_File_Info *start = node_start(anchor);
           Sg_File_Info *end = node_end(anchor);
           if (isSgBasicBlock(anchor) != nullptr ||
@@ -3958,6 +4145,14 @@ NextPreprocessorToInsert *PreprocessorInserter::evaluateInheritedAttribute(
     return node->get_endOfConstruct();
   };
   auto should_attach_preproc = [&](SgLocatedNode *node) -> bool {
+    // Keep in sync with SgLocatedNode::addToAttachedPreprocessingInfo() hard
+    // restrictions: these node kinds are not valid preprocessing anchors.
+    if (isSgTypedefSeq(node) != nullptr ||
+        isSgCatchStatementSeq(node) != nullptr ||
+        isSgCtorInitializerList(node) != nullptr) {
+      return false;
+    }
+
     Sg_File_Info *info = get_effective_file_info(node);
     if (info == nullptr) {
       return false;
@@ -4008,20 +4203,6 @@ NextPreprocessorToInsert *PreprocessorInserter::evaluateInheritedAttribute(
     }
 
     return best;
-  };
-  auto is_comment_directive = [](const PreprocessingInfo *info) -> bool {
-    if (info == nullptr) {
-      return false;
-    }
-    switch (info->getTypeOfDirective()) {
-    case PreprocessingInfo::C_StyleComment:
-    case PreprocessingInfo::CplusplusStyleComment:
-    case PreprocessingInfo::FortranStyleComment:
-    case PreprocessingInfo::F90StyleComment:
-      return true;
-    default:
-      return false;
-    }
   };
   auto is_same_file = [](Sg_File_Info *a, Sg_File_Info *b) -> bool {
     if (a == nullptr || b == nullptr) {
@@ -4777,69 +4958,6 @@ NextPreprocessorToInsert *PreprocessorInserter::evaluateInheritedAttribute(
           }
         }
       }
-      auto attach_to_candidate = [&]() {
-        if (inheritedValue->candidat == nullptr ||
-            inheritedValue->candidat == loc_node ||
-            isSgGlobal(inheritedValue->candidat) != nullptr) {
-          return;
-        }
-
-        SgLocatedNode *candidate = inheritedValue->candidat;
-        if (SgExprStatement *expr_stmt = isSgExprStatement(candidate)) {
-          if (SgExpression *expr = expr_stmt->get_expression()) {
-            candidate = expr;
-          }
-        }
-        if (!should_attach_preproc(candidate)) {
-          return;
-        }
-
-        attach_node = candidate;
-        Sg_File_Info *cursor_info = inheritedValue->cursor;
-        Sg_File_Info *candidate_start = candidate->get_startOfConstruct();
-        Sg_File_Info *candidate_end = candidate->get_endOfConstruct();
-        if (candidate_end == nullptr) {
-          candidate_end = candidate_start;
-        }
-        if (cursor_info == nullptr || candidate_end == nullptr) {
-          return;
-        }
-
-        bool same_file =
-            cursor_info->get_file_id() == candidate_end->get_file_id();
-        if (!same_file && !cursor_info->get_filenameString().empty() &&
-            !candidate_end->get_filenameString().empty()) {
-          same_file = cursor_info->get_filenameString() ==
-                      candidate_end->get_filenameString();
-        }
-        if (!same_file) {
-          return;
-        }
-
-        if (cursor_info->get_line() > candidate_end->get_line() ||
-            (cursor_info->get_line() == candidate_end->get_line() &&
-             cursor_info->get_col() > candidate_end->get_col())) {
-          inheritedValue->next_to_insert->setRelativePosition(
-              PreprocessingInfo::after);
-          return;
-        }
-
-        if (candidate_start != nullptr &&
-            (cursor_info->get_line() < candidate_start->get_line() ||
-             (cursor_info->get_line() == candidate_start->get_line() &&
-              cursor_info->get_col() < candidate_start->get_col()))) {
-          inheritedValue->next_to_insert->setRelativePosition(
-              PreprocessingInfo::before);
-          return;
-        }
-
-        inheritedValue->next_to_insert->setRelativePosition(
-            PreprocessingInfo::after);
-      };
-
-      if (is_comment_directive(inheritedValue->next_to_insert)) {
-        attach_to_candidate();
-      }
       bool is_include = is_include_directive(inheritedValue->next_to_insert);
       if (is_include && inheritedValue->cursor != nullptr &&
           attach_node != nullptr && attach_node->get_file_info() != nullptr &&
@@ -5085,11 +5203,89 @@ void SagePreprocessorRecord::recordDirective(
       return false;
     }
   };
+  auto is_comment_directive = [](PreprocessingInfo::DirectiveType type) {
+    switch (type) {
+    case PreprocessingInfo::C_StyleComment:
+    case PreprocessingInfo::CplusplusStyleComment:
+    case PreprocessingInfo::FortranStyleComment:
+    case PreprocessingInfo::F90StyleComment:
+      return true;
+    default:
+      return false;
+    }
+  };
+  auto same_record_location = [&](const Sg_File_Info *existing_info) {
+    if (existing_info == nullptr) {
+      return false;
+    }
+    if (existing_info->get_line() != static_cast<int>(ls)) {
+      return false;
+    }
+    const std::string existing_file = existing_info->get_filenameString();
+    if (!existing_file.empty() && !file.empty() && existing_file != file) {
+      return false;
+    }
+    return true;
+  };
 
   if (requires_hash(directive_type)) {
     size_t first_nonspace = content.find_first_not_of(" \t");
     if (first_nonspace != std::string::npos && content[first_nonspace] != '#') {
       content.insert(first_nonspace, "#");
+    }
+  }
+
+  // Clang can report the same main-file comment more than once in some
+  // preprocessing flows. Keep only exact duplicates at the same source point.
+  for (const auto &existing : p_preprocessor_record_list) {
+    Sg_File_Info *existing_info = existing.first;
+    PreprocessingInfo *existing_pp = existing.second;
+    if (existing_info == nullptr || existing_pp == nullptr) {
+      continue;
+    }
+    if (existing_pp->getTypeOfDirective() != directive_type) {
+      continue;
+    }
+    if (!same_record_location(existing_info) ||
+        existing_info->get_col() != static_cast<int>(cs)) {
+      continue;
+    }
+    if (existing_pp->getString() == content) {
+      return;
+    }
+  }
+
+  // A trailing comment on the same source line as a preprocessor directive
+  // should stay embedded in that directive text, not as a separate comment
+  // record.
+  if (is_comment_directive(directive_type)) {
+    for (const auto &existing : p_preprocessor_record_list) {
+      Sg_File_Info *existing_info = existing.first;
+      PreprocessingInfo *existing_pp = existing.second;
+      if (existing_info == nullptr || existing_pp == nullptr) {
+        continue;
+      }
+      if (!same_record_location(existing_info)) {
+        continue;
+      }
+      if (!is_comment_directive(existing_pp->getTypeOfDirective())) {
+        return;
+      }
+    }
+  } else {
+    for (auto it = p_preprocessor_record_list.begin();
+         it != p_preprocessor_record_list.end();) {
+      Sg_File_Info *existing_info = it->first;
+      PreprocessingInfo *existing_pp = it->second;
+      if (existing_info == nullptr || existing_pp == nullptr ||
+          !same_record_location(existing_info) ||
+          !is_comment_directive(existing_pp->getTypeOfDirective())) {
+        ++it;
+        continue;
+      }
+      delete existing_info;
+      delete existing_pp;
+      it = p_preprocessor_record_list.erase(it);
     }
   }
 
@@ -5139,14 +5335,18 @@ void SagePreprocessorRecord::InclusionDirective(
     directive = "#include_next ";
   }
 
-  std::string include_target;
-  if (IsAngled) {
-    include_target = "<" + FileName.str() + ">";
-  } else {
-    include_target = "\"" + FileName.str() + "\"";
+  // Preserve original include spelling (including trailing comments) when
+  // available from the main-file source buffer.
+  std::string include_text = collectDirectiveText(HashLoc);
+  if (include_text.empty()) {
+    std::string include_target;
+    if (IsAngled) {
+      include_target = "<" + FileName.str() + ">";
+    } else {
+      include_target = "\"" + FileName.str() + "\"";
+    }
+    include_text = directive + include_target;
   }
-
-  std::string include_text = directive + include_target + "\n";
 
   recordDirective(HashLoc, directive_type, include_text);
 }

--- a/src/frontend/SageIII/ompAstConstruction.cpp
+++ b/src/frontend/SageIII/ompAstConstruction.cpp
@@ -151,41 +151,126 @@ void collectCommentedDirectiveRelocations(
     return;
   }
 
-  struct PragmaPosition {
-    SgPragmaDeclaration *declaration = nullptr;
+  struct StatementPosition {
+    SgStatement *statement = nullptr;
     unsigned line = 0;
   };
 
-  std::unordered_map<int, std::vector<PragmaPosition>> pragma_positions_by_file;
+  std::unordered_set<SgPragmaDeclaration *> pragma_set;
+  std::unordered_map<int, std::vector<StatementPosition>>
+      statement_positions_by_file;
+  std::unordered_map<std::string, std::vector<StatementPosition>>
+      statement_positions_by_filename;
+
   for (SgPragmaDeclaration *pragma_decl : pragma_list) {
     if (pragma_decl == nullptr) {
       continue;
     }
-    const Sg_File_Info *file_info = pragma_decl->get_file_info();
+    pragma_set.insert(pragma_decl);
+  }
+
+  std::vector<SgNode *> statements =
+      NodeQuery::querySubTree(source_file, V_SgStatement);
+  for (SgNode *node : statements) {
+    SgStatement *stmt = isSgStatement(node);
+    if (stmt == nullptr) {
+      continue;
+    }
+    const Sg_File_Info *file_info = stmt->get_file_info();
     if (file_info == nullptr) {
       continue;
     }
 
-    const unsigned pragma_line = getLocatedNodeLine(pragma_decl);
-    if (pragma_line == 0) {
+    const unsigned stmt_line = getLocatedNodeLine(isSgLocatedNode(stmt));
+    if (stmt_line == 0) {
       continue;
     }
 
-    pragma_positions_by_file[file_info->get_file_id()].push_back(
-        PragmaPosition{pragma_decl, pragma_line});
+    const int file_id = file_info->get_file_id();
+    if (file_id <= 0) {
+      int physical_file_id = file_info->get_physical_file_id();
+      if (physical_file_id > 0) {
+        statement_positions_by_file[physical_file_id].push_back(
+            StatementPosition{stmt, stmt_line});
+      }
+    } else {
+      statement_positions_by_file[file_id].push_back(
+          StatementPosition{stmt, stmt_line});
+    }
+
+    const std::string filename = file_info->get_filenameString();
+    if (!filename.empty()) {
+      statement_positions_by_filename[filename].push_back(
+          StatementPosition{stmt, stmt_line});
+    }
   }
 
-  for (auto &entry : pragma_positions_by_file) {
-    std::vector<PragmaPosition> &positions = entry.second;
+  for (auto &entry : statement_positions_by_file) {
+    std::vector<StatementPosition> &positions = entry.second;
     std::sort(positions.begin(), positions.end(),
-              [](const PragmaPosition &lhs, const PragmaPosition &rhs) {
+              [](const StatementPosition &lhs, const StatementPosition &rhs) {
+                return lhs.line < rhs.line;
+              });
+  }
+  for (auto &entry : statement_positions_by_filename) {
+    std::vector<StatementPosition> &positions = entry.second;
+    std::sort(positions.begin(), positions.end(),
+              [](const StatementPosition &lhs, const StatementPosition &rhs) {
                 return lhs.line < rhs.line;
               });
   }
 
-  if (pragma_positions_by_file.empty()) {
+  if (statement_positions_by_file.empty() &&
+      statement_positions_by_filename.empty()) {
     return;
   }
+
+  auto detach_from_owner = [](SgLocatedNode *owner, PreprocessingInfo *info) {
+    if (owner == nullptr || info == nullptr) {
+      return;
+    }
+    AttachedPreprocessingInfoType *owner_info =
+        owner->get_attachedPreprocessingInfoPtr();
+    if (owner_info == nullptr) {
+      return;
+    }
+    auto owner_pos = std::find(owner_info->begin(), owner_info->end(), info);
+    if (owner_pos != owner_info->end()) {
+      owner_info->erase(owner_pos);
+    }
+  };
+
+  auto attach_to_target = [](SgStatement *target, PreprocessingInfo *info,
+                             bool attach_before) {
+    if (target == nullptr || info == nullptr) {
+      return;
+    }
+
+    AttachedPreprocessingInfoType *target_info =
+        target->get_attachedPreprocessingInfoPtr();
+    if (target_info == nullptr) {
+      target_info = new AttachedPreprocessingInfoType;
+      target->set_attachedPreprocessingInfoPtr(target_info);
+    }
+
+    if (std::find(target_info->begin(), target_info->end(), info) !=
+        target_info->end()) {
+      return;
+    }
+
+    info->setRelativePosition(attach_before ? PreprocessingInfo::before
+                                            : PreprocessingInfo::after);
+    if (attach_before) {
+      auto insert_after_existing_before = std::find_if(
+          target_info->begin(), target_info->end(),
+          [](PreprocessingInfo *current) {
+            return current->getRelativePosition() != PreprocessingInfo::before;
+          });
+      target_info->insert(insert_after_existing_before, info);
+    } else {
+      target_info->push_back(info);
+    }
+  };
 
   std::unordered_set<PreprocessingInfo *> seen_comments;
   std::vector<SgNode *> located_nodes =
@@ -213,66 +298,114 @@ void collectCommentedDirectiveRelocations(
 
       int comment_line = info->getLineNumber();
       int file_id = info->getFileId();
+      std::string comment_filename;
 
       if (comment_line <= 0) {
         comment_line = static_cast<int>(getLocatedNodeLine(owner));
       }
+      if (Sg_File_Info *comment_file_info = info->get_file_info()) {
+        if (file_id <= 0) {
+          file_id = comment_file_info->get_file_id();
+          if (file_id <= 0) {
+            int physical_file_id = comment_file_info->get_physical_file_id();
+            if (physical_file_id > 0) {
+              file_id = physical_file_id;
+            }
+          }
+        }
+        comment_filename = comment_file_info->get_filenameString();
+      }
       if (file_id <= 0) {
         if (const Sg_File_Info *owner_info = owner->get_file_info()) {
           file_id = owner_info->get_file_id();
+          if (file_id <= 0) {
+            int physical_file_id = owner_info->get_physical_file_id();
+            if (physical_file_id > 0) {
+              file_id = physical_file_id;
+            }
+          }
+          if (comment_filename.empty()) {
+            comment_filename = owner_info->get_filenameString();
+          }
         }
       }
       if (file_id <= 0) {
         if (const Sg_File_Info *source_info = source_file->get_file_info()) {
           file_id = source_info->get_file_id();
+          if (file_id <= 0) {
+            int physical_file_id = source_info->get_physical_file_id();
+            if (physical_file_id > 0) {
+              file_id = physical_file_id;
+            }
+          }
+          if (comment_filename.empty()) {
+            comment_filename = source_info->get_filenameString();
+          }
         }
       }
       if (comment_line <= 0) {
         continue;
       }
 
-      auto pragma_positions_it = pragma_positions_by_file.find(file_id);
-      if (pragma_positions_it == pragma_positions_by_file.end()) {
-        if (pragma_positions_by_file.size() == 1) {
-          pragma_positions_it = pragma_positions_by_file.begin();
-        } else {
-          continue;
+      const std::vector<StatementPosition> *positions = nullptr;
+      if (!comment_filename.empty()) {
+        auto by_name_it = statement_positions_by_filename.find(comment_filename);
+        if (by_name_it != statement_positions_by_filename.end()) {
+          positions = &by_name_it->second;
         }
       }
-
-      const std::vector<PragmaPosition> &positions =
-          pragma_positions_it->second;
-      if (positions.empty()) {
+      if (positions == nullptr && file_id > 0) {
+        auto by_id_it = statement_positions_by_file.find(file_id);
+        if (by_id_it != statement_positions_by_file.end()) {
+          positions = &by_id_it->second;
+        }
+      }
+      if (positions == nullptr && statement_positions_by_filename.size() == 1) {
+        positions = &statement_positions_by_filename.begin()->second;
+      }
+      if (positions == nullptr && statement_positions_by_file.size() == 1) {
+        positions = &statement_positions_by_file.begin()->second;
+      }
+      if (positions == nullptr) {
+        continue;
+      }
+      if (positions->empty()) {
         continue;
       }
 
-      auto next_pragma_it =
-          std::lower_bound(positions.begin(), positions.end(), comment_line,
-                           [](const PragmaPosition &position, int line) {
+      auto next_statement_it =
+          std::lower_bound(positions->begin(), positions->end(), comment_line,
+                           [](const StatementPosition &position, int line) {
                              return static_cast<int>(position.line) < line;
                            });
-      SgPragmaDeclaration *target_pragma = nullptr;
-      if (next_pragma_it != positions.end()) {
-        target_pragma = next_pragma_it->declaration;
+      SgStatement *target_stmt = nullptr;
+      int target_stmt_line = 0;
+      if (next_statement_it != positions->end()) {
+        target_stmt = next_statement_it->statement;
+        target_stmt_line = static_cast<int>(next_statement_it->line);
       } else {
-        const PragmaPosition &last_position = positions.back();
-        const int owner_line = static_cast<int>(getLocatedNodeLine(owner));
-        const bool owner_before_last_pragma =
-            owner_line > 0 &&
-            owner_line <= static_cast<int>(last_position.line);
-        if (comment_line > static_cast<int>(last_position.line) &&
-            owner_before_last_pragma) {
-          target_pragma = last_position.declaration;
-        } else {
-          continue;
-        }
+        const StatementPosition &last_position = positions->back();
+        target_stmt = last_position.statement;
+        target_stmt_line = static_cast<int>(last_position.line);
       }
-      if (target_pragma == nullptr) {
+      if (target_stmt == nullptr) {
         continue;
       }
 
-      g_pending_commented_directive_relocations[target_pragma].push_back(
-          PendingCommentedDirectiveRelocation{owner, info, comment_line});
+      const bool appears_before_target =
+          target_stmt_line == 0 || comment_line <= target_stmt_line;
+      if (SgPragmaDeclaration *target_pragma = isSgPragmaDeclaration(target_stmt)) {
+        if (pragma_set.find(target_pragma) != pragma_set.end()) {
+          g_pending_commented_directive_relocations[target_pragma].push_back(
+              PendingCommentedDirectiveRelocation{owner, info, comment_line});
+          continue;
+        }
+      }
+
+      if (isSgLocatedNode(target_stmt) != owner) {
+        detach_from_owner(owner, info);
+      }
+      attach_to_target(target_stmt, info, appears_before_target);
     }
   }
 }
@@ -3587,7 +3720,6 @@ convertDirective(std::pair<SgPragmaDeclaration *, OpenMPDirective *>
   copyStartFileInfo(pdecl, result);
   copyEndFileInfo(pdecl, result);
   if (SgLocatedNode *located_result = isSgLocatedNode(result)) {
-    located_result->setTransformation();
     located_result->setOutputInCodeGeneration();
   }
 
@@ -6560,7 +6692,6 @@ SgOmpParallelStatement *convertOmpParallelStatementFromCombinedDirectives(
   copyStartFileInfo(current_OpenMPIR_to_SageIII.first, second_stmt);
   copyEndFileInfo(current_OpenMPIR_to_SageIII.first, second_stmt);
   if (SgLocatedNode *located_second = isSgLocatedNode(second_stmt)) {
-    located_second->setTransformation();
     located_second->setOutputInCodeGeneration();
   }
   SgOmpParallelStatement *first_stmt =
@@ -6568,7 +6699,6 @@ SgOmpParallelStatement *convertOmpParallelStatementFromCombinedDirectives(
   setOneSourcePositionForTransformation(first_stmt);
   copyStartFileInfo(current_OpenMPIR_to_SageIII.first, first_stmt);
   copyEndFileInfo(current_OpenMPIR_to_SageIII.first, first_stmt);
-  first_stmt->setTransformation();
   first_stmt->setOutputInCodeGeneration();
   second_stmt->set_parent(first_stmt);
 

--- a/src/frontend/SageIII/sageInterface/sageBuilder.C
+++ b/src/frontend/SageIII/sageInterface/sageBuilder.C
@@ -77,6 +77,43 @@ void attachScopeAndParent(SgDeclarationStatement *decl,
   }
 }
 
+// buildSourceFile() can clone/reparse a file that already has preprocessing
+// directives/comments attached by the frontend (notably Clang CFE). Running
+// attachPreprocessingInfo() again on such files duplicates top-level
+// directives/comments in outlined helper files.
+bool sourceFileHasAttachedPreprocessingInfo(SgSourceFile *sourceFile) {
+  if (sourceFile == NULL) {
+    return false;
+  }
+
+  if (sourceFile->get_processedToIncludeCppDirectivesAndComments()) {
+    return true;
+  }
+
+  class AttachedPreprocessingInfoDetector : public AstSimpleProcessing {
+  public:
+    bool found = false;
+    void visit(SgNode *node) override {
+      if (found) {
+        return;
+      }
+      SgLocatedNode *located = isSgLocatedNode(node);
+      if (located == NULL) {
+        return;
+      }
+      AttachedPreprocessingInfoType *infos =
+          located->getAttachedPreprocessingInfo();
+      if (infos != NULL && !infos->empty()) {
+        found = true;
+      }
+    }
+  };
+
+  AttachedPreprocessingInfoDetector detector;
+  detector.traverse(sourceFile, preorder);
+  return detector.found;
+}
+
 } // namespace
 
 // MS 2015: utility functions used in the implementation of SageBuilder
@@ -13626,10 +13663,11 @@ void SageBuilder::fixupSourcePositionFileSpecification(
 
       SgExpression *expression = isSgExpression(node);
       if (expression != NULL) {
-        if (expression->get_operatorPosition()->get_physical_file_id() ==
-            originalFileId) {
-          expression->get_operatorPosition()->set_file_id(new_file_id);
-          expression->get_operatorPosition()->set_physical_file_id(new_file_id);
+        Sg_File_Info *operatorPosition = expression->get_operatorPosition();
+        if (operatorPosition != NULL &&
+            operatorPosition->get_physical_file_id() == originalFileId) {
+          operatorPosition->set_file_id(new_file_id);
+          operatorPosition->set_physical_file_id(new_file_id);
         }
       }
     }
@@ -14194,7 +14232,11 @@ SgSourceFile *SageBuilder::buildSourceFile(
   // secondaryPassOverSourceFile() instead of attachPreprocessingInfo() because
   // we need to support the token-based unparsing.
   // file->secondaryPassOverSourceFile();
-  attachPreprocessingInfo(sourceFile);
+  if (sourceFileHasAttachedPreprocessingInfo(sourceFile)) {
+    sourceFile->set_processedToIncludeCppDirectivesAndComments(true);
+  } else {
+    attachPreprocessingInfo(sourceFile);
+  }
 
   // DQ (11/8/2019): This is not working and breaks the current work at present.
   // DQ (11/8/2019): Support function to change the name in each of the IR

--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -10124,6 +10124,47 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
   SgStatement *surroundingStatement = targetStmt;
   int surroundingStatement_fileId =
       Sg_File_Info::BAD_FILE_ID; // No file id can have this value.
+  int targetStatement_fileId = Sg_File_Info::BAD_FILE_ID;
+
+  if (Sg_File_Info *target_file_info = targetStmt->get_file_info()) {
+    targetStatement_fileId = target_file_info->get_file_id();
+    if (targetStatement_fileId < 0) {
+      int physical_file_id = target_file_info->get_physical_file_id();
+      if (physical_file_id > 0) {
+        targetStatement_fileId = physical_file_id;
+      }
+    }
+  }
+
+  if (targetStatement_fileId < 0) {
+    if (AttachedPreprocessingInfoType *attached_comments =
+            targetStmt->getAttachedPreprocessingInfo()) {
+      for (AttachedPreprocessingInfoType::iterator it =
+               attached_comments->begin();
+           it != attached_comments->end(); ++it) {
+        PreprocessingInfo *pp_info = *it;
+        if (pp_info == NULL) {
+          continue;
+        }
+        Sg_File_Info *pp_file_info = pp_info->get_file_info();
+        if (pp_file_info == NULL) {
+          continue;
+        }
+
+        int pp_file_id = pp_file_info->get_file_id();
+        if (pp_file_id >= 0) {
+          targetStatement_fileId = pp_file_id;
+          break;
+        }
+
+        int pp_physical_file_id = pp_file_info->get_physical_file_id();
+        if (pp_physical_file_id > 0) {
+          targetStatement_fileId = pp_physical_file_id;
+          break;
+        }
+      }
+    }
+  }
 
 #if REMOVE_STATEMENT_DEBUG || 0
   printf("TOP of findSurroundingStatementFromSameFile(): "
@@ -10135,12 +10176,12 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
 
   // Only handle relocation for statements that exist in the file (at least for
   // now while debugging).
-  if (targetStmt->get_file_info()->get_file_id() >= 0) {
+  if (targetStatement_fileId >= 0) {
     surroundingStatementPreceedsTargetStatement = true;
 
 #if REMOVE_STATEMENT_DEBUG
     printf("   targetStmt->get_file_info()->get_file_id()           = %d \n",
-           targetStmt->get_file_info()->get_file_id());
+           targetStatement_fileId);
 #endif
 #if REMOVE_STATEMENT_DEBUG
     printf("Before loop: surroundingStatement = %p = %s name = %s "
@@ -10154,8 +10195,7 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
     // targetStmt->get_file_info()->get_file_id())
     while ((returningNullSurroundingStatement == false) &&
            (surroundingStatement != NULL) &&
-           surroundingStatement_fileId !=
-               targetStmt->get_file_info()->get_file_id() &&
+           surroundingStatement_fileId != targetStatement_fileId &&
            surroundingStatement_fileId !=
                Sg_File_Info::TRANSFORMATION_FILE_ID) {
       // Start by going up in the source sequence.
@@ -10255,8 +10295,7 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
         // (surroundingStatement->get_file_info()->get_file_id() !=
         // targetStmt->get_file_info()->get_file_id()) )
         while ((surroundingStatement != NULL) &&
-               (surroundingStatement_fileId !=
-                targetStmt->get_file_info()->get_file_id())) {
+               (surroundingStatement_fileId != targetStatement_fileId)) {
           // DQ (11/15/2020): Eliminate the infinite loop that is possible when
           // we iterate over a loop of statements.
           if (forwardVisitedStatementSet.find(surroundingStatement) !=
@@ -10333,8 +10372,12 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
   } else {
     printf("This is a special statement (not associated with the original "
            "source code, comment relocation is not supported for these "
-           "statements) targetStmt file id = %d \n",
-           targetStmt->get_file_info()->get_file_id());
+           "statements) targetStmt file id = %d (physical file id = %d)\n",
+           targetStmt->get_file_info() ? targetStmt->get_file_info()->get_file_id()
+                                       : Sg_File_Info::BAD_FILE_ID,
+           targetStmt->get_file_info()
+               ? targetStmt->get_file_info()->get_physical_file_id()
+               : Sg_File_Info::BAD_FILE_ID);
     surroundingStatement = NULL;
   }
 
@@ -25882,7 +25925,7 @@ SgFunctionDeclaration *SageInterface::buildFunctionPrototype(
 // want to mark it for output or template unparsing from the AST).
 SgFunctionDeclaration *
 SageInterface::replaceDefiningFunctionDeclarationWithFunctionPrototype(
-    SgFunctionDeclaration *functionDeclaration) {
+    SgFunctionDeclaration *functionDeclaration, bool movePreprocessingInfo) {
   SgFunctionDeclaration *nondefiningFunctionDeclaration = NULL;
   ROSE_ASSERT(functionDeclaration != NULL);
 
@@ -25937,17 +25980,6 @@ SageInterface::replaceDefiningFunctionDeclarationWithFunctionPrototype(
       // Likely we should build a new nondefining function declaration instead
       // of reusing the existing non-defining declaration.
       // removeStatement(functionDeclaration);
-      // DQ (11/22/2020): Note that this step will move the comments and CPP
-      // directives to the new statement (better in this step than in the copy
-      // of the pointer to the list above, which cause an iterator invalidation
-      // error). DQ (10/21/2020): I think we may want to return the orignal
-      // defining function declaration. DQ (12/2/2019): Need to support member
-      // functions which can't be declared when outside of their class. DQ
-      // (11/15/2020): Note that the default is false, and we need true.
-      bool movePreprocessingInfo = true;
-      replaceStatement(functionDeclaration, nondefiningFunctionDeclaration,
-                       movePreprocessingInfo);
-
       // DQ (11/25/2020): This is the cause of a problem in the outliner caught
       // in the resetParentPointer.C (definingDeclaration->get_parent() !=
       // __null). DQ (11/24/2020): Maybe we should set the parent of the
@@ -25956,6 +25988,11 @@ SageInterface::replaceDefiningFunctionDeclarationWithFunctionPrototype(
       // functionDeclaration is inserted into global scope and the name
       // qualification is not computed correctly (since the parent was still the
       // namespace scope where it was originally.
+      //
+      // Replace old function definition with non-defining declaration.
+      replaceStatement(functionDeclaration, nondefiningFunctionDeclaration,
+                       movePreprocessingInfo);
+
       ROSE_ASSERT(nondefiningFunctionDeclaration->get_parent() != NULL);
     }
   } else {

--- a/src/frontend/SageIII/sageInterface/sageInterface.h
+++ b/src/frontend/SageIII/sageInterface/sageInterface.h
@@ -2637,7 +2637,8 @@ ROSE_DLL_API void convertFunctionDefinitionsToFunctionPrototypes(SgNode *node);
 // SgFunctionDeclaration* functionDeclaration );
 ROSE_DLL_API SgFunctionDeclaration *
 replaceDefiningFunctionDeclarationWithFunctionPrototype(
-    SgFunctionDeclaration *functionDeclaration);
+    SgFunctionDeclaration *functionDeclaration,
+    bool movePreprocessingInfo = true);
 ROSE_DLL_API std::vector<SgFunctionDeclaration *>
 generateFunctionDefinitionsList(SgNode *node);
 

--- a/src/midend/programTransformation/ompLowering/omp_lowering.cpp
+++ b/src/midend/programTransformation/ompLowering/omp_lowering.cpp
@@ -72,6 +72,20 @@ SgVarRefExp *extractVarRefFromExpression(SgExpression *expr) {
   }
   return nullptr;
 }
+
+void prependGlobalDeclPreservingLeadingPreproc(SgStatement *decl,
+                                               SgGlobal *global_scope) {
+  ROSE_ASSERT(decl != nullptr);
+  ROSE_ASSERT(global_scope != nullptr);
+
+  if (SgStatement *first_stmt = SageInterface::getFirstStatement(global_scope);
+      first_stmt != nullptr) {
+    SageInterface::insertStatementBefore(first_stmt, decl,
+                                         /*autoMovePreprocessingInfo=*/true);
+  } else {
+    SageInterface::prependStatement(decl, global_scope);
+  }
+}
 } // namespace
 
 // This is a hack to pass the number of CUDA loop iteration count around
@@ -4271,8 +4285,8 @@ void transOmpTargetSpmd(SgNode *node, SgExpression *omp_num_teams,
   offload_entry_decl->get_decl_item(SgName(func_name + "omp_offload_entry__"))
       ->set_gnu_attribute_section_name("omp_offloading_entries");
 
-  prependStatement(offload_entry_decl, g_scope);
-  prependStatement(outlined_kernel_id_decl, g_scope);
+  prependGlobalDeclPreservingLeadingPreproc(offload_entry_decl, g_scope);
+  prependGlobalDeclPreservingLeadingPreproc(outlined_kernel_id_decl, g_scope);
 
   SgVariableDeclaration *host_point_decl = buildVariableDeclaration(
       "__host_ptr", buildPointerType(buildVoidType()),
@@ -4781,8 +4795,8 @@ void transOmpTargetSpmdWorksharing(SgNode *node, SgExpression *omp_num_teams,
   offload_entry_decl->get_decl_item(SgName(func_name + "omp_offload_entry__"))
       ->set_gnu_attribute_section_name("omp_offloading_entries");
 
-  prependStatement(offload_entry_decl, g_scope);
-  prependStatement(outlined_kernel_id_decl, g_scope);
+  prependGlobalDeclPreservingLeadingPreproc(offload_entry_decl, g_scope);
+  prependGlobalDeclPreservingLeadingPreproc(outlined_kernel_id_decl, g_scope);
 
   SgVariableDeclaration *host_point_decl = buildVariableDeclaration(
       "__host_ptr", buildPointerType(buildVoidType()),
@@ -7564,6 +7578,9 @@ generate_outlined_function_file(SgFunctionDeclaration *outlined_func,
       "rex_lib_" + original_file_name + "." + file_extension;
   new_file->get_file_info()->set_filenameString(new_file_name);
   new_file->set_unparse_output_filename(new_file_name);
+  // Outlined files are synthesized/renamed after parsing, so token-stream
+  // mappings from the original source are not valid for them.
+  new_file->set_unparse_tokens(false);
 
   // insert REX runtime header to the new file (C/C++ only)
   SgGlobal *new_scope = new_file->get_globalScope();
@@ -7668,8 +7685,12 @@ static void post_processing(SgSourceFile *file) {
   };
 
   if (!file->get_Fortran_only()) {
-    SageInterface::insertHeader("rex_kmp.h", PreprocessingInfo::before, false,
-                                g_scope);
+    // Insert host runtime header at the start of the output file, including
+    // when transformation-generated globals were prepended before source
+    // declarations.
+    SageInterface::insertHeader(file, "rex_kmp.h",
+                                /*isSystemHeader=*/false,
+                                /*asLastHeader=*/false);
   }
   if (new_file != NULL) {
     AstPostProcessing(new_file);

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/CMakeLists.txt
@@ -88,9 +88,9 @@ set(OMP_ACC_TESTCODES
   jacobi-ompacc-multiGPU.c axpy_ompacc_mpi.c axpy_ompacc4.c
   axpy_ompacc_parseonly.c)
 
-# ROSE flags for OpenMP parsing (CFE frontend only)
-# C tests use C99-style declarations in for-loop initializers.
-set(ROSE_C_FLAGS -std=c99 -rose:openmp:ast_only -w -rose:verbose 0)
+# ROSE flags for OpenMP parsing (CFE frontend only).
+# Do not force a C standard here; rely on the frontend default dialect.
+set(ROSE_C_FLAGS -rose:openmp:ast_only -w -rose:verbose 0)
 set(ROSE_CXX_FLAGS -rose:openmp:ast_only -w -rose:verbose 0)
 
 # Include path to find omp.h header
@@ -171,3 +171,6 @@ endforeach()
 add_omp_output_diff_tests(bonds-2.c OMPTEST_bonds-2 OMPTEST)
 
 add_omp_output_diff_tests(macroIds.c OMPTEST_macroIds OMPTEST)
+
+# Rodinia-derived OpenMP lowering regressions (separate from AST output refs).
+add_subdirectory(lowering_rodinia)

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(RODINIA_LOWERING_CASES
+    rodinia_bfs_like
+    rodinia_srad_comments_like
+    rodinia_btree_kernel_like
+)
+
+function(add_rodinia_lowering_test case_name)
+  set(_input_file ${CMAKE_CURRENT_SOURCE_DIR}/inputs/${case_name}.c)
+  set(_workdir ${CMAKE_CURRENT_BINARY_DIR}/${case_name})
+
+  add_test(
+    NAME OMPLOWERING_RODINIA_${case_name}
+    COMMAND ${BASH_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_and_check.sh
+            $<TARGET_FILE:parseOmp>
+            ${_input_file}
+            ${_workdir}
+            ${case_name})
+
+  set_tests_properties(
+    OMPLOWERING_RODINIA_${case_name}
+    PROPERTIES
+      LABELS "OMPLOWERING;OMPLOWERING_RODINIA"
+  )
+endfunction()
+
+foreach(_case_name IN LISTS RODINIA_LOWERING_CASES)
+  add_rodinia_lowering_test(${_case_name})
+endforeach()

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/README.md
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/README.md
@@ -1,0 +1,15 @@
+# Rodinia-Derived OpenMP Lowering Tests
+
+This suite validates lowering-specific behavior using reduced Rodinia-like
+inputs and invariant checks.
+
+Design goals:
+- no dependence on legacy output reference files;
+- catch semantic regressions that were observed during REX LLVM-21 migration;
+- keep checks robust against unstable symbol hash IDs and format churn.
+
+Current cases:
+- `rodinia_bfs_like`: duplicate preamble/include and offload-entry integrity.
+- `rodinia_srad_comments_like`: commented OpenMP pragma attachment/order.
+- `rodinia_btree_kernel_like`: host offload-entry integrity and trailing comment
+  relocation (`// main`).

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_bfs_like.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_bfs_like.c
@@ -1,0 +1,37 @@
+#define RODINIA_BFS_SIZE 32
+
+static int h_graph_mask[RODINIA_BFS_SIZE];
+static int h_graph_visited[RODINIA_BFS_SIZE];
+static int h_updating_graph_mask[RODINIA_BFS_SIZE];
+
+int main(void) {
+  int tid;
+  int stop;
+
+  for (tid = 0; tid < RODINIA_BFS_SIZE; tid++) {
+    h_graph_mask[tid] = (tid == 0);
+    h_graph_visited[tid] = (tid == 0);
+    h_updating_graph_mask[tid] = 0;
+  }
+
+  // RODINIA_BFS_PRELUDE_BEGIN
+  // if no thread changes this value then the loop stops
+#pragma omp target data                                                      \
+    map(tofrom : h_graph_mask[0:RODINIA_BFS_SIZE],                           \
+        h_graph_visited[0:RODINIA_BFS_SIZE],                                 \
+        h_updating_graph_mask[0:RODINIA_BFS_SIZE], stop)
+  {
+    stop = 0;
+#pragma omp target teams distribute parallel for map(tofrom : stop)
+    for (tid = 0; tid < RODINIA_BFS_SIZE; tid++) {
+      if (h_graph_mask[tid] && !h_graph_visited[tid]) {
+        h_graph_visited[tid] = 1;
+        h_updating_graph_mask[tid] = 1;
+        stop = 1;
+      }
+    }
+  }
+  // RODINIA_BFS_PRELUDE_END
+
+  return stop;
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_btree_kernel_like.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_btree_kernel_like.c
@@ -1,0 +1,55 @@
+#define RODINIA_BTREE_COUNT 16
+#define RODINIA_BTREE_ORDER 4
+
+typedef struct {
+  int keys[RODINIA_BTREE_ORDER + 1];
+  int indices[RODINIA_BTREE_ORDER + 1];
+} knode;
+
+static knode nodes[RODINIA_BTREE_COUNT];
+static int start_keys[RODINIA_BTREE_COUNT];
+static int end_keys[RODINIA_BTREE_COUNT];
+static int recstart[RODINIA_BTREE_COUNT];
+static int reclength[RODINIA_BTREE_COUNT];
+
+void kernel_cpu_2(int count, knode *knodes, int *start, int *end, int *out_begin,
+                  int *out_len) {
+  int bid;
+  int thid;
+
+#pragma omp target teams distribute parallel for                                \
+    map(to : knodes[0:count], start[0:count], end[0:count])                    \
+    map(tofrom : out_begin[0:count], out_len[0:count])
+  for (bid = 0; bid < count; bid++) {
+    out_begin[bid] = 0;
+    out_len[bid] = 0;
+    for (thid = 0; thid < RODINIA_BTREE_ORDER; thid++) {
+      if (knodes[bid].keys[thid] == start[bid]) {
+        out_begin[bid] = knodes[bid].indices[thid];
+      }
+      if (knodes[bid].keys[thid] == end[bid]) {
+        out_len[bid] = knodes[bid].indices[thid] - out_begin[bid] + 1;
+      }
+    }
+  }
+} // main
+
+int main(void) {
+  int i;
+  int j;
+
+  for (i = 0; i < RODINIA_BTREE_COUNT; i++) {
+    start_keys[i] = i;
+    end_keys[i] = i + 1;
+    recstart[i] = 0;
+    reclength[i] = 0;
+    for (j = 0; j <= RODINIA_BTREE_ORDER; j++) {
+      nodes[i].keys[j] = i + j;
+      nodes[i].indices[j] = i * 10 + j;
+    }
+  }
+
+  kernel_cpu_2(RODINIA_BTREE_COUNT, nodes, start_keys, end_keys, recstart,
+               reclength);
+  return reclength[0];
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_srad_comments_like.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/inputs/rodinia_srad_comments_like.c
@@ -1,0 +1,56 @@
+#define RODINIA_NR 8
+#define RODINIA_NC 8
+#define RODINIA_NE (RODINIA_NR * RODINIA_NC)
+
+static float image[RODINIA_NE];
+static int iN[RODINIA_NR];
+static int iS[RODINIA_NR];
+static int jW[RODINIA_NC];
+static int jE[RODINIA_NC];
+static float c[RODINIA_NE];
+
+int main(void) {
+  int i;
+  int j;
+  int iter;
+
+  // RODINIA_SRAD_ROWS
+  // #pragma omp parallel
+  for (i = 0; i < RODINIA_NR; i++) {
+    iN[i] = i - 1;
+    iS[i] = i + 1;
+  }
+
+  // RODINIA_SRAD_COLS
+  // #pragma omp parallel
+  for (j = 0; j < RODINIA_NC; j++) {
+    jW[j] = j - 1;
+    jE[j] = j + 1;
+  }
+
+  // RODINIA_SRAD_SCALE_DOWN
+  // #pragma omp parallel
+  for (i = 0; i < RODINIA_NE; i++) {
+    image[i] = image[i] / 255.0f;
+  }
+
+#pragma omp target data map(tofrom : image[0:RODINIA_NE])                   \
+    map(to : iN[0:RODINIA_NR], iS[0:RODINIA_NR], jW[0:RODINIA_NC],          \
+        jE[0:RODINIA_NC], c[0:RODINIA_NE])
+  {
+    for (iter = 0; iter < 2; iter++) {
+#pragma omp target teams distribute parallel for
+      for (i = 0; i < RODINIA_NE; i++) {
+        c[i] = image[i] + (float)iter;
+      }
+    }
+  }
+
+  // RODINIA_SRAD_SCALE_UP
+  // #pragma omp parallel
+  for (i = 0; i < RODINIA_NE; i++) {
+    image[i] = image[i] * 255.0f;
+  }
+
+  return (int)c[0];
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/run_and_check.sh
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/run_and_check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <parseOmp> <input.c> <workdir> <case_name>" >&2
+  exit 2
+fi
+
+parse_omp="$1"
+input_file="$2"
+workdir="$3"
+case_name="$4"
+
+mkdir -p "${workdir}"
+rm -f "${workdir}"/rose_*.c "${workdir}"/rex_lib_*.cu "${workdir}"/run.log
+
+(
+  cd "${workdir}"
+  "${parse_omp}" --rex-omp-lowering -w -rose:verbose 0 -c "${input_file}" > run.log 2>&1
+)
+
+bash "$(dirname "$0")/verify_outputs.sh" "${case_name}" "${workdir}"

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/verify_outputs.sh
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/verify_outputs.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <case_name> <workdir>" >&2
+  exit 2
+fi
+
+case_name="$1"
+workdir="$2"
+
+die() {
+  echo "ERROR(${case_name}): $*" >&2
+  exit 1
+}
+
+require_file() {
+  local file="$1"
+  [[ -f "${file}" ]] || die "missing output file: ${file}"
+}
+
+count_matches() {
+  local file="$1"
+  local regex="$2"
+  grep -Ec "${regex}" "${file}" || true
+}
+
+expect_count() {
+  local file="$1"
+  local regex="$2"
+  local expected="$3"
+  local label="$4"
+  local actual
+  actual="$(count_matches "${file}" "${regex}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    die "${label}: expected ${expected}, got ${actual} (${file})"
+  fi
+}
+
+first_line() {
+  local file="$1"
+  local regex="$2"
+  local line
+  line="$(grep -nE "${regex}" "${file}" | head -n 1 | cut -d: -f1 || true)"
+  echo "${line}"
+}
+
+case "${case_name}" in
+  rodinia_bfs_like)
+    rose_file="${workdir}/rose_rodinia_bfs_like.c"
+    cu_file="${workdir}/rex_lib_rodinia_bfs_like.cu"
+    require_file "${rose_file}"
+    require_file "${cu_file}"
+
+    expect_count "${rose_file}" '#include "rex_kmp.h"' 1 "host runtime include count"
+    expect_count "${rose_file}" 'struct[[:space:]]+__tgt_offload_entry[[:space:]]+OUT__' 1 "host offload entry count"
+    expect_count "${rose_file}" 'char[[:space:]]+OUT__.*__id__[[:space:]]*=' 1 "host kernel id count"
+
+    expect_count "${cu_file}" '#include "rex_nvidia.h"' 1 "device runtime include count"
+    expect_count "${cu_file}" 'extern "C"' 1 "device extern C count"
+    expect_count "${cu_file}" '__global__[[:space:]]+void[[:space:]]+OUT__' 1 "device kernel count"
+    ;;
+
+  rodinia_srad_comments_like)
+    rose_file="${workdir}/rose_rodinia_srad_comments_like.c"
+    cu_file="${workdir}/rex_lib_rodinia_srad_comments_like.cu"
+    require_file "${rose_file}"
+    require_file "${cu_file}"
+
+    expect_count "${rose_file}" '//[[:space:]]*#pragma omp parallel' 4 "commented pragma count"
+
+    rows_line="$(first_line "${rose_file}" 'RODINIA_SRAD_ROWS')"
+    cols_line="$(first_line "${rose_file}" 'RODINIA_SRAD_COLS')"
+    down_line="$(first_line "${rose_file}" 'RODINIA_SRAD_SCALE_DOWN')"
+    up_line="$(first_line "${rose_file}" 'RODINIA_SRAD_SCALE_UP')"
+    target_data_line="$(first_line "${rose_file}" 'Translated from #pragma omp target data|__tgt_target_data_begin')"
+
+    [[ -n "${rows_line}" ]] || die "missing RODINIA_SRAD_ROWS marker"
+    [[ -n "${cols_line}" ]] || die "missing RODINIA_SRAD_COLS marker"
+    [[ -n "${down_line}" ]] || die "missing RODINIA_SRAD_SCALE_DOWN marker"
+    [[ -n "${up_line}" ]] || die "missing RODINIA_SRAD_SCALE_UP marker"
+    [[ -n "${target_data_line}" ]] || die "missing target data marker"
+
+    mapfile -t pragma_lines < <(
+      grep -nE '//[[:space:]]*#pragma omp parallel' "${rose_file}" | cut -d: -f1
+    )
+    [[ "${#pragma_lines[@]}" -eq 4 ]] || die "expected 4 pragma lines after extraction"
+
+    p1="${pragma_lines[0]}"
+    p2="${pragma_lines[1]}"
+    p3="${pragma_lines[2]}"
+    p4="${pragma_lines[3]}"
+
+    (( rows_line < p1 && p1 < cols_line )) || die "rows pragma ordering mismatch"
+    (( cols_line < p2 && p2 < down_line )) || die "cols pragma ordering mismatch"
+    (( down_line < p3 && p3 < target_data_line )) || die "scale-down pragma moved near/after target data"
+    (( up_line < p4 )) || die "scale-up pragma ordering mismatch"
+
+    (( p1 - rows_line <= 30 )) || die "rows pragma too far from rows marker"
+    (( p2 - cols_line <= 30 )) || die "cols pragma too far from cols marker"
+    (( p3 - down_line <= 30 )) || die "scale-down pragma too far from marker"
+    (( p4 - up_line <= 30 )) || die "scale-up pragma too far from marker"
+    ;;
+
+  rodinia_btree_kernel_like)
+    rose_file="${workdir}/rose_rodinia_btree_kernel_like.c"
+    cu_file="${workdir}/rex_lib_rodinia_btree_kernel_like.cu"
+    require_file "${rose_file}"
+    require_file "${cu_file}"
+
+    expect_count "${rose_file}" '#include "rex_kmp.h"' 1 "host runtime include count"
+    expect_count "${rose_file}" 'struct[[:space:]]+__tgt_offload_entry[[:space:]]+OUT__' 1 "host offload entry count"
+    expect_count "${rose_file}" 'char[[:space:]]+OUT__.*__id__[[:space:]]*=' 1 "host kernel id count"
+    expect_count "${rose_file}" '//[[:space:]]*main' 1 "host trailing main comment count"
+
+    expect_count "${cu_file}" '#include "rex_nvidia.h"' 1 "device runtime include count"
+    expect_count "${cu_file}" '__global__[[:space:]]+void[[:space:]]+OUT__' 1 "device kernel count"
+    ;;
+
+  *)
+    die "unknown case: ${case_name}"
+    ;;
+esac


### PR DESCRIPTION
## Summary

This PR modernizes OpenMP testing and lowering regression coverage for REX (LLVM/Clang 21 branch), while keeping legacy/outdated reference-output tests untouched for follow-up work.

Main goals completed:

1. Remove hardcoded C dialect forcing in OpenMP tests (`-std=c99`) so tests use frontend defaults.
2. Add a new Rodinia-derived OpenMP lowering regression suite based on semantic/invariant checks (not fragile text snapshots).
3. Enable the new lowering suite explicitly in CI.
4. Keep existing legacy lowering/reference tests in place (no ref refresh in this PR).

---

## Key Changes

### 1) OpenMP AST test dialect policy

- Removed forced `-std=c99` from OpenMP C test flags.
- Now relies on Clang/LLVM 21 default C mode unless an individual test explicitly requests a standard.

File:
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/CMakeLists.txt`

---

### 2) New Rodinia-derived lowering regression suite

Added new directory:
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/`

New contents:
- `CMakeLists.txt` (registers lowering tests with labels `OMPLOWERING;OMPLOWERING_RODINIA`)
- `inputs/rodinia_bfs_like.c`
- `inputs/rodinia_srad_comments_like.c`
- `inputs/rodinia_btree_kernel_like.c`
- `scripts/run_and_check.sh`
- `scripts/verify_outputs.sh`
- `README.md`

Design:
- Uses `parseOmp --rex-omp-lowering` on reduced Rodinia-like kernels.
- Validates structural invariants (semantic intent) instead of brittle full-file golden diffs.
- Intentionally robust against symbol hash churn/formatting churn.

Covered regressions:
- BFS-style duplicate include/preamble risks in generated `rex_lib_*.cu`.
- SRAD-style commented pragma relocation/ordering around target-data transformation.
- B+tree-style host offload-entry integrity and trailing comment preservation (`// main`).

---

### 3) CI integration

GitHub workflow update:
- `.github/workflows/ci.yml`

CI test step now runs OpenMP tests in two phases:
1. `-L OMPLOWERING_RODINIA` (explicit gate for new lowering suite)
2. `-LE OMPLOWERING_RODINIA` (remaining OpenMP tests, no duplicate run)

This ensures Rodinia lowering checks are first-class CI gates while preserving total OpenMP coverage.

---

## Additional Included Fixes (same branch state)

This branch also includes the in-progress frontend/lowering correctness work that was already in the working tree and is needed by the new tests:

- OpenMP/comment relocation robustness in:
  - `src/frontend/SageIII/ompAstConstruction.cpp`
  - `src/frontend/SageIII/sageInterface/sageInterface.C`
- Related Clang frontend and lowering integration updates in:
  - `src/frontend/CxxFrontend/Clang/clang-frontend.cpp`
  - `src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp`
  - `src/frontend/SageIII/sageInterface/sageBuilder.C`
  - `src/frontend/SageIII/sageInterface/sageInterface.h`
  - `src/midend/programTransformation/ompLowering/omp_lowering.cpp`

---

## Validation

Executed locally on this branch:

1. New lowering suite only:
```bash
ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests \
  -L OMPLOWERING_RODINIA --output-on-failure -j8
```
Result: **3/3 passed**.

2. Targeted sanity after removing `-std=c99`:
```bash
ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests \
  -R "OMPLOWERING_RODINIA|OMPTEST_ompfor_c99.c|OMPTEST_task_dep.load.compute.c" \
  --output-on-failure -j8
```
Result: **5/5 passed**.

3. Full OpenMP suite:
```bash
ctest --test-dir build/tests/nonsmoke/functional/CompileTests/OpenMP_tests \
  --output-on-failure -j32
```
Result: **962/962 passed**.

4. Required core suite:
```bash
ctest --test-dir build \
  -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" \
  --exclude-regex "omp_lowering" --output-on-failure -j32
```
Result: **4919/4919 passed**.

---

## Notes

- Legacy OpenMP lowering output-reference tests were intentionally not rewritten in this PR.
- Local artifact directory `tmp-rodinia/` is not part of this commit.

