### PR TITLE
Fix inlineEverything specimen22_1.C invalid C++ main

### DIFF
--- a/tests/nonsmoke/functional/roseTests/astInliningTests/specimen22_1.C
+++ b/tests/nonsmoke/functional/roseTests/astInliningTests/specimen22_1.C
@@ -1,9 +1,10 @@
 const int a=10;
 int foo(int);
 
-main(){
+int main(){
    int x=1;
    foo(x);
+   return 0;
 }
 
 int foo(int x){


### PR DESCRIPTION
## Summary
This PR resolves GitHub issue #241 by fixing the root cause in the failing inlineEverything specimen input.

Issue #241 reported that `inlineEverything_v1_specimen22_1_C` fails because `specimen22_1.C` declares `main()` without a return type, which is invalid in C++ mode.

The specimen is now valid C++ while preserving test intent:
- Change `main()` to `int main()`
- Add `return 0;`

## Root Cause
`tests/nonsmoke/functional/roseTests/astInliningTests/specimen22_1.C` used an implicit-int style `main()` declaration.
That is rejected by modern Clang C++ parsing (`a type specifier is required for all declarations`), causing inlineEverything to fail before producing transformed output.

## Why this is a long-term fix
The failure source is invalid test input for the language mode (`.C` => C++). Making the specimen standards-compliant removes the parsing error at the source with no workaround/hack/fallback behavior added in the frontend or test harness.

## Files Changed
- `tests/nonsmoke/functional/roseTests/astInliningTests/specimen22_1.C`

## Validation
### Targeted reproduction (before/after)
- `ctest --test-dir build -R inlineEverything_v1_specimen22_1_C -V`
- Result after fix: **PASS**

### Requested regression suite
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: **4919/4919 passed**

### Pre-push hook validation (automatically run, not skipped)
- Re-ran the same filtered suite: **4919/4919 passed**
- Additional OpenMP suite run by hook: **962/962 passed**

## Issue Link
- Closes #241
