### PR TITLE
Fix FunctionNormalization AST invariants and re-enable tests

### DIFF
--- a/src/midend/programTransformation/functionCallNormalization/FunctionNormalization.C
+++ b/src/midend/programTransformation/functionCallNormalization/FunctionNormalization.C
@@ -155,6 +155,12 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
         replaceFunctionCallsInExpression(paramsList, fct2Var);
         replaceFunctionCallsInExpression(function, fct2Var);
 
+        // Calls returning void cannot be materialized into temporaries. Keep
+        // the call in place and only normalize nested calls in its
+        // function/argument expressions.
+        if (isSgTypeVoid(expType))
+          continue;
+
         // duplicate function call expression, for the initialization
         // declaration and the assignment
         SgTreeCopy treeCopy;
@@ -181,6 +187,7 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
         SgInitializedName *initName;
 
         bool pointerTypeNeeded = false;
+        bool useNonInitBinding = false;
 
         // mark whether to replace inside or outside of ForStatement due to the
         // function call being inside the test or the increment for a for-loop
@@ -199,11 +206,13 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
           ROSE_ASSERT(up);
 
           // function call is in the condition of the for-loop
-          if (up == testExp)
+          if (up == testExp) {
             inForTest.push_back(true);
+          }
           // function call is in the increment expression
           else {
             inForTest.push_back(false);
+            useNonInitBinding = true;
 
             // for increment expressions we need to be able to reassign the
             // return value of the function; if the ret value is a reference, we
@@ -219,6 +228,8 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
         // assign them at the end of the body of the loop
         if (isSgDoWhileStmt(stm->get_parent()) && isSgReferenceType(expType))
           pointerTypeNeeded = true;
+        if (isSgDoWhileStmt(stm->get_scope()))
+          useNonInitBinding = true;
 
         // we have a function call returning a reference and we can't initialize
         // the variable at the point of declaration; we need to define the
@@ -242,6 +253,8 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
           initName = isSgVariableDeclaration(nonInitVarDeclaration)
                          ->get_decl_item(name);
           ROSE_ASSERT(initName);
+          initName->set_scope(stm->get_scope());
+          ROSE_ASSERT(initName->get_scope());
 
           varSymbol = new SgVariableSymbol(initName);
           ROSE_ASSERT(varSymbol);
@@ -270,10 +283,24 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
               new SgVariableDeclaration(nonInitLoc, name, expType);
           ROSE_ASSERT(initVarDeclaration && nonInitVarDeclaration);
 
-          initName = isSgVariableDeclaration(nonInitVarDeclaration)
-                         ->get_decl_item(name);
-          ROSE_ASSERT(initName);
-          newExpInit->set_parent(initName);
+          SgInitializedName *nonInitName =
+              isSgVariableDeclaration(nonInitVarDeclaration)
+                  ->get_decl_item(name);
+          ROSE_ASSERT(nonInitName);
+          nonInitName->set_scope(stm->get_scope());
+          ROSE_ASSERT(nonInitName->get_scope());
+
+          SgInitializedName *initDeclName =
+              isSgVariableDeclaration(initVarDeclaration)->get_decl_item(name);
+          ROSE_ASSERT(initDeclName);
+          initDeclName->set_scope(stm->get_scope());
+          ROSE_ASSERT(initDeclName->get_scope());
+
+          initName = nonInitName;
+          newExpInit->set_parent(declInit);
+          if (!useNonInitBinding) {
+            initName = initDeclName;
+          }
           varSymbol = new SgVariableSymbol(initName);
           ROSE_ASSERT(varSymbol);
 
@@ -443,6 +470,37 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
       }
     }
 
+    for (map<SgFunctionCallExp *, SgExpression *>::iterator i = fct2Var.begin();
+         i != fct2Var.end(); ++i) {
+      SgVarRefExp *varRef = isSgVarRefExp(i->second);
+      if (!varRef) {
+        SgPointerDerefExp *ptrDeref = isSgPointerDerefExp(i->second);
+        if (ptrDeref)
+          varRef = isSgVarRefExp(ptrDeref->get_operand_i());
+      }
+      if (!varRef)
+        continue;
+
+      SgVariableSymbol *varSymbol = isSgVariableSymbol(varRef->get_symbol());
+      ROSE_ASSERT(varSymbol);
+
+      if (varSymbol->get_parent() == NULL) {
+        SgInitializedName *decl = varSymbol->get_declaration();
+        ROSE_ASSERT(decl);
+        SgScopeStatement *declScope = decl->get_scope();
+        ROSE_ASSERT(declScope);
+
+        SgVariableSymbol *existingSymbol =
+            declScope->lookup_variable_symbol(decl->get_name());
+        if (existingSymbol && existingSymbol != varSymbol) {
+          varRef->set_symbol(existingSymbol);
+        } else {
+          declScope->insert_symbol(decl->get_name(), varSymbol);
+          varSymbol->set_parent(declScope->get_symbol_table());
+        }
+      }
+    }
+
     // once we have inserted all variable declarations, we need to replace
     // top-level calls in the original statement
     if (variablesDefined) {
@@ -523,9 +581,11 @@ void FunctionCallNormalization::replaceFunctionCallsInExpression(
 
         map<SgFunctionCallExp *, SgExpression *>::iterator mapIter;
         mapIter = fct2Var.find(call);
-        if (mapIter == fct2Var.end())
-          cout << "NOT FOUND " << call->unparseToString() << "\t" << call
-               << "\n";
+        if (mapIter == fct2Var.end()) {
+          ROSE_ASSERT(isSgTypeVoid(call->get_type()));
+          toVisit.pop_front();
+          continue;
+        }
 
         // a mapping for function call exps in the subtree must already exist (
         // postorder traversal )
@@ -538,14 +598,9 @@ void FunctionCallNormalization::replaceFunctionCallsInExpression(
         SgExpression *newVar = isSgExpression(scnd->copy(treeCopy));
         ROSE_ASSERT(newVar);
 
-        SgExpression *parent = isSgExpression(call->get_parent());
-        ROSE_ASSERT(parent);
-
-        // replace the node in the AST
-        newVar->set_parent(parent);
-        int k = parent->replace_expression(call, newVar);
-        ROSE_ASSERT(k == 1);
-        delete call;
+        // Use the general replacement helper so function-call expressions can
+        // be rewritten under both expression and statement parents.
+        SageInterface::replaceExpression(call, newVar);
       }
       toVisit.pop_front();
     }

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/CMakeLists.txt
@@ -93,7 +93,6 @@ foreach(file_to_test ${function_normalization_tests})
     COMMAND testFunctionNormalization -rose:verbose 0
       -c ${CMAKE_CURRENT_SOURCE_DIR}/${file_to_test}
   )
-  set_tests_properties(functionNormalization_${file_to_test} PROPERTIES DISABLED TRUE)
 endforeach()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR fixes the root causes behind issue #247 in `FunctionNormalization` and re-enables the previously disabled `functionNormalization_` tests.

Closes #247.

## Root causes fixed
1. `replaceFunctionCallsInExpression` assumed a function call parent is always `SgExpression`. In practice, normalized calls can be rooted under statement contexts (e.g. `SgExprStatement`).
2. Newly created initializer call expressions were re-parented to the `SgInitializedName` from a different declaration (`nonInitVarDeclaration`), creating inconsistent parent links.
3. Generated temporary declaration nodes and symbols could remain partially initialized in the memory pool (`scope == NULL` / symbol parent unset), which tripped AST consistency tests.
4. Calls returning `void` were incorrectly materialized into temporaries, generating invalid output like `void __tempVar__ = foo();`.

## Changes
- Updated `replaceFunctionCallsInExpression` to use `SageInterface::replaceExpression`, which correctly handles replacement under expression and statement parents.
- Kept explicit assertion behavior for missing mappings except for `void`-typed calls (which are intentionally left in place).
- In `visit()`:
  - Skip temporary materialization for `void`-return calls while still normalizing nested calls in function/argument expressions.
  - Correct initializer parent wiring: `newExpInit` is parented to its `SgAssignInitializer` (`declInit`) instead of an unrelated `SgInitializedName`.
  - Ensure generated temp declaration initialized names have valid scopes.
  - Ensure mapped temp variable symbols are attached to/aliased from the correct scope symbol table before final replacements.
- Re-enabled functionNormalization tests in CMake by removing:
  - `set_tests_properties(functionNormalization_${file_to_test} PROPERTIES DISABLED TRUE)`

## Validation
- Targeted repro:
  - `ctest --test-dir build -R "functionNormalization_" --output-on-failure -j32`
- Requested regression set:
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Pre-push hook suite (no bypass) also passed, including broader OpenMP/Fortran/CFG coverage as enforced by the repository hooks.
