### PR TITLE
rth_run: normalize quoted CLI variable assignments

### DIFF
--- a/scripts/rth_run.pl
+++ b/scripts/rth_run.pl
@@ -578,6 +578,20 @@ sub join_shell_tokens {
   return join " ", map { shell_quote($_) } @_;
 }
 
+sub normalize_cli_var_value {
+  my ($var, $val) = @_;
+  return $val unless defined $val;
+  return $val if length($val) < 2;
+
+  my $quote = substr($val, 0, 1);
+  return $val unless $quote eq "'" || $quote eq '"';
+  my $last = substr($val, -1, 1);
+  die "$0: malformed variable definition for $var: unmatched quote in $var=$val\n"
+    if $last ne $quote;
+
+  return substr($val, 1, length($val) - 2);
+}
+
 sub insert_after_first_token {
   my ($cmd, $insert) = @_;
   return $cmd unless defined $insert && $insert ne '';
@@ -670,9 +684,9 @@ while (@ARGV) {
   /^-/ and die "$0: unknown command line switch: $_\n";
   /^(\w+)=(.*)/ and do {
     my ($var, $val) = ($1, $2);
-    # Allow CMD="..."; strip one layer so the shell sees the full command.
-    $val =~ s/^(['"])(.*)\1$/$2/s;
-    $variables{$var} = $val;
+    # CTest often passes VAR="..." values through as literal quoted strings.
+    # Normalize one outer quote pair here so variables (especially CMD) remain executable.
+    $variables{$var} = normalize_cli_var_value($var, $val);
     next;
   };
   /=/ and die "$0: malformed variable definition: $_\n";


### PR DESCRIPTION
## Summary
This PR addresses the command parsing path behind #217 by making `rth_run.pl` command-line `VAR=VALUE` normalization explicit and strict.

While investigating #217, I verified that `nonsmoke_utility_directorySupport` no longer reproduces on current `main` (the harness already strips one outer quote pair in the inline assignment parser). However, the logic was embedded inline and accepted malformed quoted values implicitly.

This change introduces a dedicated parser helper that preserves intended behavior for quoted `CMD=...` values and hard-fails on malformed quoted assignments.

## Root Cause Context
Issue #217 identified that quoted `CMD="..."` could reach shell execution as a single quoted token and fail with `not found` when the entire command line was treated as a filename.

The durable fix direction is to normalize outer quotes in one place before execution. This PR formalizes that normalization and makes parsing rules explicit.

## What Changed
- Added `normalize_cli_var_value($var, $val)` in `scripts/rth_run.pl`.
- Replaced inline regex quote stripping in `VAR=VALUE` parsing with the helper.
- Added fail-fast validation for unmatched quoted values:
  - `VAR="unterminated` now errors immediately with a clear diagnostic.
- Preserved existing behavior for properly quoted values, especially `CMD="..."` passed via CTest.

## Why This Is a Long-Term Fix
- Centralizes quote normalization into a single function instead of ad-hoc inline regex use.
- Makes parser behavior deterministic and auditable.
- Surfaces malformed input early instead of letting it propagate to shell execution ambiguities.
- No test suppression, no fallback paths, no per-test/per-command workaround.

## Validation
- `perl -c scripts/rth_run.pl`
- `ctest --test-dir build -R "nonsmoke_utility_directorySupport|gdf_f77_constprop_test2007_189_f" --output-on-failure -j32`
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Pre-push hook suite (full): `100% tests passed, 0 failed out of 5829`

Closes #217.
