### PR TITLE
Fix CFE RTTI/exception flag partitioning at cmdline build

### DIFF
--- a/src/frontend/SageIII/sage_support/cmdline.C
+++ b/src/frontend/SageIII/sage_support/cmdline.C
@@ -4197,6 +4197,9 @@ void SgFile::build_CLANG_CommandLine(vector<string> &inputCommandLine,
   std::vector<std::string> clang_frontend_args;
   std::vector<std::string> sys_dirs_list;
   std::string input_file;
+  const bool respect_rtti_flags =
+      std::find(argv.begin(), argv.end(), "-rex:clang:respect-rtti-flags") !=
+      argv.end();
 
   for (size_t i = 0; i < argv.size(); i++) {
     std::string current_arg(argv[i]);
@@ -4264,11 +4267,18 @@ void SgFile::build_CLANG_CommandLine(vector<string> &inputCommandLine,
              current_arg == "-fopenmp-simd") {
     } else if (current_arg.find("--rex-omp-") == 0) {
     } else if (current_arg == "-fexceptions" ||
-               current_arg == "-fno-exceptions" ||
-               current_arg == "-fcxx-exceptions" ||
-               current_arg == "-fno-cxx-exceptions" ||
-               current_arg == "-frtti" || current_arg == "-fno-rtti") {
+               current_arg == "-fcxx-exceptions" || current_arg == "-frtti") {
       clang_frontend_args.push_back(current_arg);
+    } else if (current_arg == "-fno-rtti") {
+      // Keep -fno-rtti backend-only unless frontend enforcement is explicitly
+      // requested.
+      if (respect_rtti_flags) {
+        clang_frontend_args.push_back(current_arg);
+      }
+    } else if (current_arg == "-fno-exceptions" ||
+               current_arg == "-fno-cxx-exceptions") {
+      // Keep exceptions enabled in frontend parsing to build a complete C++
+      // AST; disabling remains a backend concern.
     } else if (isRexClangFrontendOption(current_arg)) {
       clang_frontend_args.push_back(current_arg);
     } else if (!current_arg.empty() && current_arg[0] == '-') {


### PR DESCRIPTION
## Summary
Issue #238 is still applicable at the command-line construction layer in CFE:
`SgFile::build_CLANG_CommandLine` was forwarding `-fno-exceptions` and `-fno-rtti` into frontend args by default.

Even though downstream `clang_main` currently has defensive handling, this remained a root-cause leak in the frontend argument partitioning path.

This PR implements a long-term fix in the frontend command-line builder so backend-only flags are filtered before entering CFE parsing.

## Root Cause
- Frontend argument assembly in `src/frontend/SageIII/sage_support/cmdline.C` treated `-fno-exceptions/-fno-cxx-exceptions/-fno-rtti` like regular frontend flags.
- This mixes backend compilation policy with CFE AST construction policy.

## What Changed
### `src/frontend/SageIII/sage_support/cmdline.C`
- Added pre-scan for `-rex:clang:respect-rtti-flags`.
- Kept `-fexceptions/-fcxx-exceptions/-frtti` as frontend-pass-through flags.
- Made `-fno-exceptions/-fno-cxx-exceptions` backend-only (not forwarded to CFE).
- Made `-fno-rtti` backend-only by default, but still forwarded when explicit frontend RTTI enforcement is requested via `-rex:clang:respect-rtti-flags`.

This preserves explicit opt-in behavior while preventing accidental CFE degradation from backend flag leakage.

## Validation
### Issue-specific validation
- `ctest --test-dir build -R "Cxx_tests_rex_test2026_issue264_rtti_backend_only" --output-on-failure -V`
- `ctest --test-dir build -R "Cxx_tests_rex_test2026_issue264_rtti_respect_frontend_flags" --output-on-failure -V`
- `ctest --test-dir build -R "Cxx_tests_rex_test2026_issue317_rtti_exceptions_backend_only" --output-on-failure -V`
- `ctest --test-dir build -R "rose_example_testRoseHeaders_01" --output-on-failure -V`

All passed.

### Requested regression suite
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j16`

Result: **4897/4897 passed**.

### Pre-push hook suite (not skipped)
The repository pre-push hooks ran and passed:
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|caf|gfortran|OMPTEST_|OMPACCTEST_|OMPFORTRAN_|omp_lowering_|OMPLOWERING_CPU_|OMPLOWERING_RODINIA_" -j24`

Result: **5747/5747 passed**.

## Issue
Closes #238
