### PR TITLE
RoseExample_tests: fix stale test source list and fail fast on missing files

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/RoseExample_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/RoseExample_tests/CMakeLists.txt
@@ -1,10 +1,19 @@
 set(files_to_test
   testRoseHeaders_00.C testRoseHeaders_01.C testRoseHeaders_02.C
   testRoseHeaders_03.C testRoseHeaders_04.C testRoseHeaders_05.C
-  testRoseHeaders_06.C testRoseHeaders_07.C testRoseHeaders_08.C
+  testRoseHeaders_06.C testRoseHeaders_09.C testRoseHeaders_14.C
   test2003_33.C test2003_34.C test2004_46.C test2006_43.C)
 
 set(ROSE_FLAGS  -w )
+
+foreach(file_to_test ${files_to_test})
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${file_to_test}")
+    message(
+      FATAL_ERROR
+        "RoseExample_tests references missing source '${file_to_test}' in ${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  endif()
+endforeach()
 
 foreach(file_to_test ${files_to_test})
   compile_test(${file_to_test} rose_example)


### PR DESCRIPTION
## Summary
This PR fixes issue #236 by correcting stale RoseExample test input references in CMake.

- Removed deleted inputs `testRoseHeaders_07.C` and `testRoseHeaders_08.C` from `RoseExample_tests/CMakeLists.txt`.
- Added current in-tree header tests `testRoseHeaders_09.C` and `testRoseHeaders_14.C` to keep coverage aligned with existing sources.
- Added a configure-time hard failure if any listed test source is missing, so stale entries are caught immediately during CMake configure.

## Root Cause
`testRoseHeaders_07.C` and `testRoseHeaders_08.C` were removed in commit `675fa68ca2` (`Purge Boost.Wave and stabilize tests`), but a later CMake test registration port kept stale references to those deleted files.

## Why this is a long-term fix
- Fixes the source of truth (`CMakeLists.txt`) instead of adding runtime fallbacks.
- Introduces fail-fast validation at configure time to prevent future drift between `files_to_test` and actual files on disk.

## Validation
- Reproduced issue condition in current tree: `_07/_08` were referenced in CMake but absent from disk.
- Confirmed registration after fix:
  - `ctest --test-dir build -N -R "rose_example_testRoseHeaders_07"` -> `Total Tests: 0`
  - `ctest --test-dir build -N -R "rose_example_testRoseHeaders_08"` -> `Total Tests: 0`
  - `ctest --test-dir build -N -R "rose_example_testRoseHeaders_(07|08|09|14)"` -> `_09/_14` only
- RoseExample focused run:
  - `ctest --test-dir build -R "rose_example_testRoseHeaders_09_C|rose_example_testRoseHeaders_14_C|nonsmoke_functional_CompileTests_RoseExample_tests_check-local" --output-on-failure -j16`
  - Result: `100% tests passed, 0 tests failed out of 3`
- Required regression subset (exact command from issue request):
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j16`
  - Result: `100% tests passed, 0 tests failed out of 4897`
- Pre-push hooks (not skipped) also passed:
  - Result: `100% tests passed, 0 tests failed out of 5747`

Closes #236
