### PR TITLE
Fix varDeclNorm rth_run argument splitting

### DIFF
--- a/tests/nonsmoke/functional/roseTests/varDeclNorm/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/varDeclNorm/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${ROSE_INCLUDES})
 
 set(_rth ${CMAKE_SOURCE_DIR}/scripts/rth_run.pl)
-set(_exit_status ${CMAKE_SOURCE_DIR}/scripts/test_exit_status)
+set(_var_decl_conf ${CMAKE_CURRENT_SOURCE_DIR}/varDeclNorm.conf)
 
 set(_rose_include_flags)
 foreach(entry IN LISTS ROSE_INCLUDES)
@@ -25,6 +25,8 @@ set(_var_decl_flags
   -rose:skipfinalCompileStep
   -w
   -rose:verbose 0)
+list(JOIN _var_decl_flags " " _var_decl_flags_str)
+list(JOIN _rose_include_flags " " _rose_include_flags_str)
 
 foreach(specimen IN LISTS _var_decl_specimens)
   set(_target ${specimen}.passed)
@@ -33,8 +35,9 @@ foreach(specimen IN LISTS _var_decl_specimens)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${_rth}
       TITLE="varDeclNorm [${specimen}]"
-      CMD="$<TARGET_FILE:testTranslator> ${_var_decl_flags} ${_rose_include_flags} -I${CMAKE_CURRENT_SOURCE_DIR} -c ${CMAKE_CURRENT_SOURCE_DIR}/${specimen}"
-      ${_exit_status}
+      EXE="$<TARGET_FILE:testTranslator> ${_var_decl_flags_str} ${_rose_include_flags_str} -I${CMAKE_CURRENT_SOURCE_DIR}"
+      INPUT=${CMAKE_CURRENT_SOURCE_DIR}/${specimen}
+      ${_var_decl_conf}
       ${_target}
   )
 endforeach()

--- a/tests/nonsmoke/functional/roseTests/varDeclNorm/varDeclNorm.conf
+++ b/tests/nonsmoke/functional/roseTests/varDeclNorm/varDeclNorm.conf
@@ -1,0 +1,4 @@
+# ROSE Test Harness config file
+
+title = ${TITLE}
+cmd = ${VALGRIND} ${EXE} -c ${INPUT}


### PR DESCRIPTION
## Summary
This PR fixes the `rth_run.pl` argument-splitting problem for `varDeclNorm_*` tests described in #258.

- Reworked `varDeclNorm` test wiring to use a dedicated test-harness config (`EXE` + `INPUT`) instead of building one large `CMD=...` value from list variables.
- Added `tests/nonsmoke/functional/roseTests/varDeclNorm/varDeclNorm.conf` with:
  - `cmd = ${VALGRIND} ${EXE} -c ${INPUT}`
- Joined CMake list-based flag sets into space-delimited strings before passing them to the harness to prevent semicolon/list token splitting.

## Root Cause
`varDeclNorm` used:

- `CMD="$<TARGET_FILE:testTranslator> ${_var_decl_flags} ${_rose_include_flags} ..."`

Both `_var_decl_flags` and `_rose_include_flags` are CMake lists. In the generated CTest command these expanded into split tokens, so `rth_run.pl` received a broken `CMD` variable and failed while parsing command-line variable assignments.

## What Changed
- `tests/nonsmoke/functional/roseTests/varDeclNorm/CMakeLists.txt`
  - removed `test_exit_status`/`CMD=...` usage for this test group
  - added `varDeclNorm.conf`
  - switched each test to pass:
    - `EXE="..."`
    - `INPUT=...`
- `tests/nonsmoke/functional/roseTests/varDeclNorm/varDeclNorm.conf` (new)

## Validation
1. Reproduced issue before fix:
   - `ctest --test-dir build -R varDeclNorm_ --output-on-failure -j32`
   - failed with `rth_run.pl: malformed variable definition for CMD: unmatched quote ...`

2. Verified post-fix behavior:
   - same command no longer fails in `rth_run.pl` parsing and correctly executes translator commands for `varDeclNorm_*`.
   - remaining failures in that subset are separate compiler assertions (`token-unparse contract violation`), not command-line parsing.

3. Requested regression suite:
   - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
   - result: `100% tests passed, 0 tests failed out of 4897`

4. Pre-push hooks (not skipped) also passed:
   - result: `100% tests passed, 0 tests failed out of 5747`

Fixes #258.
