### PR TITLE
Fix typeEquivalence runtime path contract

### DIFF
--- a/tests/nonsmoke/functional/roseTests/astInterfaceTests/typeEquivalenceTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astInterfaceTests/typeEquivalenceTests/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(typecounter countDifferentTypes.cpp)
 target_link_libraries(typecounter ROSE_DLL ${link_with_libraries})
 
 set_target_properties(variableTypeTest functionTypeTest typecounter PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   BUILD_WITH_INSTALL_RPATH OFF
   BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
 )


### PR DESCRIPTION
## Summary
Issue #255 reported `typeEquivalence` failures caused by coupling test execution to runtime output directory assumptions.

Current CTest wiring already uses `$<TARGET_FILE:...>` for `variableTypeTest`/`functionTypeTest`, so test execution no longer depends on binaries being co-located with test directories. However, `typeEquivalenceTests/CMakeLists.txt` still forced a local `RUNTIME_OUTPUT_DIRECTORY`, which kept an unnecessary path coupling.

This PR removes that local runtime output override so the targets follow the global runtime output layout while tests continue to execute via explicit target paths.

## Root Cause and Long-Term Fix
Root cause: directory-based executable lookup contracts are brittle.

Long-term fix in this PR:
- Keep execution path authoritative via `$<TARGET_FILE:...>` (already in place).
- Remove local runtime output directory override to avoid encoding path assumptions in test configuration.

No symlink/workaround/hack/fallback approach is used.

## Changes
- `tests/nonsmoke/functional/roseTests/astInterfaceTests/typeEquivalenceTests/CMakeLists.txt`
  - Removed:
    - `RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}`

## Validation
Rebuilt and verified:

1. Issue repro command:
```bash
ctest --test-dir build -j16 --output-on-failure -R typeEquivalence_
```
Result: `100% tests passed, 0 tests failed out of 89`.

2. Verified concrete test command path now resolves from global runtime dir:
```bash
ctest --test-dir build -N -V -R typeEquivalence_variableTypeTest_types_001
```
Observed command uses:
`/home/ouankou/Projects/rex-codex/build/bin/variableTypeTest ...`

3. Requested regression suite:
```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j16
```
Result: `100% tests passed, 0 tests failed out of 4897`.

4. Pre-push hook gate (not skipped) also passed:
- `100% tests passed, 0 tests failed out of 5747`.

Closes #255.
