### PR TITLE
Fix root-cause static slicing CFE assertions (issue #251)

### DIFF
--- a/src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.C
@@ -6,6 +6,40 @@
 #include <iostream>
 using namespace std;
 
+namespace {
+bool canRemoveStatementFromAst(SgStatement *statement) {
+  if (statement == NULL) {
+    return false;
+  }
+
+  // Mutation APIs only support statements that are attached to a statement
+  // list.
+  if (statement->get_parent() == NULL ||
+      isSgStatement(statement->get_parent()) == NULL) {
+    return false;
+  }
+
+  return SageInterface::isRemovableStatement(statement);
+}
+} // namespace
+
+void CreateSlice::queueStatementForRemoval(SgStatement *statement) {
+  if (statement != NULL) {
+    statementsPendingRemoval.push_back(statement);
+  }
+}
+
+void CreateSlice::applyPendingRemovals() {
+  for (std::vector<SgStatement *>::iterator statement =
+           statementsPendingRemoval.begin();
+       statement != statementsPendingRemoval.end(); ++statement) {
+    if (canRemoveStatementFromAst(*statement)) {
+      SageInterface::removeStatement(*statement);
+    }
+  }
+  statementsPendingRemoval.clear();
+}
+
 void printSgNode(SgNode *node) {
   cout << "\"";
   if (isSgInitializedName(node))
@@ -145,8 +179,10 @@ CreateSlice::evaluateSynthesizedAttribute(SgNode *node,
           //                                              ())
           if (currentFile &&
               (*cand)->get_file_info()->isSameFile(currentFile)) {
-            // LowLevelRewrite::remove(isSgStatement(*cand));
-            SageInterface::removeStatement(isSgStatement(*cand));
+            SgStatement *candidateStatement = isSgStatement(*cand);
+            // Defer AST mutation until traversal finishes to keep successor
+            // container indexing stable.
+            queueStatementForRemoval(candidateStatement);
             //                                      delete
             //                                      (*cand);
           }
@@ -196,8 +232,10 @@ CreateSlice::evaluateSynthesizedAttribute(SgNode *node,
         //                                              ()->isOutputInCodeGeneration
         //                                              ())
         if (currentFile && node->get_file_info()->isSameFile(currentFile)) {
-          // LowLevelRewrite::remove(isSgStatement(node));
-          SageInterface::removeStatement(isSgStatement(node));
+          SgStatement *currentStatement = isSgStatement(node);
+          // Defer AST mutation until traversal finishes to keep successor
+          // container indexing stable.
+          queueStatementForRemoval(currentStatement);
         }
         //      delete(node);
       }

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.h
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.h
@@ -25,6 +25,8 @@
 
 #include <stack>
 
+#include <vector>
+
 class BooleanSafeKeeper {
 public:
   BooleanSafeKeeper() : boolean(false) {}
@@ -42,10 +44,19 @@ public:
   // bool traverse(SgNode * node) {return traverse(node, false);}
   bool traverse(SgNode *node) {
     currentFile = NULL;
+    statementsPendingRemoval.clear();
+    // No explicit targets means there is no slice to materialize.
+    // Keep the AST unchanged instead of attempting destructive pruning.
+    if (_toSave.empty()) {
+      return false;
+    }
     //              return traverse(node,BooleanSafeKeeper(false));
-    return AstTopDownBottomUpProcessing<BooleanSafeKeeper, BooleanSafeKeeper>::
-        traverse(node, BooleanSafeKeeper(false))
-            .boolean;
+    bool traversalResult =
+        AstTopDownBottomUpProcessing<BooleanSafeKeeper, BooleanSafeKeeper>::
+            traverse(node, BooleanSafeKeeper(false))
+                .boolean;
+    applyPendingRemovals();
+    return traversalResult;
   }
 
 protected:
@@ -62,6 +73,9 @@ protected:
     return inh;
   }
   std::stack<std::list<SgNode *>> delayedRemoveListStack;
+  void queueStatementForRemoval(SgStatement *statement);
+  void applyPendingRemovals();
+  std::vector<SgStatement *> statementsPendingRemoval;
   /*    virtual bool defaultSynthesizedAttribute()
     {
     return false;

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/test2.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/test2.C
@@ -1,21 +1,20 @@
-#include<stdio.h>
+#include <stdio.h>
 
-int add(int a, int b);
+static int add(int a, int b);
 
-void main() {
-    int i = 1;     int sum = 0;
-    while (i<11) {
-        sum = add(sum, i);
-        i = add(i, 1);
-    }
-    printf("sum = %d\n", sum);
+int main(void) {
+  int i = 1;
+  int sum = 0;
+  while (i < 11) {
+    sum = add(sum, i);
+    i = add(i, 1);
+  }
+  printf("sum = %d\n", sum);
 
 #pragma SliceTarget
-    i;
-    printf("i = %d\n", i);
+  i;
+  printf("i = %d\n", i);
+  return 0;
 }
 
-static int add(int a, int b)
-{
-    return(a+b);
-}
+static int add(int a, int b) { return (a + b); }


### PR DESCRIPTION
## Summary
This PR fixes the remaining root-cause failures from issue #251 (`staticInterproceduralSlicing` on current Clang/CFE).

Issue link: https://github.com/ouankou/rex/issues/251

## Problem
The issue still reproduced on current `main`:
- `slicing_testSlicing_test3_C`, `slicing_testSlicing_test4_C`, `slicing_slice_test3_C`, `slicing_slice_test4_C` aborted with CFE assertions in `Cxx_GrammarTreeTraversalSuccessorContainer`.
- `slicing_testSlicing_test2_C`/`slicing_slice_test2_C` also exposed invalid input in `test2.C` (`void main`, conflicting `add` linkage).

## Root Cause
`CreateSlice` was mutating AST statement/declaration lists while traversing the same lists. Under CFE this invalidates successor indexing and triggers hard assertions. It also attempted destructive slicing even when there were no slice targets.

## Fix
### 1) Make slicing mutation traversal-safe
Updated `CreateSlice` to defer AST removals until traversal completes:
- Queue statements for removal during traversal.
- Apply removals after traversal in a dedicated post-pass.
- Gate removals with `SageInterface::isRemovableStatement` and parent-list checks.

Files:
- `src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.h`
- `src/midend/programAnalysis/staticInterproceduralSlicing/CreateSlice.C`

### 2) Handle empty slice target set as a no-op
When no slicing targets exist, `CreateSlice::traverse` now exits without destructive pruning. This prevents invalid global/scope mutation paths.

### 3) Make static slicing test input valid for Clang
Updated `staticInterproceduralSlicingTests/test2.C` to be standard-conforming:
- `int main(void)` instead of `void main`.
- Consistent `static` linkage for `add` declaration/definition.

File:
- `tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/test2.C`

## Validation
### Reproduced issue before fix
- `ctest --test-dir build -R "slicing_" --output-on-failure -j32`
  - observed assertion failures and invalid `test2.C` diagnostics

### After fix
- `cmake --build build -j32`
- `ctest --test-dir build -R "slicing_" --output-on-failure -j32`
  - **44/44 passed**

- Requested regression command:
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - **4897/4897 passed**

- Pre-push hook gate:
  - full hook run completed during `git push`
  - **5747/5747 passed**

## Notes
- No assertions were removed/softened.
- No workaround flags/fallback behavior were introduced.
- Fix is in slicing implementation logic, not test masking.

Closes #251
