### PR TITLE
Fix C++20 lambda init-capture regression in unparser

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -798,18 +798,6 @@ void Unparse_ExprStmt::unparseLambdaExpression(SgExpression *expr,
         SgExpression *capture_init_expr =
             lambdaCapture->get_source_closure_variable();
         bool is_init_capture = (capture_init_expr != nullptr);
-        if (is_init_capture) {
-          if (capture_init_expr == capt_var_expr) {
-            is_init_capture = false;
-          } else {
-            SgVarRefExp *captured_var_ref = isSgVarRefExp(capt_var_expr);
-            SgVarRefExp *init_var_ref = isSgVarRefExp(capture_init_expr);
-            if (captured_var_ref != nullptr && init_var_ref != nullptr &&
-                captured_var_ref->get_symbol() == init_var_ref->get_symbol()) {
-              is_init_capture = false;
-            }
-          }
-        }
 
         if (lambdaCapture->get_capture_by_reference() == true) {
           curprint("&");


### PR DESCRIPTION
## Summary
This PR fixes a follow-up regression in lambda capture unparsing related to issue #345 work.

When an init-capture used the same symbol as the captured variable expression, the unparser forced `is_init_capture = false`. That collapsed valid C++20 init-captures into simple captures and generated invalid output for member captures.

Example of incorrect output before this fix:
- `auto l2 = [i,x]` instead of `auto l2 = [i,x=x]`
- `auto l3 = [i,&x]` instead of `auto l3 = [i,&x=x]`

## Root Cause
`Unparse_ExprStmt::unparseLambdaExpression` contained a heuristic that suppressed init-capture handling when:
- `capture_init_expr == capt_var_expr`, or
- both sides were `SgVarRefExp` with the same symbol

That heuristic is not semantically valid for C++20 init-captures such as class member captures (`x=x`, `&x=x`).

## Fix
Removed the suppression block so init-capture status comes directly from AST intent:
- keep `is_init_capture = (capture_init_expr != nullptr)`
- do not rewrite it based on symbol identity heuristics

Changed file:
- `src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C`

## Validation
1. Targeted lambda tests
- `ctest --test-dir build --output-on-failure -j32 -R '^(Cxx11_tests_test2019_247_C|Cxx11_tests_test2019_248_C|Cxx20_tests_test2020_28_C|Cxx20_tests_test2020_29_C)$'`
- Result: `100% tests passed, 0 tests failed out of 4`

2. Full issue #345 follow-up set
- `ctest --test-dir build --output-on-failure -j32 -R '^(...49 issue-345 related tests...)$'`
- Result: `100% tests passed, 0 tests failed out of 49`

3. Required pre-push gate (hook, no skip)
- Hook-built tree and executed the configured large ctest gate
- Result: `100% tests passed, 0 tests failed out of 5754`

## Notes
- This is a root-cause semantic fix in unparser logic.
- No tests were disabled or modified.
- No workaround, fallback, or string-based hack was introduced.
