### PR TITLE
Fix OpenMP test main signatures for Clang conformance

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor10.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor10.c
@@ -1,16 +1,18 @@
 #include <math.h>
 
-void main(int n, int m, float *a, float *b, float *y, float *z)
-{
+static void ompfor10_body(int n, int m, float *a, float *b, float *y,
+                          float *z) {
   int i;
   int j;
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp for nowait linear(i,j) collapse(456) ordered(i)
-      for (i=1; i<n; i++)
-        b[i] = (a[i] + a[i-1]) / 2.0;
-    #pragma omp for nowait ordered schedule ( monotonic : runtime )
-      for (i=0; i<m; i++)
-        y[i] = z[i];
+#pragma omp for nowait linear(i, j) collapse(456) ordered(i)
+    for (i = 1; i < n; i++)
+      b[i] = (a[i] + a[i - 1]) / 2.0;
+#pragma omp for nowait ordered schedule(monotonic : runtime)
+    for (i = 0; i < m; i++)
+      y[i] = z[i];
   }
 }
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor9.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor9.c
@@ -1,16 +1,17 @@
 #include <math.h>
 
-void main(int n, int m, float *a, float *b, float *y, float *z)
-{
+static void ompfor9_body(int n, int m, float *a, float *b, float *y, float *z) {
   int i;
   int j;
-  #pragma omp parallel
+#pragma omp parallel
   {
-    #pragma omp for nowait linear(val(i,j):3) collapse(456) ordered(i)
-      for (i=1; i<n; i++)
-        b[i] = (a[i] + a[i-1]) / 2.0;
-    #pragma omp for nowait ordered
-      for (i=0; i<m; i++)
-        y[i] = z[i];
+#pragma omp for nowait linear(val(i, j) : 3) collapse(456) ordered(i)
+    for (i = 1; i < n; i++)
+      b[i] = (a[i] + a[i - 1]) / 2.0;
+#pragma omp for nowait ordered
+    for (i = 0; i < m; i++)
+      y[i] = z[i];
   }
 }
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd4.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd4.c
@@ -1,11 +1,12 @@
 #include <math.h>
 
-void main(int n,int m,float *a,float *b)
-{
+static void simd4_body(int n, int m, float *a, float *b) {
   int i;
-#pragma omp simd if(simd:test) simdlen(8) safelen(8)
-{
-    for (i = 1; i < n; i++) 
+#pragma omp simd if (simd : test) simdlen(8) safelen(8)
+  {
+    for (i = 1; i < n; i++)
       b[i] = ((a[i] + a[i - 1]) / 2.0);
+  }
 }
-}
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd5.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd5.c
@@ -1,11 +1,12 @@
 #include <math.h>
 
-void main(int n,int m,float *a,float *b)
-{
+static void simd5_body(int n, int m, float *a, float *b) {
   int i;
 #pragma omp simd order(concurrent)
-{
-    for (i = 1; i < n; i++) 
+  {
+    for (i = 1; i < n; i++)
       b[i] = ((a[i] + a[i - 1]) / 2.0);
+  }
 }
-}
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate.c
@@ -1,14 +1,15 @@
-void main(float*p, float*v1, float*v2, int N)
-{
-    int i;
-    #pragma omp target data device(1)
-    {
-        #pragma omp target
-        for (i=0; i<N; i++)
-            p[i] = v1[i]*v2[i];
-        #pragma omp target update if(target update:1)
-        #pragma omp parallel for
-        for (i=0; i<N; i++)
-          p[i] = p[i] + (v1[i]*v2[i]);
-    }
+static void targetupdate_body(float *p, float *v1, float *v2, int N) {
+  int i;
+#pragma omp target data device(1)
+  {
+#pragma omp target
+    for (i = 0; i < N; i++)
+      p[i] = v1[i] * v2[i];
+#pragma omp target update if (target update : 1)
+#pragma omp parallel for
+    for (i = 0; i < N; i++)
+      p[i] = p[i] + (v1[i] * v2[i]);
+  }
 }
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_device.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_device.c
@@ -1,14 +1,15 @@
-void main(float*p, float*v1, float*v2, int N)
-{
-    int i;
-    #pragma omp target data device(1)
-    {
-        #pragma omp target
-        for (i=0; i<N; i++)
-            p[i] = v1[i]*v2[i];
-        #pragma omp target update if(target update:1) nowait device(25)
-        #pragma omp parallel for
-        for (i=0; i<N; i++)
-          p[i] = p[i] + (v1[i]*v2[i]);
-    }
+static void targetupdate_device_body(float *p, float *v1, float *v2, int N) {
+  int i;
+#pragma omp target data device(1)
+  {
+#pragma omp target
+    for (i = 0; i < N; i++)
+      p[i] = v1[i] * v2[i];
+#pragma omp target update if (target update : 1) nowait device(25)
+#pragma omp parallel for
+    for (i = 0; i < N; i++)
+      p[i] = p[i] + (v1[i] * v2[i]);
+  }
 }
+
+int main(void) { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_nowait.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_nowait.c
@@ -1,14 +1,15 @@
-void main(float*p, float*v1, float*v2, int N)
-{
-    int i;
-    #pragma omp target data device(1)
-    {
-        #pragma omp target
-        for (i=0; i<N; i++)
-            p[i] = v1[i]*v2[i];
-        #pragma omp target update if(target update:1) nowait
-        #pragma omp parallel for
-        for (i=0; i<N; i++)
-          p[i] = p[i] + (v1[i]*v2[i]);
-    }
+static void targetupdate_nowait_body(float *p, float *v1, float *v2, int N) {
+  int i;
+#pragma omp target data device(1)
+  {
+#pragma omp target
+    for (i = 0; i < N; i++)
+      p[i] = v1[i] * v2[i];
+#pragma omp target update if (target update : 1) nowait
+#pragma omp parallel for
+    for (i = 0; i < N; i++)
+      p[i] = p[i] + (v1[i] * v2[i]);
+  }
 }
+
+int main(void) { return 0; }


### PR DESCRIPTION
## Summary
This PR resolves issue #308 by making the affected OpenMP C test inputs use ISO-conforming `main` declarations.

The previous files declared `void main(...)` with more than 3 parameters, which Clang rejects as invalid `main` signatures. This could trigger hard frontend errors before OpenMP behavior is exercised.

## Root-cause fix
Refactored each affected test input to:
- keep the original OpenMP body in a dedicated helper function
- add a standard-conforming `int main(void)` wrapper

No diagnostic suppression or compiler-option workaround was introduced.

## Files changed
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor9.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/ompfor10.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd4.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/simd5.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_nowait.c`
- `tests/nonsmoke/functional/CompileTests/OpenMP_tests/targetupdate_device.c`

## Validation
1. Issue repro set:
```bash
ctest --test-dir build -j32 --output-on-failure -R '^OMPTEST_(ompfor9|ompfor10|simd4|simd5|targetupdate|targetupdate_nowait|targetupdate_device)\\.c$'
```
Passed (`7/7`).

2. Required regression command from issue workflow:
```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32
```
Passed (`4898/4898`).

3. Push hooks (not skipped) executed and passed, including broader ctest coverage (`5754/5754`).

Closes #308.
