### PR TITLE
CI: update loong64/riscv64 weekly runs and base deps

### DIFF
--- a/.github/workflows/ci-loongarch64-weekly.yml
+++ b/.github/workflows/ci-loongarch64-weekly.yml
@@ -54,22 +54,12 @@ jobs:
 
             git config --global --add safe.directory /work
 
-            JOBS="$(nproc 2>/dev/null || echo 4)"
-            if [ "${JOBS}" -gt 32 ]; then
-              JOBS=32
-            fi
-            export NUM_JOBS="${JOBS}"
+            CTEST_JOBS="$(nproc)"
 
             ./build-rex.sh /work/rex_install Debug
 
-            # RTH tests default to a 15-minute timeout; scale for QEMU user-mode emulation.
-            export ROSE_TEST_TIMEOUT_SCALE=3
-            # CTest also has a global 1500s timeout; keep it in sync with the RTH timeout scaling.
-            CTEST_TIMEOUT="$((1500 * ROSE_TEST_TIMEOUT_SCALE))"
-            ctest --test-dir /work/build \
-              -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" \
-              --exclude-regex "omp_lowering|gdf_f77_constprop_test2007_189_f|gdf_f77_constprop_test2007_227_f" \
+            ctest --test-dir build \
+              -R "rex|astInterface|testQuery|fortran|f90|f03|OMPVV_5_0_|OMPLOWERING_RODINIA_" \
               --output-on-failure \
-              --timeout "${CTEST_TIMEOUT}" \
-              -j"${JOBS}"
+              -j"${CTEST_JOBS}"
           '

--- a/.github/workflows/ci-riscv64-weekly.yml
+++ b/.github/workflows/ci-riscv64-weekly.yml
@@ -53,22 +53,12 @@ jobs:
 
             git config --global --add safe.directory /work
 
-            JOBS="$(nproc 2>/dev/null || echo 4)"
-            if [ "${JOBS}" -gt 32 ]; then
-              JOBS=32
-            fi
-            export NUM_JOBS="${JOBS}"
+            CTEST_JOBS="$(nproc)"
 
             ./build-rex.sh /work/rex_install Debug
 
-            # RTH tests default to a 15-minute timeout; scale for QEMU user-mode emulation.
-            export ROSE_TEST_TIMEOUT_SCALE=3
-            # CTest also has a global 1500s timeout; keep it in sync with the RTH timeout scaling.
-            CTEST_TIMEOUT="$((1500 * ROSE_TEST_TIMEOUT_SCALE))"
-            ctest --test-dir /work/build \
-              -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" \
-              --exclude-regex "omp_lowering|gdf_f77_constprop_test2007_189_f|gdf_f77_constprop_test2007_227_f" \
+            ctest --test-dir build \
+              -R "rex|astInterface|testQuery|fortran|f90|f03|OMPVV_5_0_|OMPLOWERING_RODINIA_" \
               --output-on-failure \
-              --timeout "${CTEST_TIMEOUT}" \
-              -j"${JOBS}"
+              -j"${CTEST_JOBS}"
           '

--- a/ci/docker/rex-loongarch64.Dockerfile
+++ b/ci/docker/rex-loongarch64.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       libclang-cpp${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
+      libomp-${LLVM_VERSION}-dev \
       libtool \
       lldb-${LLVM_VERSION} \
       llvm-${LLVM_VERSION} \

--- a/ci/docker/rex-riscv64.Dockerfile
+++ b/ci/docker/rex-riscv64.Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
       libclang-cpp${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
+      libomp-${LLVM_VERSION}-dev \
       libtool \
       lldb-${LLVM_VERSION} \
       llvm-${LLVM_VERSION} \


### PR DESCRIPTION
## Summary
This PR updates the weekly `riscv64` and `loong64` CI runs to align with the current `ci.yml` testing strategy and to ensure OpenMP dependencies are present in the architecture-specific base images.

## Motivation
The weekly QEMU workflows need:
- OpenMP runtime headers/libraries available for OMP-related tests.
- A single reduced-coverage `ctest` run so total runtime stays within the hard CI limit.
- Simpler, consistent job/thread handling in line with `ci.yml`.

## Changes
1. Add OpenMP development package to arch base images
- `ci/docker/rex-riscv64.Dockerfile`
- `ci/docker/rex-loongarch64.Dockerfile`
- Added package: `libomp-${LLVM_VERSION}-dev` (with `LLVM_VERSION=21`, this resolves to `libomp-21-dev`).

2. Refactor weekly `ctest` execution to one reduced-coverage run
- `.github/workflows/ci-riscv64-weekly.yml`
- `.github/workflows/ci-loongarch64-weekly.yml`
- Replaced prior multi-part/timeout-tuned coverage pattern with a single run:

```bash
ctest --test-dir build \
  -R "rex|astInterface|testQuery|fortran|f90|f03|OMPVV_5_0_|OMPLOWERING_RODINIA_" \
  --output-on-failure \
  -j"${CTEST_JOBS}"
```

3. Simplify thread handling to match `ci.yml`
- Both weekly workflows now use:

```bash
CTEST_JOBS="$(nproc)"
```

- Removed extra thread-variable indirection/fallback logic from these weekly jobs.

## Validation
- Local pre-push hook executed (not skipped).
- Hook completed full configured test run successfully:
  - `100% tests passed, 0 tests failed out of 5754`

## Notes
- Weekly workflows consume `ghcr.io/<owner>/rex:base`; after merge, ensure base images are rebuilt/published so `libomp-21-dev` is present in pulled images.
