### PR TITLE
Fix #218: map deprecated -rose:C89 to GNU89 in CFE

### DIFF
--- a/src/frontend/SageIII/sage_support/cmdline.C
+++ b/src/frontend/SageIII/sage_support/cmdline.C
@@ -2305,7 +2305,10 @@ void SgFile::processRoseCommandLineOptions(vector<string> &argv) {
       true) {
     printf("WARNING: Command line option -rose:C89 is deprecated!\n");
 
-    set_C89_only();
+    // Keep legacy ROSE C89 compatibility semantics for deprecated -rose:C89:
+    // historical test inputs rely on GNU89 extensions (e.g., inline) and
+    // implicit-declaration warnings rather than hard errors.
+    set_C89_gnu_only();
   }
 
   if (CommandlineProcessing::isOption(argv, "-rose:", "(C99|C99_only)", true) ==


### PR DESCRIPTION
## Summary
This PR fixes the remaining C89-compatibility gap behind issue #218 by aligning deprecated `-rose:C89` behavior with GNU89 compatibility semantics in the Clang frontend path.

Issue checked: https://github.com/ouankou/rex/issues/218 (including comments)

## Root Cause
`-rose:C89` was mapped to `set_C89_only()` (strict C89), which produced strict-C89 parse failures on legacy ROSE C tests that rely on GNU89 constructs (notably `inline`) and expect implicit function declarations to remain warnings.

This mismatch prevented consistent legacy behavior for the exact C89/implicit-declaration cases discussed in #218 and its comment repros.

## Fix
Updated deprecated `-rose:C89` handling in `SgFile::processRoseCommandLineOptions`:
- from `set_C89_only()`
- to `set_C89_gnu_only()`

File changed:
- `src/frontend/SageIII/sage_support/cmdline.C`

This is a root-cause fix in CFE command-line standard mapping (no per-test/per-header workarounds, no fallback hacks).

## Why this is the right long-term behavior
- `-rose:C89` is deprecated but still widely used in legacy test pipelines.
- GNU89 mode keeps implicit declarations as warnings (not hard errors) and accepts GNU89-era constructs used by legacy inputs.
- This aligns with #218’s required direction: ensure C89 compatibility by using GNU89-equivalent frontend semantics.

## Validation
### Targeted checks
- `build/bin/testTranslator -rose:C89 -rose:verbose 0 -c tests/nonsmoke/functional/CompileTests/C_tests/test2006_136.c`
  - Result: implicit decl diagnostics are warnings (no C99 hard-error behavior).
- `build/bin/testTranslator -rose:C89 -rose:verbose 0 -c tests/nonsmoke/functional/CompileTests/C_tests/test2012_173.c`
  - Result: GNU89-style compatibility behavior; no strict-C89 `inline` parse errors.

### Requested regression suite
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - Result: `100% tests passed, 0 tests failed out of 4919` (2 disabled as expected).

### Pre-push hooks (not skipped)
Push-triggered hooks executed full required checks and passed, including:
- same requested CTest regex group (`4919/4919 passed`)
- OpenMP/OpenACC OpenMP_tests suite (`889/889 passed`)

## Impact
- Restores expected legacy GNU89 compatibility for `-rose:C89` users.
- Eliminates strict-C89 mismatch that was still blocking issue #218 scenarios.
- No test modifications; compiler/frontend behavior fixed at the source.
