### PR TITLE
Re-enable C GNU case-range regressions for issue #292

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -936,8 +936,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2015_139.c
   test2015_14.c
   test2015_140.c
-  test2015_141.c
-  test2015_142.c
   test2015_143.c
   test2015_144.c
   test2015_146.c


### PR DESCRIPTION
## Summary
- Reviewed `ouankou/rex#292` and all issue comments via `gh issue view --comments`.
- Verified the CFE root-cause path is already implemented in current `main`: `VisitCaseStmt` now handles optional `RHS` (GNU case ranges) and stores it in `SgCaseOptionStmt::key_range_end`.
- Re-enabled two C regression tests that were still listed under `TESTCODE_CURRENTLY_FAILING`:
  - `test2015_141.c`
  - `test2015_142.c`

## Why this change
Issue #292 reports asserts in `VisitCaseStmt` for GNU case ranges (`case a ... b`).
That assert path no longer reproduces in current codebase, but two related C tests remained disabled, which reduced protection against regressions.

This PR removes those two tests from the failing/disabled list so they run as normal required C tests.

## Files changed
- `tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt`

## Validation
### Issue-specific verification
- Confirmed issue details/comments:
  - `gh issue view 292 -R ouankou/rex --comments`
  - `gh issue view 292 -R ouankou/rex --json number,title,body,state,comments`
- Verified current CFE behavior in source:
  - `src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp` (`VisitCaseStmt` handles `getRHS()` and sets `key_range_end`).
- Reproducer tests pass:
  - `ctest --test-dir build --output-on-failure -j32 -R '^(C_tests_test2015_141_c|C_tests_test2015_142_c|C_tests_test2014_82_c|Cxx_tests_test2005_202_C|CSUBSETOFCXXTEST_test2005_202|normalizationTranslator_test2005_202\.C)$'`

### Requested regression suite
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: `4919 passed, 0 failed, 2 disabled/not-run`

### Git hook validation (on push)
Pre-push hooks executed successfully and ran the repo hook suite:
- `6164/6164 passed, 0 failed` (with 2 disabled tests reported by ctest)

## Impact
- No compiler behavior change.
- Increases regression coverage by enforcing two previously disabled C tests tied to issue #292.

Closes #292.
