### PR TITLE
Fix #284: unquarantine test2010_03 after root-cause verification

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -882,7 +882,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2009_06.c
   test2009_19.c
   test2010_02.c
-  test2010_03.c
   test2010_04.c
   test2010_05.c
   test2010_12.c


### PR DESCRIPTION
## Summary
This PR closes issue #284 by removing a stale known-fail quarantine entry for `test2010_03.c`.

Issue #284 reports that a multiline pragma continuation in:

```c
#pragma rose \
  outline
```

was being unparsed as:

```c
#pragma rose
  outline
```

which turns `outline` into a standalone token and breaks backend compile.

Current `main` no longer reproduces that behavior: the pragma is now canonicalized to a single-line directive during frontend pragma capture, so backend compile succeeds.

## What changed
- Removed `test2010_03.c` from `TESTCODE_CURRENTLY_FAILING` in:
  - `tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt`

This promotes the test from disabled `C_tests_failing_*` status to normal `C_tests_*` coverage.

## Root-cause verification (no workaround)
Validated in Clang frontend pragma capture path:
- `src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp`
  - `PragmaDirective(...)` consumes backslash-continued physical lines
  - drops continuation backslash
  - joins continued lines with a single space
  - stores canonicalized directive text in `line_to_pragma`

This matches the long-term resolution direction from issue #284: canonicalize multiline pragmas at capture/unparse boundary rather than relying on ad-hoc handling.

## Validation
### Issue reproduction check
- `gh issue view 284 -R ouankou/rex --json ... --comments`
- `ctest --test-dir build -R '^frontend_integration_c_test2010_03\.c$' -V --output-on-failure`
  - pass
- `build/bin/testTranslator -std=c -w -rose:verbose 0 -Itests/nonsmoke/functional/CompileTests/C_tests -c tests/nonsmoke/functional/CompileTests/C_tests/test2010_03.c`
  - pass (no backend compile failure)

### Post-change checks
- Reconfigured build:
  - `cmake -S . -B build`
- Confirmed test promotion:
  - `ctest --test-dir build -N -R 'C_tests_.*test2010_03'`
  - now shows `C_tests_test2010_03_c`
- Ran promoted test:
  - `ctest --test-dir build -R '^C_tests_test2010_03_c$' --output-on-failure -V`
  - pass

### Requested regression suite
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - pass (`4919/4919`, 0 failures)

### Hook-gated push validation
Pre-push hook suite also passed during `git push`.

Fixes #284.
