### PR TITLE
tests: re-enable C test2015_09 and close stale issue #299 state

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -1004,7 +1004,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2014_41.c
   test2014_66.c
   test2014_91.c
-  test2015_09.c
   test2015_156.c
   test2015_157.c
   test2015_23.c


### PR DESCRIPTION
## Summary
This PR validates and closes the stale `known_fail` classification tied to issue #299.

- Checked `ouankou/rex#299` and its comments via `gh issue view --comments`.
- Reproduced the exact generated command for `C_tests_failing_test2015_09_c` on current `main`.
- Confirmed the original `get_scope` assertion is no longer reproducible.
- Re-enabled `test2015_09.c` in regular `C_tests` execution by removing it from `TESTCODE_CURRENTLY_FAILING`.

## Why this change
Issue #299 tracked a historical CFE crash (`get_scope` assertion) for Xen `BUG_ON`-style expansion in `test2015_09.c`.
On current codebase, the testcase now passes, but remained disabled as a stale known-fail entry. This prevented continuous coverage of the regression.

This PR removes only the stale failing-list entry so the test runs normally and continues guarding against regressions.

## Files changed
- `tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt`
  - Removed `test2015_09.c` from `TESTCODE_CURRENTLY_FAILING`.

## Validation
Targeted validation:
- `ctest --test-dir build -j16 --output-on-failure -R '^C_tests_test2015_09_c$'`
  - Result: passed.

Requested regression suite:
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - Result: 4919/4919 passed.

Pre-push hook suite (enforced, no hook bypass):
- Build + repo hook ctest matrix
  - Result: passed (100% of executed tests; 2 known disabled tests remained disabled as before).

Closes #299.
