### PR TITLE
Fix and re-enable C test2019_15 for issue #295

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -1017,7 +1017,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2018_24.c
   test2018_31.c
   test2018_33.c
-  test2019_15.c
   test2020_14.c
   test2020_15.c
   test2020_16.c

--- a/tests/nonsmoke/functional/CompileTests/C_tests/test2019_15.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/test2019_15.c
@@ -1,22 +1,16 @@
 
 
-struct X
-   {
-     struct Y
-        {
-          one, two
-        };
-   };
+struct X {
+  struct Y {
+    enum { one, two };
+  };
+};
 
-
-struct Z
-   {
+struct Z {
   // Note that for C, types are always in global scope.
-     struct YY
-        {
-          one, two
-        };
-   };
-
+  struct YY {
+    enum { three, four };
+  };
+};
 
 struct Y number;


### PR DESCRIPTION
## Summary
This PR resolves `#295` by fixing `C_tests/test2019_15.c` to valid C and re-enabling it as a required passing C test.

## Problem
`tests/nonsmoke/functional/CompileTests/C_tests/test2019_15.c` used enumerator-like tokens without an `enum` declaration:
- `struct Y { one, two };`

This is invalid C and Clang correctly rejects it. The test had been moved into `TESTCODE_CURRENTLY_FAILING`, so it was masked as `C_tests_failing_test2019_15_c (Disabled)`.

## Root Cause
The specimen itself was not valid C (missing `enum` declarations), and after fixing that, duplicate enumerator identifiers also violated C identifier scope rules.

## Fix
1. Updated `test2019_15.c` to valid C by using explicit enums.
2. Made the second enum use distinct identifiers to satisfy C scope rules.
3. Removed `test2019_15.c` from `TESTCODE_CURRENTLY_FAILING` in `C_tests/CMakeLists.txt` so it runs under normal `C_tests`.

## Why This Is Long-Term
This removes the invalid input and restores the test to normal passing coverage rather than keeping a disabled failing entry. No fallback or workaround behavior was added.

## Validation
- Reconfigured CMake:
  - `cmake -S . -B build`
- Verified registration:
  - `ctest --test-dir build -N -R 'test2019_15'`
  - Confirms active `C_tests_test2019_15_c`.
- Targeted test:
  - `ctest --test-dir build --output-on-failure -j32 -R '^C_tests_test2019_15_c$'`
- Requested regression sweep:
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - Result: `100% tests passed, 0 failed (4919 tests)`
- Pre-push hooks (not skipped):
  - Full hook suite passed on final push (`6547/6547 listed; 2 disabled`).

## Issue Link
Closes #295.
