### PR TITLE
Clang FE: enforce designated field symbol resolution

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -10405,9 +10405,17 @@ bool ClangToSageTranslator::VisitDesignatedInitExpr(
     if (D->isFieldDesignator()) {
       // getField() was renamed to getFieldDecl()
       clang::FieldDecl *field_decl = D->getFieldDecl();
+      ROSE_ASSERT(field_decl != nullptr);
       SgSymbol *symbol = GetSymbolFromSymbolTable(field_decl);
       SgVariableSymbol *var_sym = isSgVariableSymbol(symbol);
-      if (var_sym == nullptr && field_decl != nullptr) {
+      if (var_sym == nullptr &&
+          p_decl_translation_in_progress.find(field_decl) ==
+              p_decl_translation_in_progress.end()) {
+        TraverseOnDemand(field_decl);
+        symbol = GetSymbolFromSymbolTable(field_decl);
+        var_sym = isSgVariableSymbol(symbol);
+      }
+      if (var_sym == nullptr) {
         SgNode *field_node = nullptr;
         auto it_decl = p_decl_translation_map.find(field_decl);
         if (it_decl != p_decl_translation_map.end()) {
@@ -10422,32 +10430,24 @@ bool ClangToSageTranslator::VisitDesignatedInitExpr(
             init_name = SageInterface::getFirstInitializedName(var_decl);
           }
         }
-        if (init_name != nullptr) {
-          SgScopeStatement *decl_scope = init_name->get_scope();
+        ROSE_ASSERT(init_name != nullptr);
+        SgScopeStatement *decl_scope = init_name->get_scope();
+        if (decl_scope == nullptr) {
+          decl_scope = resolveScopeFromDeclContext(
+              field_decl->getDeclContext(), SageBuilder::topScopeStack());
           if (decl_scope != nullptr) {
-            var_sym = decl_scope->lookup_variable_symbol(init_name->get_name());
-          }
-          if (var_sym == nullptr) {
-            var_sym = new SgVariableSymbol(init_name);
-            if (decl_scope != nullptr) {
-              attachSymbolToScopeOrOrphan(var_sym, decl_scope);
-            } else {
-              attachSymbolToScopeOrOrphan(var_sym, nullptr);
-            }
+            init_name->set_scope(decl_scope);
           }
         }
-      }
-      if (var_sym == nullptr) {
-        std::string field_name =
-            field_decl ? field_decl->getNameAsString() : "";
-        if (field_name.empty()) {
-          field_name = "undefined";
+        ROSE_ASSERT(decl_scope != nullptr);
+        var_sym = decl_scope->lookup_variable_symbol(init_name->get_name());
+        if (var_sym == nullptr) {
+          var_sym = new SgVariableSymbol(init_name);
+          attachSymbolToScopeOrOrphan(var_sym, decl_scope);
         }
-        expr = SageBuilder::buildDanglingVarRefExp(
-            SgName(field_name), SageBuilder::topScopeStack());
-      } else {
-        expr = SageBuilder::buildVarRefExp_nfi(var_sym);
       }
+      ROSE_ASSERT(var_sym != nullptr);
+      expr = SageBuilder::buildVarRefExp_nfi(var_sym);
     } else if (D->isArrayDesignator()) {
       SgNode *tmp_expr = Traverse(designated_init_expr->getArrayIndex(*D));
       expr = isSgExpression(tmp_expr);


### PR DESCRIPTION
## Summary
This change tightens Clang-frontend lowering for C99 designated initializers by removing a fallback that created dangling variable references when a field designator symbol lookup failed.

Issue context: `ouankou/rex#220` reports token-stream traversal crashes from illegal placeholder nodes during designated-initializer handling. The listed repro tests are currently passing, but the designated field path still contained a silent fallback that could mask symbol-resolution defects instead of enforcing a valid AST.

## Root Cause
In `ClangToSageTranslator::VisitDesignatedInitExpr`, field designators (`.field = ...`) could fall back to `buildDanglingVarRefExp(...)` when `FieldDecl` symbol lookup failed. That behavior is a workaround path and can preserve invalid/incomplete symbol state instead of ensuring proper ROSE field-symbol linkage.

## Fix
File changed:
- `src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp`

What changed:
- Require non-null `FieldDecl` for field designators (`ROSE_ASSERT`).
- Retry symbol resolution after `TraverseOnDemand(field_decl)` when needed.
- Resolve field declaration from translation map / traversal and require a valid `SgInitializedName` (`ROSE_ASSERT`).
- Resolve and require a concrete declaration scope (via existing decl-context scope resolution when needed).
- Materialize and attach a real `SgVariableSymbol` into scope when absent.
- Remove the dangling-var-ref fallback entirely.
- Keep hard assertions so invalid frontend states fail early and loudly.

This preserves the long-term requirement: construct valid IR/symbol relationships rather than carrying forward workaround placeholders.

## Validation
Targeted issue repro tests:
- `ctest --test-dir build -j32 -R "tokenStreamMapping_test2013_(10|11|16|18|28|29|30|31|37)_c" --output-on-failure`
- Result: 9/9 passed

Requested regression slice:
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: 4923/4923 passed

Hook-enforced push validation (no hook bypass):
- Pre-push build + ctest run completed
- Result: 6577/6577 passed

Closes #220.
