### PR TITLE
CFE: define offsetof in Clang builtin C preinclude (fix #221)

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-builtin-c.h
+++ b/src/frontend/CxxFrontend/Clang/clang-builtin-c.h
@@ -22,6 +22,10 @@
 #define __INFINITY__ __builtin_inff()
 #endif
 
+#ifndef offsetof
+#define offsetof(type, member) __builtin_offsetof(type, member)
+#endif
+
 #if !__has_builtin(__builtin_va_start)
 void __builtin_va_start(__builtin_va_list, ...);
 #endif


### PR DESCRIPTION
## Summary
Issue #221 reported missing C frontend builtins/macros in legacy C mode (`-rose:C89`), notably `__NAN__`, `__INFINITY__`, `__I__`, and `offsetof`.

Current status on `main` before this patch:
- `__NAN__`, `__INFINITY__`, and `__I__` were already available from `clang-builtin-c.h`.
- `offsetof` was still missing from the Clang frontend preinclude environment.

This PR adds the missing long-term CFE builtin mapping for `offsetof`.

## Root Cause
`src/frontend/CxxFrontend/Clang/clang-builtin-c.h` provided fallback builtin macros for NaN/Infinity/imaginary constants, but did not provide `offsetof`.

As a result, C89 frontend parsing could fail for code that uses `offsetof` without explicitly including `<stddef.h>`, which is exactly the class of issue tracked in #221.

## Fix
In `clang-builtin-c.h`, define:

```c
#ifndef offsetof
#define offsetof(type, member) __builtin_offsetof(type, member)
#endif
```

This keeps behavior in the Clang frontend aligned with compiler builtins (no per-test workaround, no fallback path in tests).

## Validation
### Issue-focused checks
- Verified issue details and comments via `gh issue view 221 -R ouankou/rex --json ...`.
- Reproduced unresolved root-cause symptom before change with a minimal C89 frontend repro using `offsetof` without `<stddef.h>` (failed parse).
- Re-ran same repro after change (passes).

### Requested regression slice
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: `4924/4924` passed.

### Git hook validation (not skipped)
- Pre-push hook executed full required checks.
- Result: `6620/6620` passed.

## Notes
- This change is frontend-only (Clang C builtin preinclude), consistent with the branch guidance to fix CFE root causes.
- No tests were modified.

Closes #221.
