### PR TITLE
ci(docs): fix Publish Docs workflow for LLVM 21

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -13,6 +13,9 @@ concurrency:
   group: docs-publish-main
   cancel-in-progress: true
 
+env:
+  LLVM_VERSION: 21
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -24,6 +27,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Add LLVM apt repository
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc > /dev/null
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -31,16 +39,17 @@ jobs:
             antlr4 \
             bison \
             build-essential \
-            clang-20 \
+            clang-${LLVM_VERSION} \
             cmake \
             curl \
             flex \
-            libflang-20-dev \
-            libclang-20-dev \
+            libflang-${LLVM_VERSION}-dev \
+            libclang-${LLVM_VERSION}-dev \
+            libomp-${LLVM_VERSION}-dev \
             libantlr4-runtime-dev \
             libhpdf-dev \
-            llvm-20 \
-            llvm-20-dev \
+            llvm-${LLVM_VERSION} \
+            llvm-${LLVM_VERSION}-dev \
             perl \
             asciidoctor \
             pkg-config
@@ -64,11 +73,11 @@ jobs:
 
       - name: Build docs (shared script)
         env:
-          PATH: /usr/lib/llvm-20/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          CMAKE_PREFIX_PATH: /usr/lib/llvm-20
-          LLVM_DIR: /usr/lib/llvm-20
-          CC: clang-20
-          CXX: clang++-20
+          PATH: /usr/lib/llvm-${{ env.LLVM_VERSION }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          CMAKE_PREFIX_PATH: /usr/lib/llvm-${{ env.LLVM_VERSION }}
+          LLVM_DIR: /usr/lib/llvm-${{ env.LLVM_VERSION }}
+          CC: clang-${{ env.LLVM_VERSION }}
+          CXX: clang++-${{ env.LLVM_VERSION }}
           DOCS_ANTLR4_EXECUTABLE: ${{ github.workspace }}/.tools/antlr4/antlr4
           DOCS_JOBS: 32
         run: bash scripts/ci-docs-build


### PR DESCRIPTION
## Summary
Fixes the `Publish Docs` CI workflow so it uses the project-required LLVM/Clang 21 toolchain and completes docs generation reliably.

## Root Cause
The docs workflow (`.github/workflows/docs-publish.yml`) was still pinned to LLVM/Clang 20 (`clang-20`, `llvm-20`, `/usr/lib/llvm-20`), while the project now requires LLVM/Clang 21.

From the failed run (`Publish Docs` run `22421787396`, 2026-02-26), CMake stopped at configure with:
- `REX requires LLVM/Clang 21 or newer. Found Clang 20.`

After switching to LLVM 21, the workflow exposed a second real dependency requirement during configure:
- `LLVM OpenMP runtime library (libiomp5/libomp) not found for LLVM/Clang 21`
- This requires `libomp-21-dev` in the docs job dependency set.

## Changes
### 1) Provision LLVM 21 from apt.llvm.org in docs workflow
- Added top-level workflow env:
  - `LLVM_VERSION: 21`
- Added explicit LLVM apt repository setup step:
  - imports `apt.llvm.org` signing key
  - adds `llvm-toolchain-noble-${LLVM_VERSION}` repo

### 2) Align installed packages with LLVM version variable
Replaced hardcoded LLVM 20 packages with versioned 21 packages via `${LLVM_VERSION}`:
- `clang-${LLVM_VERSION}`
- `llvm-${LLVM_VERSION}`
- `llvm-${LLVM_VERSION}-dev`
- `libclang-${LLVM_VERSION}-dev`
- `libflang-${LLVM_VERSION}-dev`
- `libomp-${LLVM_VERSION}-dev` (newly required for configure)

### 3) Align docs build environment to LLVM 21
Updated `Build docs (shared script)` env to use `${{ env.LLVM_VERSION }}` for:
- `PATH`
- `CMAKE_PREFIX_PATH`
- `LLVM_DIR`
- `CC`
- `CXX`

## Why this is the right fix
- Fixes the actual incompatibility (workflow toolchain version drift) instead of adding bypasses.
- Keeps docs workflow consistent with repository CI/toolchain policy (LLVM 21).
- Uses variable-based versioning to reduce future drift risk.
- Adds the OpenMP runtime dependency required by current CMake checks rather than suppressing checks.

## Validation
### Reproduced failure from GitHub Actions logs
- Verified failing workflow run details with `gh run view 22421787396 --log-failed`.

### Verified full docs job with `act`
- Ran full docs job locally:
  - `act -W .github/workflows/docs-publish.yml -j docs --pull=false`
- Result: `Job succeeded`.

### Hooks / repo checks
- Push was performed without skipping hooks.
- Pre-push hook completed successfully:
  - `100% tests passed, 0 tests failed out of 6624`

## Files Changed
- `.github/workflows/docs-publish.yml`
