### PR TITLE
Fix nightly multi-arch image OpenMP runtime discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1118,6 +1118,8 @@ if(ENABLE-C)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET)
 
+  set(_rose_llvm_openmp_runtime_names
+    libiomp5.so libomp.so libomp.so.5 libomp5.so libiomp5.a libomp.a)
   set(_rose_llvm_openmp_runtime_hints "")
   if(WITH-LLVM-OMP-RUNTIME-LIBRARY)
     file(TO_CMAKE_PATH "${WITH-LLVM-OMP-RUNTIME-LIBRARY}"
@@ -1125,6 +1127,26 @@ if(ENABLE-C)
     list(APPEND _rose_llvm_openmp_runtime_hints
       "${ROSE_LLVM_OPENMP_RUNTIME_DIR}")
   endif()
+  foreach(_rose_omp_probe_name IN LISTS _rose_llvm_openmp_runtime_names)
+    execute_process(
+      COMMAND "${_rose_llvm_openmp_driver}" -print-file-name=${_rose_omp_probe_name}
+      OUTPUT_VARIABLE _rose_omp_probe_path
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET)
+    if(_rose_omp_probe_path)
+      file(TO_CMAKE_PATH "${_rose_omp_probe_path}" _rose_omp_probe_path_norm)
+      if(IS_ABSOLUTE "${_rose_omp_probe_path_norm}" AND
+         EXISTS "${_rose_omp_probe_path_norm}")
+        get_filename_component(_rose_omp_probe_dir
+          "${_rose_omp_probe_path_norm}" DIRECTORY)
+        list(APPEND _rose_llvm_openmp_runtime_hints
+          "${_rose_omp_probe_dir}")
+        unset(_rose_omp_probe_dir)
+      endif()
+      unset(_rose_omp_probe_path_norm)
+    endif()
+    unset(_rose_omp_probe_path)
+  endforeach()
   if(LLVM_LIBRARY_DIRS)
     list(APPEND _rose_llvm_openmp_runtime_hints ${LLVM_LIBRARY_DIRS})
   endif()
@@ -1135,6 +1157,14 @@ if(ENABLE-C)
       "${_rose_llvm_openmp_driver_dir}/../lib"
       "${_rose_llvm_openmp_driver_dir}/../lib64")
   endif()
+  foreach(_rose_implicit_libdir IN LISTS
+    CMAKE_C_IMPLICIT_LINK_DIRECTORIES
+    CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES
+    CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES)
+    if(_rose_implicit_libdir)
+      list(APPEND _rose_llvm_openmp_runtime_hints "${_rose_implicit_libdir}")
+    endif()
+  endforeach()
   if(_rose_clang_resource_dir)
     get_filename_component(_rose_clang_lib_dir
       "${_rose_clang_resource_dir}" DIRECTORY)
@@ -1155,8 +1185,7 @@ if(ENABLE-C)
   set(_rose_mismatched_openmp_runtime_library "")
   set(_rose_mismatched_openmp_runtime_major "")
   foreach(_rose_omp_runtime_dir IN LISTS _rose_llvm_openmp_runtime_hints)
-    foreach(_rose_omp_lib_name
-      libiomp5.so libomp.so libomp.so.5 libiomp5.a libomp.a)
+    foreach(_rose_omp_lib_name IN LISTS _rose_llvm_openmp_runtime_names)
       if(EXISTS "${_rose_omp_runtime_dir}/${_rose_omp_lib_name}")
         file(REAL_PATH "${_rose_omp_runtime_dir}/${_rose_omp_lib_name}"
           _rose_runtime_candidate)


### PR DESCRIPTION
## Summary
This fixes the nightly `Nightly REX Images` workflow failure seen on run `22516828461` (2026-02-28), where both `build-riscv64` and `build-loong64` failed in `Build and push REX runtime image` during CMake configure.

The failure was:
- `LLVM OpenMP runtime library (libiomp5/libomp) not found for LLVM/Clang 21`

## Root Cause
On `riscv64` and `loong64` base images, LLVM 21 packages expose broken symlinks in `/usr/lib/llvm-21/lib`:
- `libomp.so -> libomp.so.5`
- `libomp.so.5 -> ../../x86_64-linux-gnu/libomp.so.5` (broken for non-x86 targets)

Valid runtime libraries are present in multiarch system dirs (for example `/usr/lib/riscv64-linux-gnu/libomp.so.5` and `/usr/lib/loongarch64-linux-gnu/libomp.so.5`), but our CMake hint list only searched LLVM-prefixed paths, so detection failed.

## Changes
Updated OpenMP runtime discovery in `CMakeLists.txt`:
- Added a shared runtime soname list used by discovery (`libiomp5.so`, `libomp.so`, `libomp.so.5`, `libomp5.so`, `libiomp5.a`, `libomp.a`).
- Added compiler-based probing via `clang -print-file-name=<runtime>` and appended resolved runtime directories to hints.
- Added implicit/system linker directories (`CMAKE_C_IMPLICIT_LINK_DIRECTORIES`, `CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES`, `CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES`) to hint search.
- Kept existing strict LLVM major-version compatibility checks intact.

This is a root-cause fix to runtime discovery, not a per-arch workaround.

## Verification
### Reproduced failure before fix
- `docker buildx build --pull --platform linux/loong64 --file ci/docker/rex-nightly.Dockerfile --target runtime --build-arg BASE_IMAGE=ghcr.io/ouankou/rex:base --progress plain --output=type=cacheonly .`
- Result before patch: fails with the same CMake OpenMP runtime error.

### Docker/QEMU verification after fix
- `docker buildx build --pull --platform linux/riscv64,linux/loong64 --file ci/docker/rex-nightly.Dockerfile --target runtime --build-arg BASE_IMAGE=ghcr.io/ouankou/rex:base --progress plain --output=type=cacheonly .`
- Result: success for both architectures.

### `act` workflow verification after fix
- `act workflow_dispatch -W .github/workflows/nightly-rex-images.yml -j build-loong64 -P ubuntu-24.04=catthehacker/ubuntu:act-24.04 --secret GITHUB_TOKEN="$(gh auth token)"`
- `act workflow_dispatch -W .github/workflows/nightly-rex-images.yml -j build-riscv64 -P ubuntu-24.04=catthehacker/ubuntu:act-24.04 --secret GITHUB_TOKEN="$(gh auth token)"`
- Result: both jobs succeeded end-to-end (runtime + dev image builds).

### Git hook verification
- Push was done without skipping hooks.
- Pre-push hook completed successfully and ran the configured `ctest` suite subset (`6624/6624` passed).
