### PR TITLE
Fix #237: restore legacy escape.h/rewrite.h public headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,7 +197,7 @@ install(EXPORT RoseTargets
 )
 install(
   FILES
-    featureTests.h rose.h roseInternal.h
+    escape.h featureTests.h rewrite.h rose.h roseInternal.h
     ${CMAKE_BINARY_DIR}/rosePublicConfig.h
   DESTINATION ${INCLUDE_INSTALL_DIR})
 

--- a/src/escape.h
+++ b/src/escape.h
@@ -1,0 +1,7 @@
+#ifndef ROSE_LEGACY_ESCAPE_H
+#define ROSE_LEGACY_ESCAPE_H
+
+// Legacy compatibility header retained for code that still includes <escape.h>.
+#include "Rose/StringUtility/Escape.h"
+
+#endif // ROSE_LEGACY_ESCAPE_H

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -1,0 +1,15 @@
+#ifndef ROSE_LEGACY_REWRITE_H
+#define ROSE_LEGACY_REWRITE_H
+
+// Legacy compatibility header retained for code that still includes
+// <rewrite.h>. The legacy astRewriteMechanism was removed; AstRestructure is
+// the remaining supported rewrite-related public entry point.
+#if __has_include("AstRestructure.h")
+#include "AstRestructure.h"
+#elif __has_include("midend/astProcessing/AstRestructure.h")
+#include "midend/astProcessing/AstRestructure.h"
+#else
+#error "rewrite.h compatibility header requires AstRestructure.h"
+#endif
+
+#endif // ROSE_LEGACY_REWRITE_H


### PR DESCRIPTION
## Summary
This PR addresses `ouankou/rex#237` by restoring legacy public header compatibility for headers that were renamed/removed during cleanup.

### What changed
- Added `src/escape.h` as a compatibility forwarding header to:
  - `Rose/StringUtility/Escape.h`
- Added `src/rewrite.h` as a compatibility header for legacy `<rewrite.h>` includes.
  - It forwards to `AstRestructure.h` (with `__has_include` handling for build-tree and install-tree include layouts).
- Updated header installation in `src/CMakeLists.txt` to install:
  - `escape.h`
  - `rewrite.h`

## Root cause
- `escape.h` was removed/renamed in the StringUtility cleanup path, while legacy code/tests still include `<escape.h>`.
- `rewrite.h` was removed with `astRewriteMechanism` pruning, while legacy code/tests still include `<rewrite.h>`.

This PR restores the public include contract in code (no test modifications).

## Validation
### Focused issue checks
- `ctest --test-dir build -R 'rose_example_testRoseHeaders_0(5|6)' --output-on-failure -V`
  - `rose_example_testRoseHeaders_05_C`: **PASS**
  - `rose_example_testRoseHeaders_06_C`: **FAIL** due to pre-existing source syntax error:
    - `testRoseHeaders_06.C:120:2: error: #endif without #if`

### Required regression suite from issue request
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - **4924 passed, 0 failed**

### Push hooks (not skipped)
- Pre-push hooks ran full configured checks and passed.

## Notes
- This change intentionally fixes compiler/public-header compatibility only.
- It does not alter tests or test framework behavior.
