### PR TITLE
Fix astTokenStream linearization test executable resolution

### DIFF
--- a/tests/nonsmoke/functional/roseTests/astTokenStreamTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astTokenStreamTests/CMakeLists.txt
@@ -1140,6 +1140,7 @@ foreach(specimen IN LISTS _linearization_specimens)
     NAME tokenLinearization_${_specimen_id}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${_rth}
+      EXE=$<TARGET_FILE:testLinearization>
       SPECIMEN=${specimen}
       ${_linearization_conf}
       ${_target}

--- a/tests/nonsmoke/functional/roseTests/astTokenStreamTests/testLinearization.conf
+++ b/tests/nonsmoke/functional/roseTests/astTokenStreamTests/testLinearization.conf
@@ -1,4 +1,4 @@
 # Test configuration file (see "scripts/rth_run.pl --help" for details)
 
-cmd = ${VALGRIND} ./testLinearization  -c ${SPECIMEN}
+cmd = ${VALGRIND} ${EXE}  -c ${SPECIMEN}
 answer = ${SPECIMEN}.ans


### PR DESCRIPTION
## Summary
Fixes the root cause in issue #256: `tokenLinearization_*` tests were invoking `./testLinearization` from the test working directory, but CMake places the executable at `$<TARGET_FILE:testLinearization>` (typically `build/bin/testLinearization`).

This change wires the executable path explicitly through `rth_run.pl` instead of assuming a local binary in the cwd.

## Root Cause
`testLinearization.conf` hardcoded:

```text
cmd = ${VALGRIND} ./testLinearization -c ${SPECIMEN}
```

When run by CTest in `astTokenStreamTests` build dir, `./testLinearization` does not exist.

## Fix
1. Pass executable path from CMake to the harness:
   - `EXE=$<TARGET_FILE:testLinearization>` in `tokenLinearization_*` test definitions.
2. Use `${EXE}` in `testLinearization.conf` command.

This follows the existing long-term harness pattern used in other ROSE tests and avoids directory-dependent assumptions.

## Files Changed
- `tests/nonsmoke/functional/roseTests/astTokenStreamTests/CMakeLists.txt`
- `tests/nonsmoke/functional/roseTests/astTokenStreamTests/testLinearization.conf`

## Validation
- Reproduced issue before fix:
  - `ctest --test-dir build -R tokenLinearization_ --output-on-failure -j32`
  - failure showed `./testLinearization` command not found.
- After fix, the same tests invoke:
  - `/home/ouankou/Projects/rex-ai/rex-loong64/build/bin/testLinearization ...`
  - confirming executable path resolution is corrected.
- Required regression check from the task:
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - `100% tests passed, 0 tests failed out of 4924`
- Pre-push git hook suite also passed:
  - `100% tests passed, 0 tests failed out of 6624`

Fixes #256
