### PR TITLE
Fix C++11-invalid specimens in Cxx11 tests

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_07.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_07.C
@@ -1,41 +1,36 @@
 typedef unsigned long size_t;
 
-class MemoryPage
-   {
-     size_t size;
-     char*  buf;
+class MemoryPage {
+  size_t size;
+  char *buf;
 
-     public:
-          explicit MemoryPage(int sz=512) : size(sz), buf(new char [size]) {}
-         ~MemoryPage() { delete[] buf;}
-       // typical C++03 copy ctor and assignment operator
-          MemoryPage(const MemoryPage&);
-          MemoryPage& operator=(const MemoryPage&);
+public:
+  explicit MemoryPage(int sz = 512) : size(sz), buf(new char[size]) {}
+  ~MemoryPage() { delete[] buf; }
+  // typical C++03 copy ctor and assignment operator
+  MemoryPage(const MemoryPage &);
+  MemoryPage &operator=(const MemoryPage &);
 
-          MemoryPage(MemoryPage&& other);
+  MemoryPage(MemoryPage &&other);
 
-       // C& C::operator=(C&& other);//C++11 move assignment operator
-          MemoryPage& MemoryPage::operator=(MemoryPage&& other);
-   };
+  // C& C::operator=(C&& other); // C++11 move assignment operator
+  MemoryPage &operator=(MemoryPage &&other);
+};
 
+// Here is a definition of MemoryPage's move assignment operator:
 
-
-// Here’s a definition of MemoryPage‘s move assignment operator:
-
-//C++11
-MemoryPage::MemoryPage& MemoryPage::operator=(MemoryPage&& other)
-   {
-     if (this!=&other)
-        {
-       // release the current object’s resources
-          delete[] buf;
-          size = 0;
-       // pilfer other’s resource
-          size = other.size;
-          buf = other.buf;
-       // reset other
-          other.size = 0;
-       // other.buf = nullptr;
-        }
-     return *this;
-   }
+// C++11
+MemoryPage &MemoryPage::operator=(MemoryPage &&other) {
+  if (this != &other) {
+    // release the current object's resources
+    delete[] buf;
+    size = 0;
+    // pilfer other's resource
+    size = other.size;
+    buf = other.buf;
+    // reset other
+    other.size = 0;
+    other.buf = 0;
+  }
+  return *this;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_30.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_30.C
@@ -1,13 +1,13 @@
 // This is a test code from Cxx_tests that is an issue for Reed's deleteAST
 // implementation.  He has implemented a work around to not search for a symbol
-// if it does not exist.  The point in this code is there should likely 
-// be a symbol (but it is not found thorugh the 2nd declaration, because it
-// is not being properly marked with a reference to the first non-defining 
+// if it does not exist.  The point in this code is there should likely
+// be a symbol (but it is not found through the 2nd declaration, because it
+// is not being properly marked with a reference to the first non-defining
 // declaration.
+namespace std {}
 namespace s = std;
 
-// This second declaration is allowed, but a symbol will not be built 
-// for it and the declaration does not point to the previous declaration 
+// This second declaration is allowed, but a symbol will not be built
+// for it and the declaration does not point to the previous declaration
 // as being the first non-defining declaration.
 namespace s = std;
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_55.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2014_55.C
@@ -3,15 +3,17 @@
 int x [[foo]];          // foo applies to variable x
 void f [[foo, bar]] (); // foo and bar apply to function f
 
-// An attribute name can be optionally qualified with a single-level attribute namespace 
-// and followed by attribute arguments enclosed in parenthesis. The format of attribute 
-// arguments is attribute-dependant. For example:
+// An attribute name can be optionally qualified with a single-level attribute
+// namespace and followed by attribute arguments enclosed in parenthesis. The
+// format of attribute arguments is attribute-dependent. For example:
 
 int y [[omp::shared]];
 
-void foo()
-   {
-     int x;
+[[noreturn]] void terminate_now();
 
-     [[likely(true)]] if (x == 0) {}
-   }
+void foo() {
+  int z [[foo]] = 0;
+
+  if (z == 0) {
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_56.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_56.C
@@ -1,31 +1,25 @@
 
-class A
-   {
-     public:
-          virtual int foobar();
-          int i;
-     public:
-          int foo();
-          A();
-   };
+class A {
+public:
+  virtual int foobar();
+  int i;
 
+public:
+  int foo();
+  A();
+};
 
-class B : public A
-   {
-     public:
-       // int abc;
-       // This is an old style using-declaration.
-       // BUG: This is unparsed without the public access level.
-          A::foo;
-          B();
-     private:
-          int foobar();
-   };
+class B : public A {
+public:
+  // C++11 requires a using-declaration.
+  using A::foo;
+  B();
 
+private:
+  int foobar();
+};
 
-void myFunction()
-   {
-     B o;
-     o.foo();
-   }
-
+void myFunction() {
+  B o;
+  o.foo();
+}


### PR DESCRIPTION
## Summary
This PR resolves issue #274 by making the affected `Cxx11_tests` specimens valid under `-std=c++11`.

## Root Cause
Several files in `tests/nonsmoke/functional/CompileTests/Cxx11_tests` used syntax that is not valid C++11:
- extra qualification in move-assignment declaration/definition
- C++20-only statement attribute usage (`[[likely(true)]]`)
- namespace alias to `std` without a prior namespace declaration
- old access-declaration form (`A::foo;`) instead of a C++11 `using` declaration

These are specimen issues in the test inputs, not CFE behavior.

## Changes
1. `test2014_07.C`
- Removed invalid extra qualification on move-assignment declaration.
- Fixed move-assignment definition return type qualification.
- Kept move-assignment semantics and made reset explicit (`other.buf = 0`).

2. `test2014_55.C`
- Removed invalid `[[likely(true)]]` usage (not valid for C++11).
- Kept attribute grammar coverage with C++11-parseable attribute examples.
- Added `[[noreturn]]` declaration as a standards-valid C++11 attribute case.

3. `test2014_30.C`
- Added `namespace std {}` before aliasing to keep the namespace alias specimen parse-valid in isolation.

4. `test2019_56.C`
- Replaced old access declaration `A::foo;` with `using A::foo;` (C++11-valid form).

All updated files were formatted with `clang-format`.

## Validation
### Issue-focused tests
```bash
ctest --test-dir build -j16 --output-on-failure -R "Cxx11_tests_test2014_07_C|Cxx11_tests_test2014_30_C|Cxx11_tests_test2014_55_C|Cxx11_tests_test2019_56_C"
```
Result: `4/4` passed.

### Requested regression suite
```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32
```
Result: `4924/4924` passed.

## Notes
- Push hooks were not skipped.
- No test masking/skip workaround was introduced; specimens were corrected to standards-valid C++11 forms.

Fixes #274
