### PR TITLE
Fix #280 by enabling 5 Cxx17 tests as valid positive specimens

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
@@ -85,12 +85,8 @@ set(CXX17_DISABLED_TESTCODES
   test2018_13.C
   test2018_14.C
   test2018_20.C
-  test2018_21.C
-  test2018_22.C
   test2018_24.C
-  test2018_25.C
   test2018_28.C
-  test2018_29.C
   test2018_30.C
   test2018_31.C
   test2018_32.C
@@ -100,7 +96,6 @@ set(CXX17_DISABLED_TESTCODES
   test2018_36.C
   test2018_37.C
   test2018_38.C
-  test2018_41.C
   test2018_42.C
   test2018_43.C
   test2018_44.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_21.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_21.C
@@ -1,32 +1,17 @@
-// Constexpr Lambda
+// Constexpr lambda composition
 
-auto monoid = [](auto v) { return [=] { return v; }; };
-auto add = [](auto m1) constexpr {
-     auto ret = m1();
-     return [=](auto m2) mutable {
-          auto m1val = m1();
-          auto plus = [=] (auto m2val) mutable constexpr
-                { return m1val += m2val; };
-ret = plus(m2());
-return monoid(ret);
-    };
-  };
+constexpr auto monoid = [](int v) constexpr {
+  return [=]() constexpr { return v; };
+};
 
-  constexpr auto zero = monoid(0);
-  constexpr auto one = monoid(1);
+constexpr auto add = [](auto m1) constexpr {
+  return [=](auto m2) constexpr { return m1() + m2(); };
+};
 
-  static_assert(add(one)(zero)() == one());  // OK
+constexpr auto zero = monoid(0);
+constexpr auto one = monoid(1);
+constexpr auto two = add(one)(one);
 
-// Since 'two' below is not declared constexpr, an evaluation of its constexpr member function call operator
-// can not perform an lvalue-to-rvalue conversion on one of its subobjects (that represents its capture)
-// in a constant expression.
-
-  auto two = monoid(2);
-  assert(two() == 2);
-
-// OK, not a constant expression.
-  static_assert(add(one)(one)() == two());
-
-// ill-formed: two() is not a constant expression
-  static_assert(add(one)(one)() == monoid(2)()); // OK
-
+static_assert(add(one)(zero) == one());
+static_assert(two == 2);
+static_assert(add(one)(one) == two);

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_22.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_22.C
@@ -1,11 +1,11 @@
-// Constexpr Lambda
+// Constexpr lambda with literal class values
 
-  auto ID = [](auto a) { return a; };
-  static_assert(ID(3) == 3); // OK
+auto ID = [](auto a) { return a; };
+static_assert(ID(3) == 3);
 
-  struct NonLiteral {
-    NonLiteral(int n) : n(n) { }
-    int n;
-  };
+struct Literal {
+  constexpr explicit Literal(int value) : n(value) {}
+  int n;
+};
 
-  static_assert(ID(NonLiteral{3}).n == 3); // ill-formed
+static_assert(ID(Literal{3}).n == 3);

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_25.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_25.C
@@ -1,20 +1,16 @@
-// Lambda Capture of *this by Value as [=,*this]
+// Lambda capture of *this by value as [=, tmp = *this]
 
-class Work 
-   {
-     public:
-          void do_something() const
-             {
-            // for ( int i = 0 ; i < N ; ++i )
-               for( Parallel : 0 , N , [=,tmp=*this]( int i )
-                  {
-                 // A modestly long loop body where
-                 // every reference to a member must be modified
-                 // for qualification with 'tmp.'
-                 // Any mistaken omissions will silently fail
-                 // as references via 'this->'.
-                  }
-               );
-             }
-   };
+class Work {
+public:
+  int bias = 7;
 
+  int do_something(int n) const {
+    auto offset = [=, tmp = *this](int i) { return tmp.bias + i; };
+    return offset(n);
+  }
+};
+
+int use_work() {
+  Work w;
+  return w.do_something(35);
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_29.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_29.C
@@ -1,20 +1,22 @@
 // [[fallthrough]] attribute
 
-void f(int n) 
-   {
-     void g(), h(), i();
-    switch (n)
-       {
-         case 1:
-         case 2:
-              g();
-              [[fallthrough]];
-         case 3: // warning on fallthrough discouraged
-              h();
-         case 4: // implementation may warn on fallthrough
-              i();
-              [[fallthrough]];// ill­formed
-       }
+void g();
+void h();
+void i();
+
+void f(int n) {
+  switch (n) {
+  case 1:
+  case 2:
+    g();
+    [[fallthrough]];
+  case 3:
+    h();
+    break;
+  case 4:
+    i();
+    break;
+  default:
+    break;
   }
-
-
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_41.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_41.C
@@ -1,8 +1,17 @@
-// Removing Deprecated Exception Specifications from C++17
+// C++17 exception specification compatibility
 
-void (*p)() throw(int);
-void (**pp)() noexcept = &p; // error: cannot convert to pointer to noexcept function
+void maybe_throw();
+void never_throw() noexcept;
 
-struct S { typedef void (*p)(); operator p(); };
-void (*q)() noexcept = S(); // error: cannot convert to pointer to noexcept function
+void (*p)() = &maybe_throw;
+void (*pn)() noexcept = &never_throw;
 
+struct S {
+  using p = void (*)() noexcept;
+
+  static void target() noexcept {}
+
+  operator p() const { return &target; }
+};
+
+void (*q)() noexcept = S{};


### PR DESCRIPTION
## Summary

This PR resolves issue #280 by promoting the five cited C++17 specimens from disabled status into the regular `Cxx17_tests` pass set, without introducing any redundant test set.

Specifically, it:
- removes `test2018_21.C`, `test2018_22.C`, `test2018_25.C`, `test2018_29.C`, and `test2018_41.C` from `CXX17_DISABLED_TESTCODES`
- rewrites those five files as valid C++17 positive compile tests while keeping their original feature focus

## Root-cause fix approach

Issue #280 identified a test-classification mismatch: specimens in the normal C++17 pass list were intentionally ill-formed/DSL-like, forcing them to be disabled.

This PR takes the long-term "convert to positive tests" path:
- keep the tests in the regular C++17 suite
- make each specimen valid C++17
- avoid workarounds/hacks/fallback behavior in compiler code or test harness logic

## File-level changes

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt`
  - removed these entries from `CXX17_DISABLED_TESTCODES`:
    - `test2018_21.C`
    - `test2018_22.C`
    - `test2018_25.C`
    - `test2018_29.C`
    - `test2018_41.C`

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_21.C`
  - replaced invalid constexpr-lambda assertions with valid constexpr lambda composition/static_assert checks

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_22.C`
  - replaced non-literal-class constexpr usage with a literal-class variant that is valid in constant expressions

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_25.C`
  - replaced non-C++ DSL syntax with a valid C++17 `*this`-by-value lambda capture example

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_29.C`
  - replaced ill-formed `[[fallthrough]]` placement with valid fallthrough usage

- `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_41.C`
  - replaced invalid `throw(...)`/`noexcept` pointer conversion examples with valid C++17 exception-spec compatibility declarations

## Validation

### Targeted tests (now enabled and passing)

```bash
ctest --test-dir build --output-on-failure -j32 -R '^(Cxx17_tests_test2018_21_C|Cxx17_tests_test2018_22_C|Cxx17_tests_test2018_25_C|Cxx17_tests_test2018_29_C|Cxx17_tests_test2018_41_C)$'
```

Result:
- `100% tests passed, 0 tests failed out of 5`

### Requested regression filter

```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32
```

Result:
- `100% tests passed, 0 tests failed out of 4924`

### Git hook validation (pre-push)

Push hooks executed and completed successfully:
- `100% tests passed, 0 tests failed out of 6578`

Closes #280.
