### PR TITLE
Fix issue #400: handle C++20 <=> BinaryOperator and re-enable test2020_109

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -5217,6 +5217,9 @@ bool ClangToSageTranslator::VisitBinaryOperator(
   case clang::BO_Shr:
     *node = SageBuilder::buildRshiftOp(lhs, rhs);
     break;
+  case clang::BO_Cmp:
+    *node = SageBuilder::buildSpaceshipOp(lhs, rhs);
+    break;
   case clang::BO_LT:
     *node = SageBuilder::buildLessThanOp(lhs, rhs);
     break;

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
@@ -174,7 +174,6 @@ set(CXX20_DISABLED_TESTCODES
   test2020_75.C
   test2020_82.C
   test2020_99.C
-  test2020_109.C
   test2020_112.C
   test2020_113.C
   test2020_117.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_109.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_109.C
@@ -1,13 +1,24 @@
+#include <compare>
+
+struct Example {
+  int x;
+  int y;
+
+  // Compare each member in declaration order and return on first mismatch.
+  std::strong_ordering operator<=>(const Example &other) const {
+    if (auto cmp = x <=> other.x; cmp != 0) {
+      return cmp;
+    }
+    if (auto cmp = y <=> other.y; cmp != 0) {
+      return cmp;
+    }
+    return std::strong_ordering::equal;
+  }
+};
 
 // DQ (7/21/2020): Moved function calls into a function.
-void foobar1()
-   {
-  // DQ (7/22/2020): Not enough is defined for this to be compilable code at present.
-
-     for (/*each base or member subobject o of T*/)
-        {
-          if (auto cmp = lhs.o <=> rhs.o; cmp != 0) return cmp;
-          return strong_ordering::equal; // converts to everything
-        }
-   }
-
+void foobar1() {
+  Example lhs{1, 2};
+  Example rhs{1, 3};
+  [[maybe_unused]] std::strong_ordering cmp = lhs <=> rhs;
+}


### PR DESCRIPTION
## Summary
This PR resolves issue #400 by addressing the root cause and re-enabling the affected C++20 compile test.

- Replaced `tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_109.C` pseudo-code with a minimal valid C++20 three-way-comparison example.
- Removed `test2020_109.C` from `CXX20_DISABLED_TESTCODES` so it runs as an active positive compile test.
- Fixed Clang frontend translation gap for C++20 spaceship binary operators by adding:
  - `clang::BO_Cmp -> SageBuilder::buildSpaceshipOp(lhs, rhs)`
  - file: `src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp`

## Root Cause
`test2020_109.C` had previously been pseudo-code and was disabled to avoid failures. Once converted to valid C++20 code, the test exposed a real frontend defect: Clang `BinaryOperator` opcode `BO_Cmp` (`<=>`) was not handled in `VisitBinaryOperator`, causing translation failure and assertion abort.

## Why this is the long-term fix
This change removes masking and fixes translation support at the frontend level for the actual missing AST opcode mapping. It avoids workarounds/hacks/fallbacks and keeps the test in the positive suite as intended.

## Validation
### Targeted issue reproduction/fix validation
- `ctest --test-dir build -j16 --output-on-failure -R '^Cxx20_tests_test2020_109_C$'`

### Requested regression slice
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`

### Pre-push hooks (not skipped)
Push-triggered hooks completed successfully and ran the project’s broader gated test set (including OpenMP/OMPVV/omp_lowering groups).

## Issue
Fixes #400
