### PR TITLE
Fix C++20 module import flow for test2020_45

### DIFF
--- a/src/frontend/SageIII/sage_support/cmdline.C
+++ b/src/frontend/SageIII/sage_support/cmdline.C
@@ -4203,6 +4203,16 @@ void SgFile::build_CLANG_CommandLine(vector<string> &inputCommandLine,
   const bool respect_rtti_flags =
       std::find(argv.begin(), argv.end(), "-rex:clang:respect-rtti-flags") !=
       argv.end();
+  auto is_split_module_option = [](const std::string &arg) {
+    return arg == "-fmodule-file" || arg == "-fprebuilt-module-path" ||
+           arg == "-fmodule-map-file";
+  };
+  auto is_module_option = [&](const std::string &arg) {
+    return arg.rfind("-fmodule", 0) == 0 || arg.rfind("-fmodules", 0) == 0 ||
+           arg.rfind("-fcxx-modules", 0) == 0 ||
+           arg.rfind("-fimplicit-module", 0) == 0 ||
+           arg.rfind("-fprebuilt-module-path", 0) == 0;
+  };
 
   for (size_t i = 0; i < argv.size(); i++) {
     std::string current_arg(argv[i]);
@@ -4283,6 +4293,16 @@ void SgFile::build_CLANG_CommandLine(vector<string> &inputCommandLine,
       // Keep exceptions enabled in frontend parsing to build a complete C++
       // AST; disabling remains a backend concern.
     } else if (isRexClangFrontendOption(current_arg)) {
+      clang_frontend_args.push_back(current_arg);
+    } else if (is_split_module_option(current_arg)) {
+      clang_frontend_args.push_back(current_arg);
+      ++i;
+      if (i < argv.size()) {
+        clang_frontend_args.push_back(argv[i]);
+      } else {
+        break;
+      }
+    } else if (is_module_option(current_arg)) {
       clang_frontend_args.push_back(current_arg);
     } else if (!current_arg.empty() && current_arg[0] == '-') {
       // Ignore other frontend/driver flags that Clang cc1 doesn't accept.

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
@@ -148,7 +148,6 @@ set(CXX20_DISABLED_TESTCODES
   test2020_42.C
   test2020_43.C
   test2020_44.C
-  test2020_45.C
   test2020_46.C
   test2020_48.C
   test2020_49.C
@@ -189,10 +188,50 @@ set(ROSE_DISABLED_TESTCODES ${CXX20_DISABLED_TESTCODES})
 set(ROSE_EXPECTED_FAIL_TESTCODES ${CXX20_EXPECTED_FAIL_TESTCODES})
 
 foreach(file_to_test ${CXX20_TESTCODES})
+  if(file_to_test STREQUAL "test2020_45.C")
+    continue()
+  endif()
   compile_test(${file_to_test} "Cxx20_tests")
   rex_compile_test_name(_test_name "Cxx20_tests" ${file_to_test})
   rex_lock_test_for_input(${_test_name} ${file_to_test})
 endforeach()
+
+set(_test2020_45_source "${CMAKE_CURRENT_SOURCE_DIR}/test2020_45.C")
+set(_test2020_45_module_source "${CMAKE_CURRENT_SOURCE_DIR}/test2020_45_module.C")
+set(_test2020_45_module_dir "${CMAKE_CURRENT_BINARY_DIR}/test2020_45_modules")
+set(_test2020_45_iostream_pcm "${_test2020_45_module_dir}/iostream.pcm")
+set(_test2020_45_module_pcm "${_test2020_45_module_dir}/test2020_45_module.pcm")
+
+string(CONCAT _test2020_45_command
+  "set -eu; "
+  "module_dir=\"${_test2020_45_module_dir}\"; "
+  "mkdir -p \"$module_dir\"; "
+  "${CMAKE_CXX_COMPILER} -std=c++20 -xc++-system-header --precompile iostream "
+  "-o \"${_test2020_45_iostream_pcm}\"; "
+  "${CMAKE_CXX_COMPILER} -std=c++20 -x c++-module --precompile "
+  "\"${_test2020_45_module_source}\" "
+  "-fmodule-file=\"${_test2020_45_iostream_pcm}\" "
+  "-o \"${_test2020_45_module_pcm}\"; "
+  "translator=\"$1\"; shift; "
+  "exec \"$translator\" "
+  "-fmodule-file=\"${_test2020_45_iostream_pcm}\" "
+  "-fmodule-file=test2020_45_module=${_test2020_45_module_pcm} "
+  "\"$@\"")
+
+add_test(
+  NAME Cxx20_tests_test2020_45_C
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    sh -c
+    "${_test2020_45_command}"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${_test2020_45_source}
+)
+set_tests_properties(Cxx20_tests_test2020_45_C PROPERTIES LABELS Cxx20_tests)
+rex_lock_test_for_input(Cxx20_tests_test2020_45_C test2020_45.C)
 
 # Makefile check targets.
 set(_cxx20_make_tests)


### PR DESCRIPTION
## Summary
This PR resolves issue #390 by enabling `Cxx20_tests_test2020_45_C` in the regular CTest set and providing a correct C++20 modules workflow for the test.

Closes #390.

## Root Cause
Two independent problems kept this issue open:

1. `SgFile::build_CLANG_CommandLine()` dropped module-related frontend flags (such as `-fmodule-file` / `-fprebuilt-module-path`) before reaching the Clang frontend path.
2. `Cxx20_tests_test2020_45.C` requires a named module BMI (and a header-unit BMI for `<iostream>`), but the generic single-file `compile_test()` flow does not prebuild those BMIs.

## Changes
### 1) Preserve module flags in Clang commandline construction
File:
- `src/frontend/SageIII/sage_support/cmdline.C`

What changed:
- Added module option detection in `build_CLANG_CommandLine()`.
- Preserved split module options:
  - `-fmodule-file <arg>`
  - `-fprebuilt-module-path <arg>`
  - `-fmodule-map-file <arg>`
- Preserved module-related prefixed options (`-fmodule*`, `-fmodules*`, `-fcxx-modules`, `-fimplicit-module*`, `-fprebuilt-module-path*`).

Effect:
- Module BMI flags now correctly propagate into the CFE invocation.

### 2) Move `test2020_45` out of disabled list and run it in regular CTest with module prep
File:
- `tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt`

What changed:
- Removed `test2020_45.C` from `CXX20_DISABLED_TESTCODES`.
- Kept it in the regular `CXX20_TESTCODES`/`Cxx20_tests` labeling flow.
- Added a dedicated `Cxx20_tests_test2020_45_C` test command that:
  1. precompiles `<iostream>` as a header-unit BMI,
  2. precompiles `test2020_45_module.C` as a named-module BMI,
  3. invokes `testTranslator` with `-fmodule-file` flags for both BMIs.

Effect:
- The test now runs as part of the regular CTest suite and passes.

## Validation
### Issue repro test
- `ctest --test-dir build -j32 --output-on-failure -R '^Cxx20_tests_test2020_45(_C)?$'`
- Result: **pass** (`1/1`).

### Requested regression set
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: **pass** (`4924/4924`).

### Git-hook run during push (not skipped)
- Hook-triggered CTest suite result: **pass** (`6624/6624`).
