### PR TITLE
Fix #305: legalize FP_CONTRACT placement and re-enable C tests

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -1000,9 +1000,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2015_156.c
   test2015_157.c
   test2017_17.c
-  test2018_08.c
-  test2018_09.c
-  test2018_10.c
   test2018_24.c
   test2018_31.c
   test2018_33.c

--- a/tests/nonsmoke/functional/CompileTests/C_tests/test2018_08.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/test2018_08.c
@@ -1,14 +1,12 @@
 
-void foobar()
-   {
+void foobar() {
 #pragma STDC FENV_ACCESS ON
-     int n = 0;
-
 #pragma STDC FP_CONTRACT ON
 #pragma STDC FP_CONTRACT OFF
-     int x = 0;
-
+  int n = 0;
+  int x = 0;
+  {
 #pragma STDC FP_CONTRACT OFF
-     int y = 0;
-
-   }
+    int y = 0;
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/C_tests/test2018_09.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/test2018_09.c
@@ -1,11 +1,10 @@
 
-void foobar()
-   {
+void foobar() {
 #pragma STDC FP_CONTRACT ON
 #pragma STDC FP_CONTRACT OFF
-     int x = 0;
-
+  int x = 0;
+  {
 #pragma STDC FP_CONTRACT OFF
-     int y = 0;
-
-   }
+    int y = 0;
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/C_tests/test2018_10.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/test2018_10.c
@@ -1,9 +1,8 @@
-void foobar()
-   {
+void foobar() {
 #pragma STDC FP_CONTRACT OFF
-     int x = 0;
-
+  int x = 0;
+  {
 #pragma STDC FP_CONTRACT ON
-     int y = 0;
-
-   }
+    int y = 0;
+  }
+}


### PR DESCRIPTION
## Summary
This PR resolves issue #305 by fixing invalid `#pragma STDC FP_CONTRACT` placement in three C compile tests and moving them out of the failing/disabled bucket into the regular `C_tests` set.

Closes #305.

## Root Cause
`test2018_08.c`, `test2018_09.c`, and `test2018_10.c` contained `#pragma STDC FP_CONTRACT` directives in the middle of a compound statement, after non-pragma statements. Clang correctly rejects this placement.

Those files were simultaneously listed in:
- `TESTCODES_REQUIRED_TO_PASS`
- `TESTCODE_CURRENTLY_FAILING`

which forced them into `C_tests_failing_*` disabled entries instead of normal `C_tests_*` entries.

## What Changed
### 1) Legalized pragma placement in tests
Updated these files so each `FP_CONTRACT` pragma appears at legal positions (start of a compound statement):
- `tests/nonsmoke/functional/CompileTests/C_tests/test2018_08.c`
- `tests/nonsmoke/functional/CompileTests/C_tests/test2018_09.c`
- `tests/nonsmoke/functional/CompileTests/C_tests/test2018_10.c`

Concretely, later pragma uses were moved to the start of nested blocks where needed.

### 2) Re-enabled tests in regular CTest set (no new redundant set)
Removed:
- `test2018_08.c`
- `test2018_09.c`
- `test2018_10.c`

from `TESTCODE_CURRENTLY_FAILING` in:
- `tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt`

After reconfigure, they are now registered as normal `C_tests_test2018_0{8,9,10}_c` tests (not `C_tests_failing_*`, not disabled).

## Verification
### Repro before fix
`testTranslator` reproduced issue #305 diagnostics:
- `'#pragma fp_contract' can only appear at file scope or at the start of a compound statement`

### Targeted tests after fix
- `ctest --test-dir build --output-on-failure -j32 -R '^C_tests_test2018_0(8|9|10)_c$'`
- Result: 3/3 passed.

### Requested regression run
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
- Result: 4924/4924 passed.

### Pre-push hook (not skipped)
Hook rebuilt and ran its required suite:
- Result: 6578/6578 passed.
