### PR TITLE
Fix GNU binary conditional AST reuse in Clang frontend

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -1279,8 +1279,14 @@ SgNode *ClangToSageTranslator::Traverse(clang::Stmt *stmt) {
 
   std::map<clang::Stmt *, SgNode *>::iterator it =
       p_stmt_translation_map.find(stmt);
-  if (it != p_stmt_translation_map.end())
+  if (it != p_stmt_translation_map.end()) {
+    if (stmt->getStmtClass() == clang::Stmt::OpaqueValueExprClass) {
+      SgExpression *expr = isSgExpression(it->second);
+      ROSE_ASSERT(expr != nullptr);
+      return SageInterface::copyExpression(expr);
+    }
     return it->second;
+  }
 
   SgNode *result = nullptr;
   bool ret_status = false;
@@ -12556,14 +12562,23 @@ bool ClangToSageTranslator::VisitOpaqueValueExpr(
 #endif
   bool res = true;
 
-  // ROOT CAUSE FIX: OpaqueValueExpr is a Clang internal node representing a
-  // value that appears multiple times in the AST but should only be evaluated
-  // once. It's used for desugaring constructs like the conditional operator and
-  // range-based for. We just traverse the source expression and return it.
+  // OpaqueValueExpr is a Clang internal reference to a previously computed
+  // value. The same Clang node can appear multiple times inside one enclosing
+  // expression (for example in GNU `a ?: b`), but the ROSE AST must remain a
+  // tree. Returning the translated source expression directly would reuse the
+  // same SgExpression node in multiple parents via the statement translation
+  // cache, which later breaks analyses such as CFG consistency checks.
+  // Translate the source expression once, then return a deep copy for each
+  // OpaqueValueExpr occurrence.
 
   clang::Expr *source_expr = opaque_value_expr->getSourceExpr();
   if (source_expr) {
-    *node = Traverse(source_expr);
+    SgExpression *source = isSgExpression(Traverse(source_expr));
+    ROSE_ASSERT(source != nullptr);
+
+    SgExpression *copy = SageInterface::copyExpression(source);
+    applySourceRange(copy, opaque_value_expr->getSourceRange());
+    *node = copy;
   } else {
     // No source expression - OpaqueValueExpr is used as a placeholder
     // Create a fallback expression for ROSE

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -2677,7 +2677,6 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS_DISABLED
   test2009_34.C
   test2009_35.C
   test2009_36.C
-  test2009_38.C
   test2009_43.C
   test2009_44.C
   test2009_46.C
@@ -2995,7 +2994,6 @@ set(TESTCODE_CURRENTLY_FAILING
   test2009_34.C
   test2009_35.C
   test2009_36.C
-  test2009_38.C
   test2009_43.C
   test2009_44.C
   test2009_46.C


### PR DESCRIPTION
## Summary
- fix the Clang frontend handling of `OpaqueValueExpr` so repeated uses inside GNU binary conditional expressions (`a ?: b`) produce distinct ROSE AST nodes instead of reusing one cached expression node
- remove `test2009_38.C` from the disabled and failing C++ compile-test lists so it returns to the normal ctest set without introducing any new test bucket
- keep the fix in the CFE/root-cause path rather than adding a special-case workaround in CFG or tests

## Root cause
Clang models GNU binary conditional expressions with `OpaqueValueExpr` nodes that can be referenced multiple times within the same enclosing expression. The frontend statement cache returned the same translated `SgExpression` node for every reuse of the same `OpaqueValueExpr`, which turned the ROSE AST into a DAG. That broke later analyses, including the CFG consistency checks that still kept the C++ regression disabled.

## Fix details
- in `ClangToSageTranslator::VisitOpaqueValueExpr`, translate the source expression once and return a deep copy for the `OpaqueValueExpr` occurrence
- in `ClangToSageTranslator::Traverse(clang::Stmt *)`, return a deep copy for cached `OpaqueValueExpr` translations so repeated traversals stay tree-shaped
- remove `test2009_38.C` from:
  - `EXAMPLE_TESTCODES_REQUIRED_TO_PASS_DISABLED`
  - `TESTCODE_CURRENTLY_FAILING`

## Validation
Issue-focused validation:
- `ctest --test-dir build --output-on-failure -j32 -R '^(C_tests_test2015_33_c|Cxx_tests_test2009_38_C|ut_test2009_38\.C|ua_test2009_38\.C|testVirtualCFG_CXX_test2009_38\.C|testStaticCFG_Cxx_test2009_38\.C|testInterproceduralCFG_Cxx_test2009_38\.C)$'`

Requested regression check:
- `ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`

Git hook / pre-push validation:
- pre-push hook command completed successfully (`100% tests passed, 0 tests failed out of 6578`)

Closes #293.
