### PR TITLE
Fix issue #389 C++20 concept translation

### DIFF
--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
@@ -77,6 +77,86 @@ SgTryStmt *getFunctionTryStmt(SgFunctionDefinition *definition) {
   return try_stmt;
 }
 
+std::string trimRequiresClauseText(const std::string &text) {
+  size_t begin = 0;
+  while (begin < text.size() &&
+         std::isspace(static_cast<unsigned char>(text[begin]))) {
+    ++begin;
+  }
+
+  size_t end = text.size();
+  while (end > begin &&
+         std::isspace(static_cast<unsigned char>(text[end - 1]))) {
+    --end;
+  }
+
+  return text.substr(begin, end - begin);
+}
+
+void unparseRequiresClauseExpression(Unparse_ExprStmt *expr_unparser,
+                                     SgExpression *requires_clause,
+                                     SgUnparse_Info &info);
+
+bool isParenthesizedRequiresClauseText(const std::string &text) {
+  std::string trimmed = trimRequiresClauseText(text);
+  if (trimmed.size() < 2 || trimmed.front() != '(' || trimmed.back() != ')') {
+    return false;
+  }
+
+  int depth = 0;
+  for (size_t i = 0; i < trimmed.size(); ++i) {
+    if (trimmed[i] == '(') {
+      ++depth;
+    } else if (trimmed[i] == ')') {
+      --depth;
+      if (depth == 0 && i + 1 != trimmed.size()) {
+        return false;
+      }
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+
+  return depth == 0;
+}
+
+void unparseTrailingRequiresClauseIfPresent(
+    Unparse_ExprStmt *expr_unparser, SgFunctionDeclaration *funcdecl_stmt,
+    SgUnparse_Info &info) {
+  ASSERT_not_null(expr_unparser);
+  ASSERT_not_null(funcdecl_stmt);
+
+  if (SgExpression *requires_clause =
+          funcdecl_stmt->get_trailingRequiresClause()) {
+    SgUnparse_Info rinfo(info);
+    rinfo.set_SkipClassDefinition();
+    rinfo.set_SkipEnumDefinition();
+    expr_unparser->curprint(" requires ");
+    unparseRequiresClauseExpression(expr_unparser, requires_clause, rinfo);
+  }
+}
+
+void unparseRequiresClauseExpression(Unparse_ExprStmt *expr_unparser,
+                                     SgExpression *requires_clause,
+                                     SgUnparse_Info &info) {
+  ASSERT_not_null(expr_unparser);
+  ASSERT_not_null(requires_clause);
+
+  bool needs_grouping = true;
+  if (SgRequiresExpr *req = isSgRequiresExpr(requires_clause)) {
+    needs_grouping =
+        !isParenthesizedRequiresClauseText(req->get_expressionString());
+  }
+  if (needs_grouping) {
+    expr_unparser->curprint("(");
+  }
+  expr_unparser->unparseExpression(requires_clause, info);
+  if (needs_grouping) {
+    expr_unparser->curprint(")");
+  }
+}
+
 bool requiresTrailingReturnTypeSyntax(const SgType *return_type) {
   const SgDeclType *decl_type = isSgDeclType(return_type);
   if (decl_type == NULL) {
@@ -4336,14 +4416,7 @@ void Unparse_ExprStmt::unparseFuncDeclStmt(SgStatement *stmt,
       curprint(string("\")"));
     }
 
-    if (SgExpression *requires_clause =
-            funcdecl_stmt->get_trailingRequiresClause()) {
-      SgUnparse_Info rinfo(info);
-      rinfo.set_SkipClassDefinition();
-      rinfo.set_SkipEnumDefinition();
-      curprint(" requires ");
-      unparseExpression(requires_clause, rinfo);
-    }
+    unparseTrailingRequiresClauseIfPresent(this, funcdecl_stmt, info);
 
     const bool is_function_try_block =
         info.SkipFunctionDefinition() && !funcdecl_stmt->isForward() &&
@@ -5195,7 +5268,7 @@ void Unparse_ExprStmt::unparseTrailingFunctionModifiers(
     rinfo.set_SkipClassDefinition();
     rinfo.set_SkipEnumDefinition();
     curprint(" requires ");
-    unparseExpression(requires_clause, rinfo);
+    unparseRequiresClauseExpression(this, requires_clause, rinfo);
   }
 
   // if (mfuncdecl_stmt->isPure())
@@ -8214,9 +8287,15 @@ void Unparse_ExprStmt::unparseTemplateHeader(T *decl, SgUnparse_Info &info) {
   printf("In unparseTemplateHeader(decl = %p = %s) \n", decl,
          decl->class_name().c_str());
 #endif
-  if (!decl->get_templateParameters().empty()) {
+  SgTemplateParameterPtrList tlist;
+  for (SgTemplateParameter *param : decl->get_templateParameters()) {
+    if (!SageInterface::isAbbreviatedFunctionTemplateParameter(param)) {
+      tlist.push_back(param);
+    }
+  }
+
+  if (!tlist.empty()) {
     curprint("template ");
-    SgTemplateParameterPtrList tlist = decl->get_templateParameters();
     SgUnparse_Info tinfo(info);
     tinfo.set_declstatement_ptr(NULL);
     tinfo.set_declstatement_ptr(decl);
@@ -8226,7 +8305,7 @@ void Unparse_ExprStmt::unparseTemplateHeader(T *decl, SgUnparse_Info &info) {
       SgUnparse_Info rinfo(info);
       rinfo.set_SkipClassDefinition();
       rinfo.set_SkipEnumDefinition();
-      unparseExpression(requires_clause, rinfo);
+      unparseRequiresClauseExpression(this, requires_clause, rinfo);
       curprint(" ");
     }
     curprint("\n");
@@ -8454,6 +8533,9 @@ void Unparse_ExprStmt::unparseTemplateDeclarationStatment_support(
       if (templateMemberFunctionDeclaration != NULL) {
         unparseTrailingFunctionModifiers(templateMemberFunctionDeclaration,
                                          ninfo);
+      } else {
+        unparseTrailingRequiresClauseIfPresent(this, functionDeclaration,
+                                               ninfo);
       }
 
       SgFunctionDefinition *functionDefn =

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -3240,6 +3240,11 @@ void Unparse_Type::unparseAutoType(SgType *type, SgUnparse_Info &info) {
   bool unparse_type = info.isTypeFirstPart() ||
                       (!info.isTypeFirstPart() && !info.isTypeSecondPart());
   if (unparse_type) {
+    std::string constraint = SageInterface::getAutoTypeConstraint(auto_type);
+    if (!constraint.empty()) {
+      curprint(constraint);
+      curprint(" ");
+    }
     curprint("auto ");
   }
 }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-decl.cpp
@@ -69,6 +69,16 @@ std::string normalizeOperatorFunctionName(std::string name) {
   return name;
 }
 
+bool typeLocContainsAutoType(clang::TypeLoc type_loc) {
+  for (clang::TypeLoc current = type_loc; !current.isNull();
+       current = current.getNextTypeLoc()) {
+    if (current.getAs<clang::AutoTypeLoc>()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const clang::TemplateParameterList *
 templateParametersForDeclContext(const clang::DeclContext *context) {
   const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(context);
@@ -478,12 +488,6 @@ static std::string trimWhitespace(std::string s) {
 static std::string
 normalizedTemplateTypeParamName(const clang::TemplateTypeParmDecl *param_decl) {
   if (param_decl == nullptr) {
-    return std::string();
-  }
-  if (param_decl->isImplicit() && isImplicitAutoPlaceholderTemplateParamName(
-                                      param_decl->getNameAsString())) {
-    // Clang uses synthetic names like "x:auto" for abbreviated-template
-    // placeholders. These are not valid identifiers in template headers.
     return std::string();
   }
   return normalizeClangTemplateParamName(param_decl->getNameAsString());
@@ -4989,6 +4993,14 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
     return std::string();
   };
 
+  bool is_abbreviated_placeholder_param = false;
+  if (clang::TemplateTypeParmDecl *type_param =
+          llvm::dyn_cast<clang::TemplateTypeParmDecl>(param_decl)) {
+    is_abbreviated_placeholder_param =
+        type_param->isImplicit() && isImplicitAutoPlaceholderTemplateParamName(
+                                        type_param->getNameAsString());
+  }
+
   auto should_reuse_mapped_template_param =
       [&](SgTemplateParameter *mapped_param) -> bool {
     if (mapped_param == nullptr) {
@@ -5029,6 +5041,10 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
 #endif
     if (SgTemplateParameter *mapped_param = isSgTemplateParameter(it->second)) {
       if (should_reuse_mapped_template_param(mapped_param)) {
+        if (is_abbreviated_placeholder_param) {
+          SageInterface::setAbbreviatedFunctionTemplateParameter(mapped_param,
+                                                                 true);
+        }
         return mapped_param;
       }
     }
@@ -5043,6 +5059,10 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
         if (SgTemplateParameter *mapped_param =
                 isSgTemplateParameter(canonical_it->second)) {
           if (should_reuse_mapped_template_param(mapped_param)) {
+            if (is_abbreviated_placeholder_param) {
+              SageInterface::setAbbreviatedFunctionTemplateParameter(
+                  mapped_param, true);
+            }
             p_decl_translation_map[param_decl] = canonical_it->second;
             return mapped_param;
           }
@@ -5082,6 +5102,218 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
     return nullptr;
   };
 
+  auto translate_type_constraint_text =
+      [&](const std::string &text, clang::SourceRange range) -> SgExpression * {
+    if (!text.empty()) {
+      SgRequiresExpr *req = SageBuilder::buildRequiresExpr_nfi(text);
+      applySourceRange(req, range);
+      return req;
+    }
+    if (range.isValid()) {
+      std::string source_text = trimWhitespace(getSourceText(range));
+      if (!source_text.empty()) {
+        SgRequiresExpr *req = SageBuilder::buildRequiresExpr_nfi(source_text);
+        applySourceRange(req, range);
+        return req;
+      }
+    }
+    return nullptr;
+  };
+
+  auto concept_reference_range =
+      [&](clang::NestedNameSpecifierLoc nested,
+          clang::SourceLocation concept_name_loc,
+          bool has_explicit_template_args,
+          const clang::ASTTemplateArgumentListInfo *args)
+      -> clang::SourceRange {
+    clang::SourceLocation begin = concept_name_loc;
+    if (nested) {
+      begin = nested.getBeginLoc();
+    }
+
+    clang::SourceLocation end = concept_name_loc;
+    if (has_explicit_template_args && args != nullptr &&
+        args->getLAngleLoc().isValid() && args->getRAngleLoc().isValid()) {
+      end = args->getRAngleLoc();
+    }
+
+    return clang::SourceRange(begin, end);
+  };
+
+  auto translate_type_constraint_concept_reference =
+      [&](clang::NestedNameSpecifierLoc nested,
+          clang::SourceLocation concept_name_loc,
+          const std::string &concept_name, bool has_explicit_template_args,
+          const clang::ASTTemplateArgumentListInfo *args) -> SgExpression * {
+    clang::SourceRange range = concept_reference_range(
+        nested, concept_name_loc, has_explicit_template_args, args);
+
+    std::string text;
+    if (range.isValid()) {
+      text = trimWhitespace(getSourceText(range));
+    }
+    if (text.empty()) {
+      if (nested) {
+        text += getSourceText(nested.getSourceRange());
+      }
+      text += concept_name;
+      if (has_explicit_template_args && args != nullptr &&
+          args->getLAngleLoc().isValid() && args->getRAngleLoc().isValid()) {
+        text += getSourceText(
+            clang::SourceRange(args->getLAngleLoc(), args->getRAngleLoc()));
+      }
+      text = trimWhitespace(text);
+    }
+
+    return translate_type_constraint_text(text, range);
+  };
+
+  auto extract_spelled_type_constraint_text =
+      [&](clang::NamedDecl *decl) -> std::string {
+    if (decl == nullptr) {
+      return std::string();
+    }
+
+    std::string text = trimWhitespace(getSourceText(decl->getSourceRange()));
+    if (text.empty()) {
+      return text;
+    }
+
+    auto trim_right = [](std::string &value) {
+      while (!value.empty() &&
+             std::isspace(static_cast<unsigned char>(value.back()))) {
+        value.pop_back();
+      }
+    };
+
+    auto strip_suffix_token = [&](std::string &value,
+                                  const std::string &token) -> bool {
+      trim_right(value);
+      if (token.empty() || value.size() < token.size() ||
+          value.compare(value.size() - token.size(), token.size(), token) !=
+              0) {
+        return false;
+      }
+      size_t prefix_size = value.size() - token.size();
+      if (prefix_size != 0) {
+        unsigned char before =
+            static_cast<unsigned char>(value[prefix_size - 1]);
+        if (std::isalnum(before) || before == '_') {
+          return false;
+        }
+      }
+      value.erase(prefix_size);
+      trim_right(value);
+      return true;
+    };
+
+    auto strip_trailing_pack_ellipsis = [&](std::string &value) {
+      trim_right(value);
+      if (value.size() >= 3 && value.compare(value.size() - 3, 3, "...") == 0) {
+        value.erase(value.size() - 3);
+        trim_right(value);
+      }
+    };
+
+    std::string raw_name = decl->getNameAsString();
+    if (!raw_name.empty() &&
+        !isImplicitAutoPlaceholderTemplateParamName(raw_name)) {
+      strip_suffix_token(text, raw_name);
+    } else {
+      strip_suffix_token(text, "auto");
+    }
+    strip_trailing_pack_ellipsis(text);
+    return trimWhitespace(text);
+  };
+
+  auto translate_type_constraint =
+      [&](const clang::TypeConstraint *constraint,
+          const clang::Expr *fallback_expr) -> SgExpression * {
+    auto print_constraint_text =
+        [&](auto *concept_ref, clang::SourceRange range) -> SgExpression * {
+      if (concept_ref == nullptr) {
+        return nullptr;
+      }
+
+      clang::PrintingPolicy policy =
+          p_compiler_instance != nullptr
+              ? p_compiler_instance->getASTContext().getPrintingPolicy()
+              : clang::PrintingPolicy(clang::LangOptions());
+      std::string printed_text;
+      llvm::raw_string_ostream os(printed_text);
+      concept_ref->print(os, policy);
+      os.flush();
+      return translate_type_constraint_text(trimWhitespace(printed_text),
+                                            range);
+    };
+
+    if (constraint != nullptr) {
+      const clang::ASTTemplateArgumentListInfo *written_args =
+          constraint->getTemplateArgsAsWritten();
+      const bool has_explicit_template_args =
+          written_args != nullptr && written_args->getLAngleLoc().isValid() &&
+          written_args->getRAngleLoc().isValid();
+      const clang::ASTTemplateArgumentListInfo *args =
+          has_explicit_template_args ? written_args : nullptr;
+      clang::SourceRange range = concept_reference_range(
+          constraint->getNestedNameSpecifierLoc(),
+          constraint->getConceptNameLoc(), has_explicit_template_args, args);
+      if (SgExpression *sg_constraint =
+              translate_type_constraint_concept_reference(
+                  constraint->getNestedNameSpecifierLoc(),
+                  constraint->getConceptNameLoc(),
+                  constraint->getNamedConcept() != nullptr
+                      ? constraint->getNamedConcept()->getNameAsString()
+                      : std::string(),
+                  has_explicit_template_args, args)) {
+        return sg_constraint;
+      }
+      if (SgExpression *sg_constraint =
+              print_constraint_text(constraint, range)) {
+        return sg_constraint;
+      }
+    }
+
+    if (const auto *concept_expr =
+            llvm::dyn_cast_or_null<clang::ConceptSpecializationExpr>(
+                fallback_expr)) {
+      const clang::ASTTemplateArgumentListInfo *written_args =
+          concept_expr->getTemplateArgsAsWritten();
+      const bool has_explicit_template_args =
+          written_args != nullptr && written_args->getLAngleLoc().isValid() &&
+          written_args->getRAngleLoc().isValid();
+      const clang::ASTTemplateArgumentListInfo *args =
+          has_explicit_template_args ? written_args : nullptr;
+      clang::SourceRange range = concept_reference_range(
+          concept_expr->getNestedNameSpecifierLoc(),
+          concept_expr->getConceptNameLoc(), has_explicit_template_args, args);
+      if (SgExpression *sg_constraint =
+              translate_type_constraint_concept_reference(
+                  concept_expr->getNestedNameSpecifierLoc(),
+                  concept_expr->getConceptNameLoc(),
+                  concept_expr->getNamedConcept() != nullptr
+                      ? concept_expr->getNamedConcept()->getNameAsString()
+                      : std::string(),
+                  has_explicit_template_args, args)) {
+        return sg_constraint;
+      }
+      if (SgExpression *sg_constraint = print_constraint_text(
+              concept_expr->getConceptReference(), range)) {
+        return sg_constraint;
+      }
+    }
+
+    if (fallback_expr != nullptr) {
+      if (SgExpression *sg_constraint = translate_type_constraint_text(
+              trimWhitespace(getSourceText(fallback_expr->getSourceRange())),
+              fallback_expr->getSourceRange())) {
+        return sg_constraint;
+      }
+    }
+
+    return nullptr;
+  };
+
   if (clang::TemplateTypeParmDecl *type_param =
           llvm::dyn_cast<clang::TemplateTypeParmDecl>(param_decl)) {
     std::string name_str;
@@ -5115,6 +5347,10 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
     std::string kw =
         type_param->wasDeclaredWithTypename() ? "typename" : "class";
     SageInterface::setTemplateParameterKeyword(sg_param, kw);
+    SageInterface::setAbbreviatedFunctionTemplateParameter(
+        sg_param,
+        type_param->isImplicit() && isImplicitAutoPlaceholderTemplateParamName(
+                                        type_param->getNameAsString()));
 
     if (type_param->hasDefaultArgument()) {
       const clang::TemplateArgumentLoc &default_loc =
@@ -5198,8 +5434,14 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
       const clang::TypeConstraint *constraint = type_param->getTypeConstraint();
       const clang::Expr *constraint_expr =
           constraint ? constraint->getImmediatelyDeclaredConstraint() : nullptr;
-      if (SgExpression *sg_constraint =
-              translateConstraintExpression(constraint_expr)) {
+      std::string spelled_constraint_text =
+          extract_spelled_type_constraint_text(type_param);
+      if (SgExpression *sg_constraint = translate_type_constraint_text(
+              spelled_constraint_text, type_param->getSourceRange())) {
+        sg_param->set_typeConstraint(sg_constraint);
+        sg_constraint->set_parent(sg_param);
+      } else if (SgExpression *sg_constraint =
+                     translate_type_constraint(constraint, constraint_expr)) {
         sg_param->set_typeConstraint(sg_constraint);
         sg_constraint->set_parent(sg_param);
       }
@@ -5335,8 +5577,14 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
 
     if (const clang::Expr *constraint_expr =
             non_type_param->getPlaceholderTypeConstraint()) {
-      if (SgExpression *sg_constraint =
-              translateConstraintExpression(constraint_expr)) {
+      std::string spelled_constraint_text =
+          extract_spelled_type_constraint_text(non_type_param);
+      if (SgExpression *sg_constraint = translate_type_constraint_text(
+              spelled_constraint_text, non_type_param->getSourceRange())) {
+        sg_param->set_typeConstraint(sg_constraint);
+        sg_constraint->set_parent(sg_param);
+      } else if (SgExpression *sg_constraint =
+                     translate_type_constraint(nullptr, constraint_expr)) {
         sg_param->set_typeConstraint(sg_constraint);
         sg_constraint->set_parent(sg_param);
       }
@@ -7978,6 +8226,7 @@ bool ClangToSageTranslator::VisitTemplateDecl(
   template_stmt->set_template_kind(template_kind);
 
   applySourceRange(template_stmt, template_decl->getSourceRange());
+  template_stmt->set_unparse_template_ast(true);
   suppress_unparse_output(template_stmt);
 
   SageBuilder::getOrCreateNonrealDeclarationScope(template_stmt);
@@ -18342,6 +18591,33 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
     args_for_builder = &explicit_specialization_args;
   }
+
+  auto propagate_template_parameter_metadata =
+      [&](const SgTemplateParameterPtrList *source_params,
+          SgTemplateParameterPtrList &target_params) {
+        if (source_params == nullptr) {
+          return;
+        }
+        size_t limit = std::min(source_params->size(), target_params.size());
+        for (size_t i = 0; i < limit; ++i) {
+          SgTemplateParameter *source_param = (*source_params)[i];
+          SgTemplateParameter *target_param = target_params[i];
+          if (source_param == nullptr || target_param == nullptr) {
+            continue;
+          }
+
+          std::string keyword =
+              SageInterface::getTemplateParameterKeyword(source_param);
+          if (!keyword.empty()) {
+            SageInterface::setTemplateParameterKeyword(target_param, keyword);
+          }
+          if (SageInterface::isAbbreviatedFunctionTemplateParameter(
+                  source_param)) {
+            SageInterface::setAbbreviatedFunctionTemplateParameter(target_param,
+                                                                   true);
+          }
+        }
+      };
   unsigned int functionConstVolatileFlags = 0;
   if (isMethodDecl) {
     auto *method_decl = llvm::cast<clang::CXXMethodDecl>(function_decl);
@@ -19450,6 +19726,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                   name, ret_type, first_param_list, builder_scope,
                   functionConstVolatileFlags, effective_template_params);
           ROSE_ASSERT(first_nondef != nullptr);
+          propagate_template_parameter_metadata(
+              effective_template_params,
+              first_nondef->get_templateParameters());
 
           applySourceRange(first_nondef, function_decl->getSourceRange());
           first_param_list->set_parent(first_nondef);
@@ -19521,6 +19800,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           defining_template->get_templateParameters() =
               adjusted_template_params;
         }
+        propagate_template_parameter_metadata(
+            effective_template_params,
+            defining_template->get_templateParameters());
 
         sg_function_decl = defining_template;
         sg_function_decl->set_definingDeclaration(sg_function_decl);
@@ -19584,6 +19866,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                   name, ret_type, first_param_list, builder_scope,
                   templateParams.get());
           ROSE_ASSERT(first_nondef != nullptr);
+          propagate_template_parameter_metadata(
+              templateParams.get(), first_nondef->get_templateParameters());
 
           applySourceRange(first_nondef, function_decl->getSourceRange());
           first_param_list->set_parent(first_nondef);
@@ -19633,6 +19917,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         SgTemplateFunctionDeclaration *defining_template =
             SageBuilder::buildDefiningTemplateFunctionDeclaration(
                 name, ret_type, param_list, target_scope, first_nondef);
+        propagate_template_parameter_metadata(
+            templateParams.get(), defining_template->get_templateParameters());
 
         sg_function_decl = defining_template;
         sg_function_decl->set_definingDeclaration(sg_function_decl);
@@ -20029,6 +20315,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             SageBuilder::buildNondefiningTemplateMemberFunctionDeclaration(
                 name, ret_type, param_list, scope_for_symbol_table,
                 functionConstVolatileFlags, templateParams.get());
+        propagate_template_parameter_metadata(
+            templateParams.get(),
+            isSgTemplateMemberFunctionDeclaration(sg_function_decl)
+                ->get_templateParameters());
         param_list->set_parent(sg_function_decl);
         sg_function_decl->set_parameterList(param_list);
       } else {
@@ -20036,6 +20326,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             SageBuilder::buildNondefiningTemplateFunctionDeclaration(
                 name, ret_type, param_list, scope_for_symbol_table,
                 templateParams.get());
+        propagate_template_parameter_metadata(
+            templateParams.get(),
+            isSgTemplateFunctionDeclaration(sg_function_decl)
+                ->get_templateParameters());
 
         // Set parameter list parent
         param_list->set_parent(sg_function_decl);
@@ -20069,17 +20363,16 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       if (!built_template_member_pattern &&
           function_decl->getTemplateSpecializationKind() ==
               clang::TSK_ExplicitSpecialization) {
-        SgTemplateArgumentPtrList empty_template_args;
         if (llvm::isa<clang::CXXMethodDecl>(function_decl)) {
           sg_function_decl =
               SageBuilder::buildNondefiningMemberFunctionDeclaration(
                   name, ret_type, param_list, scope_for_symbol_table,
                   functionConstVolatileFlags,
-                  /*buildTemplateInstantiation=*/true, &empty_template_args);
+                  /*buildTemplateInstantiation=*/true, args_for_builder);
         } else {
           sg_function_decl = SageBuilder::buildNondefiningFunctionDeclaration(
               name, ret_type, param_list, scope_for_symbol_table,
-              /*buildTemplateInstantiation=*/true, &empty_template_args,
+              /*buildTemplateInstantiation=*/true, args_for_builder,
               SgStorageModifier::e_default, isFriendFreeFunction);
         }
 
@@ -20089,7 +20382,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           inst_func->set_specialization(
               SgDeclarationStatement::e_specialization);
           SageBuilder::setTemplateArgumentsInDeclaration(inst_func,
-                                                         &empty_template_args);
+                                                         args_for_builder);
           if (function_decl->getPrimaryTemplate() != nullptr) {
             if (SgNode *tmpl_node =
                     Traverse(function_decl->getPrimaryTemplate())) {
@@ -20108,7 +20401,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           inst_member->set_specialization(
               SgDeclarationStatement::e_specialization);
           SageBuilder::setTemplateArgumentsInDeclaration(inst_member,
-                                                         &empty_template_args);
+                                                         args_for_builder);
           if (!has_function_template) {
             inst_member->get_templateArguments().clear();
             inst_member->set_templateName(name);
@@ -21055,6 +21348,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   }
 
+  if (function_decl->getLiteralIdentifier() != nullptr) {
+    sg_function_decl->get_specialFunctionModifier().setUldOperator();
+    if (SgFunctionDeclaration *first_nondef = isSgFunctionDeclaration(
+            sg_function_decl->get_firstNondefiningDeclaration())) {
+      first_nondef->get_specialFunctionModifier().setUldOperator();
+    }
+  }
+
   // Many SageBuilder "defining" builders create an associated non-defining
   // declaration even when no such declaration exists in the source (notably for
   // in-class definitions). In C++, an in-class member function definition
@@ -21629,6 +21930,80 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     return isSgExpression(SageInterface::deepCopy(expr));
   };
 
+  auto reapply_translated_template_parameters =
+      [&](SgDeclarationStatement *decl, bool keep_defaults) {
+        if (decl == nullptr || templateParams == nullptr) {
+          return;
+        }
+        if (isSgTemplateFunctionDeclaration(decl) == nullptr &&
+            isSgTemplateMemberFunctionDeclaration(decl) == nullptr) {
+          return;
+        }
+
+        SgTemplateParameterPtrList copied_params;
+        copied_params.reserve(templateParams->size());
+        for (SgTemplateParameter *param : *templateParams) {
+          if (param == nullptr) {
+            continue;
+          }
+
+          SgTemplateParameter *param_copy =
+              isSgTemplateParameter(SageInterface::deepCopy(param));
+          if (param_copy == nullptr) {
+            continue;
+          }
+
+          if (!keep_defaults) {
+            param_copy->set_defaultTypeParameter(nullptr);
+            param_copy->set_defaultExpressionParameter(nullptr);
+            param_copy->set_defaultTemplateDeclarationParameter(nullptr);
+          }
+
+          param_copy->set_parent(decl);
+          if (param_copy->get_parameterType() !=
+              SgTemplateParameter::template_parameter) {
+            param_copy->set_templateDeclaration(decl);
+          }
+          if (SgInitializedName *init_name =
+                  param_copy->get_initializedName()) {
+            init_name->set_parent(param_copy);
+          }
+          if (SgExpression *constraint = param_copy->get_typeConstraint()) {
+            constraint->set_parent(param_copy);
+          }
+          if (SgExpression *default_expr =
+                  param_copy->get_defaultExpressionParameter()) {
+            default_expr->set_parent(param_copy);
+          }
+
+          copied_params.push_back(param_copy);
+        }
+
+        SageBuilder::setTemplateParametersInDeclaration(decl, &copied_params);
+        attach_nonreal_template_parameters(
+            decl, *SageBuilder::getTemplateParameterList(decl));
+      };
+
+  if (templateDecl != nullptr && templateParams != nullptr) {
+    SgFunctionDeclaration *first_nondef = isSgFunctionDeclaration(
+        sg_function_decl->get_firstNondefiningDeclaration());
+    SgFunctionDeclaration *def_decl =
+        isSgFunctionDeclaration(sg_function_decl->get_definingDeclaration());
+
+    if (first_nondef != nullptr) {
+      reapply_translated_template_parameters(first_nondef, true);
+    }
+    if (def_decl != nullptr && def_decl != first_nondef) {
+      reapply_translated_template_parameters(def_decl, false);
+    }
+    if (sg_function_decl != first_nondef && sg_function_decl != def_decl) {
+      reapply_translated_template_parameters(
+          sg_function_decl,
+          sg_function_decl->get_firstNondefiningDeclaration() ==
+              sg_function_decl);
+    }
+  }
+
   if (templateDecl != nullptr) {
     if (clang::TemplateParameterList *params =
             templateDecl->getTemplateParameters()) {
@@ -21706,6 +22081,31 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         }
       }
     }
+  }
+
+  auto enable_template_ast_unparse = [](SgFunctionDeclaration *decl) {
+    if (decl == nullptr) {
+      return;
+    }
+    if (SgTemplateFunctionDeclaration *tmpl_func =
+            isSgTemplateFunctionDeclaration(decl)) {
+      tmpl_func->set_unparse_template_ast(true);
+      return;
+    }
+    if (SgTemplateMemberFunctionDeclaration *tmpl_member =
+            isSgTemplateMemberFunctionDeclaration(decl)) {
+      tmpl_member->set_unparse_template_ast(true);
+    }
+  };
+
+  enable_template_ast_unparse(sg_function_decl);
+  if (SgFunctionDeclaration *first_nondef = isSgFunctionDeclaration(
+          sg_function_decl->get_firstNondefiningDeclaration())) {
+    enable_template_ast_unparse(first_nondef);
+  }
+  if (SgFunctionDeclaration *def_decl = isSgFunctionDeclaration(
+          sg_function_decl->get_definingDeclaration())) {
+    enable_template_ast_unparse(def_decl);
   }
 
   if (SgTemplateFunctionDeclaration *tmpl_func =
@@ -23188,9 +23588,10 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
   }
 
   SgType *type = nullptr;
-  if (preserve_type_as_written) {
-    if (clang::TypeSourceInfo *type_info =
-            param_var_decl->getTypeSourceInfo()) {
+  if (clang::TypeSourceInfo *type_info = param_var_decl->getTypeSourceInfo()) {
+    bool preserve_placeholder_type_as_written =
+        typeLocContainsAutoType(type_info->getTypeLoc());
+    if (preserve_type_as_written || preserve_placeholder_type_as_written) {
       type = buildTypeFromTypeLoc(type_info->getTypeLoc());
     }
   }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-private.hpp
@@ -63,7 +63,18 @@ inline constexpr char kExplicitGlobalQualifierAttributeName[] =
 
 inline bool
 isImplicitAutoPlaceholderTemplateParamName(const std::string &name) {
-  return name.size() >= 5 && name.compare(name.size() - 5, 5, ":auto") == 0;
+  if (name.size() >= 5 && name.compare(name.size() - 5, 5, ":auto") == 0) {
+    return true;
+  }
+  if (name.rfind("auto:", 0) == 0 && name.size() > 5) {
+    for (size_t i = 5; i < name.size(); ++i) {
+      if (!std::isdigit(static_cast<unsigned char>(name[i]))) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 inline bool isClangSyntheticTemplateParamName(const std::string &name) {
@@ -94,6 +105,10 @@ inline bool isClangSyntheticTemplateParamName(const std::string &name) {
 }
 
 inline std::string normalizeClangTemplateParamName(std::string name) {
+  if (isImplicitAutoPlaceholderTemplateParamName(name)) {
+    std::replace(name.begin(), name.end(), ':', '_');
+    return name;
+  }
   if (isClangSyntheticTemplateParamName(name)) {
     std::replace(name.begin(), name.end(), '-', '_');
   }

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -6618,9 +6618,11 @@ bool ClangToSageTranslator::VisitUserDefinedLiteral(
 #endif
   bool res = true;
 
-  // TODO
-
-  return VisitExpr(user_defined_literal, node) && res;
+  // User-defined literals are CallExpr subclasses whose callee/arguments carry
+  // the full semantic structure. Translating them through the regular CallExpr
+  // path preserves both builtin and library literal operators (e.g. "abc"s)
+  // without inventing a parallel ROSE node kind.
+  return VisitCallExpr(user_defined_literal, node) && res;
 }
 
 bool ClangToSageTranslator::VisitCastExpr(clang::CastExpr *cast_expr,
@@ -7229,16 +7231,13 @@ bool ClangToSageTranslator::VisitConceptSpecializationExpr(
   bool res = true;
 
   SgTemplateArgumentPtrList template_args;
-  if (const clang::ASTTemplateArgumentListInfo *args_written =
-          concept_specialization_expr->getTemplateArgsAsWritten()) {
+  const clang::ASTTemplateArgumentListInfo *args_written =
+      concept_specialization_expr->getTemplateArgsAsWritten();
+  if (args_written != nullptr && args_written->getLAngleLoc().isValid() &&
+      args_written->getRAngleLoc().isValid()) {
     for (const clang::TemplateArgumentLoc &arg_loc :
          args_written->arguments()) {
       appendTemplateArguments(template_args, arg_loc, true);
-    }
-  } else {
-    for (const clang::TemplateArgument &arg :
-         concept_specialization_expr->getTemplateArguments()) {
-      appendTemplateArguments(template_args, arg, false);
     }
   }
 

--- a/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-type.cpp
@@ -1278,6 +1278,128 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
 
   const bool enable_default_template_args = false;
 
+  auto build_auto_type_constraint_text =
+      [&](clang::AutoTypeLoc auto_loc) -> std::string {
+    if (!auto_loc.isConstrained()) {
+      return std::string();
+    }
+
+    clang::SourceLocation begin = auto_loc.getConceptNameLoc();
+    if (clang::NestedNameSpecifierLoc nested =
+            auto_loc.getNestedNameSpecifierLoc()) {
+      begin = nested.getBeginLoc();
+    }
+
+    clang::SourceLocation end = auto_loc.getConceptNameLoc();
+    if (auto_loc.hasExplicitTemplateArgs() &&
+        auto_loc.getLAngleLoc().isValid() &&
+        auto_loc.getRAngleLoc().isValid()) {
+      end = auto_loc.getRAngleLoc();
+    }
+
+    std::string text;
+    if (begin.isValid() && end.isValid()) {
+      text = trimWhitespace(getSourceText(clang::SourceRange(begin, end)));
+    }
+
+    if (text.empty()) {
+      if (clang::ConceptReference *concept_ref =
+              auto_loc.getConceptReference()) {
+        clang::PrintingPolicy policy =
+            p_compiler_instance != nullptr
+                ? p_compiler_instance->getASTContext().getPrintingPolicy()
+                : clang::PrintingPolicy(clang::LangOptions());
+        llvm::raw_string_ostream os(text);
+        concept_ref->print(os, policy);
+        os.flush();
+        text = trimWhitespace(text);
+      }
+    }
+
+    if (text.empty()) {
+      if (clang::NestedNameSpecifierLoc nested =
+              auto_loc.getNestedNameSpecifierLoc()) {
+        text += getSourceText(nested.getSourceRange());
+      }
+      if (clang::ConceptDecl *concept_decl = auto_loc.getNamedConcept()) {
+        text += concept_decl->getNameAsString();
+      }
+      if (auto_loc.hasExplicitTemplateArgs() &&
+          auto_loc.getLAngleLoc().isValid() &&
+          auto_loc.getRAngleLoc().isValid()) {
+        text += getSourceText(clang::SourceRange(auto_loc.getLAngleLoc(),
+                                                 auto_loc.getRAngleLoc()));
+      }
+      text = trimWhitespace(text);
+    }
+
+    return text;
+  };
+
+  auto annotate_auto_type_constraints = [&](SgType *sg_type) {
+    if (sg_type == nullptr) {
+      return;
+    }
+
+    std::vector<SgAutoType *> auto_types;
+    auto collect_auto_types = [&](auto &&self, SgType *current) -> void {
+      if (current == nullptr) {
+        return;
+      }
+      if (SgAutoType *auto_type = isSgAutoType(current)) {
+        auto_types.push_back(auto_type);
+        return;
+      }
+      if (SgModifierType *modifier_type = isSgModifierType(current)) {
+        self(self, modifier_type->get_base_type());
+        return;
+      }
+      if (SgPointerType *pointer_type = isSgPointerType(current)) {
+        self(self, pointer_type->get_base_type());
+        return;
+      }
+      if (SgPointerMemberType *pointer_member_type =
+              isSgPointerMemberType(current)) {
+        self(self, pointer_member_type->get_base_type());
+        return;
+      }
+      if (SgReferenceType *reference_type = isSgReferenceType(current)) {
+        self(self, reference_type->get_base_type());
+        return;
+      }
+      if (SgRvalueReferenceType *rvalue_reference_type =
+              isSgRvalueReferenceType(current)) {
+        self(self, rvalue_reference_type->get_base_type());
+        return;
+      }
+      if (SgArrayType *array_type = isSgArrayType(current)) {
+        self(self, array_type->get_base_type());
+        return;
+      }
+      if (SgTypedefType *typedef_type = isSgTypedefType(current)) {
+        self(self, typedef_type->get_base_type());
+        return;
+      }
+    };
+
+    collect_auto_types(collect_auto_types, sg_type);
+    if (auto_types.empty()) {
+      return;
+    }
+
+    size_t auto_index = 0;
+    for (clang::TypeLoc current_loc = type_loc;
+         !current_loc.isNull() && auto_index < auto_types.size();
+         current_loc = current_loc.getNextTypeLoc()) {
+      if (clang::AutoTypeLoc auto_loc =
+              current_loc.getAs<clang::AutoTypeLoc>()) {
+        SageInterface::setAutoTypeConstraint(
+            auto_types[auto_index], build_auto_type_constraint_text(auto_loc));
+        ++auto_index;
+      }
+    }
+  };
+
   auto build_nonreal_template_type =
       [&](const std::string &base_name, clang::NestedNameSpecifier *qualifier,
           bool has_template_keyword, SgTemplateArgumentPtrList &tpl_args,
@@ -1571,7 +1693,9 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     }
   }
 
-  return buildTypeFromQualifiedType(type_loc.getType());
+  SgType *result = buildTypeFromQualifiedType(type_loc.getType());
+  annotate_auto_type_constraints(result);
+  return result;
 }
 
 SgNode *ClangToSageTranslator::Traverse(const clang::Type *type) {
@@ -2275,6 +2399,27 @@ bool ClangToSageTranslator::VisitAutoType(clang::AutoType *auto_type,
 
   // Represent C++ auto explicitly so we do not synthesize an opaque typedef.
   *node = SageBuilder::buildAutoType();
+  if (SgAutoType *sg_auto = isSgAutoType(*node)) {
+    if (auto_type->isConstrained()) {
+      std::string constraint_text;
+      if (clang::ConceptDecl *concept_decl =
+              auto_type->getTypeConstraintConcept()) {
+        constraint_text = concept_decl->getQualifiedNameAsString();
+        llvm::ArrayRef<clang::TemplateArgument> constraint_args =
+            auto_type->getTypeConstraintArguments();
+        if (!constraint_args.empty()) {
+          constraint_text += "<";
+          bool need_separator = false;
+          for (const clang::TemplateArgument &arg : constraint_args) {
+            appendTemplateInstantiationArg(constraint_text, need_separator,
+                                           arg);
+          }
+          constraint_text += ">";
+        }
+      }
+      SageInterface::setAutoTypeConstraint(sg_auto, constraint_text);
+    }
+  }
 
   return VisitDeducedType(auto_type, node) && res;
 }

--- a/src/frontend/CxxFrontend/Clang/clang-to-dot-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-to-dot-stmt.cpp
@@ -1922,9 +1922,7 @@ bool ClangToDotTranslator::VisitUserDefinedLiteral(
 
   node_desc.kind_hierarchy.push_back("UserDefinedLiteral");
 
-  // TODO
-
-  return VisitExpr(user_defined_literal, node_desc) && res;
+  return VisitCallExpr(user_defined_literal, node_desc) && res;
 }
 
 bool ClangToDotTranslator::VisitCastExpr(clang::CastExpr *cast_expr,

--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -171,18 +171,149 @@ typedef std::set<SgLabelStatement *> SgLabelStatementPtrSet;
 namespace SageInterface {
 ROSE_DLL_API Transformation_Record trans_records;
 
-// REX FIX: Global map for template parameter keywords
+class AutoTypeConstraintAttribute : public AstAttribute {
+public:
+  explicit AutoTypeConstraintAttribute(std::string constraint)
+      : constraint_(std::move(constraint)) {}
+
+  const std::string &constraint() const { return constraint_; }
+
+  AstAttribute *copy() const override {
+    return new AutoTypeConstraintAttribute(*this);
+  }
+
+  OwnershipPolicy getOwnershipPolicy() const override {
+    return CONTAINER_OWNERSHIP;
+  }
+
+  std::string toString() override { return constraint_; }
+
+private:
+  std::string constraint_;
+};
+
+static constexpr char kAutoTypeConstraintAttributeName[] =
+    "rex_auto_type_constraint";
+
+// REX FIX: Global maps for frontend-only template placeholder metadata.
 static std::map<SgTemplateParameter *, std::string> templateKeywordMap;
+static std::map<SgTemplateParameter *, bool>
+    abbreviatedFunctionTemplateParameterMap;
 
 void setTemplateParameterKeyword(SgTemplateParameter *param, std::string kw) {
   if (param) {
-    templateKeywordMap[param] = kw;
+    templateKeywordMap[param] = std::move(kw);
   }
 }
 
 std::string getTemplateParameterKeyword(SgTemplateParameter *param) {
   if (param && templateKeywordMap.find(param) != templateKeywordMap.end()) {
     return templateKeywordMap[param];
+  }
+  return "";
+}
+
+void setAbbreviatedFunctionTemplateParameter(SgTemplateParameter *param,
+                                             bool is_abbreviated_placeholder) {
+  if (param) {
+    abbreviatedFunctionTemplateParameterMap[param] = is_abbreviated_placeholder;
+  }
+}
+
+bool isAbbreviatedFunctionTemplateParameter(SgTemplateParameter *param) {
+  auto it = abbreviatedFunctionTemplateParameterMap.find(param);
+  if (it != abbreviatedFunctionTemplateParameterMap.end()) {
+    return it->second;
+  }
+  if (param == nullptr) {
+    return false;
+  }
+
+  auto looks_like_placeholder_name = [](const std::string &name) {
+    if (name.empty()) {
+      return false;
+    }
+    if (name.rfind("auto_", 0) == 0 && name.size() > 5) {
+      for (size_t i = 5; i < name.size(); ++i) {
+        if (!std::isdigit(static_cast<unsigned char>(name[i]))) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return name.size() > 5 && name.compare(name.size() - 5, 5, "_auto") == 0;
+  };
+
+  auto type_contains_auto = [&](auto &&self, SgType *type) -> bool {
+    if (type == nullptr) {
+      return false;
+    }
+    if (isSgAutoType(type) != nullptr) {
+      return true;
+    }
+    if (SgModifierType *modifier_type = isSgModifierType(type)) {
+      return self(self, modifier_type->get_base_type());
+    }
+    if (SgPointerType *pointer_type = isSgPointerType(type)) {
+      return self(self, pointer_type->get_base_type());
+    }
+    if (SgPointerMemberType *pointer_member_type =
+            isSgPointerMemberType(type)) {
+      return self(self, pointer_member_type->get_base_type());
+    }
+    if (SgReferenceType *reference_type = isSgReferenceType(type)) {
+      return self(self, reference_type->get_base_type());
+    }
+    if (SgRvalueReferenceType *rvalue_reference_type =
+            isSgRvalueReferenceType(type)) {
+      return self(self, rvalue_reference_type->get_base_type());
+    }
+    if (SgArrayType *array_type = isSgArrayType(type)) {
+      return self(self, array_type->get_base_type());
+    }
+    return false;
+  };
+
+  if (param->get_parameterType() == SgTemplateParameter::type_parameter) {
+    if (SgTemplateType *template_type = isSgTemplateType(param->get_type())) {
+      return looks_like_placeholder_name(template_type->get_name().getString());
+    }
+  }
+
+  if (param->get_parameterType() == SgTemplateParameter::nontype_parameter) {
+    if (SgInitializedName *init_name = param->get_initializedName()) {
+      std::string name = init_name->get_name().getString();
+      if (looks_like_placeholder_name(name) || name.empty()) {
+        return type_contains_auto(type_contains_auto, init_name->get_type());
+      }
+    }
+  }
+
+  return false;
+}
+
+void setAutoTypeConstraint(SgAutoType *type, std::string constraint) {
+  if (type == nullptr) {
+    return;
+  }
+  if (constraint.empty()) {
+    type->removeAttribute(kAutoTypeConstraintAttributeName);
+    return;
+  }
+  type->setAttribute(kAutoTypeConstraintAttributeName,
+                     new AutoTypeConstraintAttribute(std::move(constraint)));
+}
+
+std::string getAutoTypeConstraint(SgAutoType *type) {
+  if (type == nullptr) {
+    return "";
+  }
+  if (AstAttribute *attr =
+          type->getAttribute(kAutoTypeConstraintAttributeName)) {
+    if (auto *constraint_attr =
+            dynamic_cast<AutoTypeConstraintAttribute *>(attr)) {
+      return constraint_attr->constraint();
+    }
   }
   return "";
 }
@@ -10423,8 +10554,9 @@ SgStatement *SageInterface::findSurroundingStatementFromSameFile(
     printf("This is a special statement (not associated with the original "
            "source code, comment relocation is not supported for these "
            "statements) targetStmt file id = %d (physical file id = %d)\n",
-           targetStmt->get_file_info() ? targetStmt->get_file_info()->get_file_id()
-                                       : Sg_File_Info::BAD_FILE_ID,
+           targetStmt->get_file_info()
+               ? targetStmt->get_file_info()->get_file_id()
+               : Sg_File_Info::BAD_FILE_ID,
            targetStmt->get_file_info()
                ? targetStmt->get_file_info()->get_physical_file_id()
                : Sg_File_Info::BAD_FILE_ID);

--- a/src/frontend/SageIII/sageInterface/sageInterface.h
+++ b/src/frontend/SageIII/sageInterface/sageInterface.h
@@ -141,6 +141,14 @@ ROSE_DLL_API void setTemplateParameterKeyword(SgTemplateParameter *param,
                                               std::string kw);
 ROSE_DLL_API std::string
 getTemplateParameterKeyword(SgTemplateParameter *param);
+ROSE_DLL_API void
+setAbbreviatedFunctionTemplateParameter(SgTemplateParameter *param,
+                                        bool is_abbreviated_placeholder = true);
+ROSE_DLL_API bool
+isAbbreviatedFunctionTemplateParameter(SgTemplateParameter *param);
+ROSE_DLL_API void setAutoTypeConstraint(SgAutoType *type,
+                                        std::string constraint);
+ROSE_DLL_API std::string getAutoTypeConstraint(SgAutoType *type);
 
 //------------------------------------------------------------------------
 //@{

--- a/tests/nonsmoke/functional/CompileTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/CMakeLists.txt
@@ -25,6 +25,10 @@ function(compile_test input_file label)
     # Keep translating when Clang reports recoverable diagnostics for this input.
     list(APPEND _rose_flags "-rex:clang:continue-on-error")
   endif()
+  if(DEFINED ROSE_SKIP_FINAL_COMPILE_TESTCODES AND
+     input_file IN_LIST ROSE_SKIP_FINAL_COMPILE_TESTCODES)
+    list(APPEND _rose_flags "-rose:skipfinalCompileStep")
+  endif()
   if(DEFINED ROSE_OUTPUT_TO_BUILD_TESTCODES AND
      input_file IN_LIST ROSE_OUTPUT_TO_BUILD_TESTCODES)
     set(_output_dir "${ROSE_TEST_OUTPUT_DIR}")

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
@@ -145,28 +145,6 @@ set(CXX20_DISABLED_TESTCODES
   test2020_36.C
   test2020_38.C
   test2020_41.C
-  test2020_46.C
-  test2020_48.C
-  test2020_49.C
-  test2020_50.C
-  test2020_51.C
-  test2020_52.C
-  test2020_53.C
-  test2020_54.C
-  test2020_55.C
-  test2020_56.C
-  test2020_57.C
-  test2020_58.C
-  test2020_59.C
-  test2020_60.C
-  test2020_61.C
-  test2020_62.C
-  test2020_63.C
-  test2020_64.C
-  test2020_65.C
-  test2020_66.C
-  test2020_67.C
-  test2020_68.C
   test2020_75.C
   test2020_82.C
   test2020_99.C
@@ -176,6 +154,22 @@ set(CXX20_DISABLED_TESTCODES
 )
 set(CXX20_EXPECTED_FAIL_TESTCODES
   test2020_47.C
+)
+
+list(APPEND REX_FRONTEND_ERROR_TESTS
+  test2020_46.C
+  test2020_49.C
+  test2020_56.C
+  test2020_59.C
+  test2020_66.C
+)
+
+set(ROSE_SKIP_FINAL_COMPILE_TESTCODES
+  test2020_46.C
+  test2020_49.C
+  test2020_56.C
+  test2020_59.C
+  test2020_66.C
 )
 
 set(ROSE_FLAGS -w -rose:verbose 0 -std=c++20)

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/cxx20_concepts_test_support.hpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/cxx20_concepts_test_support.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+template <class T, class U>
+concept Same = std::same_as<T, U>;
+
+template <class T>
+concept EqualityComparable = std::equality_comparable<T>;
+
+template <class T>
+concept DefaultConstructible = std::default_initializable<T>;
+
+template <class T>
+concept CopyConstructible = std::copy_constructible<T>;
+
+template <class T>
+concept Destructible = std::destructible<T>;
+
+template <class T>
+concept CopyAssignable = std::assignable_from<T &, T>;
+
+template <class T>
+concept Incrementable = requires(T t) { ++t; };
+
+template <class T>
+concept Decrementable = requires(T t) { --t; };
+
+template <class T>
+concept Eq = requires(T a, T b) {
+  { a == b } -> std::convertible_to<bool>;
+};
+
+struct Base {};
+
+template <class> struct S;
+
+template <class>
+concept C1 = true;
+
+template <class>
+concept C3 = true;
+
+template <class>
+concept C4 = true;
+
+using std::size_t;

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_48.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_48.C
@@ -1,6 +1,7 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
 // concept
 template <class T, class U>
 concept Derived = std::is_base_of<U, T>::value;
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_50.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_50.C
@@ -1,23 +1,28 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<Incrementable T>
-void f(T) requires Decrementable<T>;
- 
-template<Incrementable T>
-void f(T) requires Decrementable<T>; // OK, redeclaration
- 
-template<typename T>
-    requires Incrementable<T> && Decrementable<T>
+template <Incrementable T>
+void f(T)
+  requires Decrementable<T>;
+
+template <Incrementable T>
+void f(T)
+  requires Decrementable<T>; // OK, redeclaration
+
+template <typename T>
+  requires Incrementable<T> && Decrementable<T>
 void f(T); // Ill-formed, no diagnostic required
- 
+
 // the following two declarations have different constraints:
 // the first declaration has Incrementable<T> && Decrementable<T>
 // the second declaration has Decrementable<T> && Incrementable<T>
 // Even though they are logically equivalent.
- 
-template<Incrementable T> 
-void g(T) requires Decrementable<T>;
- 
-template<Decrementable T> 
-void g(T) requires Incrementable<T>; // ill-formed, no diagnostic required
 
+template <Incrementable T>
+void g(T)
+  requires Decrementable<T>;
+
+template <Decrementable T>
+void g(T)
+  requires Incrementable<T>; // ill-formed, no diagnostic required

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_51.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_51.C
@@ -1,8 +1,8 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
 template <class T, class U>
 concept Derived = std::is_base_of<U, T>::value;
- 
-template<Derived<Base> T>
-void f(T);  // T is constrained by Derived<T, Base>
 
+template <Derived<Base> T> void f(T); // T is constrained by Derived<T, Base>

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_52.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_52.C
@@ -1,3 +1,5 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
 template <class T>
@@ -6,5 +8,3 @@ template <class T>
 concept SignedIntegral = Integral<T> && std::is_signed<T>::value;
 template <class T>
 concept UnsignedIntegral = Integral<T> && !SignedIntegral<T>;
-
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_54.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_54.C
@@ -1,6 +1,7 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
 template <class T = void>
-    requires EqualityComparable<T> || Same<T, void>
+  requires EqualityComparable<T> || Same<T, void>
 struct equal_to;
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_58.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_58.C
@@ -1,9 +1,16 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<typename T>
-void f(T&&) requires Eq<T>; // can appear as the last element of a function declarator
- 
-template<typename T> requires Addable<T> // or right after a template parameter list
-T add(T a, T b) { return a + b; }
+template <typename T>
+concept Addable = requires(T a, T b) { a + b; };
 
+template <typename T>
+void f(T &&)
+  requires Eq<T>; // can appear as the last element of a function declarator
 
+template <typename T>
+  requires Addable<T> // or right after a template parameter list
+T add(T a, T b) {
+  return a + b;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_62.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_62.C
@@ -1,15 +1,16 @@
+#include "cxx20_concepts_test_support.hpp"
+
+using std::swap;
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<typename T>
-concept Addable =
-requires (T a, T b) {
-    a + b; // "the expression a+b is a valid expression that will compile"
+template <typename T>
+concept Addable = requires(T a, T b) {
+  a + b; // "the expression a+b is a valid expression that will compile"
 };
- 
+
 template <class T, class U = T>
-concept Swappable = requires(T&& t, U&& u) {
-    swap(std::forward<T>(t), std::forward<U>(u));
-    swap(std::forward<U>(u), std::forward<T>(t));
+concept Swappable = requires(T &&t, U &&u) {
+  swap(std::forward<T>(t), std::forward<U>(u));
+  swap(std::forward<U>(u), std::forward<T>(t));
 };
-
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_63.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_63.C
@@ -1,19 +1,19 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<typename T> using Ref = T&;
-template<typename T> concept C =
-requires {
-    typename T::inner; // required nested member name
-    typename S<T>;     // required class template specialization
-    typename Ref<T>;   // required alias template substitution
+template <typename T> using Ref = T &;
+template <typename T>
+concept C = requires {
+  typename T::inner; // required nested member name
+  typename S<T>;     // required class template specialization
+  typename Ref<T>;   // required alias template substitution
 };
- 
+
 template <class T, class U> using CommonType = std::common_type_t<T, U>;
-template <class T, class U> concept Common =
-requires (T t, U u) {
-    typename CommonType<T, U>; // CommonType<T, U> is valid and names a type
-    { CommonType<T, U>{std::forward<T>(t)} }; 
-    { CommonType<T, U>{std::forward<U>(u)} }; 
+template <class T, class U>
+concept Common = requires(T t, U u) {
+  typename CommonType<T, U>; // CommonType<T, U> is valid and names a type
+  { CommonType<T, U>{std::forward<T>(t)} };
+  { CommonType<T, U>{std::forward<U>(u)} };
 };
-
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_64.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_64.C
@@ -1,15 +1,24 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<typename T> concept C2 =
-requires(T x) {
-    {*x} -> std::convertible_to<typename T::inner>; // the expression *x must be valid
-                                                    // AND the type T::inner must be valid
-                                                    // AND the result of *x must be convertible to T::inner
-    {x + 1} -> std::same_as<int>; // the expression x + 1 must be valid 
-                               // AND std::same_as<decltype((x + 1)), int> must be satisfied
-                               // i.e., (x + 1) must be a prvalue of type int
-    {x * 1} -> std::convertible_to<T>; // the expression x * 1 must be valid
-                                       // AND its result must be convertible to T
+template <typename T>
+concept C2 = requires(T x) {
+  {
+    *x
+  }
+  -> std::convertible_to<typename T::inner>; // the expression *x must be valid
+                                             // AND the type T::inner must be
+                                             // valid AND the result of *x must
+                                             // be convertible to T::inner
+  {
+    x + 1
+  }
+  -> std::same_as<int>; // the expression x + 1 must be valid
+                        // AND std::same_as<decltype((x + 1)), int> must be
+                        // satisfied i.e., (x + 1) must be a prvalue of type int
+  {
+    x * 1
+  } -> std::convertible_to<T>; // the expression x * 1 must be valid
+                               // AND its result must be convertible to T
 };
-
-

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_65.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_65.C
@@ -1,15 +1,18 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
 template <class T>
-concept Semiregular = DefaultConstructible<T> &&
-    CopyConstructible<T> && Destructible<T> && CopyAssignable<T> &&
-requires(T a, size_t n) {  
-    requires Same<T*, decltype(&a)>;  // nested: "Same<...> evaluates to true"
-    { a.~T() } noexcept;  // compound: "a.~T()" is a valid expression that doesn't throw
-    requires Same<T*, decltype(new T)>; // nested: "Same<...> evaluates to true"
-    requires Same<T*, decltype(new T[n])>; // nested
-    { delete new T };  // compound
-    { delete new T[n] }; // compound
-};
-
-
+concept Semiregular =
+    DefaultConstructible<T> && CopyConstructible<T> && Destructible<T> &&
+    CopyAssignable<T> && requires(T a, size_t n) {
+      requires Same<T *, decltype(&a)>; // nested: "Same<...> evaluates to true"
+      {
+        a.~T()
+      } noexcept; // compound: "a.~T()" is a valid expression that doesn't throw
+      requires Same<T *,
+                    decltype(new T)>; // nested: "Same<...> evaluates to true"
+      requires Same<T *, decltype(new T[n])>; // nested
+      { delete new T };                       // compound
+      { delete new T[n] };                    // compound
+    };

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_66.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_66.C
@@ -1,39 +1,39 @@
 // DQ (7/21/2020): Concept support is not available in legacy frontend 6.0.
 
-template<typename T>
+template <typename T>
 concept Decrementable = requires(T t) { --t; };
-template<typename T>
+
+template <typename T>
 concept RevIterator = Decrementable<T> && requires(T t) { *t; };
- 
+
 // RevIterator subsumes Decrementable, but not the other way around
- 
-template<Decrementable T>
-void f(T); // #1
- 
-template<RevIterator T>
-void f(T); // #2, more constrained than #1
- 
-f(0);       // int only satisfies Decrementable, selects #1
-f((int*)0); // int* satisfies both constraints, selects #2 as more constrained
- 
-template<class T>
-void g(T); // #3 (unconstrained)
- 
-template<Decrementable T>
-void g(T); // #4
- 
-g(true);  // bool does not satisfy Decrementable, selects #3
-g(0);     // int satisfies Decrementable, selects #4 because it is more constrained
- 
-template<typename T>
-concept RevIterator2 = requires(T t) { --t; *t; };
- 
-template<Decrementable T>
-void h(T); // #5
- 
-template<RevIterator2 T>
-void h(T); // #6
- 
-h((int*)0); //ambiguous
 
+template <Decrementable T> void f(T); // #1
 
+template <RevIterator T> void f(T); // #2, more constrained than #1
+
+template <class T> void g(T); // #3 (unconstrained)
+
+template <Decrementable T> void g(T); // #4
+
+template <typename T>
+concept RevIterator2 = requires(T t) {
+  --t;
+  *t;
+};
+
+template <Decrementable T> void h(T); // #5
+
+template <RevIterator2 T> void h(T); // #6
+
+void test() {
+  f(0);        // int only satisfies Decrementable, selects #1
+  f((int *)0); // int* satisfies both constraints, selects #2 as more
+               // constrained
+
+  g(true); // bool does not satisfy Decrementable, selects #3
+  g(0);    // int satisfies Decrementable, selects #4 because it is more
+           // constrained
+
+  h((int *)0); // ambiguous
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_67.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_67.C
@@ -1,10 +1,19 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): This appears to fail in legacy frontend 6.0.
 
-void f1(auto); // same as template<class T> void f(T)
-void f2(C1 auto); // same as template<C1 T> void f2(T), if C1 is a concept
-void f3(C2 auto...); // same as template<C2... Ts> void f3(Ts...), if C2 is a concept
-void f4(const C3 auto*, C4 auto&); // same as template<C3 T, C4 U> void f4(const T*, U&);
+template <class>
+concept C = true;
+
+template <class>
+concept C2 = true;
+
+void f1(auto);       // same as template<class T> void f(T)
+void f2(C1 auto);    // same as template<C1 T> void f2(T), if C1 is a concept
+void f3(C2 auto...); // same as template<C2... Ts> void f3(Ts...), if C2 is a
+                     // concept
+void f4(const C3 auto *,
+        C4 auto &); // same as template<C3 T, C4 U> void f4(const T*, U&);
 template <class T, C U>
-void g(T x, U y, C auto z); // same as template<class T, C U, C W> void g(T x, U y, W z);
-
-
+void g(T x, U y,
+       C auto z); // same as template<class T, C U, C W> void g(T x, U y, W z);

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_68.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/test2020_68.C
@@ -1,14 +1,19 @@
+#include "cxx20_concepts_test_support.hpp"
+
 // DQ (7/21/2020): This appears to fail in legacy frontend 6.0.
 
 // void f1(auto); // same as template<class T> void f(T)
 // void f2(C1 auto); // same as template<C1 T> void f2(T), if C1 is a concept
-// void f3(C2 auto...); // same as template<C2... Ts> void f3(Ts...), if C2 is a concept
+// void f3(C2 auto...); // same as template<C2... Ts> void f3(Ts...), if C2 is a
+// concept
 
-void f4(const C3 auto*, C4 auto&); // same as template<C3 T, C4 U> void f4(const T*, U&);
+void f4(const C3 auto *,
+        C4 auto &); // same as template<C3 T, C4 U> void f4(const T*, U&);
 
 // template <class T, C U>
-// void g(T x, U y, C auto z); // same as template<class T, C U, C W> void g(T x, U y, W z);
+// void g(T x, U y, C auto z); // same as template<class T, C U, C W> void g(T
+// x, U y, W z);
 
-template<>
-void f4<int>(const int*, const double&); // specialization of f4<int, const double>
-
+template <>
+void f4<int>(const int *,
+             const double &); // specialization of f4<int, const double>


### PR DESCRIPTION
## Summary
- fixes `#389` by restoring full C++20 concept/constraint coverage for the affected repros instead of leaving them disabled
- moves the affected `Cxx20_tests_test2020_{46,48-68}` coverage back into the normal CTest flow without introducing a redundant test set
- keeps the fix in the Clang frontend / AST translation / unparsing path rather than adding ad-hoc test-only fallbacks

## What changed
- re-enabled the affected C++20 tests in `tests/nonsmoke/functional/CompileTests/CMakeLists.txt` and `tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt`
- updated the invalid repro sources to be self-contained C++20 tests, including a shared `cxx20_concepts_test_support.hpp` for the concept definitions used by `test2020_67.C` and `test2020_68.C`
- fixed user-defined literal lowering by routing `UserDefinedLiteral` expressions through normal call-expression handling
- fixed concept specialization translation so written template arguments are only materialized when they are actually written in source
- normalized placeholder template parameter names (`auto:<n>` -> `auto_<n>`) and preserved template-parameter metadata needed for abbreviated function templates
- preserved constrained placeholder `auto` information from Clang semantic `AutoType` / `TypeLoc` data into Sage IR and unparsed it back as constrained `auto`
- suppressed abbreviated placeholder parameters from emitted template headers so reconstructed code matches the original abbreviated syntax instead of inventing redundant template parameters
- preserved explicit-specialization arguments in the nondefining declaration path so forms like `f4<int>` are reconstructed correctly
- added SageInterface support for template-parameter keyword / abbreviated-template metadata and auto-type constraints used by the frontend and unparser

## Validation
- `env -u LD_LIBRARY_PATH ctest --test-dir build -R '^Cxx20_tests_test2020_(46|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63|64|65|66|67|68)_C$' --output-on-failure -j32`
- `env -u LD_LIBRARY_PATH ctest --test-dir build -R '^rex_install_tree_(clang_headers|astQuery|astInterface)$' --output-on-failure -j32`
- `env -u LD_LIBRARY_PATH ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`
- pre-push hook passed, including its build and broader CTest coverage
