### PR TITLE
Fix remaining GNU binary conditional CFG bug

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -4985,22 +4985,82 @@ bool ClangToSageTranslator::VisitBinaryConditionalOperator(
 #endif
   bool res = true;
 
-  SgNode *tmp_cond = Traverse(binary_conditional_operator->getCond());
-  SgExpression *cond_expr = isSgExpression(tmp_cond);
-  ROSE_ASSERT(cond_expr);
-  SgNode *tmp_true = Traverse(binary_conditional_operator->getTrueExpr());
-  SgExpression *true_expr = isSgExpression(tmp_true);
-  ROSE_ASSERT(true_expr);
-  SgNode *tmp_false = Traverse(binary_conditional_operator->getFalseExpr());
-  SgExpression *false_expr = isSgExpression(tmp_false);
-  ROSE_ASSERT(false_expr);
+  SgExpression *common_expr =
+      isSgExpression(Traverse(binary_conditional_operator->getCommon()));
+  ROSE_ASSERT(common_expr != nullptr);
 
-  SgType *cond_type =
+  SgExpression *false_expr =
+      isSgExpression(Traverse(binary_conditional_operator->getFalseExpr()));
+  ROSE_ASSERT(false_expr != nullptr);
+
+  SgType *common_type = buildTypeFromQualifiedType(
+      binary_conditional_operator->getCommon()->getType());
+  ROSE_ASSERT(common_type != nullptr);
+
+  SgType *result_type =
       buildTypeFromQualifiedType(binary_conditional_operator->getType());
-  SgConditionalExp *cond_exp = SageBuilder::buildConditionalExp_nfi(
-      cond_expr, true_expr, false_expr, cond_type);
-  applySourceRange(cond_exp, binary_conditional_operator->getSourceRange());
-  *node = cond_exp;
+  ROSE_ASSERT(result_type != nullptr);
+
+  SgBasicBlock *block = SageBuilder::buildBasicBlock();
+  ROSE_ASSERT(block != nullptr);
+
+  const std::string temp_name =
+      SageInterface::generateUniqueVariableName(block, "gnu_binary_cond");
+
+  SgExpression *result_expr = nullptr;
+  if (binary_conditional_operator->isLValue()) {
+    SgType *pointer_common_type = SageBuilder::buildPointerType(common_type);
+    SgType *pointer_result_type = SageBuilder::buildPointerType(result_type);
+    ROSE_ASSERT(pointer_common_type != nullptr);
+    ROSE_ASSERT(pointer_result_type != nullptr);
+
+    SgExpression *common_addr = SageBuilder::buildAddressOfOp(common_expr);
+    SgAssignInitializer *initializer =
+        SageBuilder::buildAssignInitializer(common_addr);
+    SgVariableDeclaration *temp_decl = SageBuilder::buildVariableDeclaration(
+        temp_name, pointer_common_type, initializer, block);
+    ROSE_ASSERT(temp_decl != nullptr);
+    SageInterface::appendStatement(temp_decl, block);
+
+    SgExpression *cond_expr = SageBuilder::buildPointerDerefExp(
+        SageBuilder::buildVarRefExp(temp_decl));
+    SgExpression *true_expr = SageBuilder::buildVarRefExp(temp_decl);
+    SgExpression *false_ptr_expr = SageBuilder::buildAddressOfOp(false_expr);
+    SgConditionalExp *pointer_conditional =
+        SageBuilder::buildConditionalExp_nfi(
+            cond_expr, true_expr, false_ptr_expr, pointer_result_type);
+    ROSE_ASSERT(pointer_conditional != nullptr);
+
+    SageInterface::appendStatement(
+        SageBuilder::buildExprStatement(pointer_conditional), block);
+
+    SgStatementExpression *statement_expression =
+        SageBuilder::buildStatementExpression_nfi(block);
+    ROSE_ASSERT(statement_expression != nullptr);
+    result_expr = SageBuilder::buildPointerDerefExp(statement_expression);
+  } else {
+    SgAssignInitializer *initializer =
+        SageBuilder::buildAssignInitializer(common_expr);
+    SgVariableDeclaration *temp_decl = SageBuilder::buildVariableDeclaration(
+        temp_name, common_type, initializer, block);
+    ROSE_ASSERT(temp_decl != nullptr);
+    SageInterface::appendStatement(temp_decl, block);
+
+    SgExpression *cond_expr = SageBuilder::buildVarRefExp(temp_decl);
+    SgExpression *true_expr = SageBuilder::buildVarRefExp(temp_decl);
+    SgConditionalExp *conditional = SageBuilder::buildConditionalExp_nfi(
+        cond_expr, true_expr, false_expr, result_type);
+    ROSE_ASSERT(conditional != nullptr);
+
+    SageInterface::appendStatement(SageBuilder::buildExprStatement(conditional),
+                                   block);
+
+    result_expr = SageBuilder::buildStatementExpression_nfi(block);
+  }
+
+  ROSE_ASSERT(result_expr != nullptr);
+  applySourceRange(result_expr, binary_conditional_operator->getSourceRange());
+  *node = result_expr;
 
   return VisitAbstractConditionalOperator(binary_conditional_operator, node) &&
          res;


### PR DESCRIPTION
## Summary
- fix the remaining root cause for issue #293 in the Clang frontend
- lower GNU binary conditional `a ?: b` from Clang's source-form `getCommon()` semantics instead of reusing Clang's semantic-form children directly
- preserve single evaluation of the common operand and keep the ROSE AST a proper tree, which removes the CFG inconsistency still affecting `test2009_38.C`
- leave the relevant tests in the normal CTest sets; no test-list changes were needed because the issue-covering tests are already regular CMake/CTest entries

## Root cause
Clang represents GNU binary conditional as `BinaryConditionalOperator`, where:
- `getCommon()` is the source operand written before `?:`
- `getCond()` / `getTrueExpr()` are semantic-form expressions built around Clang's internal opaque-value model

The previous fix handled the missing translation and copied `OpaqueValueExpr` results, but it still let ROSE construct the operator from those semantic-form children. That path could still produce CFG inconsistencies because the translated tree did not faithfully model the single-evaluation source semantics of GNU `a ?: b`.

## Fix
`VisitBinaryConditionalOperator` now builds a statement-expression-based lowering that evaluates the common operand exactly once:
- for non-lvalue results, it stores the common operand in a compiler-generated temporary and evaluates `tmp ? tmp : false`
- for lvalue results, it stores the address of the common operand in a temporary pointer and lowers to a pointer-selecting conditional inside the statement-expression, then dereferences the result outside so lvalue behavior is preserved

This keeps the ROSE AST tree-shaped, preserves single evaluation, and removes the shared-child CFG mismatch that was still hitting the virtual/static CFG tests.

## Validation
Focused issue coverage:
- `ctest --test-dir build --output-on-failure -j32 -R '^(C_tests_test2015_33_c|Cxx_tests_test2009_38_C|ut_test2009_38\.C|ua_test2009_38\.C|testVirtualCFG_CXX_test2009_38\.C|testStaticCFG_Cxx_test2009_38\.C|testInterproceduralCFG_Cxx_test2009_38\.C)$'`

Broader regression coverage requested in the issue workflow:
- `ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`

Git hooks also ran during `git push` and completed successfully.

## Issue
- closes #293
