### PR TITLE
Fix ill-formed Cxx11 enum specimens

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
@@ -958,8 +958,6 @@ set(CXX11_DISABLED_TESTCODES
   test2019_306.C
   test2019_311.C
   test2019_313.C
-  test2019_345.C
-  test2019_346.C
   test2019_382.C
   test2019_388.C
   test2019_453.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_345.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_345.C
@@ -1,21 +1,19 @@
 
 
-class myVector
-   {
-     public:
-          myVector operator/( double x) const;
+enum class vector : int { value = 0 };
 
-          myVector();
+class myVector {
+public:
+  myVector operator/(double x) const;
 
-          myVector operator= (enum class vector &x) const;
-       // myVector operator= (enum vector &x) const;
-   };
+  myVector();
 
-void foo()
-   {
-     myVector a;
+  myVector operator=(vector &x) const;
+};
+
+void foo() {
+  myVector a;
 
   // Problem code
-     myVector b = a / 1.0;
-
-   }
+  myVector b = a / 1.0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_346.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_346.C
@@ -2,23 +2,20 @@
 // This code passes for legacy frontend, but fails for GNU 5.1 (so the identity
 // translator fails in the backend as well).
 
-class myVector
-   {
-     public:
-          myVector operator/( double x) const;
+enum vector : int { value = 0 };
 
-          myVector();
+class myVector {
+public:
+  myVector operator/(double x) const;
 
-       // Failing code!
-       // myVector operator= (enum class vector &x) const;
-          myVector operator= (enum vector &x) const;
-   };
+  myVector();
 
-void foo()
-   {
-     myVector a;
+  myVector operator=(enum vector &x) const;
+};
+
+void foo() {
+  myVector a;
 
   // Problem code
-     myVector b = a / 1.0;
-
-   }
+  myVector b = a / 1.0;
+}


### PR DESCRIPTION
## Summary
- make `test2019_345.C` standard-conforming by defining the scoped enum and using the declared type in the operator parameter
- make `test2019_346.C` standard-conforming by defining the unscoped enum before the elaborated parameter use
- re-enable both Cxx11 compile tests in `tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt`

## Root cause
Issue #364 still applied in the current tree: both specimens used enum types in ill-formed ways for a positive compile-test suite.
- `test2019_345.C` used `enum class vector` directly as a parameter type, which is invalid syntax for referencing a scoped enum type.
- `test2019_346.C` used an unscoped enum type before any valid declaration/definition.

The fix is to make the specimens themselves valid C++11, which matches the issue guidance and keeps the tests in the positive compile suite without permissive flags or fallback behavior.

## Validation
- `ctest --test-dir build --output-on-failure -j16 -R 'Cxx11_tests_test2019_345_C|Cxx11_tests_test2019_346_C'`
- `ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`

Closes #364
