### PR TITLE
tests: promote stale issue-453 failing entries

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -2640,14 +2640,12 @@ set(EXAMPLE_TESTCODES_REQUIRED_TO_PASS_DISABLED
   test2007_56.C
   test2007_58.C
   test2007_60.C
-  test2007_61.C
   test2007_62.C
   test2007_63.C
   test2007_64.C
   test2007_65.C
   test2007_66.C
   test2007_67.C
-  test2007_68.C
   test2007_69.C
   test2007_71.C
   test2007_73.C
@@ -2956,14 +2954,12 @@ set(TESTCODE_CURRENTLY_FAILING
   test2007_54.C
   test2007_58.C
   test2007_60.C
-  test2007_61.C
   test2007_62.C
   test2007_63.C
   test2007_64.C
   test2007_65.C
   test2007_66.C
   test2007_67.C
-  test2007_68.C
   test2007_69.C
   test2007_71.C
   test2007_73.C


### PR DESCRIPTION
## Summary

Issue #453 no longer reproduces on the current codebase.

For both `test2007_61.C` and `test2007_68.C`:
- the current unparser no longer emits the unterminated conditional-directive failure described in the issue
- the remaining problem was stale CTest classification keeping the tests in failing/disabled buckets

This PR promotes those stale entries back into the regular CTest flow without creating any new redundant test set.

Closes #453.

## What changed

Updated `tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt` to:
- remove `test2007_61.C` and `test2007_68.C` from `EXAMPLE_TESTCODES_REQUIRED_TO_PASS_DISABLED`
- remove `test2007_61.C` and `test2007_68.C` from `TESTCODE_CURRENTLY_FAILING`

Because `unparseToString_tests`, `virtualCFG_tests`, and `staticCFG_tests` derive their failing/regular split from those shared lists, the affected tests are now registered under their normal names automatically after reconfigure.

## Why no compiler change

I reproduced the issue inputs directly with the current binaries before changing registration:
- `testTranslator` generated balanced preprocessor directives for `test2007_61.C`
- `testTranslator` and `unparseToString` both handled `test2007_68.C` without the issue's reported `unterminated conditional directive` failure
- focused Cxx / unparse / CFG executions all passed on the current codebase

So the root-cause bug described by #453 appears to have already been fixed elsewhere; this PR removes the stale failing/disabled bookkeeping that remained after that fix.

## Validation

### Registration
- `ctest --test-dir build -N -R 'Cxx_tests_(failing_)?test2007_6(1|8)_C|ut_(failing_)?test2007_6(1|8)\.C|ua_(failing_)?test2007_6(1|8)\.C|testVirtualCFG_CXX_(failing_)?test2007_6(1|8)\.C|testStaticCFG_Cxx_(failing_)?test2007_6(1|8)\.C'`
  - regular names present
- `ctest --test-dir build -N -R 'failing_test2007_61|failing_test2007_68'`
  - `Total Tests: 0`

### Focused issue-related tests
- `ctest --test-dir build --output-on-failure -j32 -R 'Cxx_tests_test2007_61_C|Cxx_tests_test2007_68_C|ut_test2007_61\.C|ua_test2007_61\.C|ut_test2007_68\.C|ua_test2007_68\.C|testVirtualCFG_CXX_test2007_61\.C|testVirtualCFG_CXX_test2007_68\.C|testStaticCFG_Cxx_test2007_61\.C|testStaticCFG_Cxx_test2007_68\.C'`
  - `10/10 passed`

### Requested regression suite
- `ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`
  - `4924/4924 passed`

### Pre-push hook suite
- normal `git push` (no hook skipping)
  - `6578/6578 passed`
