### PR TITLE
Fix invalid extra-qualified Cxx11 specimen

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2020_66.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2020_66.C
@@ -1,21 +1,17 @@
 
-class A
-   {
-     protected:
-          virtual void foo1(void) {}
-          char* b;
-   };
+class A {
+protected:
+  virtual void foo1(void) {}
+  char *b;
+};
 
-class B : public A
-   {
-     public:
-          B();
-          virtual void B::foo1();
-   };
+class B : public A {
+public:
+  B();
+  virtual void foo1();
+};
 
-class C
-   {
-     public:
-          friend void B::foo1(void);
-   };
-
+class C {
+public:
+  friend void B::foo1(void);
+};


### PR DESCRIPTION
## Summary
- resolves the remaining reproduction from issue #360 in the regular `Cxx11_tests` suite
- keeps the affected specimen in the existing `Cxx11_tests` ctest set; no redundant test set was introduced
- makes `test2020_66.C` valid under `-std=c++11` by removing the invalid extra qualification on the in-class member declaration

## Current issue status
- `test2014_07.C` is already fixed on `main` and already passes in `Cxx11_tests`
- `test2020_66.C` was still present in the regular `Cxx11_tests` set and still failed with Clang:
  - `error: extra qualification on member 'foo1'`
- no test registration move was needed because both issue specimens are already part of the normal ctest inventory

## Root cause
`tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2020_66.C` declared `virtual void B::foo1();` inside the class definition. That syntax is ill-formed in C++11, so Clang correctly rejects it and the positive compile test failed.

This is a specimen issue in the test input, not a frontend bug.

## Fix
- changed the in-class declaration to the standards-valid form `virtual void foo1();`
- kept the friend declaration `friend void B::foo1(void);` intact so the specimen still exercises the intended member/friend relationship
- formatted the file with `clang-format`

## Validation
### Issue-focused tests
```bash
ctest --test-dir build --output-on-failure -j32 -R 'Cxx11_tests_test2014_07_C|Cxx11_tests_test2020_66_C'
```
Result: `2/2` passed.

### Requested regression suite
```bash
ctest --test-dir build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32
```
Result: `4924/4924` passed.

## Notes
- push hooks were not skipped
- no workaround, fallback, permissive flag, or test masking was introduced

Fixes #360
