### PR TITLE
Fix invalid Cxx11 pointer-to-member specimen

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
@@ -925,7 +925,6 @@ set(CXX11_TESTCODES
 )
 set(CXX11_DISABLED_TESTCODES
   test2016_41.C
-  test2019_16.C
   test2019_34.C
   test2019_37.C
   test2019_38.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_16.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_16.C
@@ -4,19 +4,18 @@
 // #define test__builtin_va_arg(v,l) (__typeof__(l))(sizeof(l))
 // #define test__builtin_va_arg(v,l) (unsigned long)(sizeof(l))
 
-struct MyClass {
+struct X_ {
   int a, b, c;
 };
 
-MyClass mc_ = {1, 2, 3};
+X_ x_ = {1, 2, 3};
 
 void foobar(int x, ...) {
   int value = 0;
   va_list ap;
   va_start(ap, x);
 
-  // value = x_.*__builtin_va_arg(ap, int X_::*);
-  value = x_.*((decltype(int X_::*))(sizeof(int X_::*)));
+  value = x_.*__builtin_va_arg(ap, int X_::*);
 
   va_end(ap);
 }


### PR DESCRIPTION
## Summary
- fixes issue #366 by repairing the broken positive `Cxx11_tests` specimen `test2019_16.C`
- removes `test2019_16.C` from `CXX11_DISABLED_TESTCODES` so it runs in the regular `Cxx11_tests` ctest set
- does not introduce any new or redundant test set

## Current issue status
Issue #366 still applies on current `main`.

The registered test `Cxx11_tests_test2019_16_C` was still present in the normal `Cxx11_tests` suite, but it was marked `DISABLED TRUE` in CTest. The specimen also still failed directly with Clang diagnostics about undeclared `x_` / `X_`.

## Root cause
`tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_16.C` was an incomplete positive compile test. It referenced `x_` and `X_` in a pointer-to-member `__builtin_va_arg` expression without declaring them, and the fallback `decltype(int X_::*)` expression in the file was not valid C++.

This is a bad test specimen, not a Clang frontend regression in REX.

## Fix
- replaced the placeholder `MyClass` / `mc_` setup with the actual `X_` type and `x_` object used by the expression
- restored a valid direct pointer-to-member builtin expression:
  - `x_.*__builtin_va_arg(ap, int X_::*)`
- removed `test2019_16.C` from `CXX11_DISABLED_TESTCODES` while keeping it in `CXX11_TESTCODES`
- formatted the specimen with `clang-format`

## Why this is the long-term fix
The root cause is the specimen itself. Repairing the source and re-enabling it fixes the problem at the source:

- no permissive flags
- no workaround or fallback path
- no masking in the test framework
- no redundant ctest registration

## Validation
### Issue-focused test
```bash
ctest --test-dir build --output-on-failure -j32 -R '^Cxx11_tests_test2019_16_C$'
```
Result: passed.

### Requested regression slice
```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32
```
Result: `4924/4924` passed.

### Pre-push hook validation
The required git hooks also ran successfully during `git push`, including a larger hook-managed test/build pass, and the push completed without bypassing hooks.

Fixes #366
