### PR TITLE
Fix C_tests_test2012_145 string macro quoting

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -1066,7 +1066,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Intel")
   set(_c_tests_disable_m32 TRUE)
 endif()
 
-set(_c_tests_string_macro -DSTRING_MACRO=\\\"some_text\\\")
+set(_c_tests_string_macro [[-DSTRING_MACRO="some_text"]])
 
 add_test(
   NAME C_tests_check_pthread


### PR DESCRIPTION
Closes #294.

## Summary
- fix `C_tests_test2012_145` so its `ctest` command line passes `STRING_MACRO` as a real quoted C string literal
- keep the test in the regular `C_tests` set; no new issue-specific or redundant test group was added
- preserve the existing dedicated per-test harness override, but correct the CMake quoting so `ctest` no longer injects backslashes into the macro body

## Root Cause
`C_tests_test2012_145` already had a dedicated `add_test(...)` entry on `main`, but the `STRING_MACRO` argument was stored as:

```cmake
-DSTRING_MACRO=\"some_text\"
```

That survives into the generated `ctest` argv with literal backslashes, so Clang sees:

```c
#define STRING_MACRO \"some_text\"
```

That is not a valid string-literal macro expansion for this test and causes the current reproducer to fail under `ctest`.

## Fix
- change the CMake token to a raw bracket-quoted argument:

```cmake
set(_c_tests_string_macro [[-DSTRING_MACRO="some_text"]])
```

This keeps the argument as a single `add_test` command-line element while ensuring `ctest` passes the inner quotes through correctly.

## Validation
Targeted reproducer before the fix:

```bash
ctest --test-dir build -R '^C_tests_test2012_145$' --output-on-failure -j32 -V
```

Result before the fix:
- failed with `warning: missing terminating '"' character`
- failed with `error: expected expression`

Targeted reproducer after the fix:

```bash
ctest --test-dir build -R '^C_tests_test2012_145$' --output-on-failure -j32 -V
```

Result after the fix:
- `C_tests_test2012_145`: passed

Requested regression slice:

```bash
ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32
```

Result:
- `4924/4924` tests passed

Push-hook validation also ran successfully during `git push`:
- `6624/6624` tests passed
