### PR TITLE
Fix C++17 switch-init handling for issue #381

### DIFF
--- a/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/CxxFrontend/Clang/clang-frontend-stmt.cpp
@@ -5075,6 +5075,78 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
 
   bool res = true;
 
+  clang::Stmt *clang_switch_init_stmt = switch_stmt->getInit();
+  // SgSwitchStatement has no dedicated child for a C++17 init-statement.
+  // Lower it into an enclosing block so the translated AST remains
+  // structurally valid while preserving the initializer's scope for the switch
+  // body.
+  SgBasicBlock *switch_init_wrapper = nullptr;
+  if (clang_switch_init_stmt != nullptr) {
+    switch_init_wrapper = SageBuilder::buildBasicBlock_nfi();
+    switch_init_wrapper->set_parent(SageBuilder::topScopeStack());
+    SageBuilder::pushScopeStack(switch_init_wrapper);
+  }
+
+  auto ensure_decl_scope = [](SgStatement *stmt, SgScopeStatement *scope) {
+    if (stmt == nullptr || scope == nullptr) {
+      return;
+    }
+
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(stmt)) {
+      decl->set_scope(scope);
+      if (SgVariableDeclaration *var_decl = isSgVariableDeclaration(decl)) {
+        for (SgInitializedName *init_name : var_decl->get_variables()) {
+          if (init_name != nullptr) {
+            init_name->set_scope(scope);
+          }
+        }
+      }
+    }
+  };
+
+  auto translate_wrapper_stmt = [&](clang::Stmt *clang_stmt) -> SgStatement * {
+    if (clang_stmt == nullptr) {
+      return nullptr;
+    }
+
+    SgNode *tmp_stmt = Traverse(clang_stmt);
+    SgStatement *sg_stmt = isSgStatement(tmp_stmt);
+    SgExpression *sg_expr = isSgExpression(tmp_stmt);
+    if (tmp_stmt == nullptr) {
+      return nullptr;
+    }
+    if (sg_stmt == nullptr && sg_expr == nullptr) {
+      MLOG_ERROR_CXX(MLOG_FRONTEND)
+          << "Runtime error: switch init did not translate to SgStatement or "
+             "SgExpression ("
+          << tmp_stmt->class_name() << ")." << std::endl;
+      res = false;
+      return nullptr;
+    }
+    if (sg_expr != nullptr) {
+      sg_stmt = SageBuilder::buildExprStatement(sg_expr);
+    }
+    if (sg_stmt == nullptr) {
+      return nullptr;
+    }
+
+    applySourceRange(sg_stmt, clang_stmt->getSourceRange());
+    sg_stmt->set_parent(switch_init_wrapper);
+    ensure_decl_scope(sg_stmt, switch_init_wrapper);
+    switch_init_wrapper->append_statement(sg_stmt);
+    return sg_stmt;
+  };
+
+  if (switch_init_wrapper != nullptr && clang_switch_init_stmt != nullptr) {
+    SgStatement *sg_init_stmt = translate_wrapper_stmt(clang_switch_init_stmt);
+    if (sg_init_stmt == nullptr) {
+      sg_init_stmt = SageBuilder::buildNullStatement_nfi();
+      setCompilerGeneratedFileInfo(sg_init_stmt, true);
+      sg_init_stmt->set_parent(switch_init_wrapper);
+      switch_init_wrapper->append_statement(sg_init_stmt);
+    }
+  }
+
   SgSwitchStatement *sg_switch_stmt =
       SageBuilder::buildSwitchStatement_nfi(nullptr, nullptr);
   sg_switch_stmt->set_parent(SageBuilder::topScopeStack());
@@ -5149,6 +5221,23 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
   // Pei-Hung (07/29/2024) In the case of test2001_14.C, body can be the
   // SgDefaultStmt and the parent needs to be set properly.
   body->set_parent(sg_switch_stmt);
+
+  if (switch_init_wrapper != nullptr) {
+    applySourceRange(sg_switch_stmt, switch_stmt->getSourceRange());
+    sg_switch_stmt->set_parent(switch_init_wrapper);
+    switch_init_wrapper->append_statement(sg_switch_stmt);
+
+    if (clang_switch_init_stmt->getBeginLoc().isValid() &&
+        switch_stmt->getEndLoc().isValid()) {
+      applySourceRange(switch_init_wrapper,
+                       clang::SourceRange(clang_switch_init_stmt->getBeginLoc(),
+                                          switch_stmt->getEndLoc()));
+    }
+
+    SageBuilder::popScopeStack();
+    *node = switch_init_wrapper;
+    return res;
+  }
 
   *node = sg_switch_stmt;
 

--- a/src/frontend/SageIII/astPostProcessing/fixupInitializers.C
+++ b/src/frontend/SageIII/astPostProcessing/fixupInitializers.C
@@ -288,10 +288,12 @@ FixupInitializersUsingIncludeFilesTraversal::evaluateInheritedAttribute(
         SgIfStmt *ifStatementScope = isSgIfStmt(scope);
         SgRangeBasedForStatement *rangeBasedForStatement =
             isSgRangeBasedForStatement(scope);
+        SgSwitchStatement *switchStatementScope = isSgSwitchStatement(scope);
 
         bool ignoreThisScope = (forStatementScope != nullptr) ||
                                (rangeBasedForStatement != nullptr) ||
-                               (ifStatementScope != nullptr);
+                               (ifStatementScope != nullptr) ||
+                               (switchStatementScope != nullptr);
 
         if (ignoreThisScope == false) {
           SgStatement *next_statement = SageInterface::getNextStatement(

--- a/src/frontend/SageIII/sage_support/utility_functions.C
+++ b/src/frontend/SageIII/sage_support/utility_functions.C
@@ -1438,6 +1438,15 @@ SgStatement *Rose::getNextStatement(SgStatement *currentStatement) {
   // function (previous bug fixed, but tested here).
   ROSE_ASSERT(scope != currentStatement);
 
+  if (SgSwitchStatement *switch_scope = isSgSwitchStatement(scope)) {
+    if (switch_scope->get_item_selector() == currentStatement) {
+      SgBasicBlock *switch_body =
+          SageInterface::ensureBasicBlockAsBodyOfSwitch(switch_scope);
+      SgStatementPtrList &body_statements = switch_body->getStatementList();
+      return body_statements.empty() ? nullptr : body_statements.front();
+    }
+  }
+
   switch (currentStatement->variantT()) {
   case V_SgForInitStatement:
   // case V_SgBasicBlock: // Liao 10/20/2010, We should allow users to get a

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
@@ -100,7 +100,6 @@ set(CXX17_DISABLED_TESTCODES
   test2018_44.C
   test2018_45.C
   test2018_46.C
-  test2018_47.C
   test2018_48.C
   test2018_49.C
   test2018_50.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_47.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_47.C
@@ -1,19 +1,41 @@
 // Selection statements with initializer
 
-typedef int status_code;
-// int SUCCESS = 1;
-// int bar();
+enum status_code { OK, Bad };
 
-status_code foo() 
-   {   
-     switch (Foo gadget(args); auto s = gadget.status())
-        {
-          case OK: 
-               gadget.zip(); 
-               break;
-          case Bad: 
-               throw BadFoo(s.message());
-        }
-   }
+struct Args {};
 
+struct status_info {
+  status_code code;
 
+  operator status_code() const { return code; }
+  const char *message() const { return "Bad status"; }
+};
+
+struct Foo {
+  explicit Foo(const Args &) {}
+
+  status_info status() const {
+    status_info result{OK};
+    return result;
+  }
+  void zip() const {}
+};
+
+struct BadFoo {
+  explicit BadFoo(const char *) {}
+};
+
+const Args args{};
+
+status_code foo() {
+  // Keep the sample self-contained so this stays a positive C++17 compile test.
+  switch (Foo gadget{args}; auto s = gadget.status()) {
+  case OK:
+    gadget.zip();
+    return OK;
+  case Bad:
+    throw BadFoo(s.message());
+  }
+
+  return Bad;
+}


### PR DESCRIPTION
## Summary

Closes #381.

Issue #381 still applied on the current codebase in two ways:

1. `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_47.C` was still disabled in `CXX17_DISABLED_TESTCODES`.
2. Once the test was made into a valid positive C++17 compile test and re-enabled, the Clang frontend still failed on `switch (init; cond)` by leaving the init-statement unlowered and later tripping switch-selector traversal/fixup logic.

## Root Cause Fix

- Lower C++17 switch init-statements in `VisitSwitchStmt` into an enclosing `SgBasicBlock`, matching the existing `if (init; cond)` strategy so the init-statement scope is preserved for the switch body.
- Teach `Rose::getNextStatement()` how to advance from a switch selector declaration into the switch body instead of asserting on this shape.
- Extend `FixupInitializersUsingIncludeFilesTraversal` to treat `SgSwitchStatement` like the other statement-scoped declaration contexts that do not obey the default `getNextStatement()` assumptions.

## Test Changes

- Replaced the old ill-formed `test2018_47.C` source with a self-contained valid C++17 switch-with-initializer example.
- Removed `test2018_47.C` from `CXX17_DISABLED_TESTCODES` so it runs in the normal `Cxx17_tests` ctest set instead of a redundant special-case bucket.

## Validation

- `env LD_LIBRARY_PATH=/home/ouankou/Projects/rex-ai/rex-flang/build/lib ctest --test-dir build --output-on-failure -j32 -R '^Cxx17_tests_test2018_47_C$'`
- `env LD_LIBRARY_PATH=/home/ouankou/Projects/rex-ai/rex-flang/build/lib ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`

Note: the explicit `LD_LIBRARY_PATH` is needed in this workspace because `build/bin/testTranslator` otherwise resolves to the installed `librose.so` under `/home/ouankou/rex_install/lib` instead of the just-built `build/lib/librose.so`.
