### PR TITLE
Fix Cxx17 test2018_69 missing cstdint include

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
@@ -117,7 +117,6 @@ set(CXX17_DISABLED_TESTCODES
   test2018_65.C
   test2018_67.C
   test2018_68.C
-  test2018_69.C
   test2018_70.C
   test2018_71.C
   test2018_72.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_69.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_69.C
@@ -1,5 +1,6 @@
 // aggregate initialization
 
+#include <cstdint>
 #include<string>
 
 // simple example of aggregate initialization
@@ -10,4 +11,3 @@ struct user
 };
 
 user u1{10, "Alice"};
-


### PR DESCRIPTION
## Summary

Fixes #386.

This restores `Cxx17_tests_test2018_69_C` to the regular CTest set and makes the test source valid C++17.

## Root Cause

`tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_69.C` used `uint32_t` without including `<cstdint>`.
That caused both plain Clang and `testTranslator` to fail with:

- `error: unknown type name 'uint32_t'`

The test had been parked in `CXX17_DISABLED_TESTCODES`, so the failure no longer surfaced in the normal `Cxx17` suite.

## Fix

- Add `#include <cstdint>` to `test2018_69.C`.
- Remove `test2018_69.C` from `CXX17_DISABLED_TESTCODES` in the `Cxx17` CMake list.

This keeps the test in the existing `Cxx17` suite instead of creating or relying on a redundant disabled/failing set.

## Validation

- `clang++ -std=c++17 -c tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_69.C -o /tmp/test2018_69.o`
- `ctest --test-dir build --output-on-failure -j32 -R '^Cxx17_tests_test2018_69_C$'`
- `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  Result: `4924/4924` tests passed.
- Pre-push hook validation
  Result: `6624/6624` tests passed.
