### PR TITLE
Re-enable Cxx17 test2018_58

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt
@@ -106,7 +106,6 @@ set(CXX17_DISABLED_TESTCODES
   test2018_55.C
   test2018_56.C
   test2018_57.C
-  test2018_58.C
   test2018_59.C
   test2018_60.C
   test2018_61.C


### PR DESCRIPTION
## Summary

This PR re-enables `Cxx17_tests_test2018_58_C` by removing the stale disabled entry for `test2018_58.C` from `CXX17_DISABLED_TESTCODES`.

Fixes #373.

## Why this change

Issue #373 describes a historical segfault in `Cxx17_tests_test2018_58_C` on a minimal `std::map<int, int>` assignment case. I re-checked the current tree before changing test registration:

- The test was still marked disabled in `tests/nonsmoke/functional/CompileTests/Cxx17_tests/CMakeLists.txt`.
- The current `testTranslator` invocation for `tests/nonsmoke/functional/CompileTests/Cxx17_tests/test2018_58.C` completed successfully.
- Running the same translator command under `gdb` also exited normally, so the original crash signature no longer reproduces on the current codebase.

Given that the root issue no longer applies, the remaining problem was stale test metadata keeping the test out of the regular CTest set.

## What changed

- Removed `test2018_58.C` from `CXX17_DISABLED_TESTCODES`.
- Left the existing `Cxx17_tests` registration structure unchanged, so the test now runs in the normal `Cxx17` CTest set without adding any new or redundant grouping.

## Validation

- `ctest --test-dir /home/ouankou/Projects/rex/build -R 'Cxx17_tests_test2018_58_C' --output-on-failure -j32`
- `ctest --test-dir /home/ouankou/Projects/rex/build -R 'rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran' --exclude-regex 'omp_lowering' --output-on-failure -j32`
  - Result: `4947/4947` tests passed.
- Pre-push hook validation
  - Result: `6647/6647` tests passed.
