### PR TITLE
Fix invalid template scope in Cxx11 tests

### DIFF
--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
@@ -931,8 +931,6 @@ set(CXX11_DISABLED_TESTCODES
   test2019_103.C
   test2019_104.C
   test2019_132.C
-  test2019_148.C
-  test2019_149.C
   test2019_243.C
   test2019_244.C
   test2019_245.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_148.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_148.C
@@ -1,11 +1,8 @@
-// DQ (2/19/2019): This does not appear to be valid C++11 (or C++14 or C++17)
+// Alias templates are valid at namespace or class scope.
+template <class T> using ptr = T *;
 
-void foobar()
-   {
-  // alias template
-     template<class T>
-     using ptr = T*; 
+void foobar() {
   // the name 'ptr<T>' is now an alias for pointer to T
-     ptr<int> x;
-   }
-
+  ptr<int> x = nullptr;
+  (void)x;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_149.C
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_149.C
@@ -1,12 +1,16 @@
-// DQ (2/19/2019): This does not appear to be valid C++11 (or C++14 or C++17)
+// Templates are valid at namespace or class scope.
+template <typename T> struct Container {
+  using value_type = T;
+};
 
-void foobar()
-   {
-  // type alias can introduce a member typedef name
-     template<typename T>
-     struct Container { using value_type = T; };
-  // which can be used in generic programming
-     template<typename Container>
-     void g(const Container& c) { typename Container::value_type n; }
-   }
+template <typename ContainerType> void g(const ContainerType &c) {
+  typename ContainerType::value_type n{};
+  (void)c;
+  (void)n;
+}
 
+void foobar() {
+  // A member typedef introduced by a class template can be used generically.
+  Container<int> c;
+  g(c);
+}


### PR DESCRIPTION
## Summary

Closes #365.

This updates the two affected C++11 compile tests so they use valid template scope and removes their disabled classification from the existing `Cxx11_tests` registration.

## Root Cause

`test2019_148.C` and `test2019_149.C` declared templates inside `foobar()`, which is ill-formed C++. Clang correctly rejects those files with:

- `templates can only be declared in namespace or class scope`

Because the specimens themselves were invalid, CMake had them listed in `CXX11_DISABLED_TESTCODES` even though they were already part of the normal `Cxx11_tests` set.

## Changes

- Moved the alias template in `test2019_148.C` to namespace scope and kept the test exercising alias-template use inside the function body.
- Moved the class/function templates in `test2019_149.C` to namespace scope and kept the test exercising a member typedef in generic code.
- Removed `test2019_148.C` and `test2019_149.C` from `CXX11_DISABLED_TESTCODES`.

No new test suite was added. The existing `Cxx11_tests_test2019_148_C` and `Cxx11_tests_test2019_149_C` entries now run as ordinary CTest tests.

## Validation

- Reproduced the pre-fix failure directly with:
  - `build/bin/testTranslator -w -rose:verbose 0 -rose:skip_unparse_asm_commands -std=c++11 -c tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_148.C`
  - `build/bin/testTranslator -w -rose:verbose 0 -rose:skip_unparse_asm_commands -std=c++11 -c tests/nonsmoke/functional/CompileTests/Cxx11_tests/test2019_149.C`
- Verified the fixed tests pass in CTest:
  - `ctest --test-dir build -j32 --output-on-failure -R '^Cxx11_tests_test2019_14[89]_C$'`
- Ran the requested regression command:
  - `ctest --test-dir build -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering" --output-on-failure -j32`
  - Result: `4947/4947` tests passed
