### PR TITLE
[codex] Fix docs Pages workflow

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -7,25 +7,31 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: docs-publish-main
+  group: pages
   cancel-in-progress: true
 
 env:
   LLVM_VERSION: 22
 
 jobs:
-  docs:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
       - name: Add LLVM apt repository
         run: |
@@ -84,12 +90,20 @@ jobs:
           DOCS_JOBS: 32
         run: bash scripts/ci-docs-build
 
+      - name: Upload GitHub Pages Artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./_site
+
+  deploy:
+    runs-on: ubuntu-24.04
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         if: ${{ !env.ACT }}
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: _site
-          force_orphan: true
-          cname: rex.ouankou.com
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+rex.ouankou.com

--- a/scripts/ci-docs-build
+++ b/scripts/ci-docs-build
@@ -96,6 +96,7 @@ if [ ! -f "$BUILD_DIR/compile_commands.json" ]; then
   cmake -S "$root" -B "$BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DROSE_ENABLE_PCH=OFF \
     -DENABLE-C=ON \
     -DENABLE-FORTRAN=OFF \
     -DENABLE-TESTS-DIRECTORY=OFF \

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -577,7 +577,7 @@ def is_in_inputs(path: Path) -> bool:
     return False
 
 def is_cmake_pch_arg(arg: str) -> bool:
-    return arg.replace("\\", "/").split("/")[-1].startswith("cmake_pch.")
+    return arg.rsplit("/", 1)[-1].startswith("cmake_pch.")
 
 def strip_cmake_pch_args(argv: list[str]) -> list[str]:
     if not any(is_cmake_pch_arg(arg) for arg in argv):
@@ -660,6 +660,8 @@ for entry in data:
     if is_excluded(file_path):
         continue
     if not is_in_inputs(file_path):
+        continue
+    if is_cmake_pch_arg(str(file_path)):
         continue
     new_entry = dict(entry)
     new_entry["file"] = str(file_path)

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -600,6 +600,14 @@ def strip_cmake_pch_args(argv: list[str]) -> list[str]:
             i += 2
             continue
 
+        if (
+            arg in {"-I", "-isystem", "-iquote", "-idirafter"}
+            and i + 1 < len(argv)
+            and is_cmake_pch_arg(argv[i + 1])
+        ):
+            i += 2
+            continue
+
         if arg == "-Xclang" and i + 1 < len(argv):
             xclang_arg = argv[i + 1]
             if xclang_arg == "-include-pch":

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -661,7 +661,7 @@ for entry in data:
         continue
     if not is_in_inputs(file_path):
         continue
-    if is_cmake_pch_arg(str(file_path)):
+    if file_path.name.startswith("cmake_pch."):
         continue
     new_entry = dict(entry)
     new_entry["file"] = str(file_path)

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -576,6 +576,71 @@ def is_in_inputs(path: Path) -> bool:
             continue
     return False
 
+def is_cmake_pch_arg(arg: str) -> bool:
+    return "cmake_pch." in arg or "cmake_pch.hxx" in arg
+
+def strip_cmake_pch_args(argv: list[str]) -> list[str]:
+    if not any(is_cmake_pch_arg(arg) for arg in argv):
+        return list(argv)
+
+    cleaned = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+
+        if arg in {"-Winvalid-pch", "-fpch-instantiate-templates"}:
+            i += 1
+            continue
+
+        if arg == "-include-pch" and i + 1 < len(argv) and is_cmake_pch_arg(argv[i + 1]):
+            i += 2
+            continue
+
+        if arg.startswith("-include-pch") and is_cmake_pch_arg(arg):
+            i += 1
+            continue
+
+        if arg == "-include" and i + 1 < len(argv) and is_cmake_pch_arg(argv[i + 1]):
+            i += 2
+            continue
+
+        if arg.startswith("-include") and is_cmake_pch_arg(arg):
+            i += 1
+            continue
+
+        if arg == "-Xclang" and i + 1 < len(argv):
+            xclang_arg = argv[i + 1]
+            if xclang_arg == "-include-pch":
+                if (
+                    i + 3 < len(argv)
+                    and argv[i + 2] == "-Xclang"
+                    and is_cmake_pch_arg(argv[i + 3])
+                ):
+                    i += 4
+                    continue
+                if i + 2 < len(argv) and is_cmake_pch_arg(argv[i + 2]):
+                    i += 3
+                    continue
+            if xclang_arg == "-include":
+                if (
+                    i + 3 < len(argv)
+                    and argv[i + 2] == "-Xclang"
+                    and is_cmake_pch_arg(argv[i + 3])
+                ):
+                    i += 4
+                    continue
+                if i + 2 < len(argv) and is_cmake_pch_arg(argv[i + 2]):
+                    i += 3
+                    continue
+
+        if is_cmake_pch_arg(arg):
+            i += 1
+            continue
+
+        cleaned.append(arg)
+        i += 1
+    return cleaned
+
 data = json.loads(compile_db_path.read_text(encoding="utf-8"))
 if not isinstance(data, list):
     raise SystemExit("compile_commands.json is not a list")
@@ -607,6 +672,8 @@ for entry in data:
             import shlex
             args = shlex.split(cmd)
     if isinstance(args, list) and args:
+        args = strip_cmake_pch_args(args)
+
         def is_cpp_source(path: Path, argv: list[str]) -> bool:
             suffix = path.suffix
             suffix_lower = suffix.lower()

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -577,7 +577,7 @@ def is_in_inputs(path: Path) -> bool:
     return False
 
 def is_cmake_pch_arg(arg: str) -> bool:
-    return Path(arg).name.startswith("cmake_pch.")
+    return arg.replace("\\", "/").split("/")[-1].startswith("cmake_pch.")
 
 def strip_cmake_pch_args(argv: list[str]) -> list[str]:
     if not any(is_cmake_pch_arg(arg) for arg in argv):

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -596,16 +596,8 @@ def strip_cmake_pch_args(argv: list[str]) -> list[str]:
             i += 2
             continue
 
-        if arg.startswith("-include-pch") and is_cmake_pch_arg(arg):
-            i += 1
-            continue
-
         if arg == "-include" and i + 1 < len(argv) and is_cmake_pch_arg(argv[i + 1]):
             i += 2
-            continue
-
-        if arg.startswith("-include") and is_cmake_pch_arg(arg):
-            i += 1
             continue
 
         if arg == "-Xclang" and i + 1 < len(argv):

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -577,7 +577,7 @@ def is_in_inputs(path: Path) -> bool:
     return False
 
 def is_cmake_pch_arg(arg: str) -> bool:
-    return "cmake_pch." in arg or "cmake_pch.hxx" in arg
+    return Path(arg).name.startswith("cmake_pch.")
 
 def strip_cmake_pch_args(argv: list[str]) -> list[str]:
     if not any(is_cmake_pch_arg(arg) for arg in argv):


### PR DESCRIPTION
## Summary

This PR fixes the docs publishing pipeline after the recent PCH build changes and migrates the docs deploy path from branch publishing to the official GitHub Pages workflow artifact flow.

## Root Cause

The failing docs publish run broke during `Build docs (shared script)`, before deployment. MrDocs consumes `compile_commands.json`, and after the PCH build-time change the docs extraction path could inherit CMake-generated PCH arguments such as `cmake_pch.hxx.pch`. In CI, those PCH artifacts were missing or incompatible with the compiler invocation MrDocs was using, causing extraction failures before the site could be generated.

## Changes

- Disable REX PCH for the docs CI configuration with `-DROSE_ENABLE_PCH=OFF`, keeping normal REX builds free to use PCH.
- Sanitize MrDocs compile commands by stripping only CMake-generated `cmake_pch` arguments before handing them to MrDocs.
- Replace the legacy `peaceiris/actions-gh-pages` branch publish path with the official Pages workflow split:
  - `actions/configure-pages@v5`
  - `actions/upload-pages-artifact@v4`
  - `actions/deploy-pages@v4`
- Keep local `act` validation usable by skipping the GitHub-hosted artifact upload/deploy steps under `ACT`, where GitHub's artifact runtime token is unavailable.
- Add `docs/CNAME` with `rex.ouankou.com` so the uploaded Pages artifact preserves the custom domain.

## Validation

- Reset local `main` to the forced-updated `origin/main` at `df71ce3120`, reapplied the changes without conflicts, and retested on that base.
- Removed ignored `build/` and `_site/` before the clean workflow run to avoid stale artifacts.
- Passed:
  - `act workflow_dispatch -W .github/workflows/docs-publish.yml -j build -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 --container-architecture linux/amd64 -q`
  - `act workflow_dispatch -W .github/workflows/docs-publish.yml -n -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 --container-architecture linux/amd64`
  - `git diff --check`
  - `bash -n scripts/ci-docs-build scripts/generate-api-documentation`
  - focused PCH argument stripping cases
- Confirmed GitHub Pages reports:
  - `build_type: workflow`
  - `cname: rex.ouankou.com`
  - `html_url: https://rex.ouankou.com/`