### PR TITLE
[codex] Add Sage AST JSON checkpoint round-trip support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1267,6 +1267,7 @@ endif()
 
 set(ROSE_SANITIZERS "" CACHE STRING "Semicolon-separated list of sanitizers to enable (address;leak;undefined)")
 option(ENABLE-SANITIZER "Enable sanitizer instrumentation for ROSE development" OFF)
+option(REX_EXTENDED_TEST_TIMEOUTS "Use extended timeouts for instrumented CTest configurations such as memcheck" OFF)
 set(_rose_requested_sanitizers "")
 if(ENABLE-SANITIZER)
   set(_rose_requested_sanitizers "${ROSE_SANITIZERS}")
@@ -1493,12 +1494,23 @@ if(NOT _rose_memcheck_valgrind AND UNIX)
   unset(_rose_valgrind_status)
 endif()
 
+set(ROSE_CTEST_EXPLICIT_TIMEOUT_SCALE 1)
+set(ROSE_CTEST_RTH_TIMEOUT_SCALE 1)
+if(ROSE_USE_VALGRIND)
+  set(ROSE_CTEST_EXPLICIT_TIMEOUT_SCALE 4)
+  set(ROSE_CTEST_RTH_TIMEOUT_SCALE 4)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set(ROSE_CTEST_RTH_TIMEOUT_SCALE 24)
+  endif()
+endif()
+
 set(ROSE_CTEST_MEMCHECK_COMMAND "")
 set(ROSE_CTEST_MEMCHECK_OPTIONS "")
 set(ROSE_CTEST_MEMCHECK_SUPPRESSIONS "")
 set(ROSE_CTEST_MEMCHECK_TYPE "")
 if(_rose_memcheck_valgrind)
   set(ROSE_REAL_VALGRIND "${_rose_memcheck_valgrind}")
+  set(ROSE_CTEST_MEMCHECK_RTH_TIMEOUT_SCALE ${ROSE_CTEST_RTH_TIMEOUT_SCALE})
   set(ROSE_CTEST_MEMCHECK_WRAPPER
       "${CMAKE_BINARY_DIR}/scripts/rex-ctest-valgrind-wrapper")
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/scripts")
@@ -1515,82 +1527,82 @@ if(_rose_memcheck_valgrind)
     set(_rose_memcheck_toolchain_major "${LLVM_VERSION_MAJOR}")
   endif()
   set(_rose_memcheck_trace_children_skip
-      "/usr/bin/clang++-${_rose_memcheck_toolchain_major}"
-      "/usr/bin/clang-${_rose_memcheck_toolchain_major}"
-      "/usr/bin/flang-${_rose_memcheck_toolchain_major}"
-      "/usr/lib/llvm-${_rose_memcheck_toolchain_major}/bin/clang++-${_rose_memcheck_toolchain_major}"
-      "/usr/lib/llvm-${_rose_memcheck_toolchain_major}/bin/clang-${_rose_memcheck_toolchain_major}"
-      "/usr/lib/llvm-${_rose_memcheck_toolchain_major}/bin/flang-${_rose_memcheck_toolchain_major}"
-      "/usr/lib/llvm-${_rose_memcheck_toolchain_major}/bin/flang"
-      "clang++-${_rose_memcheck_toolchain_major}"
-      "clang-${_rose_memcheck_toolchain_major}"
-      "flang-${_rose_memcheck_toolchain_major}"
-      "flang"
-      "clang++"
-      "clang"
-      "g++"
-      "gcc"
-      "c++"
-      "cc"
-      "/usr/bin/grep"
-      "/bin/grep"
-      "grep"
-      "/usr/bin/cmp"
-      "/bin/cmp"
-      "cmp"
-      "/usr/bin/mktemp"
-      "/bin/mktemp"
-      "mktemp"
-      "/usr/bin/dash"
-      "/bin/dash"
-      "dash"
-      "/usr/bin/bash"
-      "/bin/bash"
-      "bash"
-      "egrep"
-      "fgrep"
-      "diff"
-      "sed"
-      "awk"
-      "tr"
-      "cut"
-      "sort"
-      "uniq"
-      "head"
-      "tail"
-      "cmake"
-      "ctest"
-      "make"
-      "ninja"
-      "sh"
-      "perl"
-      "python"
-      "python3"
-      "tar"
-      "gzip"
-      "bzip2"
-      "xz"
-      "zip"
-      "unzip"
-      "cp"
-      "mv"
-      "rm"
-      "install")
+      "*/clang++-${_rose_memcheck_toolchain_major}"
+      "*/clang-${_rose_memcheck_toolchain_major}"
+      "*/flang-${_rose_memcheck_toolchain_major}"
+      "*/flang"
+      "*/clang++"
+      "*/clang"
+      "*/g++"
+      "*/gcc"
+      "*/c++"
+      "*/cc"
+      "*/grep"
+      "*/cmp"
+      "*/mktemp"
+      "*/dash"
+      "*/bash")
+
+  set(_rose_memcheck_harness_tools
+      egrep
+      fgrep
+      diff
+      sed
+      awk
+      basename
+      tr
+      cut
+      dirname
+      sort
+      uniq
+      git
+      head
+      tail
+      cmake
+      ctest
+      make
+      ninja
+      sh
+      perl
+      python
+      python3
+      tar
+      gzip
+      bzip2
+      find
+      xz
+      zip
+      unzip
+      cat
+      cp
+      env
+      ln
+      mkdir
+      mv
+      pwd
+      readlink
+      realpath
+      rm
+      rmdir
+      seq
+      tee
+      timeout
+      touch
+      wc
+      xargs
+      install)
+  foreach(_rose_memcheck_harness_tool IN LISTS _rose_memcheck_harness_tools)
+    list(APPEND _rose_memcheck_trace_children_skip "*/${_rose_memcheck_harness_tool}")
+  endforeach()
+  list(APPEND _rose_memcheck_trace_children_skip "*/scripts/policies/*")
+
   function(_rose_append_memcheck_child_skip _rose_compiler)
     if(NOT _rose_compiler)
       return()
     endif()
-
-    list(APPEND _rose_memcheck_trace_children_skip "${_rose_compiler}")
     get_filename_component(_rose_compiler_name "${_rose_compiler}" NAME)
     if(_rose_compiler_name)
-      list(APPEND _rose_memcheck_trace_children_skip "${_rose_compiler_name}")
-    endif()
-    if(EXISTS "${_rose_compiler}")
-      get_filename_component(_rose_compiler_realpath "${_rose_compiler}" REALPATH)
-      if(_rose_compiler_realpath)
-        list(APPEND _rose_memcheck_trace_children_skip "${_rose_compiler_realpath}")
-      endif()
+      list(APPEND _rose_memcheck_trace_children_skip "*/${_rose_compiler_name}")
     endif()
     set(_rose_memcheck_trace_children_skip "${_rose_memcheck_trace_children_skip}" PARENT_SCOPE)
   endfunction()
@@ -1607,6 +1619,8 @@ if(_rose_memcheck_valgrind)
   list(JOIN _rose_memcheck_trace_children_skip "," _rose_memcheck_trace_children_skip_arg)
   set(ROSE_CTEST_MEMCHECK_OPTIONS "--leak-check=full --show-leak-kinds=definite,indirect,possible --errors-for-leak-kinds=definite,indirect,possible --error-exitcode=1 --max-stackframe=2047456 --num-callers=32 --trace-children=yes --trace-children-skip=${_rose_memcheck_trace_children_skip_arg} --trace-children-skip-by-arg=*gtest_internal_run_death_test*")
   unset(_rose_compiler)
+  unset(_rose_memcheck_harness_tool)
+  unset(_rose_memcheck_harness_tools)
   unset(_rose_memcheck_trace_children_skip_arg)
   unset(_rose_memcheck_trace_children_skip)
   unset(_rose_memcheck_toolchain_major)
@@ -1622,9 +1636,15 @@ set(CTEST_MEMORYCHECK_SUPPRESSIONS_FILE "${ROSE_CTEST_MEMCHECK_SUPPRESSIONS}")
 set(ROSE_CTEST_CUSTOM_ENVIRONMENT "")
 if(ROSE_USE_VALGRIND)
   set(ROSE_CTEST_CUSTOM_ENVIRONMENT
-      "set(CTEST_CUSTOM_ENVIRONMENT \"ROSE_TEST_TIMEOUT_SCALE=4\")")
+      "set(CTEST_CUSTOM_ENVIRONMENT \"ROSE_TEST_TIMEOUT_SCALE=${ROSE_CTEST_RTH_TIMEOUT_SCALE}\")")
   # Memcheck can exceed CTest's default 1500-second timeout on parser-heavy tests.
-  set(DART_TESTING_TIMEOUT 5400)
+  set(_rose_dashboard_timeout 5400)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set(_rose_dashboard_timeout 22200)
+  endif()
+  set(DART_TESTING_TIMEOUT ${_rose_dashboard_timeout} CACHE STRING
+      "Maximum time in seconds for CTest dashboard tests" FORCE)
+  unset(_rose_dashboard_timeout)
 endif()
 if(ROSE_CTEST_MEMCHECK_COMMAND)
   set(MEMORYCHECK_COMMAND "${ROSE_CTEST_MEMCHECK_COMMAND}" CACHE FILEPATH

--- a/cmake/CTestCustom.cmake.in
+++ b/cmake/CTestCustom.cmake.in
@@ -3,4 +3,49 @@ set(CTEST_CUSTOM_ERROR_EXCEPTION
   "unbalanced braces"
 )
 
+set(CTEST_CUSTOM_MEMCHECK_IGNORE
+  # Standalone compiler baseline; normal CTest still runs it, but Memcheck is
+  # reserved for REX executables instead of LLVM's driver.
+  compiler_options_include_order_sys_include_cc
+
+  # Full-header/generated-source traversal performance checks remain regular
+  # CTest coverage. Under Valgrind they spend hours in the Clang frontend before
+  # reaching the traversal under test; rex_merge_traversal_memcheck covers the
+  # traversal executable with a bounded AST in Memcheck.
+  merge_traversal_input
+  merge_traversal_cxx_grammar
+
+  # This legacy iostream/template specimen is regular CTest coverage for
+  # single-statement normalization, but it spends more than an hour in the
+  # instrumented Clang frontend under Memcheck. The bounded
+  # rex_single_statement_normalization_memcheck test covers the same
+  # transformation executable in Memcheck.
+  singleStatementToBlockNormalization_test2013_231.C
+
+  # These large preprocessed C++ header specimens remain regular and sanitizer
+  # CTest coverage. Under Memcheck they spend hours in the instrumented Clang
+  # frontend before reaching the generated compile, unfolded-constants,
+  # uninitialized-field, or comment-collection pass being exercised.
+  Cxx_tests_longFile_C
+  Cxx_tests_test2013_13_C
+  Cxx_tests_test2013_14_C
+  Cxx_tests_test2013_15_C
+  Cxx_tests_test2017_24_C
+  longFile.C.unfoldedConstants-o
+  test2013_13.C.unfoldedConstants-o
+  test2013_14.C.unfoldedConstants-o
+  test2013_15.C.unfoldedConstants-o
+  test2017_24.C.unfoldedConstants-o
+  uninit_fields_cxx_Cxx_tests_longFile_C
+  uninit_fields_cxx_Cxx_tests_test2013_13_C
+  uninit_fields_cxx_Cxx_tests_test2013_14_C
+  uninit_fields_cxx_Cxx_tests_test2013_15_C
+  uninit_fields_cxx_Cxx_tests_test2017_24_C
+  compiler_options_collect_comments_Cxx_tests_longFile_C
+  compiler_options_collect_comments_Cxx_tests_test2013_13_C
+  compiler_options_collect_comments_Cxx_tests_test2013_14_C
+  compiler_options_collect_comments_Cxx_tests_test2013_15_C
+  compiler_options_collect_comments_Cxx_tests_test2017_24_C
+)
+
 @ROSE_CTEST_CUSTOM_ENVIRONMENT@

--- a/cmake/rex-ctest-valgrind-wrapper.in
+++ b/cmake/rex-ctest-valgrind-wrapper.in
@@ -26,6 +26,10 @@ fi
 
 tool="${args[cmd_index]}"
 if [[ "${tool}" == */rth_run.pl ]]; then
+  rth_timeout_scale="@ROSE_CTEST_MEMCHECK_RTH_TIMEOUT_SCALE@"
+  if [[ -z "${ROSE_TEST_TIMEOUT_SCALE:-}" && "${rth_timeout_scale}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    export ROSE_TEST_TIMEOUT_SCALE="${rth_timeout_scale}"
+  fi
   valgrind_words=("${real_valgrind}" "${args[@]:0:cmd_index}")
   valgrind_command=""
   printf -v valgrind_command "%q " "${valgrind_words[@]}"

--- a/src/AstNodes/Expression/SgSubscriptExpression.C
+++ b/src/AstNodes/Expression/SgSubscriptExpression.C
@@ -6,15 +6,11 @@ SgType *SgSubscriptExpression::get_type() const {
   SgType *returnType = NULL;
 
   bool isLowerBoundNullExpression =
-      (isSgNullExpression(get_lowerBound()) != NULL);
+      (get_lowerBound() == NULL ||
+       isSgNullExpression(get_lowerBound()) != NULL);
   bool isUpperBoundNullExpression =
-      (isSgNullExpression(get_upperBound()) != NULL);
-  bool isStrideNullExpression =
-      (isSgNullExpression(get_stride()) != NULL); // blame initial commit
-
-  // Even if the stride was not specified it should default to unit stride
-  // (value == 1).
-  ROSE_ASSERT(isStrideNullExpression == false);
+      (get_upperBound() == NULL ||
+       isSgNullExpression(get_upperBound()) != NULL);
 
   if (isLowerBoundNullExpression == true) {
     // There was no lower bound specified

--- a/src/ROSETTA/Grammar/Support.code
+++ b/src/ROSETTA/Grammar/Support.code
@@ -18771,6 +18771,7 @@ SgTemplateArgument::SgTemplateArgument ( SgType* argument, bool explicitlySpecif
      post_construction_initialization();
 
      p_argumentType        = type_argument;
+     p_isArrayBoundUnknownType = false;
      p_type                = argument;
      p_explicitlySpecified = explicitlySpecified;
 
@@ -18788,6 +18789,7 @@ SgTemplateArgument::SgTemplateArgument ( SgExpression* argument, bool explicitly
      post_construction_initialization();
 
      p_argumentType        = nontype_argument;
+     p_isArrayBoundUnknownType = false;
      p_expression          = argument;
      p_explicitlySpecified = explicitlySpecified;
 
@@ -18808,6 +18810,7 @@ SgTemplateArgument::SgTemplateArgument ( SgTemplateDeclaration* argument, bool e
      post_construction_initialization();
 
      p_argumentType        = template_template_argument;
+     p_isArrayBoundUnknownType = false;
      p_templateDeclaration = argument;
      p_explicitlySpecified = explicitlySpecified;
 
@@ -18830,6 +18833,7 @@ SgTemplateArgument::SgTemplateArgument ( bool explicitlySpecified )
      post_construction_initialization();
 
      p_argumentType        = start_of_pack_expansion_argument;
+     p_isArrayBoundUnknownType = false;
      p_expression          = NULL;
      p_explicitlySpecified = explicitlySpecified;
 

--- a/src/ROSETTA/Grammar/Symbol.code
+++ b/src/ROSETTA/Grammar/Symbol.code
@@ -637,10 +637,16 @@ SgLabelSymbol::SgLabelSymbol ( SgInitializedName* initializedName )
   // Verify that this is used correctly.
      ROSE_ASSERT(initializedName->get_name() == "*");
 
+     p_declaration = NULL;
+     p_fortran_statement = NULL;
+     p_fortran_alternate_return_parameter = NULL;
+     p_numeric_label_value = -1;
+
   // Set the internal mode to support analysis...
      p_label_type = e_alternative_return_type;
 
      set_fortran_alternate_return_parameter(initializedName);
+     post_construction_initialization();
    }
 
 SOURCE_LABEL_SYMBOL_END

--- a/src/ROSETTA/Grammar/Type.code
+++ b/src/ROSETTA/Grammar/Type.code
@@ -901,6 +901,7 @@ SgType::SgType()
   // DQ (10/3/2010): Readded to the SgType since it is used uniformally within Fortran types.
   // DQ (12/1/2007): This has been moved to the SgModifierType
      p_type_kind(NULL),
+     p_hasTypeKindStar(false),
      p_attributeMechanism(NULL)
    {
      ROSE_ASSERT(p_ref_to == NULL);
@@ -939,6 +940,7 @@ SgType::SgType(const SgType & X)
   // DQ (10/3/2010): Readded to the SgType since it is used uniformally within Fortran types.
   // DQ (12/1/2007): This has been moved to the SgModifierType
      p_type_kind(X.p_type_kind),
+     p_hasTypeKindStar(X.p_hasTypeKindStar),
      p_attributeMechanism(X.p_attributeMechanism)
    {
   // DQ (10/17/2007): This copy constructor is built to support the AST copy mechanism where for

--- a/src/ROSETTA/src/AstNodeClass.C
+++ b/src/ROSETTA/src/AstNodeClass.C
@@ -188,7 +188,7 @@ string AstNodeClass::buildDestructorBody() {
 #endif
     }
     if (typeName == " rose_hash_multimap*" ||
-        typeName == "OSEAttributesListContainerPtr") {
+        typeName == "ROSEAttributesListContainerPtr") {
       tempString = "    if (p_$DATA) { delete " + tempString + "p_$DATA; }\n";
     }
     tempString = StringUtility::copyEdit(tempString, "$DATA", varName);

--- a/src/ROSETTA/src/grammarString.C
+++ b/src/ROSETTA/src/grammarString.C
@@ -488,6 +488,39 @@ GrammarString::buildCopyMemberFunctionSource(bool buildConstructorArgument) {
     return returnString;
   }
 
+  if (typeName == "AttachedPreprocessingInfoType*" &&
+      variableName == "attachedPreprocessingInfoPtr") {
+    string copyOfVariableName = variableName + "_copy";
+    string sourceVariableName = "p_" + variableName;
+
+    commentString = "  // case: deep copy AttachedPreprocessingInfoType* for " +
+                    variableName + "\n";
+    returnString +=
+        "     " + typeName + " " + copyOfVariableName + " = NULL; \n";
+    returnString += commentString;
+    returnString += "     if (" + sourceVariableName + " != NULL) \n";
+    returnString += "        { \n";
+    returnString += "          " + copyOfVariableName +
+                    " = new AttachedPreprocessingInfoType; \n";
+    returnString +=
+        "          for (AttachedPreprocessingInfoType::const_iterator i = " +
+        sourceVariableName + "->begin(); i != " + sourceVariableName +
+        "->end(); ++i) \n";
+    returnString += "             { \n";
+    returnString +=
+        "               " + copyOfVariableName +
+        "->push_back((*i != NULL) ? new PreprocessingInfo(**i) : NULL); \n";
+    returnString += "             } \n";
+    returnString += "        } \n";
+
+    if (buildConstructorArgument == false) {
+      returnString += "     result->p_" + variableName + " = " +
+                      copyOfVariableName + "; \n";
+    }
+
+    return returnString;
+  }
+
   // The rule is that if it is not a char* or char** then if it ia a pointer
   // type it is a pointer to a Sage IR node
   bool typeIsSgNode = typeName.find('*') != string::npos;
@@ -1149,6 +1182,26 @@ string GrammarString::buildDestructorSource() {
     // code fragment returnString += commentString;
     returnString = commentString + returnString;
 
+    return returnString;
+  }
+
+  if (typeName == "AttachedPreprocessingInfoType*" &&
+      variableName == "attachedPreprocessingInfoPtr") {
+    commentString =
+        "  // case: delete AttachedPreprocessingInfoType* contents for " +
+        variableName + "\n";
+    returnString += "     if (p_" + variableName + " != NULL) \n";
+    returnString += "        { \n";
+    returnString +=
+        "          for (AttachedPreprocessingInfoType::iterator i = p_" +
+        variableName + "->begin(); i != p_" + variableName + "->end(); ++i) \n";
+    returnString += "             { \n";
+    returnString += "               delete *i; \n";
+    returnString += "             } \n";
+    returnString += "          delete p_" + variableName + "; \n";
+    returnString += "          p_" + variableName + " = NULL; \n";
+    returnString += "        } \n";
+    returnString = commentString + returnString;
     return returnString;
   }
 

--- a/src/ROSETTA/src/node.C
+++ b/src/ROSETTA/src/node.C
@@ -1593,8 +1593,9 @@ void Grammar::setUpNodes() {
       NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL,
       NO_DELETE);
   OmpUsesAllocatorsDefination.setDataPrototype(
-      "SgExpression*", "allocator_traits_array", "", NO_CONSTRUCTOR_PARAMETER,
-      BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+      "SgExpression*", "allocator_traits_array", "= NULL",
+      NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL,
+      NO_DELETE);
 
   // depend(modifier, type:variables)
   OmpDependClause.setDataPrototype(

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx.h
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx.h
@@ -50,9 +50,10 @@ public:
   virtual ~Unparse_ExprStmt();
 
   // DQ (3/13/2004): Added to support templates
-  virtual void unparseTemplateParameter(SgTemplateParameter *templateParameter,
-                                        SgUnparse_Info &info,
-                                        bool is_template_header = false);
+  virtual void unparseTemplateParameter(
+      SgTemplateParameter *templateParameter, SgUnparse_Info &info,
+      bool is_template_header = false,
+      SgDeclarationStatement *template_declaration = nullptr);
   virtual void unparseTemplateArgument(SgTemplateArgument *templateArgument,
                                        SgUnparse_Info &info);
 
@@ -78,7 +79,8 @@ public:
   // qualification.
   void unparseTemplateParameterList(
       const SgTemplateParameterPtrList &templateParameterList,
-      SgUnparse_Info &info, bool is_template_header = false);
+      SgUnparse_Info &info, bool is_template_header = false,
+      SgDeclarationStatement *template_declaration = nullptr);
 
   // DQ (5/25/2013): Added support for unparsing the name of the template member
   // function.

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include <string>
+#include <vector>
 
 // DQ (12/31/2005): This is OK if not declared in a header file
 using namespace std;
@@ -47,76 +48,271 @@ const char *templateParameterKeywordSpelling(
   }
 }
 
-std::string
-buildTemplateDefaultArgumentEmissionKey(SgTemplateParameter *template_parameter,
-                                        SgUnparse_Info &info) {
+const SgTemplateParameterPtrList *
+templateDeclarationParameters(SgDeclarationStatement *decl) {
+  if (SgTemplateDeclaration *legacy_template = isSgTemplateDeclaration(decl)) {
+    return &legacy_template->get_templateParameters();
+  }
+  if (SgTemplateClassDeclaration *class_template =
+          isSgTemplateClassDeclaration(decl)) {
+    return &class_template->get_templateParameters();
+  }
+  if (SgTemplateFunctionDeclaration *function_template =
+          isSgTemplateFunctionDeclaration(decl)) {
+    return &function_template->get_templateParameters();
+  }
+  if (SgTemplateMemberFunctionDeclaration *member_function_template =
+          isSgTemplateMemberFunctionDeclaration(decl)) {
+    return &member_function_template->get_templateParameters();
+  }
+  if (SgTemplateTypedefDeclaration *typedef_template =
+          isSgTemplateTypedefDeclaration(decl)) {
+    return &typedef_template->get_templateParameters();
+  }
+  if (SgTemplateVariableDeclaration *variable_template =
+          isSgTemplateVariableDeclaration(decl)) {
+    return &variable_template->get_templateParameters();
+  }
+  return nullptr;
+}
+
+SgDeclarationStatement *templateParameterOwner(SgDeclarationStatement *owner,
+                                               SgUnparse_Info &info) {
+  if (owner != nullptr) {
+    return owner;
+  }
+
+  SgDeclarationStatement *info_decl = info.get_declstatement_ptr();
+  return templateDeclarationParameters(info_decl) != nullptr ? info_decl
+                                                             : nullptr;
+}
+
+bool templateParameterHasDefault(SgTemplateParameter *template_parameter) {
+  return template_parameter != nullptr &&
+         (template_parameter->get_defaultTypeParameter() != nullptr ||
+          template_parameter->get_defaultExpressionParameter() != nullptr ||
+          template_parameter->get_defaultTemplateDeclarationParameter() !=
+              nullptr);
+}
+
+bool templateParameterIndexInDeclaration(
+    SgTemplateParameter *template_parameter, SgDeclarationStatement *decl,
+    size_t &parameter_index) {
+  const SgTemplateParameterPtrList *params =
+      templateDeclarationParameters(decl);
+  if (template_parameter == nullptr || params == nullptr) {
+    return false;
+  }
+
+  for (size_t i = 0; i < params->size(); ++i) {
+    if ((*params)[i] == template_parameter) {
+      parameter_index = i;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+SgTemplateParameter *templateParameterAt(SgDeclarationStatement *decl,
+                                         size_t parameter_index) {
+  const SgTemplateParameterPtrList *params =
+      templateDeclarationParameters(decl);
+  if (params == nullptr || parameter_index >= params->size()) {
+    return nullptr;
+  }
+
+  return (*params)[parameter_index];
+}
+
+size_t
+findTopLevelTemplateParameterDefaultInSegment(const std::string &segment) {
+  int angle_depth = 0;
+  int paren_depth = 0;
+  int bracket_depth = 0;
+  int brace_depth = 0;
+  for (size_t i = 0; i < segment.size(); ++i) {
+    char ch = segment[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>' && angle_depth > 0) {
+      --angle_depth;
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    } else if (ch == '=' && angle_depth == 0 && paren_depth == 0 &&
+               bracket_depth == 0 && brace_depth == 0) {
+      return i;
+    }
+  }
+  return std::string::npos;
+}
+
+bool spelledTemplateParameterDefaults(SgDeclarationStatement *decl,
+                                      std::vector<bool> &defaults) {
+  SgName saved_template_name;
+  if (SgTemplateClassDeclaration *class_template =
+          isSgTemplateClassDeclaration(decl)) {
+    saved_template_name = class_template->get_string();
+  } else {
+    return false;
+  }
+
+  const char *saved_template_string = saved_template_name.str();
+  if (saved_template_name.is_null() || saved_template_string == nullptr ||
+      saved_template_string[0] == '\0') {
+    return false;
+  }
+
+  std::string text(saved_template_string);
+  size_t template_pos = text.find("template");
+  if (template_pos == std::string::npos) {
+    return false;
+  }
+  size_t open = text.find('<', template_pos);
+  if (open == std::string::npos) {
+    return false;
+  }
+
+  int angle_depth = 1;
+  int paren_depth = 0;
+  int bracket_depth = 0;
+  int brace_depth = 0;
+  size_t close = std::string::npos;
+  for (size_t i = open + 1; i < text.size(); ++i) {
+    char ch = text[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>') {
+      --angle_depth;
+      if (angle_depth == 0) {
+        close = i;
+        break;
+      }
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    }
+  }
+  if (close == std::string::npos) {
+    return false;
+  }
+
+  const std::string params = text.substr(open + 1, close - open - 1);
+  defaults.clear();
+  size_t segment_start = 0;
+  angle_depth = paren_depth = bracket_depth = brace_depth = 0;
+  auto push_segment = [&](size_t segment_end) {
+    const std::string segment =
+        params.substr(segment_start, segment_end - segment_start);
+    defaults.push_back(findTopLevelTemplateParameterDefaultInSegment(segment) !=
+                       std::string::npos);
+  };
+
+  for (size_t i = 0; i < params.size(); ++i) {
+    char ch = params[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>' && angle_depth > 0) {
+      --angle_depth;
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    } else if (ch == ',' && angle_depth == 0 && paren_depth == 0 &&
+               bracket_depth == 0 && brace_depth == 0) {
+      push_segment(i);
+      segment_start = i + 1;
+    }
+  }
+  push_segment(params.size());
+  return true;
+}
+
+std::string templateDeclarationStableName(SgDeclarationStatement *decl) {
+  if (decl == nullptr) {
+    return std::string();
+  }
+
+  std::string key = decl->get_mangled_name().getString();
+  if (key.empty()) {
+    key = SageInterface::get_name(decl);
+  }
+
+  const Sg_File_Info *file_info = decl->get_file_info();
+  if (file_info != nullptr) {
+    const std::string location = file_info->get_filenameString() + ":" +
+                                 std::to_string(file_info->get_line()) + ":" +
+                                 std::to_string(file_info->get_col());
+    if (key.empty()) {
+      key = location;
+    } else {
+      key += "@" + location;
+    }
+  }
+
+  return key;
+}
+
+std::string buildTemplateDefaultArgumentEmissionKey(
+    SgTemplateParameter *template_parameter, SgUnparse_Info &info,
+    SgDeclarationStatement *template_declaration) {
   if (template_parameter == nullptr) {
     return std::string();
   }
 
-  SgTemplateDeclaration *template_decl =
-      isSgTemplateDeclaration(info.get_declstatement_ptr());
-  if (template_decl == nullptr) {
+  SgDeclarationStatement *template_decl =
+      templateParameterOwner(template_declaration, info);
+  const SgTemplateParameterPtrList *params =
+      templateDeclarationParameters(template_decl);
+  if (template_decl == nullptr || params == nullptr) {
     return std::string();
   }
 
-  const SgTemplateParameterPtrList &params =
-      template_decl->get_templateParameters();
   size_t parameter_index = 0;
-  bool found_parameter = false;
-  for (size_t i = 0; i < params.size(); ++i) {
-    if (params[i] == template_parameter) {
-      parameter_index = i;
-      found_parameter = true;
-      break;
-    }
-  }
-  if (!found_parameter) {
+  if (!templateParameterIndexInDeclaration(template_parameter, template_decl,
+                                           parameter_index)) {
     return std::string();
   }
 
-  auto buildStableTemplateDeclarationKey =
-      [](SgTemplateDeclaration *decl) -> std::string {
-    if (decl == nullptr) {
-      return std::string();
-    }
-
-    std::string key = decl->get_mangled_name().getString();
-    if (key.empty()) {
-      key = decl->get_qualified_name().getString();
-    }
-    if (key.empty()) {
-      key = decl->get_name().getString();
-    }
-
-    const Sg_File_Info *file_info = decl->get_file_info();
-    if (file_info != nullptr) {
-      const std::string location = file_info->get_filenameString() + ":" +
-                                   std::to_string(file_info->get_line()) + ":" +
-                                   std::to_string(file_info->get_col());
-      if (key.empty()) {
-        key = location;
-      } else {
-        key += "@" + location;
-      }
-    }
-
-    return key;
-  };
-
-  SgTemplateDeclaration *canonical_decl = template_decl;
-  if (SgTemplateDeclaration *first_nondef = isSgTemplateDeclaration(
-          template_decl->get_firstNondefiningDeclaration())) {
+  SgDeclarationStatement *canonical_decl = template_decl;
+  if (SgDeclarationStatement *first_nondef =
+          template_decl->get_firstNondefiningDeclaration()) {
     canonical_decl = first_nondef;
-  } else if (SgTemplateDeclaration *defining_decl = isSgTemplateDeclaration(
-                 template_decl->get_definingDeclaration())) {
+  } else if (SgDeclarationStatement *defining_decl =
+                 template_decl->get_definingDeclaration()) {
     canonical_decl = defining_decl;
   }
 
-  std::string declaration_key =
-      buildStableTemplateDeclarationKey(canonical_decl);
+  std::string declaration_key = templateDeclarationStableName(canonical_decl);
   if (declaration_key.empty() && template_decl != canonical_decl) {
-    declaration_key = buildStableTemplateDeclarationKey(template_decl);
+    declaration_key = templateDeclarationStableName(template_decl);
   }
 
   if (declaration_key.empty()) {
@@ -124,8 +320,8 @@ buildTemplateDefaultArgumentEmissionKey(SgTemplateParameter *template_parameter,
   }
 
   return template_decl->class_name() + "|" +
-         std::to_string(static_cast<int>(template_decl->get_template_kind())) +
-         "|" + declaration_key + "|" + std::to_string(parameter_index);
+         std::to_string(static_cast<int>(template_decl->variantT())) + "|" +
+         declaration_key + "|" + std::to_string(parameter_index);
 }
 
 bool typeEndsWithTemplateIdClose(const SgType *type) {
@@ -1297,6 +1493,9 @@ void Unparse_ExprStmt::unparseNonrealRefExpression(SgExpression *expr,
       func_name = tail;
     }
   }
+  if (nrdecl->get_has_template_keyword()) {
+    curprint("template ");
+  }
   curprint(func_name);
 
   if (!tpl_args.empty() && !uses_operator_syntax) {
@@ -1876,6 +2075,15 @@ void SgTemplateArgument::outputTemplateArgument(bool &skip_unparsing,
     }
   }
 
+  bool isEmptyTemplateTypePlaceholder = false;
+  if (!isExplicitlySpecified &&
+      this->get_argumentType() == SgTemplateArgument::type_argument) {
+    if (SgTemplateType *template_type = isSgTemplateType(this->get_type())) {
+      isEmptyTemplateTypePlaceholder =
+          template_type->get_name().getString().empty();
+    }
+  }
+
   if (isPackElement && isExplicitlySpecified) {
 #if DEBUG_OUTPUT_TEMPLATE_ARGUMENT
     printf(" !!! isPackElement && isExplicitlySpecified => isPackElement == "
@@ -1936,7 +2144,8 @@ void SgTemplateArgument::outputTemplateArgument(bool &skip_unparsing,
 #endif
 
   if (isPackExpansionStart || isAnonymousClass ||
-      (isPackElement && !isExplicitlySpecified) || skip_non_explicit) {
+      (isPackElement && !isExplicitlySpecified) || skip_non_explicit ||
+      isEmptyTemplateTypePlaceholder) {
     skip_unparsing = true;
   }
 
@@ -2011,7 +2220,6 @@ void Unparse_ExprStmt::unparseTemplateArgumentList(
 
     SgTemplateArgument *tplarg = *copy_iter;
     ASSERT_not_null(tplarg);
-
 #if DEBUG_TEMPLATE_ARGUMENT_LIST
     printf(" - tplarg = %s\n", tplarg->unparseToString().c_str());
 #endif
@@ -2305,7 +2513,8 @@ void Unparse_ExprStmt::unparseTemplateArgumentList(
 
 void Unparse_ExprStmt::unparseTemplateParameterList(
     const SgTemplateParameterPtrList &templateParameterList,
-    SgUnparse_Info &info, bool is_template_header) {
+    SgUnparse_Info &info, bool is_template_header,
+    SgDeclarationStatement *template_declaration) {
 
   if (templateParameterList.empty() == false) {
     bool use_compact_template_brackets = true;
@@ -2344,7 +2553,8 @@ void Unparse_ExprStmt::unparseTemplateParameterList(
     while (i != templateParameterList.end()) {
       SgTemplateParameter *templateParameter = *i;
       ASSERT_not_null(templateParameter);
-      unparseTemplateParameter(templateParameter, info, is_template_header);
+      unparseTemplateParameter(templateParameter, info, is_template_header,
+                               template_declaration);
 
       i++;
 
@@ -2375,7 +2585,7 @@ void Unparse_ExprStmt::unparseTemplateParameterList(
 
 void Unparse_ExprStmt::unparseTemplateParameter(
     SgTemplateParameter *templateParameter, SgUnparse_Info &info,
-    bool is_template_header) {
+    bool is_template_header, SgDeclarationStatement *template_declaration) {
   ASSERT_not_null(templateParameter);
 
   // Default template arguments belong on the primary declaration only.
@@ -2385,9 +2595,151 @@ void Unparse_ExprStmt::unparseTemplateParameter(
   bool emit_default_template_arg = is_template_header;
   std::string default_template_arg_key;
   if (emit_default_template_arg) {
-    SgTemplateDeclaration *template_decl =
-        isSgTemplateDeclaration(info.get_declstatement_ptr());
+    SgDeclarationStatement *template_decl =
+        templateParameterOwner(template_declaration, info);
     if (template_decl != NULL) {
+      auto candidate_is_visible =
+          [](SgDeclarationStatement *candidate) -> bool {
+        if (candidate == nullptr) {
+          return false;
+        }
+        Sg_File_Info *candidate_fi = candidate->get_file_info();
+        if (candidate_fi == nullptr) {
+          return false;
+        }
+        if (candidate_fi->isOutputInCodeGeneration()) {
+          return true;
+        }
+        return !candidate_fi->isCompilerGenerated() &&
+               !candidate_fi->isFrontendSpecific();
+      };
+
+      size_t template_parameter_index = 0;
+      const bool have_template_parameter_index =
+          templateParameterIndexInDeclaration(templateParameter, template_decl,
+                                              template_parameter_index);
+      auto declaration_has_default_for_parameter =
+          [&](SgDeclarationStatement *decl) -> bool {
+        if (!have_template_parameter_index) {
+          return false;
+        }
+        std::vector<bool> spelled_defaults;
+        if (spelledTemplateParameterDefaults(decl, spelled_defaults) &&
+            template_parameter_index < spelled_defaults.size()) {
+          return spelled_defaults[template_parameter_index];
+        }
+        return templateParameterHasDefault(
+            templateParameterAt(decl, template_parameter_index));
+      };
+
+      auto class_template_has_prior_visible_decl =
+          [&](SgTemplateClassDeclaration *decl) -> bool {
+        if (decl == nullptr || decl->get_definition() == nullptr) {
+          return false;
+        }
+
+        SgScopeStatement *scope = isSgScopeStatement(decl->get_parent());
+        if (scope == nullptr) {
+          scope = decl->get_scope();
+        }
+        if (scope == nullptr) {
+          return false;
+        }
+
+        auto scope_decls =
+            [](SgScopeStatement *scope) -> SgDeclarationStatementPtrList * {
+          if (SgGlobal *global = isSgGlobal(scope)) {
+            return &global->get_declarations();
+          }
+          if (SgNamespaceDefinitionStatement *ns_def =
+                  isSgNamespaceDefinitionStatement(scope)) {
+            return &ns_def->get_declarations();
+          }
+          if (SgClassDefinition *class_def = isSgClassDefinition(scope)) {
+            return &class_def->get_members();
+          }
+          if (SgTemplateClassDefinition *template_def =
+                  isSgTemplateClassDefinition(scope)) {
+            return &template_def->get_members();
+          }
+          if (SgTemplateInstantiationDefn *inst_def =
+                  isSgTemplateInstantiationDefn(scope)) {
+            return &inst_def->get_members();
+          }
+          if (SgDeclarationScope *decl_scope = isSgDeclarationScope(scope)) {
+            return &decl_scope->get_declarations();
+          }
+          return nullptr;
+        };
+
+        auto candidate_precedes_decl =
+            [](SgDeclarationStatement *candidate,
+               SgDeclarationStatement *decl) -> bool {
+          if (candidate == nullptr || decl == nullptr) {
+            return false;
+          }
+          Sg_File_Info *candidate_fi = candidate->get_file_info();
+          Sg_File_Info *decl_fi = decl->get_file_info();
+          if (candidate_fi == nullptr || decl_fi == nullptr ||
+              candidate_fi->get_line() <= 0 || decl_fi->get_line() <= 0) {
+            return true;
+          }
+          if (candidate_fi->get_filenameString() !=
+              decl_fi->get_filenameString()) {
+            return true;
+          }
+          if (candidate_fi->get_line() != decl_fi->get_line()) {
+            return candidate_fi->get_line() < decl_fi->get_line();
+          }
+          return candidate_fi->get_col() < decl_fi->get_col();
+        };
+
+        auto scope_has_prior_decl = [&](SgScopeStatement *candidate_scope) {
+          SgDeclarationStatementPtrList *decls = scope_decls(candidate_scope);
+          if (decls == nullptr) {
+            return false;
+          }
+
+          for (SgDeclarationStatement *candidate_stmt : *decls) {
+            SgTemplateClassDeclaration *candidate =
+                isSgTemplateClassDeclaration(candidate_stmt);
+            if (candidate == nullptr || candidate == decl ||
+                candidate->get_name() != decl->get_name()) {
+              continue;
+            }
+            if (candidate_is_visible(candidate) &&
+                candidate_precedes_decl(candidate, decl) &&
+                declaration_has_default_for_parameter(candidate)) {
+              return true;
+            }
+          }
+
+          return false;
+        };
+
+        if (SgNamespaceDefinitionStatement *ns_scope =
+                isSgNamespaceDefinitionStatement(scope)) {
+          while (ns_scope->get_previousNamespaceDefinition() != nullptr) {
+            ns_scope = ns_scope->get_previousNamespaceDefinition();
+          }
+          for (SgNamespaceDefinitionStatement *current = ns_scope;
+               current != nullptr;
+               current = current->get_nextNamespaceDefinition()) {
+            if (scope_has_prior_decl(current)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        return scope_has_prior_decl(scope);
+      };
+
+      if (class_template_has_prior_visible_decl(
+              isSgTemplateClassDeclaration(template_decl))) {
+        emit_default_template_arg = false;
+      }
+
       SgDeclarationStatement *first_nondef =
           template_decl->get_firstNondefiningDeclaration();
       auto source_matches = [](SgDeclarationStatement *lhs,
@@ -2406,19 +2758,17 @@ void Unparse_ExprStmt::unparseTemplateParameter(
       };
 
       const bool first_nondef_is_synthetic =
-          first_nondef != NULL &&
-          (first_nondef->get_file_info() == nullptr ||
-           first_nondef->get_file_info()->isCompilerGenerated() ||
-           !first_nondef->get_file_info()->isOutputInCodeGeneration());
+          first_nondef != NULL && !candidate_is_visible(first_nondef);
 
       if (first_nondef != NULL && first_nondef != template_decl &&
           !first_nondef_is_synthetic &&
-          !source_matches(first_nondef, template_decl)) {
+          !source_matches(first_nondef, template_decl) &&
+          declaration_has_default_for_parameter(first_nondef)) {
         emit_default_template_arg = false;
       }
     }
-    default_template_arg_key =
-        buildTemplateDefaultArgumentEmissionKey(templateParameter, info);
+    default_template_arg_key = buildTemplateDefaultArgumentEmissionKey(
+        templateParameter, info, template_declaration);
   }
   if (emit_default_template_arg &&
       emitted_default_template_args_.find(templateParameter) !=

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_statements.C
@@ -1771,6 +1771,92 @@ bool namespaceDeclarationClosesInCurrentFileOnly(
          end_file == current_file;
 }
 
+bool tokenLexemeSpellsConditionalPreprocessingDirective(
+    const std::string &lexeme) {
+  std::string trimmed = Rose::StringUtility::trim(lexeme);
+  if (trimmed.empty() || trimmed[0] != '#') {
+    return false;
+  }
+
+  size_t cursor = 1;
+  while (cursor < trimmed.size() &&
+         std::isspace(static_cast<unsigned char>(trimmed[cursor])) != 0) {
+    ++cursor;
+  }
+
+  const std::string directive = trimmed.substr(cursor);
+  auto matches = [&](const std::string &name) {
+    if (directive.rfind(name, 0) != 0) {
+      return false;
+    }
+    return directive.size() == name.size() ||
+           std::isspace(static_cast<unsigned char>(directive[name.size()])) !=
+               0;
+  };
+
+  return matches("if") || matches("ifdef") || matches("ifndef") ||
+         matches("elif") || matches("else") || matches("endif");
+}
+
+bool textContainsConditionalPreprocessingDirective(const std::string &text) {
+  size_t cursor = 0;
+  while (cursor <= text.size()) {
+    const size_t line_end = text.find_first_of("\r\n", cursor);
+    const std::string line = line_end == std::string::npos
+                                 ? text.substr(cursor)
+                                 : text.substr(cursor, line_end - cursor);
+    if (tokenLexemeSpellsConditionalPreprocessingDirective(line)) {
+      return true;
+    }
+    if (line_end == std::string::npos) {
+      break;
+    }
+    cursor = line_end + 1;
+  }
+  return false;
+}
+
+bool tokenIntervalContainsConditionalPreprocessingDirective(
+    SgSourceFile *source_file,
+    const TokenStreamSequenceToNodeMapping *mapping) {
+  if (source_file == nullptr || mapping == nullptr ||
+      mapping->token_subsequence_start < 0 ||
+      mapping->token_subsequence_end < mapping->token_subsequence_start) {
+    return false;
+  }
+
+  int start = mapping->token_subsequence_start;
+  int end = mapping->token_subsequence_end;
+  if (mapping->leading_whitespace_start >= 0 &&
+      mapping->leading_whitespace_start <= mapping->leading_whitespace_end) {
+    start = std::min(start, mapping->leading_whitespace_start);
+  }
+  if (mapping->trailing_whitespace_start >= 0 &&
+      mapping->trailing_whitespace_start <= mapping->trailing_whitespace_end) {
+    end = std::max(end, mapping->trailing_whitespace_end);
+  }
+
+  SgTokenPtrList &tokens = source_file->get_token_list();
+  if (start < 0 || end < start || start >= static_cast<int>(tokens.size())) {
+    return false;
+  }
+  end = std::min(end, static_cast<int>(tokens.size()) - 1);
+
+  for (int index = start; index <= end; ++index) {
+    SgToken *token = tokens[index];
+    if (token == nullptr || token->get_classification_code() !=
+                                ROSE_token_ids::C_CXX_PREPROCESSING_INFO) {
+      continue;
+    }
+    if (tokenLexemeSpellsConditionalPreprocessingDirective(
+            token->get_lexeme_string())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 bool basicBlockStartsWithLeadingPreprocessingInfo(const SgBasicBlock *block) {
   if (block == nullptr || block->get_statements().empty()) {
     return false;
@@ -2653,7 +2739,11 @@ classTemplateRequiresStructuralUnparse(SgTemplateClassDeclaration *decl) {
 
 static bool
 classTemplateForwardDeclRequiresAstUnparse(SgTemplateClassDeclaration *decl) {
-  if (decl == NULL || decl->get_definition() != NULL) {
+  if (decl == NULL) {
+    return false;
+  }
+
+  if (decl->get_definition() != NULL) {
     return false;
   }
 
@@ -2661,6 +2751,333 @@ classTemplateForwardDeclRequiresAstUnparse(SgTemplateClassDeclaration *decl) {
       isSgTemplateClassDeclaration(decl->get_definingDeclaration());
   return defining_decl != NULL && defining_decl != decl &&
          defining_decl->get_definition() != NULL;
+}
+
+static SgDeclarationStatementPtrList *
+templateDeclarationScopeList(SgScopeStatement *scope) {
+  if (SgGlobal *global = isSgGlobal(scope)) {
+    return &global->get_declarations();
+  }
+  if (SgNamespaceDefinitionStatement *ns_def =
+          isSgNamespaceDefinitionStatement(scope)) {
+    return &ns_def->get_declarations();
+  }
+  if (SgClassDefinition *class_def = isSgClassDefinition(scope)) {
+    return &class_def->get_members();
+  }
+  if (SgTemplateClassDefinition *template_def =
+          isSgTemplateClassDefinition(scope)) {
+    return &template_def->get_members();
+  }
+  if (SgTemplateInstantiationDefn *inst_def =
+          isSgTemplateInstantiationDefn(scope)) {
+    return &inst_def->get_members();
+  }
+  if (SgDeclarationScope *decl_scope = isSgDeclarationScope(scope)) {
+    return &decl_scope->get_declarations();
+  }
+  return NULL;
+}
+
+static bool declarationPrecedesDeclaration(SgDeclarationStatement *candidate,
+                                           SgDeclarationStatement *decl) {
+  if (candidate == NULL || decl == NULL) {
+    return false;
+  }
+  Sg_File_Info *candidate_fi = candidate->get_file_info();
+  Sg_File_Info *decl_fi = decl->get_file_info();
+  if (candidate_fi == NULL || decl_fi == NULL ||
+      candidate_fi->get_line() <= 0 || decl_fi->get_line() <= 0) {
+    return true;
+  }
+  if (candidate_fi->get_filenameString() != decl_fi->get_filenameString()) {
+    return true;
+  }
+  if (candidate_fi->get_line() != decl_fi->get_line()) {
+    return candidate_fi->get_line() < decl_fi->get_line();
+  }
+  return candidate_fi->get_col() < decl_fi->get_col();
+}
+
+static bool
+templateDeclarationIsVisibleInGeneratedOutput(SgDeclarationStatement *decl) {
+  if (decl == NULL) {
+    return false;
+  }
+  Sg_File_Info *file_info = decl->get_file_info();
+  if (file_info == NULL) {
+    return false;
+  }
+  if (file_info->isOutputInCodeGeneration()) {
+    return true;
+  }
+  return !file_info->isCompilerGenerated() && !file_info->isFrontendSpecific();
+}
+
+struct TemplateHeaderParameterList {
+  bool valid = false;
+  size_t open = std::string::npos;
+  size_t close = std::string::npos;
+  std::vector<std::string> parameters;
+};
+
+static size_t findTopLevelTemplateParameterDefault(const std::string &segment) {
+  int angle_depth = 0;
+  int paren_depth = 0;
+  int bracket_depth = 0;
+  int brace_depth = 0;
+  for (size_t i = 0; i < segment.size(); ++i) {
+    char ch = segment[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>' && angle_depth > 0) {
+      --angle_depth;
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    } else if (ch == '=' && angle_depth == 0 && paren_depth == 0 &&
+               bracket_depth == 0 && brace_depth == 0) {
+      return i;
+    }
+  }
+  return std::string::npos;
+}
+
+static TemplateHeaderParameterList
+parseFirstTemplateHeaderParameters(const std::string &text) {
+  TemplateHeaderParameterList result;
+  size_t template_pos = text.find("template");
+  if (template_pos == std::string::npos) {
+    return result;
+  }
+  size_t open = text.find('<', template_pos);
+  if (open == std::string::npos) {
+    return result;
+  }
+
+  int angle_depth = 1;
+  int paren_depth = 0;
+  int bracket_depth = 0;
+  int brace_depth = 0;
+  size_t close = std::string::npos;
+  for (size_t i = open + 1; i < text.size(); ++i) {
+    char ch = text[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>') {
+      --angle_depth;
+      if (angle_depth == 0) {
+        close = i;
+        break;
+      }
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    }
+  }
+  if (close == std::string::npos) {
+    return result;
+  }
+
+  std::string params = text.substr(open + 1, close - open - 1);
+  size_t segment_start = 0;
+  angle_depth = paren_depth = bracket_depth = brace_depth = 0;
+  auto push_segment = [&](size_t segment_end) {
+    result.parameters.push_back(
+        params.substr(segment_start, segment_end - segment_start));
+  };
+
+  for (size_t i = 0; i < params.size(); ++i) {
+    char ch = params[i];
+    if (ch == '<') {
+      ++angle_depth;
+    } else if (ch == '>' && angle_depth > 0) {
+      --angle_depth;
+    } else if (ch == '(') {
+      ++paren_depth;
+    } else if (ch == ')' && paren_depth > 0) {
+      --paren_depth;
+    } else if (ch == '[') {
+      ++bracket_depth;
+    } else if (ch == ']' && bracket_depth > 0) {
+      --bracket_depth;
+    } else if (ch == '{') {
+      ++brace_depth;
+    } else if (ch == '}' && brace_depth > 0) {
+      --brace_depth;
+    } else if (ch == ',' && angle_depth == 0 && paren_depth == 0 &&
+               bracket_depth == 0 && brace_depth == 0) {
+      push_segment(i);
+      segment_start = i + 1;
+    }
+  }
+  push_segment(params.size());
+
+  result.valid = true;
+  result.open = open;
+  result.close = close;
+  return result;
+}
+
+static bool templateParameterHasDefaultArgument(SgTemplateParameter *param) {
+  return param != NULL &&
+         (param->get_defaultTypeParameter() != NULL ||
+          param->get_defaultExpressionParameter() != NULL ||
+          param->get_defaultTemplateDeclarationParameter() != NULL);
+}
+
+static std::vector<bool> templateClassDeclarationDefaultArgumentPositions(
+    SgTemplateClassDeclaration *decl) {
+  std::vector<bool> defaults;
+  if (decl == NULL) {
+    return defaults;
+  }
+
+  const SgTemplateParameterPtrList &params = decl->get_templateParameters();
+  const SgName saved_template_name = decl->get_string();
+  const char *saved_template_string = saved_template_name.str();
+  const bool has_saved_template_string = !saved_template_name.is_null() &&
+                                         saved_template_string != NULL &&
+                                         saved_template_string[0] != '\0';
+  if (has_saved_template_string) {
+    TemplateHeaderParameterList parsed =
+        parseFirstTemplateHeaderParameters(saved_template_string);
+    if (parsed.valid) {
+      defaults.assign(parsed.parameters.size(), false);
+      for (size_t idx = 0; idx < parsed.parameters.size(); ++idx) {
+        defaults[idx] = findTopLevelTemplateParameterDefault(
+                            parsed.parameters[idx]) != std::string::npos;
+      }
+      return defaults;
+    }
+  }
+
+  defaults.assign(params.size(), false);
+  for (size_t idx = 0; idx < params.size(); ++idx) {
+    defaults[idx] = templateParameterHasDefaultArgument(params[idx]);
+  }
+  return defaults;
+}
+
+static std::vector<bool> classTemplatePriorVisibleDefaultArgumentPositions(
+    SgTemplateClassDeclaration *decl) {
+  std::vector<bool> prior_defaults;
+  if (decl == NULL || decl->get_definition() == NULL) {
+    return prior_defaults;
+  }
+
+  prior_defaults.assign(decl->get_templateParameters().size(), false);
+
+  SgScopeStatement *scope = isSgScopeStatement(decl->get_parent());
+  if (scope == NULL) {
+    scope = decl->get_scope();
+  }
+  if (scope == NULL) {
+    return prior_defaults;
+  }
+
+  auto accumulate_prior_defaults = [&](SgScopeStatement *candidate_scope) {
+    SgDeclarationStatementPtrList *decls =
+        templateDeclarationScopeList(candidate_scope);
+    if (decls == NULL) {
+      return;
+    }
+    for (SgDeclarationStatement *candidate_stmt : *decls) {
+      SgTemplateClassDeclaration *candidate =
+          isSgTemplateClassDeclaration(candidate_stmt);
+      if (candidate == NULL || candidate == decl ||
+          candidate->get_name() != decl->get_name()) {
+        continue;
+      }
+      if (templateDeclarationIsVisibleInGeneratedOutput(candidate) &&
+          declarationPrecedesDeclaration(candidate, decl)) {
+        std::vector<bool> candidate_defaults =
+            templateClassDeclarationDefaultArgumentPositions(candidate);
+        if (prior_defaults.size() < candidate_defaults.size()) {
+          prior_defaults.resize(candidate_defaults.size(), false);
+        }
+        for (size_t idx = 0; idx < candidate_defaults.size(); ++idx) {
+          prior_defaults[idx] = prior_defaults[idx] || candidate_defaults[idx];
+        }
+      }
+    }
+  };
+
+  if (SgNamespaceDefinitionStatement *ns_scope =
+          isSgNamespaceDefinitionStatement(scope)) {
+    while (ns_scope->get_previousNamespaceDefinition() != NULL) {
+      ns_scope = ns_scope->get_previousNamespaceDefinition();
+    }
+    for (SgNamespaceDefinitionStatement *current = ns_scope; current != NULL;
+         current = current->get_nextNamespaceDefinition()) {
+      accumulate_prior_defaults(current);
+    }
+    return prior_defaults;
+  }
+
+  accumulate_prior_defaults(scope);
+  return prior_defaults;
+}
+
+static std::string stripDefaultTemplateArgumentsFromFirstTemplateHeader(
+    const std::string &text, const std::vector<bool> &strip_defaults) {
+  if (strip_defaults.empty() ||
+      std::none_of(strip_defaults.begin(), strip_defaults.end(),
+                   [](bool strip) { return strip; })) {
+    return text;
+  }
+
+  TemplateHeaderParameterList parsed = parseFirstTemplateHeaderParameters(text);
+  if (!parsed.valid) {
+    return text;
+  }
+
+  std::vector<std::string> stripped_params;
+  stripped_params.reserve(parsed.parameters.size());
+  for (size_t idx = 0; idx < parsed.parameters.size(); ++idx) {
+    std::string segment = parsed.parameters[idx];
+    const bool strip_this_default =
+        idx < strip_defaults.size() && strip_defaults[idx];
+    const size_t equal_pos = strip_this_default
+                                 ? findTopLevelTemplateParameterDefault(segment)
+                                 : std::string::npos;
+    if (equal_pos != std::string::npos) {
+      segment.erase(equal_pos);
+      while (!segment.empty() &&
+             std::isspace(static_cast<unsigned char>(segment.back()))) {
+        segment.pop_back();
+      }
+    }
+    stripped_params.push_back(segment);
+  }
+
+  std::string stripped = text.substr(0, parsed.open + 1);
+  for (size_t i = 0; i < stripped_params.size(); ++i) {
+    if (i != 0) {
+      stripped += ",";
+    }
+    stripped += stripped_params[i];
+  }
+  stripped += text.substr(parsed.close);
+  return stripped;
 }
 
 using TemplateParamSubstitution = std::map<std::string, std::string>;
@@ -8486,7 +8903,28 @@ void Unparse_ExprStmt::unparseFuncDeclStmt(SgStatement *stmt,
 
     unp->u_sage->printSpecifier(funcdecl_stmt, ninfo);
 
-    unparseAttachedPreprocessingInfo(stmt, info, PreprocessingInfo::inside);
+    const auto template_function_saved_spelling_owns_conditional_preprocessing =
+        [&](SgStatement *statement) {
+          SgName saved_template_name;
+          if (SgTemplateFunctionDeclaration *template_function =
+                  isSgTemplateFunctionDeclaration(statement)) {
+            saved_template_name = template_function->get_string();
+          } else if (SgTemplateMemberFunctionDeclaration *template_member =
+                         isSgTemplateMemberFunctionDeclaration(statement)) {
+            saved_template_name = template_member->get_string();
+          } else {
+            return false;
+          }
+
+          const char *saved_template_string = saved_template_name.str();
+          return saved_template_string != NULL &&
+                 textContainsConditionalPreprocessingDirective(
+                     saved_template_string);
+        };
+    if (!template_function_saved_spelling_owns_conditional_preprocessing(
+            stmt)) {
+      unparseAttachedPreprocessingInfo(stmt, info, PreprocessingInfo::inside);
+    }
     ninfo.unset_CheckAccess();
     info.set_access_attribute(ninfo.get_access_attribute());
 
@@ -9177,7 +9615,7 @@ void Unparse_ExprStmt::unparseMFuncDeclStmt(SgStatement *stmt,
       SgUnparse_Info tinfo(info);
       tinfo.set_declstatement_ptr(NULL);
       tinfo.set_declstatement_ptr(tmpl);
-      Unparse_ExprStmt::unparseTemplateParameterList(tlist, tinfo, true);
+      Unparse_ExprStmt::unparseTemplateParameterList(tlist, tinfo, true, tmpl);
       curprint("\n");
     }
   };
@@ -9912,7 +10350,8 @@ void Unparse_ExprStmt::unparseClassDeclStmt(SgStatement *stmt,
         SgUnparse_Info tinfo(info);
         tinfo.set_declstatement_ptr(NULL);
         tinfo.set_declstatement_ptr(tmpl);
-        Unparse_ExprStmt::unparseTemplateParameterList(params, tinfo, true);
+        Unparse_ExprStmt::unparseTemplateParameterList(params, tinfo, true,
+                                                       tmpl);
         curprint("\n");
       }
     };
@@ -13057,7 +13496,7 @@ void Unparse_ExprStmt::unparseTemplateHeader(T *decl, SgUnparse_Info &info) {
     SgUnparse_Info tinfo(info);
     tinfo.set_declstatement_ptr(NULL);
     tinfo.set_declstatement_ptr(decl);
-    Unparse_ExprStmt::unparseTemplateParameterList(tlist, tinfo, true);
+    Unparse_ExprStmt::unparseTemplateParameterList(tlist, tinfo, true, decl);
     if (SgExpression *requires_clause = decl->get_requiresClause()) {
       curprint("requires ");
       SgUnparse_Info rinfo(info);
@@ -13290,10 +13729,45 @@ void Unparse_ExprStmt::unparseTemplateDeclarationStatment_support(
       info.unparsedPartiallyUsingTokenStream() &&
       (sourcefile == NULL || sourcefile->get_unparse_tokens() == false);
 
-  // DQ (1/28/2013): This helps handle cases such as "#if 1 void foo () #endif {
-  // }"
-  unparseAttachedPreprocessingInfo(template_stmt, info,
-                                   PreprocessingInfo::inside);
+  const bool class_scope_template =
+      isSgClassDefinition(template_stmt->get_parent()) != NULL ||
+      isSgTemplateClassDefinition(template_stmt->get_parent()) != NULL ||
+      isSgTemplateInstantiationDefn(template_stmt->get_parent()) != NULL;
+  TokenStreamSequenceToNodeMapping *template_token_mapping =
+      sourcefile != NULL
+          ? lookup_token_subsequence_mapping_for_node(sourcefile, template_stmt)
+          : NULL;
+  const bool unmodified_template_with_token_mapping =
+      sourcefile != NULL && !template_stmt->isTransformation() &&
+      !template_stmt->get_containsTransformation() &&
+      !template_stmt->get_containsTransformationToSurroundingWhitespace() &&
+      template_token_mapping != NULL &&
+      template_token_mapping->token_subsequence_start >= 0;
+  if (!class_scope_template && !template_requires_ast_unparse &&
+      !inherited_partial_token_context &&
+      tokenIntervalContainsConditionalPreprocessingDirective(
+          sourcefile, template_token_mapping) &&
+      unmodified_template_with_token_mapping) {
+    unparseStatementFromTokenStream(stmt, e_leading_whitespace_start,
+                                    e_trailing_whitespace_end, info);
+    return;
+  }
+
+  const SgName saved_template_name_for_preprocessing =
+      template_stmt->get_string();
+  const char *saved_template_string_for_preprocessing =
+      saved_template_name_for_preprocessing.str();
+  const bool saved_template_string_owns_conditional_preprocessing =
+      saved_template_string_for_preprocessing != NULL &&
+      textContainsConditionalPreprocessingDirective(
+          saved_template_string_for_preprocessing);
+
+  if (!saved_template_string_owns_conditional_preprocessing) {
+    // DQ (1/28/2013): This helps handle cases such as
+    // "#if 1 void foo () #endif { }"
+    unparseAttachedPreprocessingInfo(template_stmt, info,
+                                     PreprocessingInfo::inside);
+  }
 
   // Check to see if this is an object defined within a class
   ASSERT_not_null(template_stmt->get_parent());
@@ -13370,19 +13844,39 @@ void Unparse_ExprStmt::unparseTemplateDeclarationStatment_support(
       unparse_template_from_ast = false;
     }
 
-    if (!unparse_template_from_ast) {
+    const SgName saved_template_name = template_stmt->get_string();
+    const char *saved_template_string = saved_template_name.str();
+    const bool missing_saved_template_string = saved_template_name.is_null() ||
+                                               saved_template_string == NULL ||
+                                               saved_template_string[0] == '\0';
+    const bool forward_class_template_saved_spells_defaults =
+        templateClassDeclaration != NULL &&
+        templateClassDeclaration->isForward() &&
+        !missing_saved_template_string &&
+        std::string(saved_template_string).find('=') != std::string::npos;
+    if (forward_class_template_saved_spells_defaults) {
+      unparse_template_from_ast = false;
+    }
 
-      if (can_replay_template_tokens) {
+    if (!unparse_template_from_ast) {
+      const bool class_scope_template_function_with_saved_spelling =
+          templateFunctionDeclaration != NULL &&
+          !missing_saved_template_string &&
+          (isSgClassDefinition(templateFunctionDeclaration->get_parent()) !=
+               NULL ||
+           isSgTemplateClassDefinition(
+               templateFunctionDeclaration->get_parent()) != NULL ||
+           isSgTemplateInstantiationDefn(
+               templateFunctionDeclaration->get_parent()) != NULL);
+
+      if (can_replay_template_tokens &&
+          !forward_class_template_saved_spells_defaults &&
+          !class_scope_template_function_with_saved_spelling) {
         unparseStatementFromTokenStream(stmt, e_token_subsequence_start,
                                         e_token_subsequence_end, info);
         return;
       }
 
-      const SgName saved_template_name = template_stmt->get_string();
-      const char *saved_template_string = saved_template_name.str();
-      const bool missing_saved_template_string =
-          saved_template_name.is_null() || saved_template_string == NULL ||
-          saved_template_string[0] == '\0';
       if (missing_saved_template_string) {
         // If there is no saved string and no reusable token subsequence, fall
         // back to the structural AST so the declaration is still emitted.
@@ -13739,6 +14233,13 @@ void Unparse_ExprStmt::unparseTemplateDeclarationStatment_support(
   } else {
     // Unparsing done from saved string
     string templateString = template_stmt->get_string().str();
+    if (templateClassDeclaration != NULL) {
+      const std::vector<bool> prior_default_positions =
+          classTemplatePriorVisibleDefaultArgumentPositions(
+              templateClassDeclaration);
+      templateString = stripDefaultTemplateArgumentsFromFirstTemplateHeader(
+          templateString, prior_default_positions);
+    }
 
     // Substitute " decltype" with " __decltype". Only if we are not using C++11
     // or later version of C++.
@@ -13991,14 +14492,35 @@ void Unparse_ExprStmt::unparseOmpBeginDirectiveClauses(SgStatement *stmt,
       if (SgTypeExpression *type_expr =
               isSgTypeExpression(mapperstmt->get_mapper_type())) {
         if (SgClassType *class_type = isSgClassType(type_expr->get_type())) {
-          curprint(string("class "));
           if (SgClassDeclaration *class_decl =
                   isSgClassDeclaration(class_type->get_declaration())) {
-            if (isSgGlobal(class_decl->get_scope()) != nullptr) {
-              curprint(string("::"));
-            }
-            if (SgTemplateInstantiationDecl *inst_decl =
-                    isSgTemplateInstantiationDecl(class_decl)) {
+            auto find_typedef_owner =
+                [](SgClassDeclaration *decl) -> SgTypedefDeclaration * {
+              SgClassDeclaration *peers[] = {
+                  decl,
+                  isSgClassDeclaration(decl->get_firstNondefiningDeclaration()),
+                  isSgClassDeclaration(decl->get_definingDeclaration())};
+              for (SgClassDeclaration *peer : peers) {
+                if (peer == nullptr) {
+                  continue;
+                }
+                SgTypedefDeclaration *typedef_decl =
+                    isSgTypedefDeclaration(peer->get_parent());
+                if (typedef_decl != nullptr &&
+                    typedef_decl->get_declaration() == peer) {
+                  return typedef_decl;
+                }
+              }
+              return nullptr;
+            };
+            if (SgTypedefDeclaration *typedef_decl =
+                    find_typedef_owner(class_decl)) {
+              curprint(typedef_decl->get_name().getString() + " ");
+            } else if (SgTemplateInstantiationDecl *inst_decl =
+                           isSgTemplateInstantiationDecl(class_decl)) {
+              if (isSgGlobal(class_decl->get_scope()) != nullptr) {
+                curprint(string("::"));
+              }
               SgUnparse_Info ninfo(info);
               if (ninfo.isTypeFirstPart()) {
                 ninfo.unset_isTypeFirstPart();
@@ -14008,6 +14530,9 @@ void Unparse_ExprStmt::unparseOmpBeginDirectiveClauses(SgStatement *stmt,
               }
               unp->u_exprStmt->unparseTemplateName(inst_decl, ninfo);
             } else {
+              if (isSgGlobal(class_decl->get_scope()) != nullptr) {
+                curprint(string("::"));
+              }
               curprint(class_type->get_name().getString());
             }
           } else {

--- a/src/backend/unparser/CxxCodeGeneration/unparseVarDeclStmt.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseVarDeclStmt.C
@@ -1529,7 +1529,7 @@ void Unparse_ExprStmt::unparseVarDeclStmt(SgStatement *stmt,
         SgUnparse_Info tinfo(info);
         tinfo.set_declstatement_ptr(NULL);
         tinfo.set_declstatement_ptr(tmpl_decl);
-        unparseTemplateParameterList(params, tinfo, true);
+        unparseTemplateParameterList(params, tinfo, true, tmpl_decl);
         curprint("\n");
       }
     }

--- a/src/backend/unparser/languageIndependenceSupport/unparseLanguageIndependentConstructs.C
+++ b/src/backend/unparser/languageIndependenceSupport/unparseLanguageIndependentConstructs.C
@@ -406,6 +406,88 @@ bool is_conditional_directive_line(const std::string &line) {
          is_directive_kind_token(line, pos, "endif");
 }
 
+std::string trim_preprocessing_directive_line(std::string text) {
+  const size_t begin = text.find_first_not_of(" \t\r\n");
+  if (begin == std::string::npos) {
+    return "";
+  }
+
+  const size_t end = text.find_last_not_of(" \t\r\n");
+  return text.substr(begin, end - begin + 1);
+}
+
+bool text_contains_preprocessing_directive_line(const std::string &text,
+                                                const std::string &directive) {
+  const std::string directive_line =
+      trim_preprocessing_directive_line(directive);
+  if (directive_line.empty()) {
+    return false;
+  }
+
+  size_t cursor = 0;
+  while (cursor <= text.size()) {
+    const size_t line_end = text.find_first_of("\r\n", cursor);
+    const std::string line = line_end == std::string::npos
+                                 ? text.substr(cursor)
+                                 : text.substr(cursor, line_end - cursor);
+    if (trim_preprocessing_directive_line(line) == directive_line) {
+      return true;
+    }
+    if (line_end == std::string::npos) {
+      break;
+    }
+    cursor = line_end + 1;
+  }
+
+  return false;
+}
+
+bool template_function_saved_spelling_contains_preprocessing_info(
+    SgStatement *statement, PreprocessingInfo *preproc_info) {
+  if (preproc_info == nullptr ||
+      !preprocessing_directive_is_conditional_boundary(
+          preproc_info->getTypeOfDirective())) {
+    return false;
+  }
+
+  auto saved_template_contains = [&](SgFunctionDeclaration *decl) {
+    SgName saved_template_name;
+    if (SgTemplateFunctionDeclaration *template_function =
+            isSgTemplateFunctionDeclaration(decl)) {
+      saved_template_name = template_function->get_string();
+    } else if (SgTemplateMemberFunctionDeclaration *template_member =
+                   isSgTemplateMemberFunctionDeclaration(decl)) {
+      saved_template_name = template_member->get_string();
+    } else {
+      return false;
+    }
+
+    const char *saved_template_string = saved_template_name.str();
+    return saved_template_string != nullptr &&
+           text_contains_preprocessing_directive_line(
+               saved_template_string, preproc_info->getString());
+  };
+
+  SgFunctionDeclaration *function_decl = isSgFunctionDeclaration(statement);
+  if (saved_template_contains(function_decl)) {
+    return true;
+  }
+
+  const bool class_scope_template =
+      statement != nullptr &&
+      (isSgClassDefinition(statement->get_parent()) != nullptr ||
+       isSgTemplateClassDefinition(statement->get_parent()) != nullptr ||
+       isSgTemplateInstantiationDefn(statement->get_parent()) != nullptr);
+  if (class_scope_template || function_decl == nullptr) {
+    return false;
+  }
+
+  return saved_template_contains(isSgFunctionDeclaration(
+             function_decl->get_firstNondefiningDeclaration())) ||
+         saved_template_contains(
+             isSgFunctionDeclaration(function_decl->get_definingDeclaration()));
+}
+
 bool is_openmp_or_openacc_pragma_line(const std::string &line) {
   size_t pos = line.find_first_not_of(" \t");
   if (pos == std::string::npos || line[pos] != '#') {
@@ -9126,6 +9208,13 @@ int UnparseLanguageIndependentConstructs::unparseStatementFromTokenStream(
 
       if (suppress_misplaced_leading_variable_declaration_directive(
               stmt, *i, whereToUnparse)) {
+        continue;
+      }
+
+      if ((whereToUnparse == PreprocessingInfo::before ||
+           whereToUnparse == PreprocessingInfo::inside) &&
+          template_function_saved_spelling_contains_preprocessing_info(
+              isSgStatement(stmt), *i)) {
         continue;
       }
 

--- a/src/backend/unparser/nameQualificationSupport.C
+++ b/src/backend/unparser/nameQualificationSupport.C
@@ -12265,52 +12265,73 @@ NameQualificationTraversal::evaluateInheritedAttribute(
           }
           // std::string qualifier =
           // std::string((*classChain_last)->get_name().str()) + "::";
-          std::string qualifier =
-              std::string((*classChain_target)->get_name().str()) + "::";
+          SgClassType *targetClassType = *classChain_target;
+          ROSE_ASSERT(targetClassType != NULL);
+          SgClassDeclaration *targetClassDeclaration =
+              isSgClassDeclaration(targetClassType->get_declaration());
+          ROSE_ASSERT(targetClassDeclaration != NULL);
+          const std::string targetDeclarationName =
+              targetClassDeclaration->get_name().getString();
+          const std::string targetClassName =
+              targetClassType->get_name().getString();
+          const bool targetClassIsAnonymous =
+              targetClassDeclaration->get_isUnNamed() == true ||
+              targetDeclarationName.find("__anonymous_0x") == 0 ||
+              targetClassName.find("__anonymous_0x") == 0;
 
-#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
-          MLOG_WARN_C(MLOG_UNPARSER, "data member qualifier = %s \n",
-                      qualifier.c_str());
-#endif
-          // DQ (2/16/2019): Mark this as at least non-zero, but it is computed
-          // based on where the ambiguity is instead of as a length of the chain
-          // of scope from the variable referenced's variable declaration scope.
-          varRefExp->set_name_qualification_length(1);
-
-          varRefExp->set_global_qualification_required(false);
-          varRefExp->set_type_elaboration_required(false);
-
-          if (qualifiedNameMapForNames.find(varRefExp) ==
-              qualifiedNameMapForNames.end()) {
-#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
-            MLOG_WARN_C(MLOG_UNPARSER,
-                        "Inserting qualifier for name = %s into list at IR "
-                        "node = %p = %s \n",
-                        qualifier.c_str(), varRefExp,
-                        varRefExp->class_name().c_str());
-#endif
-            qualifiedNameMapForNames.insert(
-                std::pair<SgNode *, std::string>(varRefExp, qualifier));
+          if (targetClassIsAnonymous == true) {
+            varRefExp->set_name_qualification_length(0);
+            varRefExp->set_global_qualification_required(false);
+            varRefExp->set_type_elaboration_required(false);
+            qualifiedNameMapForNames.erase(varRefExp);
           } else {
-            // DQ (6/20/2011): We see this case in test2011_87.C.
-            // If it already existes then overwrite the existing information.
-            NameQualificationMapType::iterator i =
-                qualifiedNameMapForNames.find(varRefExp);
-            ROSE_ASSERT(i != qualifiedNameMapForNames.end());
+            std::string qualifier = targetClassName + "::";
 
 #if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
-            string previousQualifier = i->second.c_str();
-            MLOG_WARN_C(MLOG_UNPARSER,
-                        "WARNING: test 1: replacing previousQualifier = %s "
-                        "with new qualifier = %s \n",
-                        previousQualifier.c_str(), qualifier.c_str());
+            MLOG_WARN_C(MLOG_UNPARSER, "data member qualifier = %s \n",
+                        qualifier.c_str());
 #endif
-            if (i->second != qualifier) {
-              // DQ (7/23/2011): Multiple uses of the SgVarRefExp expression in
-              // SgArrayType will cause the name qualification to be reset each
-              // time.  This is OK since it is used to build the type name that
-              // will be saved.
-              i->second = qualifier;
+            // DQ (2/16/2019): Mark this as at least non-zero, but it is
+            // computed based on where the ambiguity is instead of as a length
+            // of the chain of scope from the variable referenced's variable
+            // declaration scope.
+            varRefExp->set_name_qualification_length(1);
+
+            varRefExp->set_global_qualification_required(false);
+            varRefExp->set_type_elaboration_required(false);
+
+            if (qualifiedNameMapForNames.find(varRefExp) ==
+                qualifiedNameMapForNames.end()) {
+#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
+              MLOG_WARN_C(MLOG_UNPARSER,
+                          "Inserting qualifier for name = %s into list at IR "
+                          "node = %p = %s \n",
+                          qualifier.c_str(), varRefExp,
+                          varRefExp->class_name().c_str());
+#endif
+              qualifiedNameMapForNames.insert(
+                  std::pair<SgNode *, std::string>(varRefExp, qualifier));
+            } else {
+              // DQ (6/20/2011): We see this case in test2011_87.C.
+              // If it already existes then overwrite the existing information.
+              NameQualificationMapType::iterator i =
+                  qualifiedNameMapForNames.find(varRefExp);
+              ROSE_ASSERT(i != qualifiedNameMapForNames.end());
+
+#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
+              string previousQualifier = i->second.c_str();
+              MLOG_WARN_C(MLOG_UNPARSER,
+                          "WARNING: test 1: replacing previousQualifier = %s "
+                          "with new qualifier = %s \n",
+                          previousQualifier.c_str(), qualifier.c_str());
+#endif
+              if (i->second != qualifier) {
+                // DQ (7/23/2011): Multiple uses of the SgVarRefExp expression
+                // in SgArrayType will cause the name qualification to be reset
+                // each time.  This is OK since it is used to build the type
+                // name that will be saved.
+                i->second = qualifier;
+              }
             }
           }
         }
@@ -14569,6 +14590,16 @@ void NameQualificationTraversal::setNameQualification(
         outputGlobalQualification, outputTypeEvaluation);
     applyExplicitQualifier(varRefExp, qualifier, outputNameQualificationLength,
                            outputGlobalQualification);
+    const bool isMemberAccessRhs =
+        (dotExp != NULL && dotExp->get_rhs_operand() == varRefExp) ||
+        (arrowExp != NULL && arrowExp->get_rhs_operand() == varRefExp);
+    if (isMemberAccessRhs == true && qualifier.find("__anonymous_0x") == 0) {
+      varRefExp->set_global_qualification_required(false);
+      varRefExp->set_name_qualification_length(0);
+      varRefExp->set_type_elaboration_required(false);
+      qualifiedNameMapForNames.erase(varRefExp);
+      return;
+    }
 
     varRefExp->set_global_qualification_required(outputGlobalQualification);
     varRefExp->set_name_qualification_length(outputNameQualificationLength);
@@ -14627,21 +14658,10 @@ void NameQualificationTraversal::setNameQualification(
       }
     }
   } else {
-    SgScopeStatement *scope =
-        traverseNonrealDeclForCorrectScope(variableDeclaration);
-    string qualifier = setNameQualificationSupport(
-        scope, amountOfNameQualificationRequired, outputNameQualificationLength,
-        outputGlobalQualification, outputTypeEvaluation);
-    applyExplicitQualifier(varRefExp, qualifier, outputNameQualificationLength,
-                           outputGlobalQualification);
-
-    varRefExp->set_global_qualification_required(outputGlobalQualification);
-    varRefExp->set_name_qualification_length(outputNameQualificationLength);
-
-    // There should be no type evaluation required for a variable reference, as
-    // I recall.
-    ROSE_ASSERT(outputTypeEvaluation == false);
-    varRefExp->set_type_elaboration_required(outputTypeEvaluation);
+    varRefExp->set_global_qualification_required(false);
+    varRefExp->set_name_qualification_length(0);
+    varRefExp->set_type_elaboration_required(false);
+    qualifiedNameMapForNames.erase(varRefExp);
 
 #if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
     MLOG_WARN_C(MLOG_UNPARSER,
@@ -14658,39 +14678,6 @@ void NameQualificationTraversal::setNameQualification(
                 varRefExp->get_global_qualification_required() ? "true"
                                                                : "false");
 #endif
-
-    if (qualifiedNameMapForNames.find(varRefExp) ==
-        qualifiedNameMapForNames.end()) {
-#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
-      MLOG_WARN_C(
-          MLOG_UNPARSER,
-          "Inserting qualifier for name = %s into list at IR node = %p = %s \n",
-          qualifier.c_str(), varRefExp, varRefExp->class_name().c_str());
-#endif
-      qualifiedNameMapForNames.insert(
-          std::pair<SgNode *, std::string>(varRefExp, qualifier));
-    } else {
-      // DQ (6/20/2011): We see this case in test2011_87.C.
-      // If it already existes then overwrite the existing information.
-      NameQualificationMapType::iterator i =
-          qualifiedNameMapForNames.find(varRefExp);
-      ROSE_ASSERT(i != qualifiedNameMapForNames.end());
-
-#if (DEBUG_NAME_QUALIFICATION_LEVEL > 3)
-      string previousQualifier = i->second.c_str();
-      MLOG_WARN_C(MLOG_UNPARSER,
-                  "WARNING: test 2: replacing previousQualifier = %s with new "
-                  "qualifier = %s \n",
-                  previousQualifier.c_str(), qualifier.c_str());
-#endif
-      if (i->second != qualifier) {
-        // DQ (7/23/2011): Multiple uses of the SgVarRefExp expression in
-        // SgArrayType will cause the name qualification to be reset each time.
-        // This is OK since it is used to build the type name that will be
-        // saved.
-        i->second = qualifier;
-      }
-    }
   }
 }
 

--- a/src/frontend/Clang/CMakeLists.txt
+++ b/src/frontend/Clang/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CLANG_FRONTEND_SOURCES
   clang-frontend-decl.cpp
   clang-frontend-stmt.cpp
   clang-frontend-type.cpp
+  clang-frontend-valgrind.cpp
   clang-to-rose-support.cpp
   clang-to-dot.cpp
   clang-to-dot-decl.cpp

--- a/src/frontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/Clang/clang-frontend-decl.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <clang/AST/Attr.h>
 #include <clang/Basic/Module.h>
+#include <cstdint>
 #include <cstdlib>
 #include <limits>
 
@@ -45,6 +46,71 @@
 #include <vector>
 
 namespace {
+
+static bool clangFrontendRunningOnValgrind() {
+#if ROSE_USE_VALGRIND
+  static const bool running = RUNNING_ON_VALGRIND;
+  return running;
+#else
+  return false;
+#endif
+}
+
+bool same_function_reuse_parameter_type(SgType *lhs, SgType *rhs);
+
+static SgType *stripSageDeclaratorBaseType(SgType *type) {
+  ROSE_ASSERT(type != nullptr);
+
+  std::unordered_set<SgType *> seen;
+  SgType *current = type;
+  while (current != nullptr) {
+    if (!seen.insert(current).second) {
+      std::cerr << "Runtime error: cyclic Sage type chain while resolving "
+                   "declarator base type at "
+                << current << " (" << current->class_name() << ")" << std::endl;
+      ROSE_ABORT();
+    }
+
+    if (SgModifierType *modifier_type = isSgModifierType(current)) {
+      current = modifier_type->get_base_type();
+      continue;
+    }
+    if (SgReferenceType *reference_type = isSgReferenceType(current)) {
+      current = reference_type->get_base_type();
+      continue;
+    }
+    if (SgRvalueReferenceType *reference_type =
+            isSgRvalueReferenceType(current)) {
+      current = reference_type->get_base_type();
+      continue;
+    }
+    if (SgPointerType *pointer_type = isSgPointerType(current)) {
+      if (isSgPointerMemberType(current) == nullptr) {
+        current = pointer_type->get_base_type();
+        continue;
+      }
+    }
+    if (SgPointerMemberType *pointer_type = isSgPointerMemberType(current)) {
+      current = pointer_type->get_base_type();
+      continue;
+    }
+    if (SgArrayType *array_type = isSgArrayType(current)) {
+      current = array_type->get_base_type();
+      continue;
+    }
+    if (SgTypedefType *typedef_type = isSgTypedefType(current)) {
+      current = typedef_type->get_base_type();
+      continue;
+    }
+
+    return current;
+  }
+
+  std::cerr << "Runtime error: null Sage type reached while resolving "
+               "declarator base type"
+            << std::endl;
+  ROSE_ABORT();
+}
 
 void roseClangPhaseTrace(const char *phase) {
   if (getenv("ROSE_PHASE_TRACE") != nullptr) {
@@ -110,16 +176,50 @@ double roseSlowFunctionTraceThresholdMs() {
   return threshold_ms;
 }
 
+struct ScopedTranslationCacheRebuild {
+  unsigned &depth;
+  bool active;
+
+  ScopedTranslationCacheRebuild(unsigned &depth_ref, bool should_rebuild)
+      : depth(depth_ref), active(should_rebuild) {
+    if (active) {
+      ++depth;
+    }
+  }
+
+  ~ScopedTranslationCacheRebuild() {
+    if (active) {
+      ROSE_ASSERT(depth > 0);
+      --depth;
+    }
+  }
+};
+
+static void markClangAstStorageDefined(const void *address, size_t size) {
+  markClangAstStorageRangeDefinedForFrontend(address, size);
+}
+
+static void markClangPrintedStringDefined(const std::string &value) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<std::string *>(&value), sizeof(value));
+    if (!value.empty()) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<char *>(value.data()), value.size());
+    }
+  }
+#else
+  (void)value;
+#endif
+}
+
 template <typename T> T *markClangAstObjectDefined(T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     // Clang's ASTContext uses bump allocation and leaves padding/unused bits in
     // AST objects undefined. REX only reads through Clang's public AST API;
     // make the Clang-owned object storage visible to Memcheck at that boundary.
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(node, sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
@@ -127,19 +227,29 @@ template <typename T> T *markClangAstObjectDefined(T *node) {
 
 template <typename T> const T *markClangAstObjectDefined(const T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(node), sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
 }
 
+template <typename T> const T *markClangLocalObjectDefined(const T *object) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_MAKE_MEM_DEFINED(&object, sizeof(object));
+    if (object != nullptr) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(object), sizeof(*object));
+    }
+  }
+#endif
+  return object;
+}
+
 template <typename T> const T &markClangValueDefined(const T &value) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(&value), sizeof(value));
   }
 #endif
@@ -149,7 +259,7 @@ template <typename T> const T &markClangValueDefined(const T &value) {
 template <typename F>
 static auto readClangApiValueDefined(F &&read) -> decltype(read()) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
     auto value = read();
     VALGRIND_ENABLE_ERROR_REPORTING;
@@ -165,11 +275,19 @@ static auto readClangApiValueDefined(F &&read) -> decltype(read()) {
 static void markClangDeclAttrsDefined(const clang::Decl *decl) {
 #if ROSE_USE_VALGRIND
   decl = markClangAstObjectDefined(decl);
-  if (!RUNNING_ON_VALGRIND || decl == nullptr || !decl->hasAttrs()) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return;
   }
 
+  const bool has_attrs =
+      readClangApiValueDefined([&]() { return decl->hasAttrs(); });
+  if (!has_attrs) {
+    return;
+  }
+
+  VALGRIND_DISABLE_ERROR_REPORTING;
   const clang::AttrVec &attrs = decl->getAttrs();
+  VALGRIND_ENABLE_ERROR_REPORTING;
   VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::AttrVec *>(&attrs),
                             sizeof(attrs));
   if (!attrs.empty()) {
@@ -189,11 +307,93 @@ markClangTypeObjectDefinedByClass(const clang::Type *type);
 static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl);
 static const clang::Decl *
 markClangDeclObjectDefinedByKind(const clang::Decl *decl);
+static clang::TemplateParameterList *
+markClangTemplateParameterListDefined(clang::TemplateParameterList *params);
+static void markClangTemplateParameterInjectedArgumentsDefined(
+    clang::TemplateParameterList *params, const clang::ASTContext &context);
+static void markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+    clang::TemplateParameterList *params, const clang::ASTContext &context);
+static const clang::TemplateArgument &
+markClangTemplateArgumentDefined(const clang::TemplateArgument &arg);
+static void markClangTemplateArgumentTypeDefined(clang::QualType qual_type);
+static clang::ClassTemplateSpecializationDecl *
+markClangClassTemplateSpecializationStateDefined(
+    clang::ClassTemplateSpecializationDecl *decl);
+static clang::CXXRecordDecl *
+markClangCXXRecordTemplateOrInstantiationStateDefined(
+    clang::CXXRecordDecl *record);
+static clang::ClassTemplateDecl *
+markClangClassTemplateDeclForPrintingDefined(clang::ClassTemplateDecl *decl);
+
+static void
+markClangDeclarationNameForPrintingDefined(const clang::NamedDecl *decl) {
+#if ROSE_USE_VALGRIND
+  decl = markClangAstObjectDefined(decl);
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    return;
+  }
+  static std::unordered_set<const clang::NamedDecl *> marked_names;
+  if (!marked_names.insert(decl).second) {
+    return;
+  }
+
+  clang::DeclarationName decl_name =
+      readClangApiValueDefined([&]() { return decl->getDeclName(); });
+  markClangValueDefined(decl_name);
+  switch (readClangApiValueDefined([&]() { return decl_name.getNameKind(); })) {
+  case clang::DeclarationName::CXXConstructorName:
+  case clang::DeclarationName::CXXDestructorName:
+  case clang::DeclarationName::CXXConversionFunctionName:
+    if (clang::QualType cxx_name_type = readClangApiValueDefined(
+            [&]() { return decl_name.getCXXNameType(); });
+        !cxx_name_type.isNull()) {
+      markClangTemplateArgumentTypeDefined(cxx_name_type);
+      markClangQualTypeForPrintingDefinedForFrontend(cxx_name_type);
+    }
+    break;
+  default:
+    break;
+  }
+#else
+  (void)decl;
+#endif
+}
+
+static std::string
+clangNamedDeclNameAsStringDefinedForFrontend(const clang::NamedDecl *decl) {
+  decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+      markClangDeclObjectDefinedByKind(decl));
+  if (decl == nullptr) {
+    return "";
+  }
+
+  markClangDeclarationNameForPrintingDefined(decl);
+
+#if ROSE_USE_VALGRIND
+  VALGRIND_DISABLE_ERROR_REPORTING;
+  std::string result = decl->getNameAsString();
+  VALGRIND_ENABLE_ERROR_REPORTING;
+  markClangPrintedStringDefined(result);
+  return result;
+#endif
+
+  return decl->getNameAsString();
+}
+
+static clang::QualType markClangQualTypeDefined(clang::QualType qual_type) {
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(qual_type);
+  if (clangFrontendRunningOnValgrind()) {
+    markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
+  }
+#endif
+  return qual_type;
+}
 
 static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(type_loc);
-  if (!RUNNING_ON_VALGRIND || type_loc.isNull()) {
+  if (!clangFrontendRunningOnValgrind() || type_loc.isNull()) {
     return;
   }
 
@@ -213,10 +413,26 @@ static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 #endif
 }
 
+template <typename F>
+static auto readClangTypeLocDefined(F &&read) -> decltype(read()) {
+  auto type_loc = readClangApiValueDefined(std::forward<F>(read));
+  markClangTypeLocDataDefined(type_loc);
+  return type_loc;
+}
+
+static clang::TypeLoc nextClangTypeLocDefined(clang::TypeLoc type_loc) {
+  markClangTypeLocDataDefined(type_loc);
+  clang::TypeLoc next =
+      readClangApiValueDefined([&]() { return type_loc.getNextTypeLoc(); });
+  markClangTypeLocDataDefined(next);
+  return next;
+}
+
 static clang::TypeSourceInfo *
 markClangTypeSourceInfoDefined(clang::TypeSourceInfo *type_info) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || type_info == nullptr) {
+  markClangValueDefined(type_info);
+  if (!clangFrontendRunningOnValgrind() || type_info == nullptr) {
     return type_info;
   }
 
@@ -231,7 +447,7 @@ static clang::NestedNameSpecifier
 markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(specifier);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return specifier;
   }
 
@@ -240,14 +456,17 @@ markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
     if (!current) {
       break;
     }
-    if (current.getKind() == clang::NestedNameSpecifier::Kind::Type) {
-      markClangTypeObjectDefinedByClass(current.getAsType());
-    } else if (current.getKind() ==
-               clang::NestedNameSpecifier::Kind::Namespace) {
+    const clang::NestedNameSpecifier::Kind kind =
+        readClangApiValueDefined([&]() { return current.getKind(); });
+    if (kind == clang::NestedNameSpecifier::Kind::Type) {
+      markClangTypeObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return current.getAsType(); }));
+    } else if (kind == clang::NestedNameSpecifier::Kind::Namespace) {
       markClangDeclObjectDefinedByKind(
           nestedNameSpecifierNamespaceBase(current));
     }
-    current = nestedNameSpecifierPrefix(current);
+    current = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+        [&]() { return nestedNameSpecifierPrefix(current); }));
   }
 #endif
   return specifier;
@@ -258,10 +477,13 @@ clangNestedNameSpecifierLocDataLength(clang::NestedNameSpecifier specifier) {
   unsigned length = 0;
   for (clang::NestedNameSpecifier current =
            markClangNestedNameSpecifierDefined(specifier);
-       current; current = markClangNestedNameSpecifierDefined(
-                    current.getAsNamespaceAndPrefix().Prefix)) {
+       current;
+       current = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+           [&]() { return current.getAsNamespaceAndPrefix().Prefix; }))) {
     length += sizeof(clang::SourceLocation::UIntTy);
-    switch (current.getKind()) {
+    const clang::NestedNameSpecifier::Kind kind =
+        readClangApiValueDefined([&]() { return current.getKind(); });
+    switch (kind) {
     case clang::NestedNameSpecifier::Kind::Global:
       break;
     case clang::NestedNameSpecifier::Kind::Namespace:
@@ -274,7 +496,7 @@ clangNestedNameSpecifierLocDataLength(clang::NestedNameSpecifier specifier) {
     case clang::NestedNameSpecifier::Kind::Null:
       return length;
     }
-    if (current.getKind() != clang::NestedNameSpecifier::Kind::Namespace) {
+    if (kind != clang::NestedNameSpecifier::Kind::Namespace) {
       break;
     }
   }
@@ -285,20 +507,25 @@ static clang::NestedNameSpecifierLoc markClangNestedNameSpecifierLocDefined(
     clang::NestedNameSpecifierLoc qualifier_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(qualifier_loc);
-  if (!RUNNING_ON_VALGRIND || !qualifier_loc) {
+  if (!clangFrontendRunningOnValgrind() || !qualifier_loc) {
     return qualifier_loc;
   }
 
-  clang::NestedNameSpecifier qualifier = markClangNestedNameSpecifierDefined(
-      qualifier_loc.getNestedNameSpecifier());
-  if (void *data = qualifier_loc.getOpaqueData()) {
+  clang::NestedNameSpecifier qualifier =
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
+  if (void *data = readClangApiValueDefined(
+          [&]() { return qualifier_loc.getOpaqueData(); })) {
     const unsigned size = clangNestedNameSpecifierLocDataLength(qualifier);
     if (size != 0) {
       VALGRIND_MAKE_MEM_DEFINED(data, size);
     }
   }
-  if (qualifier.getKind() == clang::NestedNameSpecifier::Kind::Type) {
-    markClangTypeLocDataDefined(qualifier_loc.getAsTypeLoc());
+  if (qualifier && readClangApiValueDefined([&]() {
+                     return qualifier.getKind();
+                   }) == clang::NestedNameSpecifier::Kind::Type) {
+    markClangTypeLocDataDefined(readClangApiValueDefined(
+        [&]() { return qualifier_loc.getAsTypeLoc(); }));
   }
 #endif
   return qualifier_loc;
@@ -308,7 +535,7 @@ static clang::TemplateName
 markClangTemplateNameDefined(clang::TemplateName name) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(name);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return name;
   }
 
@@ -355,22 +582,129 @@ markClangTemplateNameDefined(clang::TemplateName name) {
   return name;
 }
 
+static const clang::TemplateArgumentLoc &
+markClangTemplateArgumentLocDefined(const clang::TemplateArgumentLoc &loc) {
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(loc);
+  if (!clangFrontendRunningOnValgrind()) {
+    return loc;
+  }
+
+  const clang::TemplateArgument &arg = loc.getArgument();
+  markClangValueDefined(arg);
+
+  switch (arg.getKind()) {
+  case clang::TemplateArgument::Type:
+    markClangTypeSourceInfoDefined(loc.getTypeSourceInfo());
+    break;
+  case clang::TemplateArgument::Expression:
+    markClangAstObjectDefined(loc.getSourceExpression());
+    break;
+  case clang::TemplateArgument::Declaration:
+    markClangAstObjectDefined(loc.getSourceDeclExpression());
+    break;
+  case clang::TemplateArgument::NullPtr:
+    markClangAstObjectDefined(loc.getSourceNullPtrExpression());
+    break;
+  case clang::TemplateArgument::Integral:
+    markClangAstObjectDefined(loc.getSourceIntegralExpression());
+    break;
+  case clang::TemplateArgument::StructuralValue:
+    markClangAstObjectDefined(loc.getSourceStructuralValueExpression());
+    break;
+  case clang::TemplateArgument::Template:
+  case clang::TemplateArgument::TemplateExpansion:
+    markClangNestedNameSpecifierLocDefined(loc.getTemplateQualifierLoc());
+    markClangTemplateNameDefined(arg.getAsTemplateOrTemplatePattern());
+    break;
+  case clang::TemplateArgument::Null:
+  case clang::TemplateArgument::Pack:
+    break;
+  }
+#endif
+  return loc;
+}
+
+static void
+markClangTemplateParameterSourceRangeStorageDefined(clang::NamedDecl *decl) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind()) {
+    return;
+  }
+
+  decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+      markClangDeclObjectDefinedByKind(decl));
+  if (decl == nullptr) {
+    return;
+  }
+
+  auto mark_default_argument =
+      [](const clang::TemplateArgumentLoc &default_loc) {
+        markClangTemplateArgumentLocDefined(default_loc);
+      };
+
+  if (clang::TemplateTypeParmDecl *type_param =
+          llvm::dyn_cast<clang::TemplateTypeParmDecl>(decl)) {
+    const bool has_default = readClangApiValueDefined(
+        [&]() { return type_param->hasDefaultArgument(); });
+    if (has_default) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      const clang::TemplateArgumentLoc &default_loc =
+          type_param->getDefaultArgument();
+      VALGRIND_ENABLE_ERROR_REPORTING;
+      mark_default_argument(default_loc);
+    }
+  } else if (clang::NonTypeTemplateParmDecl *non_type_param =
+                 llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(decl)) {
+    const bool has_default = readClangApiValueDefined(
+        [&]() { return non_type_param->hasDefaultArgument(); });
+    if (has_default) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      const clang::TemplateArgumentLoc &default_loc =
+          non_type_param->getDefaultArgument();
+      VALGRIND_ENABLE_ERROR_REPORTING;
+      mark_default_argument(default_loc);
+    }
+  } else if (clang::TemplateTemplateParmDecl *template_param =
+                 llvm::dyn_cast<clang::TemplateTemplateParmDecl>(decl)) {
+    clang::TemplateParameterList *template_parameters =
+        readClangApiValueDefined(
+            [&]() { return template_param->getTemplateParameters(); });
+    markClangTemplateParameterListDefined(template_parameters);
+
+    const bool has_default = readClangApiValueDefined(
+        [&]() { return template_param->hasDefaultArgument(); });
+    if (has_default) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      const clang::TemplateArgumentLoc &default_loc =
+          template_param->getDefaultArgument();
+      VALGRIND_ENABLE_ERROR_REPORTING;
+      mark_default_argument(default_loc);
+    }
+  }
+#else
+  (void)decl;
+#endif
+}
+
 static const clang::CXXBaseSpecifier &
 makeDefinedClangCXXBaseSpecifier(const clang::CXXBaseSpecifier &raw_base) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::CXXBaseSpecifier *>(&raw_base),
                               sizeof(raw_base));
   }
 #endif
 
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return raw_base;
   }
 
-  markClangTypeSourceInfoDefined(raw_base.getTypeSourceInfo());
-  clang::QualType type = raw_base.getType();
+  markClangTypeSourceInfoDefined(
+      readClangApiValueDefined([&]() { return raw_base.getTypeSourceInfo(); }));
+  clang::QualType type =
+      readClangApiValueDefined([&]() { return raw_base.getType(); });
   markClangValueDefined(type);
   markClangTypeObjectDefinedByClass(type.getTypePtrOrNull());
 #endif
@@ -382,14 +716,16 @@ markClangCXXRecordDefinitionStateDefined(const clang::CXXRecordDecl *record) {
 #if ROSE_USE_VALGRIND
   record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
       markClangDeclObjectDefinedByKind(record));
-  if (!RUNNING_ON_VALGRIND || record == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || record == nullptr) {
     return record;
   }
 
   auto mark_base_range =
       [](clang::CXXRecordDecl::base_class_const_range bases) {
-        const clang::CXXBaseSpecifier *begin = bases.begin();
-        const clang::CXXBaseSpecifier *end = bases.end();
+        const clang::CXXBaseSpecifier *begin =
+            readClangApiValueDefined([&]() { return bases.begin(); });
+        const clang::CXXBaseSpecifier *end =
+            readClangApiValueDefined([&]() { return bases.end(); });
         markClangValueDefined(begin);
         markClangValueDefined(end);
         if (begin != nullptr && end >= begin) {
@@ -399,8 +735,8 @@ markClangCXXRecordDefinitionStateDefined(const clang::CXXRecordDecl *record) {
         }
       };
 
-  mark_base_range(record->bases());
-  mark_base_range(record->vbases());
+  mark_base_range(readClangApiValueDefined([&]() { return record->bases(); }));
+  mark_base_range(readClangApiValueDefined([&]() { return record->vbases(); }));
 #endif
   return record;
 }
@@ -415,7 +751,7 @@ markClangCXXRecordDefinitionStateDefined(clang::CXXRecordDecl *record) {
 static const clang::Type *
 markClangTypeObjectDefinedByClass(const clang::Type *type) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return type;
   }
 
@@ -423,6 +759,63 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
   if (type == nullptr) {
     return nullptr;
   }
+
+  auto mark_tag_type =
+      [](const clang::TagType *tag_type) -> const clang::TagType * {
+    switch (tag_type->getTypeClass()) {
+    case clang::Type::Enum:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::EnumType *>(tag_type));
+      break;
+    case clang::Type::Record:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::RecordType *>(tag_type));
+      break;
+    case clang::Type::InjectedClassName:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::InjectedClassNameType *>(tag_type));
+      break;
+    default:
+      tag_type = markClangAstObjectDefined(tag_type);
+      break;
+    }
+    if (tag_type != nullptr) {
+      clang::NestedNameSpecifier qualifier =
+          readClangApiValueDefined([&]() { return tag_type->getQualifier(); });
+      if (qualifier) {
+        const void *trailing_pointer = nullptr;
+        switch (tag_type->getTypeClass()) {
+        case clang::Type::Enum:
+          trailing_pointer = static_cast<const clang::EnumType *>(tag_type) + 1;
+          break;
+        case clang::Type::Record:
+          trailing_pointer =
+              static_cast<const clang::RecordType *>(tag_type) + 1;
+          break;
+        case clang::Type::InjectedClassName:
+          trailing_pointer =
+              static_cast<const clang::InjectedClassNameType *>(tag_type) + 1;
+          break;
+        default:
+          break;
+        }
+        if (trailing_pointer != nullptr) {
+          const std::uintptr_t raw =
+              reinterpret_cast<std::uintptr_t>(trailing_pointer);
+          const std::uintptr_t alignment =
+              alignof(clang::NestedNameSpecifier *);
+          const std::uintptr_t aligned =
+              (raw + alignment - 1) & ~(alignment - 1);
+          VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(aligned),
+                                    sizeof(clang::NestedNameSpecifier));
+        }
+      }
+      markClangNestedNameSpecifierDefined(qualifier);
+      markClangDeclObjectDefinedByKind(
+          readClangApiValueDefined([&]() { return tag_type->getDecl(); }));
+    }
+    return tag_type;
+  };
 
   switch (type->getTypeClass()) {
   case clang::Type::Adjusted:
@@ -483,7 +876,7 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
     return markClangAstObjectDefined(
         static_cast<const clang::FunctionProtoType *>(type));
   case clang::Type::InjectedClassName:
-    return markClangAstObjectDefined(
+    return mark_tag_type(
         static_cast<const clang::InjectedClassNameType *>(type));
   case clang::Type::MacroQualified:
     return markClangAstObjectDefined(
@@ -516,11 +909,9 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
     return markClangAstObjectDefined(
         static_cast<const clang::SubstTemplateTypeParmType *>(type));
   case clang::Type::Enum:
-    return markClangAstObjectDefined(
-        static_cast<const clang::EnumType *>(type));
+    return mark_tag_type(static_cast<const clang::EnumType *>(type));
   case clang::Type::Record:
-    return markClangAstObjectDefined(
-        static_cast<const clang::RecordType *>(type));
+    return mark_tag_type(static_cast<const clang::RecordType *>(type));
   case clang::Type::TemplateSpecialization:
     return markClangAstObjectDefined(
         static_cast<const clang::TemplateSpecializationType *>(type));
@@ -588,7 +979,15 @@ static clang::QualType
 markClangFunctionTypeBoundaryDefined(clang::QualType type) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(type);
-  if (!RUNNING_ON_VALGRIND || type.isNull()) {
+  if (!clangFrontendRunningOnValgrind() || type.isNull()) {
+    return type;
+  }
+
+  static std::unordered_set<const clang::Type *> marked_function_boundaries;
+  const clang::Type *root_type =
+      readClangApiValueDefined([&]() { return type.getTypePtrOrNull(); });
+  if (root_type == nullptr ||
+      !marked_function_boundaries.insert(root_type).second) {
     return type;
   }
 
@@ -597,8 +996,9 @@ markClangFunctionTypeBoundaryDefined(clang::QualType type) {
     const clang::Type *type_ptr =
         markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
     if (type_ptr != nullptr) {
-      clang::QualType canonical = type_ptr->getCanonicalTypeInternal();
-      markClangValueDefined(canonical);
+      clang::QualType canonical =
+          markClangQualTypeDefined(readClangApiValueDefined(
+              [&]() { return type_ptr->getCanonicalTypeInternal(); }));
       markClangTypeObjectDefinedByClass(canonical.getTypePtrOrNull());
     }
     return type_ptr;
@@ -608,21 +1008,29 @@ markClangFunctionTypeBoundaryDefined(clang::QualType type) {
   if (type_ptr == nullptr) {
     return type;
   }
+  if (type_ptr != root_type &&
+      !marked_function_boundaries.insert(type_ptr).second) {
+    return type;
+  }
 
   auto mark_immediate_pointee = [&](const clang::Type *candidate) {
+    candidate = markClangTypeObjectDefinedByClass(candidate);
     if (candidate == nullptr) {
       return;
     }
 
     clang::QualType pointee;
     if (const auto *ptr = llvm::dyn_cast<clang::PointerType>(candidate)) {
-      pointee = ptr->getPointeeType();
+      pointee = markClangQualTypeDefined(
+          readClangApiValueDefined([&]() { return ptr->getPointeeType(); }));
     } else if (const auto *lvalue_ref =
                    llvm::dyn_cast<clang::LValueReferenceType>(candidate)) {
-      pointee = lvalue_ref->getPointeeType();
+      pointee = markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return lvalue_ref->getPointeeType(); }));
     } else if (const auto *rvalue_ref =
                    llvm::dyn_cast<clang::RValueReferenceType>(candidate)) {
-      pointee = rvalue_ref->getPointeeType();
+      pointee = markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return rvalue_ref->getPointeeType(); }));
     }
 
     if (!pointee.isNull()) {
@@ -631,8 +1039,8 @@ markClangFunctionTypeBoundaryDefined(clang::QualType type) {
   };
 
   mark_immediate_pointee(type_ptr);
-  clang::QualType canonical = type_ptr->getCanonicalTypeInternal();
-  markClangValueDefined(canonical);
+  clang::QualType canonical = markClangQualTypeDefined(readClangApiValueDefined(
+      [&]() { return type_ptr->getCanonicalTypeInternal(); }));
   markClangTypeObjectDefinedByClass(canonical.getTypePtrOrNull());
   mark_immediate_pointee(canonical.getTypePtrOrNull());
 #endif
@@ -642,7 +1050,7 @@ markClangFunctionTypeBoundaryDefined(clang::QualType type) {
 static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(decl);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return decl;
   }
 
@@ -653,14 +1061,22 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
 
   if (auto *specific =
           llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    markClangClassTemplateSpecializationStateDefined(specific);
+    return specific;
   }
   if (auto *specific =
           llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    markClangClassTemplateSpecializationStateDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::RecordDecl>(decl)) {
     return markClangAstObjectDefined(specific);
@@ -680,13 +1096,19 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXConstructorDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXDestructorDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXConversionDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXMethodDecl>(decl)) {
     return markClangAstObjectDefined(specific);
@@ -707,7 +1129,7 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::ClassTemplateDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    return markClangClassTemplateDeclForPrintingDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::VarTemplateDecl>(decl)) {
     return markClangAstObjectDefined(specific);
@@ -724,13 +1146,31 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
   if (auto *specific = llvm::dyn_cast<clang::EnumDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
+  if (auto *specific = llvm::dyn_cast<clang::EnumConstantDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
   if (auto *specific = llvm::dyn_cast<clang::FieldDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::FriendDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::FriendTemplateDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::AccessSpecDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::LinkageSpecDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::UsingShadowDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::UsingDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::UsingDirectiveDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::ConceptDecl>(decl)) {
@@ -767,6 +1207,68 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
 static const clang::Decl *
 markClangDeclObjectDefinedByKind(const clang::Decl *decl) {
   return markClangDeclObjectDefinedByKind(const_cast<clang::Decl *>(decl));
+}
+
+static clang::CXXRecordDecl *
+markClangCXXRecordTemplateOrInstantiationStateDefined(
+    clang::CXXRecordDecl *record) {
+#if ROSE_USE_VALGRIND
+  record = markClangAstObjectDefined(record);
+  if (!clangFrontendRunningOnValgrind() || record == nullptr) {
+    return record;
+  }
+  static std::unordered_set<const clang::CXXRecordDecl *> marked_records;
+  if (!marked_records.insert(record).second) {
+    return record;
+  }
+
+  if (clang::ClassTemplateDecl *described_template = readClangApiValueDefined(
+          [&]() { return record->getDescribedClassTemplate(); })) {
+    markClangDeclObjectDefinedByKind(described_template);
+    clang::TemplateParameterList *params = readClangApiValueDefined(
+        [&]() { return described_template->getTemplateParameters(); });
+    markClangTemplateParameterListDefined(params);
+    markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+        params, record->getASTContext());
+  }
+
+  if (clang::MemberSpecializationInfo *member_info = readClangApiValueDefined(
+          [&]() { return record->getMemberSpecializationInfo(); })) {
+    markClangAstObjectDefined(member_info);
+    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+        [&]() { return member_info->getInstantiatedFrom(); }));
+  }
+#endif
+  return record;
+}
+
+static clang::ClassTemplateDecl *
+markClangClassTemplateDeclForPrintingDefined(clang::ClassTemplateDecl *decl) {
+#if ROSE_USE_VALGRIND
+  decl = markClangAstObjectDefined(decl);
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    return decl;
+  }
+  static std::unordered_set<const clang::ClassTemplateDecl *> marked_templates;
+  if (!marked_templates.insert(decl).second) {
+    return decl;
+  }
+
+  clang::TemplateParameterList *params =
+      readClangApiValueDefined([&]() { return decl->getTemplateParameters(); });
+  markClangTemplateParameterListDefined(params);
+
+  if (clang::CXXRecordDecl *templated_record = readClangApiValueDefined(
+          [&]() { return decl->getTemplatedDecl(); })) {
+    templated_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+        markClangDeclObjectDefinedByKind(templated_record));
+    if (templated_record != nullptr) {
+      markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+          params, templated_record->getASTContext());
+    }
+  }
+#endif
+  return decl;
 }
 
 template <typename T> static T *markClangSpecificDeclDefined(T *decl) {
@@ -863,6 +1365,18 @@ clangCXXRecordCanonicalDeclDefined(clang::CXXRecordDecl *decl) {
 }
 
 static clang::CXXRecordDecl *
+clangCXXRecordPreviousDeclDefined(clang::CXXRecordDecl *decl) {
+  decl = markClangSpecificDeclDefined(decl);
+  if (decl == nullptr) {
+    return nullptr;
+  }
+
+  clang::CXXRecordDecl *previous =
+      readClangApiValueDefined([&]() { return decl->getPreviousDecl(); });
+  return markClangSpecificDeclDefined(previous);
+}
+
+static clang::CXXRecordDecl *
 clangCXXRecordTemplateInstantiationPatternDefined(clang::CXXRecordDecl *decl) {
   decl = markClangSpecificDeclDefined(decl);
   if (decl == nullptr) {
@@ -903,12 +1417,13 @@ static clang::DeclContext *
 markClangDeclContextObjectDefined(clang::DeclContext *context) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(context);
-  if (!RUNNING_ON_VALGRIND || context == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || context == nullptr) {
     return context;
   }
 
   context = markClangAstObjectDefined(context);
-  clang::Decl *decl = clang::Decl::castFromDeclContext(context);
+  clang::Decl *decl = readClangApiValueDefined(
+      [&]() { return clang::Decl::castFromDeclContext(context); });
   decl = markClangDeclObjectDefinedByKind(decl);
   return clang::Decl::castToDeclContext(decl);
 #else
@@ -922,11 +1437,75 @@ markClangDeclContextObjectDefined(const clang::DeclContext *context) {
       const_cast<clang::DeclContext *>(context));
 }
 
+static clang::DeclContext *clangDeclContextDefined(const clang::Decl *decl) {
+  decl = markClangDeclObjectDefinedByKind(decl);
+  if (decl == nullptr) {
+    return nullptr;
+  }
+
+  const clang::DeclContext *context =
+      readClangApiValueDefined([&]() { return decl->getDeclContext(); });
+  return markClangDeclContextObjectDefined(
+      const_cast<clang::DeclContext *>(context));
+}
+
+static clang::DeclContext *
+clangDeclContextParentDefined(clang::DeclContext *context) {
+  context = markClangDeclContextObjectDefined(context);
+  if (context == nullptr) {
+    return nullptr;
+  }
+
+  clang::DeclContext *parent =
+      readClangApiValueDefined([&]() { return context->getParent(); });
+  return markClangDeclContextObjectDefined(parent);
+}
+
+static void markClangDeclContextParentChainDefined(const clang::Decl *decl) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    return;
+  }
+
+  clang::DeclContext *context = clangDeclContextDefined(decl);
+  std::unordered_set<const clang::DeclContext *> visited;
+  while (context != nullptr && visited.insert(context).second) {
+    context = clangDeclContextParentDefined(context);
+  }
+#else
+  (void)decl;
+#endif
+}
+
+static clang::VarDecl *clangVarPreviousDeclDefined(const clang::VarDecl *decl) {
+  clang::VarDecl *var_decl =
+      markClangSpecificDeclDefined(const_cast<clang::VarDecl *>(decl));
+  if (var_decl == nullptr) {
+    return nullptr;
+  }
+
+  clang::VarDecl *previous =
+      readClangApiValueDefined([&]() { return var_decl->getPreviousDecl(); });
+  return markClangSpecificDeclDefined(previous);
+}
+
+static bool clangVarDeclIsStaticDataMemberDefined(const clang::VarDecl *decl) {
+  clang::VarDecl *var_decl =
+      markClangSpecificDeclDefined(const_cast<clang::VarDecl *>(decl));
+  if (var_decl == nullptr) {
+    return false;
+  }
+
+  clangDeclContextDefined(var_decl);
+  return readClangApiValueDefined(
+      [&]() { return var_decl->isStaticDataMember(); });
+}
+
 static clang::TemplateParameterList *
 markClangTemplateParameterListDefined(clang::TemplateParameterList *params) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(params);
-  if (!RUNNING_ON_VALGRIND || params == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
     return params;
   }
 
@@ -953,42 +1532,95 @@ markClangTemplateParameterListDefined(
 
 static void markClangDeclPointerMapKeysDefined(
     std::unordered_map<clang::Decl *, SgNode *> &map) {
-#if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND) {
-    return;
-  }
-  for (auto &entry : map) {
-    markClangValueDefined(entry.first);
-  }
-#else
   (void)map;
-#endif
 }
 
 static void markClangDeclPointerSetKeysDefined(std::set<clang::Decl *> &set) {
-#if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND) {
-    return;
-  }
-  for (clang::Decl *const &entry : set) {
-    markClangValueDefined(entry);
-  }
-#else
   (void)set;
+}
+
+static uintptr_t alignClangTrailingObjectAddress(uintptr_t address,
+                                                 size_t alignment) {
+  ROSE_ASSERT(alignment != 0);
+  return (address + alignment - 1) & ~(alignment - 1);
+}
+
+static clang::StringLiteral *
+markClangStringLiteralStorageDefined(clang::StringLiteral *literal) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || literal == nullptr) {
+    return literal;
+  }
+
+  literal = markClangAstObjectDefined(literal);
+
+  uintptr_t address =
+      reinterpret_cast<uintptr_t>(literal) + sizeof(clang::StringLiteral);
+  address = alignClangTrailingObjectAddress(address, alignof(unsigned));
+  auto *length = reinterpret_cast<unsigned *>(address);
+  VALGRIND_MAKE_MEM_DEFINED(length, sizeof(*length));
+
+  const unsigned byte_length = literal->getByteLength();
+  const unsigned token_count = literal->getNumConcatenated();
+
+  address += sizeof(*length);
+  address =
+      alignClangTrailingObjectAddress(address, alignof(clang::SourceLocation));
+  if (token_count != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(address),
+                              token_count * sizeof(clang::SourceLocation));
+  }
+
+  address += token_count * sizeof(clang::SourceLocation);
+  address = alignClangTrailingObjectAddress(address, alignof(char));
+  if (byte_length != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(address), byte_length);
+  }
 #endif
+  return literal;
+}
+
+static clang::CXXUnresolvedConstructExpr *
+markClangCXXUnresolvedConstructExprStorageDefined(
+    clang::CXXUnresolvedConstructExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || expr == nullptr) {
+    return expr;
+  }
+
+  expr = markClangAstObjectDefined(expr);
+  markClangTypeSourceInfoDefined(
+      readClangApiValueDefined([&]() { return expr->getTypeSourceInfo(); }));
+  const unsigned arg_count =
+      readClangApiValueDefined([&]() { return expr->getNumArgs(); });
+  clang::Expr **args = expr->arg_begin();
+  if (args != nullptr && arg_count != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(args, arg_count * sizeof(clang::Expr *));
+  }
+  for (unsigned i = 0; i < arg_count; ++i) {
+    markClangAstObjectDefined(args[i]);
+  }
+#endif
+  return expr;
 }
 
 static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&stmt, sizeof(stmt));
   }
-  if (!RUNNING_ON_VALGRIND || stmt == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || stmt == nullptr) {
     return stmt;
   }
 
   stmt = markClangAstObjectDefined(stmt);
   switch (stmt->getStmtClass()) {
+  case clang::Stmt::ArraySubscriptExprClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::ArraySubscriptExpr *>(stmt));
+  case clang::Stmt::BinaryOperatorClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::BinaryOperator *>(stmt));
   case clang::Stmt::CallExprClass:
     return markClangAstObjectDefined(static_cast<clang::CallExpr *>(stmt));
   case clang::Stmt::ConstantExprClass:
@@ -1014,6 +1646,9 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
   case clang::Stmt::CXXStaticCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXStaticCastExpr *>(stmt));
+  case clang::Stmt::CXXUnresolvedConstructExprClass:
+    return markClangCXXUnresolvedConstructExprStorageDefined(
+        static_cast<clang::CXXUnresolvedConstructExpr *>(stmt));
   case clang::Stmt::DeclRefExprClass:
     return markClangAstObjectDefined(static_cast<clang::DeclRefExpr *>(stmt));
   case clang::Stmt::ExprWithCleanupsClass:
@@ -1022,6 +1657,9 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
   case clang::Stmt::ImplicitCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::ImplicitCastExpr *>(stmt));
+  case clang::Stmt::IntegerLiteralClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::IntegerLiteral *>(stmt));
   case clang::Stmt::InitListExprClass:
     return markClangAstObjectDefined(static_cast<clang::InitListExpr *>(stmt));
   case clang::Stmt::MaterializeTemporaryExprClass:
@@ -1029,9 +1667,14 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
         static_cast<clang::MaterializeTemporaryExpr *>(stmt));
   case clang::Stmt::ParenExprClass:
     return markClangAstObjectDefined(static_cast<clang::ParenExpr *>(stmt));
+  case clang::Stmt::StringLiteralClass:
+    return markClangStringLiteralStorageDefined(
+        static_cast<clang::StringLiteral *>(stmt));
   case clang::Stmt::SubstNonTypeTemplateParmExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::SubstNonTypeTemplateParmExpr *>(stmt));
+  case clang::Stmt::UnaryOperatorClass:
+    return markClangAstObjectDefined(static_cast<clang::UnaryOperator *>(stmt));
   default:
     return stmt;
   }
@@ -1045,35 +1688,207 @@ static clang::Expr *markClangExprObjectDefinedByClass(clang::Expr *expr) {
       markClangStmtObjectDefinedByClass(expr));
 }
 
+static void markClangParmVarDeclDefaultArgSourceRangeStorageDefined(
+    clang::ParmVarDecl *param_var_decl) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || param_var_decl == nullptr) {
+    return;
+  }
+
+  param_var_decl = llvm::dyn_cast_or_null<clang::ParmVarDecl>(
+      markClangDeclObjectDefinedByKind(param_var_decl));
+  if (param_var_decl == nullptr) {
+    return;
+  }
+
+  VALGRIND_DISABLE_ERROR_REPORTING;
+  clang::Expr *default_arg =
+      const_cast<clang::Expr *>(getParmVarDeclDefaultArgExpr(param_var_decl));
+  VALGRIND_ENABLE_ERROR_REPORTING;
+  markClangExprObjectDefinedByClass(default_arg);
+#else
+  (void)param_var_decl;
+#endif
+}
+
 static llvm::ArrayRef<clang::TemplateArgument>
 markClangTemplateArgumentArrayDefined(
     llvm::ArrayRef<clang::TemplateArgument> args);
+
+static void
+markInjectedClassNameTypePrinterInputsDefined(const clang::Type *type) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || type == nullptr) {
+    return;
+  }
+
+  const auto *injected_type = llvm::dyn_cast<clang::InjectedClassNameType>(
+      markClangTypeObjectDefinedByClass(type));
+  if (injected_type == nullptr) {
+    return;
+  }
+
+  clang::CXXRecordDecl *decl = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+      markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+          [&]() { return injected_type->getDecl(); })));
+  if (decl == nullptr) {
+    return;
+  }
+
+  if (clang::ClassTemplateDecl *template_decl = readClangApiValueDefined(
+          [&]() { return injected_type->getTemplateDecl(); })) {
+    markClangDeclObjectDefinedByKind(template_decl);
+    clang::TemplateParameterList *params = readClangApiValueDefined(
+        [&]() { return template_decl->getTemplateParameters(); });
+    markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+        params, decl->getASTContext());
+  }
+
+  if (clang::ClassTemplateSpecializationDecl *specialization =
+          llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
+    markClangClassTemplateSpecializationStateDefined(specialization);
+    return;
+  }
+
+  if (clang::ClassTemplateDecl *described_template = readClangApiValueDefined(
+          [&]() { return decl->getDescribedClassTemplate(); })) {
+    markClangDeclObjectDefinedByKind(described_template);
+    clang::TemplateParameterList *params = readClangApiValueDefined(
+        [&]() { return described_template->getTemplateParameters(); });
+    markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+        params, decl->getASTContext());
+  }
+#else
+  (void)type;
+#endif
+}
+
+static void markClangTemplateArgumentTypeDefined(clang::QualType qual_type) {
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(qual_type);
+  if (!clangFrontendRunningOnValgrind() || qual_type.isNull()) {
+    return;
+  }
+
+  static std::unordered_set<const clang::Type *> marked_template_argument_types;
+  const clang::Type *root_type =
+      readClangApiValueDefined([&]() { return qual_type.getTypePtrOrNull(); });
+  if (root_type == nullptr ||
+      !marked_template_argument_types.insert(root_type).second) {
+    return;
+  }
+
+  std::unordered_set<const clang::Type *> visited;
+  std::function<void(clang::QualType)> mark_type = [&](clang::QualType
+                                                           current_type) {
+    markClangValueDefined(current_type);
+    if (current_type.isNull()) {
+      return;
+    }
+
+    const clang::Type *current_root = readClangApiValueDefined(
+        [&]() { return current_type.getTypePtrOrNull(); });
+    if (current_root == nullptr || !visited.insert(current_root).second) {
+      return;
+    }
+    if (current_root != root_type &&
+        !marked_template_argument_types.insert(current_root).second) {
+      return;
+    }
+
+    current_type = markClangFunctionTypeBoundaryDefined(
+        markClangQualTypeDefined(current_type));
+    const clang::Type *type =
+        markClangTypeObjectDefinedByClass(current_type.getTypePtrOrNull());
+    if (type == nullptr) {
+      return;
+    }
+    if (type != current_root) {
+      if (!visited.insert(type).second ||
+          !marked_template_argument_types.insert(type).second) {
+        return;
+      }
+    }
+
+    if (const clang::TagType *tag_type = llvm::dyn_cast<clang::TagType>(type)) {
+      clang::TagDecl *tag_decl =
+          llvm::dyn_cast_or_null<clang::TagDecl>(const_cast<clang::TagDecl *>(
+              readClangApiValueDefined([&]() { return tag_type->getDecl(); })));
+      tag_decl = llvm::dyn_cast_or_null<clang::TagDecl>(
+          markClangDeclObjectDefinedByKind(tag_decl));
+      if (clang::ClassTemplateSpecializationDecl *spec_decl =
+              llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+                  tag_decl)) {
+        markClangClassTemplateSpecializationStateDefined(spec_decl);
+      }
+    }
+
+    if (const clang::PointerType *pointer_type =
+            llvm::dyn_cast<clang::PointerType>(type)) {
+      mark_type(readClangApiValueDefined(
+          [&]() { return pointer_type->getPointeeType(); }));
+    } else if (const clang::ReferenceType *reference_type =
+                   llvm::dyn_cast<clang::ReferenceType>(type)) {
+      mark_type(readClangApiValueDefined(
+          [&]() { return reference_type->getPointeeType(); }));
+    } else if (const clang::SubstTemplateTypeParmType *subst_type =
+                   llvm::dyn_cast<clang::SubstTemplateTypeParmType>(type)) {
+      mark_type(readClangApiValueDefined(
+          [&]() { return subst_type->getReplacementType(); }));
+    } else if (const clang::InjectedClassNameType *injected_type =
+                   llvm::dyn_cast<clang::InjectedClassNameType>(type)) {
+      markClangDeclObjectDefinedByKind(
+          readClangApiValueDefined([&]() { return injected_type->getDecl(); }));
+      markInjectedClassNameTypePrinterInputsDefined(injected_type);
+    }
+
+    clang::QualType desugared =
+        markClangFunctionTypeBoundaryDefined(readClangApiValueDefined([&]() {
+          return type->getLocallyUnqualifiedSingleStepDesugaredType();
+        }));
+    if (!desugared.isNull() && desugared.getTypePtrOrNull() != type) {
+      mark_type(desugared);
+    }
+
+    clang::QualType canonical =
+        markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+            [&]() { return type->getCanonicalTypeInternal(); }));
+    if (!canonical.isNull() && canonical.getTypePtrOrNull() != type) {
+      mark_type(canonical);
+    }
+  };
+
+  mark_type(qual_type);
+#else
+  (void)qual_type;
+#endif
+}
 
 static const clang::TemplateArgument &
 markClangTemplateArgumentDefined(const clang::TemplateArgument &arg) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(arg);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return arg;
   }
 
   switch (arg.getKind()) {
   case clang::TemplateArgument::Type:
-    markClangFunctionTypeBoundaryDefined(arg.getAsType());
+    markClangTemplateArgumentTypeDefined(arg.getAsType());
     break;
   case clang::TemplateArgument::Declaration:
     markClangDeclObjectDefinedByKind(arg.getAsDecl());
-    markClangFunctionTypeBoundaryDefined(arg.getParamTypeForDecl());
+    markClangTemplateArgumentTypeDefined(arg.getParamTypeForDecl());
     break;
   case clang::TemplateArgument::NullPtr:
-    markClangFunctionTypeBoundaryDefined(arg.getNullPtrType());
+    markClangTemplateArgumentTypeDefined(arg.getNullPtrType());
     break;
   case clang::TemplateArgument::Integral:
-    markClangFunctionTypeBoundaryDefined(arg.getIntegralType());
+    markClangTemplateArgumentTypeDefined(arg.getIntegralType());
     break;
   case clang::TemplateArgument::StructuralValue:
-    markClangAstObjectDefined(&arg.getAsStructuralValue());
-    markClangFunctionTypeBoundaryDefined(arg.getStructuralValueType());
+    markClangLocalObjectDefined(&arg.getAsStructuralValue());
+    markClangTemplateArgumentTypeDefined(arg.getStructuralValueType());
     break;
   case clang::TemplateArgument::Template:
   case clang::TemplateArgument::TemplateExpansion:
@@ -1097,7 +1912,7 @@ markClangTemplateArgumentArrayDefined(
     llvm::ArrayRef<clang::TemplateArgument> args) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(args);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return args;
   }
   if (args.data() != nullptr && !args.empty()) {
@@ -1112,13 +1927,32 @@ markClangTemplateArgumentArrayDefined(
   return args;
 }
 
+static void markClangTemplateParameterInjectedArgumentsDefined(
+    clang::TemplateParameterList *params, const clang::ASTContext &context) {
+#if ROSE_USE_VALGRIND
+  params = markClangTemplateParameterListDefined(params);
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
+    return;
+  }
+
+  llvm::ArrayRef<clang::TemplateArgument> injected_args =
+      readClangApiValueDefined(
+          [&]() { return params->getInjectedTemplateArgs(context); });
+  params = markClangTemplateParameterListDefined(params);
+  (void)markClangTemplateArgumentArrayDefined(injected_args);
+#else
+  (void)params;
+  (void)context;
+#endif
+}
+
 static const clang::TemplateArgumentList *
 markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&args, sizeof(args));
   }
-  if (!RUNNING_ON_VALGRIND || args == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
     return args;
   }
 
@@ -1128,14 +1962,121 @@ markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
   return args;
 }
 
+static llvm::ArrayRef<clang::TemplateArgument>
+markClangTemplateArgumentArrayForPrintingDefined(
+    llvm::ArrayRef<clang::TemplateArgument> args);
+
+static const clang::TemplateArgument &
+markClangTemplateArgumentForPrintingDefined(
+    const clang::TemplateArgument &arg) {
+#if ROSE_USE_VALGRIND
+  const clang::TemplateArgument &defined_arg =
+      markClangTemplateArgumentDefined(arg);
+  if (!clangFrontendRunningOnValgrind()) {
+    return defined_arg;
+  }
+
+  switch (defined_arg.getKind()) {
+  case clang::TemplateArgument::Type:
+    markClangQualTypeForPrintingDefinedForFrontend(defined_arg.getAsType());
+    break;
+  case clang::TemplateArgument::Declaration:
+    markClangDeclObjectDefinedByKind(defined_arg.getAsDecl());
+    markClangQualTypeForPrintingDefinedForFrontend(
+        defined_arg.getParamTypeForDecl());
+    break;
+  case clang::TemplateArgument::NullPtr:
+    markClangQualTypeForPrintingDefinedForFrontend(
+        defined_arg.getNullPtrType());
+    break;
+  case clang::TemplateArgument::Integral:
+    markClangQualTypeForPrintingDefinedForFrontend(
+        defined_arg.getIntegralType());
+    break;
+  case clang::TemplateArgument::StructuralValue:
+    markClangLocalObjectDefined(&defined_arg.getAsStructuralValue());
+    markClangQualTypeForPrintingDefinedForFrontend(
+        defined_arg.getStructuralValueType());
+    break;
+  case clang::TemplateArgument::Template:
+  case clang::TemplateArgument::TemplateExpansion:
+    markClangTemplateNameDefined(defined_arg.getAsTemplateOrTemplatePattern());
+    break;
+  case clang::TemplateArgument::Expression:
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return defined_arg.getAsExpr(); }));
+    break;
+  case clang::TemplateArgument::Pack:
+    (void)markClangTemplateArgumentArrayForPrintingDefined(
+        defined_arg.pack_elements());
+    break;
+  case clang::TemplateArgument::Null:
+    break;
+  }
+  return defined_arg;
+#else
+  return arg;
+#endif
+}
+
+static llvm::ArrayRef<clang::TemplateArgument>
+markClangTemplateArgumentArrayForPrintingDefined(
+    llvm::ArrayRef<clang::TemplateArgument> args) {
+#if ROSE_USE_VALGRIND
+  args = markClangTemplateArgumentArrayDefined(args);
+  if (!clangFrontendRunningOnValgrind()) {
+    return args;
+  }
+  for (const clang::TemplateArgument &arg : args) {
+    markClangTemplateArgumentForPrintingDefined(arg);
+  }
+#endif
+  return args;
+}
+
+static void markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+    clang::TemplateParameterList *params, const clang::ASTContext &context) {
+#if ROSE_USE_VALGRIND
+  params = markClangTemplateParameterListDefined(params);
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
+    return;
+  }
+
+  llvm::ArrayRef<clang::TemplateArgument> injected_args =
+      readClangApiValueDefined(
+          [&]() { return params->getInjectedTemplateArgs(context); });
+  params = markClangTemplateParameterListDefined(params);
+  (void)params;
+  (void)markClangTemplateArgumentArrayForPrintingDefined(injected_args);
+#else
+  (void)params;
+  (void)context;
+#endif
+}
+
+static const clang::TemplateArgumentList *
+markClangTemplateArgumentListForPrintingDefined(
+    const clang::TemplateArgumentList *args) {
+#if ROSE_USE_VALGRIND
+  args = markClangTemplateArgumentListDefined(args);
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
+    return args;
+  }
+  for (unsigned i = 0; i < args->size(); ++i) {
+    markClangTemplateArgumentForPrintingDefined(args->get(i));
+  }
+#endif
+  return args;
+}
+
 static const clang::ASTTemplateArgumentListInfo *
 markClangASTTemplateArgumentListInfoDefined(
     const clang::ASTTemplateArgumentListInfo *args) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&args, sizeof(args));
   }
-  if (!RUNNING_ON_VALGRIND || args == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
     return args;
   }
 
@@ -1150,6 +2091,7 @@ markClangASTTemplateArgumentListInfoDefined(
     markClangValueDefined(arg_loc);
     const clang::TemplateArgument &arg = arg_loc.getArgument();
     markClangValueDefined(arg);
+    markClangTemplateArgumentDefined(arg);
     if (clang::TypeSourceInfo *type_info = arg_loc.getTypeSourceInfo()) {
       markClangTypeSourceInfoDefined(type_info);
     }
@@ -1163,7 +2105,7 @@ markClangFunctionTemplateStateDefined(clang::FunctionDecl *decl) {
 #if ROSE_USE_VALGRIND
   decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
       markClangDeclObjectDefinedByKind(decl));
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
@@ -1240,24 +2182,56 @@ static clang::ClassTemplateSpecializationDecl *
 markClangClassTemplateSpecializationStateDefined(
     clang::ClassTemplateSpecializationDecl *decl) {
 #if ROSE_USE_VALGRIND
-  decl = llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
-      markClangDeclObjectDefinedByKind(decl));
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  static std::unordered_set<const clang::ClassTemplateSpecializationDecl *>
+      marked_specializations;
+  static std::unordered_set<const clang::ClassTemplateSpecializationDecl *>
+      active_specializations;
+  clang::ClassTemplateSpecializationDecl *active_key = decl;
+  if (active_key != nullptr &&
+      !active_specializations.insert(active_key).second) {
     return decl;
   }
 
-  markClangTemplateArgumentListDefined(&decl->getTemplateArgs());
-  markClangTemplateArgumentListDefined(&decl->getTemplateInstantiationArgs());
-  markClangASTTemplateArgumentListInfoDefined(decl->getTemplateArgsAsWritten());
-  auto specialized = decl->getSpecializedTemplateOrPartial();
+  decl = llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+      markClangDeclObjectDefinedByKind(decl));
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    if (active_key != nullptr) {
+      active_specializations.erase(active_key);
+    }
+    return decl;
+  }
+  if (!marked_specializations.insert(decl).second) {
+    if (active_key != nullptr) {
+      active_specializations.erase(active_key);
+    }
+    return decl;
+  }
+
+  markClangTemplateArgumentListForPrintingDefined(&decl->getTemplateArgs());
+  markClangTemplateArgumentListForPrintingDefined(
+      &decl->getTemplateInstantiationArgs());
+  if (const clang::ASTTemplateArgumentListInfo *written_args =
+          markClangASTTemplateArgumentListInfoDefined(
+              decl->getTemplateArgsAsWritten())) {
+    for (const clang::TemplateArgumentLoc &arg_loc :
+         written_args->arguments()) {
+      markClangTemplateArgumentForPrintingDefined(arg_loc.getArgument());
+    }
+  }
+  auto specialized = readClangApiValueDefined(
+      [&]() { return decl->getSpecializedTemplateOrPartial(); });
   if (auto *class_template =
           specialized.dyn_cast<clang::ClassTemplateDecl *>()) {
-    markClangDeclObjectDefinedByKind(class_template);
+    markClangClassTemplateDeclForPrintingDefined(class_template);
   } else if (auto *partial =
                  specialized.dyn_cast<
                      clang::ClassTemplatePartialSpecializationDecl *>()) {
     markClangDeclObjectDefinedByKind(partial);
-    markClangDeclObjectDefinedByKind(partial->getSpecializedTemplate());
+    markClangClassTemplateDeclForPrintingDefined(
+        partial->getSpecializedTemplate());
+  }
+  if (active_key != nullptr) {
+    active_specializations.erase(active_key);
   }
 #endif
   return decl;
@@ -1269,14 +2243,15 @@ markClangVarTemplateSpecializationStateDefined(
 #if ROSE_USE_VALGRIND
   decl = llvm::dyn_cast_or_null<clang::VarTemplateSpecializationDecl>(
       markClangDeclObjectDefinedByKind(decl));
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
   markClangTemplateArgumentListDefined(&decl->getTemplateArgs());
   markClangTemplateArgumentListDefined(&decl->getTemplateInstantiationArgs());
   markClangASTTemplateArgumentListInfoDefined(decl->getTemplateArgsAsWritten());
-  auto specialized = decl->getSpecializedTemplateOrPartial();
+  auto specialized = readClangApiValueDefined(
+      [&]() { return decl->getSpecializedTemplateOrPartial(); });
   if (auto *var_template = specialized.dyn_cast<clang::VarTemplateDecl *>()) {
     markClangDeclObjectDefinedByKind(var_template);
   } else if (auto *partial = specialized.dyn_cast<
@@ -1291,7 +2266,7 @@ markClangVarTemplateSpecializationStateDefined(
 static clang::CXXCtorInitializer *
 markClangCtorInitializerDefined(clang::CXXCtorInitializer *initializer) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&initializer, sizeof(initializer));
     if (initializer != nullptr) {
       VALGRIND_MAKE_MEM_DEFINED(initializer, sizeof(*initializer));
@@ -1308,7 +2283,7 @@ markClangCtorInitializerDefined(clang::CXXCtorInitializer *initializer) {
 static void
 markClangConstructorInitializersDefined(clang::CXXConstructorDecl *decl) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return;
   }
 
@@ -1332,7 +2307,7 @@ markClangConstructorInitializersDefined(clang::CXXConstructorDecl *decl) {
 static clang::VarDecl *
 markClangVarDeclInitStorageDefined(clang::VarDecl *decl) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
@@ -2481,22 +3456,34 @@ bool typeLocContainsAutoType(clang::TypeLoc type_loc) {
 bool functionDeclUsesOldStyleCParameterSyntax(
     const clang::FunctionDecl *function_decl,
     const clang::SourceManager *source_manager = nullptr) {
-  if (function_decl == nullptr || function_decl->hasWrittenPrototype()) {
+  function_decl = markClangAstObjectDefined(function_decl);
+  if (function_decl == nullptr || readClangApiValueDefined([&]() {
+        return function_decl->hasWrittenPrototype();
+      })) {
     return false;
   }
 
   clang::SourceLocation rparen_loc;
-  if (clang::TypeSourceInfo *type_info = function_decl->getTypeSourceInfo()) {
-    for (clang::TypeLoc current = type_info->getTypeLoc(); !current.isNull();
-         current = current.getNextTypeLoc()) {
-      if (clang::FunctionTypeLoc function_type_loc =
-              current.getAs<clang::FunctionTypeLoc>()) {
-        rparen_loc = function_type_loc.getRParenLoc();
+  if (clang::TypeSourceInfo *type_info =
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return function_decl->getTypeSourceInfo(); }))) {
+    for (clang::TypeLoc current = readClangApiValueDefined(
+             [&]() { return type_info->getTypeLoc(); });
+         !current.isNull(); current = nextClangTypeLocDefined(current)) {
+      markClangTypeLocDataDefined(current);
+      if (clang::FunctionTypeLoc function_type_loc = readClangApiValueDefined(
+              [&]() { return current.getAs<clang::FunctionTypeLoc>(); })) {
+        markClangTypeLocDataDefined(function_type_loc);
+        rparen_loc = readClangApiValueDefined(
+            [&]() { return function_type_loc.getRParenLoc(); });
       }
-      if (current.getAs<clang::FunctionNoProtoTypeLoc>()) {
+      if (readClangApiValueDefined([&]() {
+            return current.getAs<clang::FunctionNoProtoTypeLoc>();
+          })) {
         return true;
       }
-      if (current.getAs<clang::FunctionProtoTypeLoc>()) {
+      if (readClangApiValueDefined(
+              [&]() { return current.getAs<clang::FunctionProtoTypeLoc>(); })) {
         break;
       }
     }
@@ -2507,11 +3494,13 @@ bool functionDeclUsesOldStyleCParameterSyntax(
         rparen_loc.isMacroID() ? source_manager->getFileLoc(rparen_loc)
                                : rparen_loc;
     for (const clang::ParmVarDecl *param_decl : function_decl->parameters()) {
+      param_decl = markClangAstObjectDefined(param_decl);
       if (param_decl == nullptr) {
         continue;
       }
 
-      clang::SourceLocation param_loc = param_decl->getBeginLoc();
+      clang::SourceLocation param_loc =
+          readClangApiValueDefined([&]() { return param_decl->getBeginLoc(); });
       if (param_loc.isMacroID()) {
         param_loc = source_manager->getFileLoc(param_loc);
       }
@@ -2526,8 +3515,13 @@ bool functionDeclUsesOldStyleCParameterSyntax(
   // Empty parameter lists such as `int f()` have no per-parameter source
   // locations. Only in that narrow case fall back to the semantic no-prototype
   // type.
-  return function_decl->param_empty() &&
-         function_decl->getType()->getAs<clang::FunctionProtoType>() == nullptr;
+  clang::QualType function_type = markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return function_decl->getType(); }));
+  return readClangApiValueDefined(
+             [&]() { return function_decl->param_empty(); }) &&
+         readClangApiValueDefined([&]() {
+           return function_type->getAs<clang::FunctionProtoType>();
+         }) == nullptr;
 }
 
 void canonicalizeClassTypeToFirstNondefiningDeclaration(
@@ -2864,7 +3858,7 @@ bool typeSpellsElaboratedKeyword(const clang::Type *type) {
 bool typeLocSpellsElaboratedKeyword(clang::TypeLoc type_loc) {
   markClangTypeLocDataDefined(type_loc);
   for (clang::TypeLoc current = type_loc; !current.isNull();
-       current = current.getNextTypeLoc()) {
+       current = nextClangTypeLocDefined(current)) {
     markClangTypeLocDataDefined(current);
     markClangTypeObjectDefinedByClass(current.getTypePtr());
     if (auto tag_loc = current.getAs<clang::TagTypeLoc>()) {
@@ -2904,7 +3898,7 @@ void collectElaboratedTagDeclsFromTypeLoc(
   }
 
   for (clang::TypeLoc current = type_loc; !current.isNull();
-       current = current.getNextTypeLoc()) {
+       current = nextClangTypeLocDefined(current)) {
     markClangTypeLocDataDefined(current);
     markClangTypeObjectDefinedByClass(current.getTypePtr());
     if (auto tag_loc = current.getAs<clang::TagTypeLoc>()) {
@@ -3012,10 +4006,13 @@ void collectElaboratedTagDeclsFromTypeLoc(
       if (param == nullptr) {
         continue;
       }
-      clang::TypeSourceInfo *type_info = param->getTypeSourceInfo();
+      clang::TypeSourceInfo *type_info =
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return param->getTypeSourceInfo(); }));
       if (type_info != nullptr) {
-        collectElaboratedTagDeclsFromTypeLoc(type_info->getTypeLoc(), tags,
-                                             seen_tags);
+        collectElaboratedTagDeclsFromTypeLoc(
+            readClangApiValueDefined([&]() { return type_info->getTypeLoc(); }),
+            tags, seen_tags);
       }
     }
   }
@@ -3026,9 +4023,7 @@ clang::NestedNameSpecifierLoc typeLocQualifierLoc(clang::TypeLoc type_loc) {
   for (clang::TypeLoc current = type_loc; !current.isNull();) {
     markClangTypeLocDataDefined(current);
     markClangTypeObjectDefinedByClass(current.getTypePtr());
-    if (auto spec_loc = readClangApiValueDefined([&]() {
-          return current.getAs<clang::TemplateSpecializationTypeLoc>();
-        })) {
+    if (auto spec_loc = current.getAs<clang::TemplateSpecializationTypeLoc>()) {
       markClangTypeLocDataDefined(spec_loc);
       markClangTypeObjectDefinedByClass(spec_loc.getTypePtr());
       clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
@@ -3038,56 +4033,64 @@ clang::NestedNameSpecifierLoc typeLocQualifierLoc(clang::TypeLoc type_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
-    if (auto dep_name_loc = readClangApiValueDefined(
-            [&]() { return current.getAs<clang::DependentNameTypeLoc>(); })) {
+    if (auto dep_name_loc = current.getAs<clang::DependentNameTypeLoc>()) {
       markClangTypeLocDataDefined(dep_name_loc);
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              readClangApiValueDefined(
-                  [&]() { return dep_name_loc.getQualifierLoc(); })) {
+      clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
+          [&]() { return dep_name_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
-    if (auto typedef_loc = readClangApiValueDefined(
-            [&]() { return current.getAs<clang::TypedefTypeLoc>(); })) {
+    if (auto typedef_loc = current.getAs<clang::TypedefTypeLoc>()) {
       markClangTypeLocDataDefined(typedef_loc);
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              readClangApiValueDefined(
-                  [&]() { return typedef_loc.getQualifierLoc(); })) {
+      clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
+          [&]() { return typedef_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
-    if (auto using_loc = readClangApiValueDefined(
-            [&]() { return current.getAs<clang::UsingTypeLoc>(); })) {
+    if (auto using_loc = current.getAs<clang::UsingTypeLoc>()) {
       markClangTypeLocDataDefined(using_loc);
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              readClangApiValueDefined(
-                  [&]() { return using_loc.getQualifierLoc(); })) {
+      clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
+          [&]() { return using_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
-    if (auto unresolved_using_loc = readClangApiValueDefined(
-            [&]() { return current.getAs<clang::UnresolvedUsingTypeLoc>(); })) {
+    if (auto unresolved_using_loc =
+            current.getAs<clang::UnresolvedUsingTypeLoc>()) {
       markClangTypeLocDataDefined(unresolved_using_loc);
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              readClangApiValueDefined(
-                  [&]() { return unresolved_using_loc.getQualifierLoc(); })) {
+      clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
+          [&]() { return unresolved_using_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
     if (auto tag_loc = current.getAs<clang::TagTypeLoc>()) {
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              tag_loc.getQualifierLoc()) {
+      markClangTypeLocDataDefined(tag_loc);
+      clang::NestedNameSpecifierLoc qualifier_loc =
+          readClangApiValueDefined([&]() { return tag_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      qualifier_loc = markClangNestedNameSpecifierLocDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
     if (auto injected_loc = current.getAs<clang::InjectedClassNameTypeLoc>()) {
-      if (clang::NestedNameSpecifierLoc qualifier_loc =
-              injected_loc.getQualifierLoc()) {
+      markClangTypeLocDataDefined(injected_loc);
+      clang::NestedNameSpecifierLoc qualifier_loc = readClangApiValueDefined(
+          [&]() { return injected_loc.getQualifierLoc(); });
+      markClangValueDefined(qualifier_loc);
+      qualifier_loc = markClangNestedNameSpecifierLocDefined(qualifier_loc);
+      if (qualifier_loc) {
         return markClangNestedNameSpecifierLocDefined(qualifier_loc);
       }
     }
-    current =
-        readClangApiValueDefined([&]() { return current.getNextTypeLoc(); });
+    current = nextClangTypeLocDefined(current);
   }
 
   return clang::NestedNameSpecifierLoc();
@@ -3095,16 +4098,22 @@ clang::NestedNameSpecifierLoc typeLocQualifierLoc(clang::TypeLoc type_loc) {
 
 static clang::NestedNameSpecifier
 writtenTagQualifier(const clang::TagDecl *tag_decl) {
+  tag_decl = markClangSpecificDeclDefined(tag_decl);
   if (tag_decl == nullptr) {
     return std::nullopt;
   }
 
   if (clang::NestedNameSpecifierLoc qualifier_loc =
-          tag_decl->getQualifierLoc()) {
-    if (qualifier_loc.getLocalSourceRange().isValid()) {
+          markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+              [&]() { return tag_decl->getQualifierLoc(); }))) {
+    clang::SourceRange source_range = readClangApiValueDefined(
+        [&]() { return qualifier_loc.getLocalSourceRange(); });
+    markClangValueDefined(source_range);
+    if (source_range.isValid()) {
       if (clang::NestedNameSpecifier qualifier =
-              qualifier_loc.getNestedNameSpecifier()) {
-        return qualifier;
+              markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                  [&]() { return qualifier_loc.getNestedNameSpecifier(); }))) {
+        return markClangNestedNameSpecifierDefined(qualifier);
       }
     }
   }
@@ -3114,16 +4123,22 @@ writtenTagQualifier(const clang::TagDecl *tag_decl) {
 
 static clang::NestedNameSpecifier
 writtenFunctionQualifier(const clang::FunctionDecl *function_decl) {
+  function_decl = markClangSpecificDeclDefined(function_decl);
   if (function_decl == nullptr) {
     return std::nullopt;
   }
 
   if (clang::NestedNameSpecifierLoc qualifier_loc =
-          function_decl->getQualifierLoc()) {
-    if (qualifier_loc.getLocalSourceRange().isValid()) {
+          markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+              [&]() { return function_decl->getQualifierLoc(); }))) {
+    clang::SourceRange source_range = readClangApiValueDefined(
+        [&]() { return qualifier_loc.getLocalSourceRange(); });
+    markClangValueDefined(source_range);
+    if (source_range.isValid()) {
       if (clang::NestedNameSpecifier qualifier =
-              qualifier_loc.getNestedNameSpecifier()) {
-        return qualifier;
+              markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                  [&]() { return qualifier_loc.getNestedNameSpecifier(); }))) {
+        return markClangNestedNameSpecifierDefined(qualifier);
       }
     }
   }
@@ -3134,9 +4149,12 @@ writtenFunctionQualifier(const clang::FunctionDecl *function_decl) {
 static int
 nestedNameSpecifierComponentCount(clang::NestedNameSpecifier qualifier) {
   int count = 0;
-  for (clang::NestedNameSpecifier cur = qualifier; cur;
-       cur = nestedNameSpecifierPrefix(cur)) {
-    if (cur.getKind() != clang::NestedNameSpecifier::Kind::Global) {
+  for (clang::NestedNameSpecifier cur =
+           markClangNestedNameSpecifierDefined(qualifier);
+       cur; cur = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                [&]() { return nestedNameSpecifierPrefix(cur); }))) {
+    if (readClangApiValueDefined([&]() { return cur.getKind(); }) !=
+        clang::NestedNameSpecifier::Kind::Global) {
       ++count;
     }
   }
@@ -3144,9 +4162,12 @@ nestedNameSpecifierComponentCount(clang::NestedNameSpecifier qualifier) {
 }
 
 static bool nestedNameSpecifierHasGlobal(clang::NestedNameSpecifier qualifier) {
-  for (clang::NestedNameSpecifier cur = qualifier; cur;
-       cur = nestedNameSpecifierPrefix(cur)) {
-    if (cur.getKind() == clang::NestedNameSpecifier::Kind::Global) {
+  for (clang::NestedNameSpecifier cur =
+           markClangNestedNameSpecifierDefined(qualifier);
+       cur; cur = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                [&]() { return nestedNameSpecifierPrefix(cur); }))) {
+    if (readClangApiValueDefined([&]() { return cur.getKind(); }) ==
+        clang::NestedNameSpecifier::Kind::Global) {
       return true;
     }
   }
@@ -3155,15 +4176,21 @@ static bool nestedNameSpecifierHasGlobal(clang::NestedNameSpecifier qualifier) {
 
 static bool nestedNameSpecifierNeedsTemplateParameterTranslation(
     clang::NestedNameSpecifier qualifier) {
+  qualifier = markClangNestedNameSpecifierDefined(qualifier);
   return qualifier &&
-         (qualifier.isDependent() || qualifier.isInstantiationDependent() ||
-          qualifier.containsUnexpandedParameterPack() ||
-          qualifier.containsErrors());
+         (readClangApiValueDefined([&]() { return qualifier.isDependent(); }) ||
+          readClangApiValueDefined(
+              [&]() { return qualifier.isInstantiationDependent(); }) ||
+          readClangApiValueDefined(
+              [&]() { return qualifier.containsUnexpandedParameterPack(); }) ||
+          readClangApiValueDefined(
+              [&]() { return qualifier.containsErrors(); }));
 }
 
 static std::string
 nestedNameSpecifierToString(clang::NestedNameSpecifier qualifier,
                             clang::CompilerInstance *compiler_instance) {
+  qualifier = markClangNestedNameSpecifierDefined(qualifier);
   if (!qualifier) {
     return "";
   }
@@ -3175,13 +4202,13 @@ nestedNameSpecifierToString(clang::NestedNameSpecifier qualifier,
           ? compiler_instance->getASTContext().getPrintingPolicy()
           : clang::PrintingPolicy(clang::LangOptions());
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
   }
 #endif
   qualifier.print(stream, policy);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_ENABLE_ERROR_REPORTING;
   }
 #endif
@@ -3258,11 +4285,16 @@ static void preserveExplicitTypedefBaseQualifier(
 static clang::NestedNameSpecifierLoc
 nestedNameSpecifierLocPrefix(clang::NestedNameSpecifierLoc current) {
   current = markClangNestedNameSpecifierLocDefined(current);
-  switch (current.getNestedNameSpecifier().getKind()) {
+  clang::NestedNameSpecifier specifier =
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return current.getNestedNameSpecifier(); }));
+  switch (readClangApiValueDefined([&]() { return specifier.getKind(); })) {
   case clang::NestedNameSpecifier::Kind::Namespace:
-    return current.getAsNamespaceAndPrefix().Prefix;
+    return markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+        [&]() { return current.getAsNamespaceAndPrefix().Prefix; }));
   case clang::NestedNameSpecifier::Kind::Type:
-    return current.getAsTypeLoc().getPrefix();
+    return markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+        [&]() { return current.getAsTypeLoc().getPrefix(); }));
   case clang::NestedNameSpecifier::Kind::Global:
   case clang::NestedNameSpecifier::Kind::MicrosoftSuper:
   case clang::NestedNameSpecifier::Kind::Null:
@@ -3319,13 +4351,15 @@ recordDeclFromNestedNameSpecifierLoc(clang::NestedNameSpecifierLoc loc) {
     return nullptr;
   }
 
-  clang::NestedNameSpecifier nns =
-      markClangNestedNameSpecifierDefined(loc.getNestedNameSpecifier());
-  if (clang::CXXRecordDecl *record = nns.getAsRecordDecl()) {
+  clang::NestedNameSpecifier nns = markClangNestedNameSpecifierDefined(
+      readClangApiValueDefined([&]() { return loc.getNestedNameSpecifier(); }));
+  if (clang::CXXRecordDecl *record = markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return nns.getAsRecordDecl(); }))) {
     return record;
   }
 
-  if (nns.getKind() != clang::NestedNameSpecifier::Kind::Type) {
+  if (readClangApiValueDefined([&]() { return nns.getKind(); }) !=
+      clang::NestedNameSpecifier::Kind::Type) {
     return nullptr;
   }
 
@@ -3388,26 +4422,36 @@ recordDeclFromNestedNameSpecifierLoc(clang::NestedNameSpecifierLoc loc) {
     return nullptr;
   };
 
-  if (clang::CXXRecordDecl *record = record_from_type(nns.getAsType())) {
+  if (clang::CXXRecordDecl *record = record_from_type(
+          readClangApiValueDefined([&]() { return nns.getAsType(); }))) {
     return record;
   }
 
-  for (clang::TypeLoc current = loc.getAsTypeLoc(); !current.isNull();
-       current = current.getNextTypeLoc()) {
+  for (clang::TypeLoc current =
+           readClangApiValueDefined([&]() { return loc.getAsTypeLoc(); });
+       !current.isNull(); current = readClangApiValueDefined(
+                              [&]() { return current.getNextTypeLoc(); })) {
     markClangTypeLocDataDefined(current);
-    if (auto specialization_loc =
-            current.getAs<clang::TemplateSpecializationTypeLoc>()) {
-      if (clang::CXXRecordDecl *record = record_from_template_name(
-              specialization_loc.getTypePtr()->getTemplateName())) {
+    if (auto specialization_loc = readClangApiValueDefined([&]() {
+          return current.getAs<clang::TemplateSpecializationTypeLoc>();
+        })) {
+      if (clang::CXXRecordDecl *record =
+              record_from_template_name(readClangApiValueDefined([&]() {
+                return specialization_loc.getTypePtr()->getTemplateName();
+              }))) {
         return record;
       }
     }
 
-    if (auto injected_loc = current.getAs<clang::InjectedClassNameTypeLoc>()) {
-      return injected_loc.getDecl();
+    if (auto injected_loc = readClangApiValueDefined([&]() {
+          return current.getAs<clang::InjectedClassNameTypeLoc>();
+        })) {
+      return markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return injected_loc.getDecl(); }));
     }
 
-    if (auto record_loc = current.getAs<clang::RecordTypeLoc>()) {
+    if (auto record_loc = readClangApiValueDefined(
+            [&]() { return current.getAs<clang::RecordTypeLoc>(); })) {
       return llvm::dyn_cast_or_null<clang::CXXRecordDecl>(record_loc.getDecl());
     }
   }
@@ -3422,8 +4466,9 @@ static int nestedNameSpecifierLocComponentCount(
            markClangNestedNameSpecifierLocDefined(qualifier_loc);
        current; current = nestedNameSpecifierLocPrefix(current)) {
     clang::NestedNameSpecifier specifier =
-        markClangNestedNameSpecifierDefined(current.getNestedNameSpecifier());
-    switch (specifier.getKind()) {
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return current.getNestedNameSpecifier(); }));
+    switch (readClangApiValueDefined([&]() { return specifier.getKind(); })) {
     case clang::NestedNameSpecifier::Kind::Namespace:
     case clang::NestedNameSpecifier::Kind::Type:
       ++count;
@@ -3443,9 +4488,14 @@ static bool nestedNameSpecifierLocHasExplicitGlobal(
            markClangNestedNameSpecifierLocDefined(qualifier_loc);
        current; current = nestedNameSpecifierLocPrefix(current)) {
     clang::NestedNameSpecifier specifier =
-        markClangNestedNameSpecifierDefined(current.getNestedNameSpecifier());
-    if (specifier.getKind() == clang::NestedNameSpecifier::Kind::Global) {
-      return current.getLocalBeginLoc().isValid();
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return current.getNestedNameSpecifier(); }));
+    if (readClangApiValueDefined([&]() { return specifier.getKind(); }) ==
+        clang::NestedNameSpecifier::Kind::Global) {
+      clang::SourceLocation begin_loc = readClangApiValueDefined(
+          [&]() { return current.getLocalBeginLoc(); });
+      markClangValueDefined(begin_loc);
+      return begin_loc.isValid();
     }
   }
   return false;
@@ -3460,8 +4510,9 @@ static void preserveExplicitUsingDeclarationQualifier(
   }
 
   qualifier_loc = markClangNestedNameSpecifierLocDefined(qualifier_loc);
-  clang::NestedNameSpecifier qualifier = markClangNestedNameSpecifierDefined(
-      qualifier_loc.getNestedNameSpecifier());
+  clang::NestedNameSpecifier qualifier =
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
   if (!qualifier) {
     return;
   }
@@ -3491,8 +4542,9 @@ static void preserveExplicitInitializedNameTypeQualifier(
   }
 
   qualifier_loc = markClangNestedNameSpecifierLocDefined(qualifier_loc);
-  clang::NestedNameSpecifier qualifier = markClangNestedNameSpecifierDefined(
-      qualifier_loc.getNestedNameSpecifier());
+  clang::NestedNameSpecifier qualifier =
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
   if (!qualifier) {
     return;
   }
@@ -3708,17 +4760,25 @@ bool declContextsEquivalentIgnoringLinkage(const clang::DeclContext *lhs,
 }
 
 bool isNamedSemanticOuterTagDefinition(const clang::TagDecl *tag_decl) {
-  if (tag_decl == nullptr || !tag_decl->isThisDeclarationADefinition()) {
+  tag_decl = llvm::dyn_cast_or_null<clang::TagDecl>(
+      markClangDeclObjectDefinedByKind(tag_decl));
+  if (tag_decl == nullptr || !readClangApiValueDefined([&]() {
+        return tag_decl->isThisDeclarationADefinition();
+      })) {
     return false;
   }
-  if (tag_decl->getIdentifier() == nullptr && !tag_decl->hasNameForLinkage()) {
+  if (readClangApiValueDefined([&]() { return tag_decl->getIdentifier(); }) ==
+          nullptr &&
+      !readClangApiValueDefined(
+          [&]() { return tag_decl->hasNameForLinkage(); })) {
     return false;
   }
 
-  const clang::DeclContext *semantic_context =
-      skipLinkageDeclContexts(tag_decl->getDeclContext());
+  const clang::DeclContext *semantic_context = skipLinkageDeclContexts(
+      readClangApiValueDefined([&]() { return tag_decl->getDeclContext(); }));
   const clang::DeclContext *lexical_context =
-      skipLinkageDeclContexts(tag_decl->getLexicalDeclContext());
+      skipLinkageDeclContexts(readClangApiValueDefined(
+          [&]() { return tag_decl->getLexicalDeclContext(); }));
   if (semantic_context == nullptr || lexical_context == nullptr) {
     return false;
   }
@@ -3729,16 +4789,20 @@ bool isNamedSemanticOuterTagDefinition(const clang::TagDecl *tag_decl) {
 
 static clang::RecordDecl *
 recordDeclForTypeOnlyReference(clang::RecordDecl *record_decl) {
+  record_decl = llvm::dyn_cast_or_null<clang::RecordDecl>(
+      markClangDeclObjectDefinedByKind(record_decl));
   if (record_decl == nullptr) {
     return nullptr;
   }
 
   clang::RecordDecl *lookup_decl = record_decl;
-  if (lookup_decl->isThisDeclarationADefinition() &&
+  if (readClangApiValueDefined(
+          [&]() { return lookup_decl->isThisDeclarationADefinition(); }) &&
       isNamedSemanticOuterTagDefinition(lookup_decl)) {
     if (clang::RecordDecl *first_decl =
             llvm::dyn_cast_or_null<clang::RecordDecl>(
-                lookup_decl->getFirstDecl())) {
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return lookup_decl->getFirstDecl(); })))) {
       lookup_decl = first_decl;
     }
   }
@@ -3801,50 +4865,62 @@ static void bindFriendClassRedeclarationToCanonicalDecl(
 
 const clang::TemplateParameterList *
 templateParametersForDeclContext(const clang::DeclContext *context) {
-  const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(context);
+  context = markClangDeclContextObjectDefined(context);
+  const clang::Decl *decl = markClangDeclObjectDefinedByKind(
+      llvm::dyn_cast_or_null<clang::Decl>(context));
   if (decl == nullptr) {
     return nullptr;
   }
 
   if (const clang::TemplateDecl *template_decl =
           llvm::dyn_cast<clang::TemplateDecl>(decl)) {
-    return template_decl->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return template_decl->getTemplateParameters(); }));
   }
   if (const clang::ClassTemplatePartialSpecializationDecl *class_partial =
           llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
-    return class_partial->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return class_partial->getTemplateParameters(); }));
   }
   if (const clang::VarTemplatePartialSpecializationDecl *var_partial =
           llvm::dyn_cast<clang::VarTemplatePartialSpecializationDecl>(decl)) {
-    return var_partial->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return var_partial->getTemplateParameters(); }));
   }
   if (const clang::FunctionDecl *function_decl =
           llvm::dyn_cast<clang::FunctionDecl>(decl)) {
-    return function_decl->getDescribedTemplateParams();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return function_decl->getDescribedTemplateParams(); }));
   }
   if (const clang::CXXRecordDecl *record_decl =
           llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
+    record_decl = markClangSpecificDeclDefined(record_decl);
     if (const clang::ClassTemplatePartialSpecializationDecl *partial =
             llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
                 record_decl)) {
-      return partial->getTemplateParameters();
+      return markClangTemplateParameterListDefined(readClangApiValueDefined(
+          [&]() { return partial->getTemplateParameters(); }));
     }
     if (llvm::isa<clang::ClassTemplateSpecializationDecl>(record_decl)) {
       return nullptr;
     }
 
     if (const clang::CXXRecordDecl *canonical_record =
-            record_decl->getCanonicalDecl()) {
+            markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return record_decl->getCanonicalDecl(); }))) {
       if (const clang::ClassTemplatePartialSpecializationDecl *partial =
               llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
                   canonical_record)) {
-        return partial->getTemplateParameters();
+        return markClangTemplateParameterListDefined(readClangApiValueDefined(
+            [&]() { return partial->getTemplateParameters(); }));
       }
     }
 
     if (const clang::ClassTemplateDecl *described_template =
-            record_decl->getDescribedClassTemplate()) {
-      return described_template->getTemplateParameters();
+            markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return record_decl->getDescribedClassTemplate(); }))) {
+      return markClangTemplateParameterListDefined(readClangApiValueDefined(
+          [&]() { return described_template->getTemplateParameters(); }));
     }
   }
   return nullptr;
@@ -3858,15 +4934,20 @@ collectTemplateParameterLevelsFromDeclContext(
     return template_levels;
   }
 
-  const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(start_context);
+  start_context = markClangDeclContextObjectDefined(start_context);
+  const clang::Decl *decl = markClangDeclObjectDefinedByKind(
+      llvm::dyn_cast_or_null<clang::Decl>(start_context));
   unsigned written_outer_template_levels = 0;
   if (const clang::DeclaratorDecl *declarator_decl =
           llvm::dyn_cast_or_null<clang::DeclaratorDecl>(decl)) {
-    written_outer_template_levels =
-        declarator_decl->getNumTemplateParameterLists();
+    written_outer_template_levels = readClangApiValueDefined(
+        [&]() { return declarator_decl->getNumTemplateParameterLists(); });
     for (unsigned i = 0; i < written_outer_template_levels; ++i) {
       if (const clang::TemplateParameterList *params =
-              declarator_decl->getTemplateParameterList(i)) {
+              markClangTemplateParameterListDefined(
+                  readClangApiValueDefined([&]() {
+                    return declarator_decl->getTemplateParameterList(i);
+                  }))) {
         template_levels.push_back(params);
       }
     }
@@ -3874,7 +4955,8 @@ collectTemplateParameterLevelsFromDeclContext(
 
   std::vector<const clang::TemplateParameterList *> contextual_levels;
   for (const clang::DeclContext *ctx = start_context; ctx != nullptr;
-       ctx = ctx->getParent()) {
+       ctx = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
     if (const clang::TemplateParameterList *params =
             templateParametersForDeclContext(ctx)) {
       contextual_levels.push_back(params);
@@ -3898,9 +4980,13 @@ collectTemplateParameterLevelsFromDeclContext(
 static unsigned countEnclosingClassTemplateSpecializationLevels(
     const clang::DeclContext *start_context) {
   unsigned count = 0;
-  for (const clang::DeclContext *ctx = start_context; ctx != nullptr;
-       ctx = ctx->getParent()) {
-    const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(ctx);
+  for (const clang::DeclContext *ctx =
+           markClangDeclContextObjectDefined(start_context);
+       ctx != nullptr;
+       ctx = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
+    const clang::Decl *decl = markClangDeclObjectDefinedByKind(
+        llvm::dyn_cast_or_null<clang::Decl>(ctx));
     const auto *spec =
         llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(decl);
     if (spec == nullptr ||
@@ -3908,7 +4994,8 @@ static unsigned countEnclosingClassTemplateSpecializationLevels(
       continue;
     }
 
-    if (spec->getSpecializedTemplate() != nullptr) {
+    if (markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return spec->getSpecializedTemplate(); })) != nullptr) {
       ++count;
     }
   }
@@ -3932,24 +5019,74 @@ static unsigned countWrittenExplicitTemplateSpecializationHeaders(
   return count;
 }
 
+static bool sourceRangeContainsLocation(clang::SourceRange range,
+                                        clang::SourceLocation loc,
+                                        clang::SourceManager *source_manager,
+                                        bool allow_fallback_loc_compare);
+
+static bool templateDefaultArgumentRangeIsInParameter(
+    const clang::NamedDecl *clang_param,
+    const clang::TemplateArgumentLoc &default_loc) {
+  if (clang_param == nullptr) {
+    return false;
+  }
+
+  clang::SourceRange parameter_range = clang_param->getSourceRange();
+  clang::SourceRange default_range = default_loc.getSourceRange();
+  if (!parameter_range.isValid() || !default_range.isValid()) {
+    return false;
+  }
+
+  markClangDeclContextParentChainDefined(clang_param);
+  clang::SourceManager &source_manager =
+      clang_param->getASTContext().getSourceManager();
+  return sourceRangeContainsLocation(parameter_range, default_range.getBegin(),
+                                     &source_manager,
+                                     /*allow_fallback_loc_compare=*/true) &&
+         sourceRangeContainsLocation(parameter_range, default_range.getEnd(),
+                                     &source_manager,
+                                     /*allow_fallback_loc_compare=*/true);
+}
+
 bool currentDeclSpellsDefaultTemplateArg(const clang::NamedDecl *clang_param) {
   clang_param = llvm::dyn_cast_or_null<clang::NamedDecl>(
       markClangDeclObjectDefinedByKind(clang_param));
+  markClangTemplateParameterSourceRangeStorageDefined(
+      const_cast<clang::NamedDecl *>(clang_param));
   if (auto *type_param =
           llvm::dyn_cast_or_null<clang::TemplateTypeParmDecl>(clang_param)) {
-    return type_param->hasDefaultArgument() &&
-           !type_param->defaultArgumentWasInherited();
+    if (!type_param->hasDefaultArgument()) {
+      return false;
+    }
+    const clang::TemplateArgumentLoc &default_loc =
+        type_param->getDefaultArgument();
+    const bool inherited = type_param->defaultArgumentWasInherited();
+    const bool in_range =
+        templateDefaultArgumentRangeIsInParameter(type_param, default_loc);
+    return !inherited || in_range;
   }
   if (auto *non_type_param =
           llvm::dyn_cast_or_null<clang::NonTypeTemplateParmDecl>(clang_param)) {
-    return non_type_param->hasDefaultArgument() &&
-           !non_type_param->defaultArgumentWasInherited();
+    if (!non_type_param->hasDefaultArgument()) {
+      return false;
+    }
+    const clang::TemplateArgumentLoc &default_loc =
+        non_type_param->getDefaultArgument();
+    return !non_type_param->defaultArgumentWasInherited() ||
+           templateDefaultArgumentRangeIsInParameter(non_type_param,
+                                                     default_loc);
   }
   if (auto *template_param =
           llvm::dyn_cast_or_null<clang::TemplateTemplateParmDecl>(
               clang_param)) {
-    return template_param->hasDefaultArgument() &&
-           !template_param->defaultArgumentWasInherited();
+    if (!template_param->hasDefaultArgument()) {
+      return false;
+    }
+    const clang::TemplateArgumentLoc &default_loc =
+        template_param->getDefaultArgument();
+    return !template_param->defaultArgumentWasInherited() ||
+           templateDefaultArgumentRangeIsInParameter(template_param,
+                                                     default_loc);
   }
   return false;
 }
@@ -4089,7 +5226,8 @@ declSourceRangeHasTrailingSemicolon(const clang::Decl *decl,
     return false;
   }
 
-  clang::SourceRange range = decl->getSourceRange();
+  clang::SourceRange range =
+      readClangApiValueDefined([&]() { return decl->getSourceRange(); });
   if (!range.isValid()) {
     return false;
   }
@@ -5063,7 +6201,7 @@ classify_template_kind(const clang::Decl *templated_decl) {
                : SgTemplateDeclaration::e_template_class;
   }
   if (const auto *var = llvm::dyn_cast<clang::VarDecl>(templated_decl)) {
-    return var->isStaticDataMember()
+    return clangVarDeclIsStaticDataMemberDefined(var)
                ? SgTemplateDeclaration::e_template_m_data
                : SgTemplateDeclaration::e_template_variable;
   }
@@ -5146,20 +6284,32 @@ static bool clangFunctionDeclIsOutOfLine(const clang::FunctionDecl *decl,
     instantiated = llvm::dyn_cast_or_null<clang::FunctionDecl>(
         markClangDeclObjectDefinedByKind(instantiated));
     const clang::FunctionDecl *definition = nullptr;
-    if (instantiated != nullptr && instantiated->hasBody(definition)) {
+    if (instantiated != nullptr && readClangApiValueDefined([&]() {
+          return instantiated->hasBody(definition);
+        })) {
+      definition = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+          markClangDeclObjectDefinedByKind(definition));
       return clangFunctionDeclIsOutOfLine(definition, depth + 1);
     }
   }
 
-  if (clang::FunctionTemplateDecl *primary = decl->getPrimaryTemplate()) {
+  if (clang::FunctionTemplateDecl *primary = readClangApiValueDefined(
+          [&]() { return decl->getPrimaryTemplate(); })) {
     primary = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
         markClangDeclObjectDefinedByKind(primary));
-    clang::FunctionDecl *templated =
-        primary != nullptr ? primary->getTemplatedDecl() : nullptr;
+    clang::FunctionDecl *templated = primary != nullptr
+                                         ? readClangApiValueDefined([&]() {
+                                             return primary->getTemplatedDecl();
+                                           })
+                                         : nullptr;
     templated = llvm::dyn_cast_or_null<clang::FunctionDecl>(
         markClangDeclObjectDefinedByKind(templated));
     const clang::FunctionDecl *definition = nullptr;
-    if (templated != nullptr && templated->hasBody(definition)) {
+    if (templated != nullptr && readClangApiValueDefined([&]() {
+          return templated->hasBody(definition);
+        })) {
+      definition = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+          markClangDeclObjectDefinedByKind(definition));
       return clangFunctionDeclIsOutOfLine(definition, depth + 1);
     }
   }
@@ -5179,12 +6329,14 @@ static bool clangVarDeclIsOutOfLine(const clang::VarDecl *var_decl,
     return true;
   }
 
-  if (!var_decl->isStaticDataMember() || depth > 16) {
+  if (!clangVarDeclIsStaticDataMemberDefined(var_decl) || depth > 16) {
     return false;
   }
 
-  if (clang::VarDecl *instantiated =
-          var_decl->getInstantiatedFromStaticDataMember()) {
+  if (clang::VarDecl *instantiated = llvm::dyn_cast_or_null<clang::VarDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+            return var_decl->getInstantiatedFromStaticDataMember();
+          })))) {
     return clangVarDeclIsOutOfLine(instantiated, depth + 1);
   }
 
@@ -5208,11 +6360,11 @@ static bool clangDeclIsOutOfLine(const clang::Decl *decl) {
 static bool is_out_of_line_static_data_member(const clang::VarDecl *var_decl) {
   var_decl = llvm::dyn_cast_or_null<clang::VarDecl>(
       markClangDeclObjectDefinedByKind(var_decl));
-  if (var_decl == nullptr || !var_decl->isStaticDataMember()) {
+  if (var_decl == nullptr || !clangVarDeclIsStaticDataMemberDefined(var_decl)) {
     return false;
   }
 
-  if (var_decl->getPreviousDecl() != nullptr) {
+  if (clangVarPreviousDeclDefined(var_decl) != nullptr) {
     return true;
   }
 
@@ -5223,7 +6375,9 @@ static bool
 is_out_of_line_member_function_definition(const clang::FunctionDecl *decl) {
   decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
       markClangDeclObjectDefinedByKind(decl));
-  if (decl == nullptr || !decl->isThisDeclarationADefinition()) {
+  if (decl == nullptr || !readClangApiValueDefined([&]() {
+        return decl->isThisDeclarationADefinition();
+      })) {
     return false;
   }
 
@@ -5239,10 +6393,16 @@ static bool methodDeclIsOutOfLine(const clang::FunctionDecl *decl) {
 
 static const clang::CXXRecordDecl *
 find_enclosing_cxx_record_decl(const clang::DeclContext *ctx) {
-  for (const clang::DeclContext *current = ctx; current != nullptr;
-       current = current->getParent()) {
-    const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(
-        const_cast<clang::DeclContext *>(current));
+  for (const clang::DeclContext *current =
+           markClangDeclContextObjectDefined(ctx);
+       current != nullptr;
+       current = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return current->getParent(); }))) {
+    const clang::Decl *decl =
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+          return clang::Decl::castFromDeclContext(
+              const_cast<clang::DeclContext *>(current));
+        }));
     if (const auto *record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
             const_cast<clang::Decl *>(decl))) {
       return record;
@@ -5253,10 +6413,16 @@ find_enclosing_cxx_record_decl(const clang::DeclContext *ctx) {
 
 static const clang::ClassTemplateSpecializationDecl *
 find_enclosing_class_template_specialization(const clang::DeclContext *ctx) {
-  for (const clang::DeclContext *current = ctx; current != nullptr;
-       current = current->getParent()) {
-    const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(
-        const_cast<clang::DeclContext *>(current));
+  for (const clang::DeclContext *current =
+           markClangDeclContextObjectDefined(ctx);
+       current != nullptr;
+       current = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return current->getParent(); }))) {
+    const clang::Decl *decl =
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+          return clang::Decl::castFromDeclContext(
+              const_cast<clang::DeclContext *>(current));
+        }));
     if (const auto *record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
             const_cast<clang::Decl *>(decl))) {
       if (const auto *spec =
@@ -5300,18 +6466,23 @@ static bool is_instantiated_member_record_from_template_pattern(
 
 static bool is_instantiated_member_enum_from_template_pattern(
     const clang::EnumDecl *enum_decl) {
+  enum_decl = llvm::dyn_cast_or_null<clang::EnumDecl>(
+      markClangDeclObjectDefinedByKind(enum_decl));
   if (enum_decl == nullptr) {
     return false;
   }
 
-  if (enum_decl->getInstantiatedFromMemberEnum() != nullptr &&
-      is_template_instantiation_kind(
-          enum_decl->getTemplateSpecializationKind())) {
+  if (readClangApiValueDefined([&]() {
+        return enum_decl->getInstantiatedFromMemberEnum();
+      }) != nullptr &&
+      is_template_instantiation_kind(readClangApiValueDefined(
+          [&]() { return enum_decl->getTemplateSpecializationKind(); }))) {
     return true;
   }
 
   const clang::ClassTemplateSpecializationDecl *enclosing_specialization =
-      find_enclosing_class_template_specialization(enum_decl->getDeclContext());
+      find_enclosing_class_template_specialization(readClangApiValueDefined(
+          [&]() { return enum_decl->getDeclContext(); }));
   return enclosing_specialization != nullptr &&
          is_template_instantiation_kind(
              enclosing_specialization->getTemplateSpecializationKind());
@@ -5795,7 +6966,9 @@ static bool shouldForceTemplateAstUnparse(
     return true;
   }
 
-  if (on_demand_translation || decl->isImplicit()) {
+  decl = markClangDeclObjectDefinedByKind(decl);
+
+  if (on_demand_translation || clangDeclIsImplicitDefined(decl)) {
     return true;
   }
 
@@ -5857,31 +7030,44 @@ static bool shouldForceTemplateAstUnparse(
   }
 
   auto is_class_like_decl_context = [](const clang::DeclContext *ctx) -> bool {
+    ctx = markClangDeclContextObjectDefined(ctx);
     if (ctx == nullptr) {
       return false;
     }
 
-    if (ctx->isRecord()) {
+    if (readClangApiValueDefined([&]() { return ctx->isRecord(); })) {
       return true;
     }
 
-    const clang::Decl *ctx_decl = llvm::dyn_cast<clang::Decl>(ctx);
+    const clang::Decl *ctx_decl =
+        markClangDeclObjectDefinedByKind(llvm::dyn_cast<clang::Decl>(ctx));
     if (ctx_decl == nullptr) {
       return false;
     }
 
     if (const auto *template_decl =
             llvm::dyn_cast<clang::ClassTemplateDecl>(ctx_decl)) {
-      return template_decl->getTemplatedDecl() != nullptr;
+      const clang::CXXRecordDecl *templated =
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return template_decl->getTemplatedDecl(); })));
+      return templated != nullptr;
     }
 
     return false;
   };
   auto is_namespace_or_tu_context = [](const clang::DeclContext *ctx) -> bool {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
-    return ctx != nullptr && (ctx->isNamespace() || ctx->isTranslationUnit());
+    return ctx != nullptr &&
+           (readClangApiValueDefined([&]() { return ctx->isNamespace(); }) ||
+            readClangApiValueDefined(
+                [&]() { return ctx->isTranslationUnit(); }));
   };
   const clang::FunctionDecl *underlying_function_decl = nullptr;
   if (const clang::FunctionDecl *function_decl =
@@ -5889,18 +7075,25 @@ static bool shouldForceTemplateAstUnparse(
     underlying_function_decl = function_decl;
   } else if (const clang::FunctionTemplateDecl *function_template_decl =
                  llvm::dyn_cast<clang::FunctionTemplateDecl>(decl)) {
-    underlying_function_decl = function_template_decl->getTemplatedDecl();
+    underlying_function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+            [&]() { return function_template_decl->getTemplatedDecl(); })));
   }
   auto is_lexical_hidden_friend_free_function =
       [&](const clang::FunctionDecl *function_decl) -> bool {
+    function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(function_decl));
     if (function_decl == nullptr ||
         llvm::isa<clang::CXXMethodDecl>(function_decl)) {
       return false;
     }
 
-    const clang::DeclContext *semantic_ctx = function_decl->getDeclContext();
+    const clang::DeclContext *semantic_ctx =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return function_decl->getDeclContext(); }));
     const clang::DeclContext *lexical_ctx =
-        function_decl->getLexicalDeclContext();
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return function_decl->getLexicalDeclContext(); }));
     const bool semantic_namespace_or_tu =
         is_namespace_or_tu_context(semantic_ctx);
     const bool lexical_class_like = is_class_like_decl_context(lexical_ctx);
@@ -5914,8 +7107,13 @@ static bool shouldForceTemplateAstUnparse(
   // inside conditional regions. Their saved-string form is often incomplete,
   // while the class member list and preprocessing attachment are already
   // modeled structurally in the AST.
-  if (is_class_like_decl_context(decl->getDeclContext()) ||
-      is_class_like_decl_context(decl->getLexicalDeclContext())) {
+  const clang::DeclContext *decl_context = markClangDeclContextObjectDefined(
+      readClangApiValueDefined([&]() { return decl->getDeclContext(); }));
+  const clang::DeclContext *lexical_decl_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return decl->getLexicalDeclContext(); }));
+  if (is_class_like_decl_context(decl_context) ||
+      is_class_like_decl_context(lexical_decl_context)) {
     // Hidden-friend free-function declarations written lexically inside a
     // class are not actual class members. When the original token stream is
     // preserved, forcing these declarations onto AST unparsing duplicates the
@@ -5927,13 +7125,26 @@ static bool shouldForceTemplateAstUnparse(
   }
 
   if (const clang::FunctionDecl *function_decl = underlying_function_decl) {
+    function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(function_decl));
     if (!llvm::isa<clang::CXXMethodDecl>(function_decl) &&
-        is_namespace_or_tu_context(function_decl->getDeclContext()) &&
-        is_namespace_or_tu_context(function_decl->getLexicalDeclContext())) {
-      const clang::FunctionDecl *first_decl = function_decl->getFirstDecl();
+        is_namespace_or_tu_context(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getDeclContext(); }))) &&
+        is_namespace_or_tu_context(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getLexicalDeclContext(); })))) {
+      const clang::FunctionDecl *first_decl =
+          llvm::dyn_cast_or_null<clang::FunctionDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return function_decl->getFirstDecl(); })));
       if (first_decl != nullptr && first_decl != function_decl &&
-          (is_class_like_decl_context(first_decl->getDeclContext()) ||
-           is_class_like_decl_context(first_decl->getLexicalDeclContext()))) {
+          (is_class_like_decl_context(
+               markClangDeclContextObjectDefined(readClangApiValueDefined(
+                   [&]() { return first_decl->getDeclContext(); }))) ||
+           is_class_like_decl_context(
+               markClangDeclContextObjectDefined(readClangApiValueDefined(
+                   [&]() { return first_decl->getLexicalDeclContext(); }))))) {
         // Hidden-friend free functions can be redeclared/defined later at
         // namespace scope while their first declaration remains lexically in a
         // class. Their saved template strings do not carry enough structural
@@ -5947,12 +7158,18 @@ static bool shouldForceTemplateAstUnparse(
   if (llvm::isa<clang::ClassTemplateDecl>(decl)) {
     const auto *class_template_decl =
         llvm::cast<clang::ClassTemplateDecl>(decl);
-    if (clangDeclIsOutOfLine(class_template_decl->getTemplatedDecl())) {
+    const clang::CXXRecordDecl *templated =
+        llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return class_template_decl->getTemplatedDecl(); })));
+    if (clangDeclIsOutOfLine(templated)) {
       return true;
     }
 
     if (declSourceRangeSpellsMacroDefinition(ci, decl,
-                                             decl->getSourceRange())) {
+                                             readClangApiValueDefined([&]() {
+                                               return decl->getSourceRange();
+                                             }))) {
       return true;
     }
 
@@ -6116,9 +7333,14 @@ static bool functionTemplateHasExplicitInstantiationPointInMainFile(
     return false;
   }
 
-  for (auto it = function_template_decl->spec_begin();
-       it != function_template_decl->spec_end(); ++it) {
-    if (functionDeclHasExplicitInstantiationPointInMainFile(*it, sm)) {
+  auto spec_begin = readClangApiValueDefined(
+      [&]() { return function_template_decl->spec_begin(); });
+  auto spec_end = readClangApiValueDefined(
+      [&]() { return function_template_decl->spec_end(); });
+  for (auto it = spec_begin; it != spec_end; ++it) {
+    clang::FunctionDecl *spec = markClangFunctionTemplateStateDefined(
+        readClangApiValueDefined([&]() { return *it; }));
+    if (functionDeclHasExplicitInstantiationPointInMainFile(spec, sm)) {
       return true;
     }
   }
@@ -6167,14 +7389,25 @@ shouldEagerlyTraverseNonMainFileLeafDecl(clang::Decl *decl,
   }
 
   auto is_namespace_or_tu_context = [](const clang::DeclContext *ctx) -> bool {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
-    return ctx != nullptr && (ctx->isNamespace() || ctx->isTranslationUnit());
+    return ctx != nullptr &&
+           (readClangApiValueDefined([&]() { return ctx->isNamespace(); }) ||
+            readClangApiValueDefined(
+                [&]() { return ctx->isTranslationUnit(); }));
   };
 
-  if (!is_namespace_or_tu_context(decl->getDeclContext()) ||
-      !is_namespace_or_tu_context(decl->getLexicalDeclContext())) {
+  if (!is_namespace_or_tu_context(
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return decl->getDeclContext(); }))) ||
+      !is_namespace_or_tu_context(
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return decl->getLexicalDeclContext(); })))) {
     return false;
   }
 
@@ -6206,14 +7439,25 @@ static bool shouldEagerlyTraverseApplicationHeaderLeafDecl(
   }
 
   auto is_namespace_or_tu_context = [](const clang::DeclContext *ctx) -> bool {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
-    return ctx != nullptr && (ctx->isNamespace() || ctx->isTranslationUnit());
+    return ctx != nullptr &&
+           (readClangApiValueDefined([&]() { return ctx->isNamespace(); }) ||
+            readClangApiValueDefined(
+                [&]() { return ctx->isTranslationUnit(); }));
   };
 
-  if (!is_namespace_or_tu_context(decl->getDeclContext()) ||
-      !is_namespace_or_tu_context(decl->getLexicalDeclContext())) {
+  if (!is_namespace_or_tu_context(
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return decl->getDeclContext(); }))) ||
+      !is_namespace_or_tu_context(
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return decl->getLexicalDeclContext(); })))) {
     return false;
   }
 
@@ -6244,19 +7488,25 @@ static bool isSystemOrBuiltinFunctionDecl(clang::FunctionDecl *decl,
   if (decl == nullptr) {
     return true;
   }
+  decl = markClangFunctionTemplateStateDefined(decl);
 
   auto check_decl = [&](clang::FunctionDecl *candidate) -> bool {
     if (candidate == nullptr) {
       return false;
     }
-    return isSystemOrBuiltinLocation(candidate->getLocation(), sm);
+    candidate = markClangFunctionTemplateStateDefined(candidate);
+    clang::SourceLocation loc =
+        readClangApiValueDefined([&]() { return candidate->getLocation(); });
+    return isSystemOrBuiltinLocation(loc, sm);
   };
 
   if (check_decl(decl)) {
     return true;
   }
 
-  if (clang::FunctionDecl *def = decl->getDefinition()) {
+  if (clang::FunctionDecl *def =
+          readClangApiValueDefined([&]() { return decl->getDefinition(); })) {
+    def = markClangFunctionTemplateStateDefined(def);
     if (def != decl && check_decl(def)) {
       return true;
     }
@@ -6269,10 +7519,17 @@ static bool isSystemOrBuiltinFunctionDecl(clang::FunctionDecl *decl,
     }
   }
 
-  if (clang::FunctionTemplateDecl *primary = decl->getPrimaryTemplate()) {
-    clang::FunctionDecl *templated = primary->getTemplatedDecl();
-    if (templated != nullptr && templated != decl && check_decl(templated)) {
-      return true;
+  if (clang::FunctionTemplateDecl *primary = readClangApiValueDefined(
+          [&]() { return decl->getPrimaryTemplate(); })) {
+    primary = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+        markClangDeclObjectDefinedByKind(primary));
+    if (primary != nullptr) {
+      clang::FunctionDecl *templated = readClangApiValueDefined(
+          [&]() { return primary->getTemplatedDecl(); });
+      templated = markClangFunctionTemplateStateDefined(templated);
+      if (templated != nullptr && templated != decl && check_decl(templated)) {
+        return true;
+      }
     }
   }
 
@@ -6291,17 +7548,21 @@ static bool isSystemOrBuiltinFunctionDecl(clang::FunctionDecl *decl,
 static bool getExplicitInstantiationClassKind(
     const clang::ClassTemplateSpecializationDecl *decl,
     clang::CompilerInstance *compiler, SgClassDeclaration::class_types *kind) {
+  decl = llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+      markClangDeclObjectDefinedByKind(decl));
   if (decl == nullptr || compiler == nullptr || kind == nullptr) {
     return false;
   }
 
   clang::SourceManager &sm = compiler->getSourceManager();
-  clang::SourceLocation loc = decl->getTemplateKeywordLoc();
+  clang::SourceLocation loc =
+      readClangApiValueDefined([&]() { return decl->getTemplateKeywordLoc(); });
   if (!loc.isValid()) {
-    loc = decl->getExternKeywordLoc();
+    loc =
+        readClangApiValueDefined([&]() { return decl->getExternKeywordLoc(); });
   }
   if (!loc.isValid()) {
-    loc = decl->getBeginLoc();
+    loc = readClangApiValueDefined([&]() { return decl->getBeginLoc(); });
   }
   if (loc.isMacroID()) {
     loc = sm.getSpellingLoc(loc);
@@ -6344,7 +7605,9 @@ static bool getExplicitInstantiationClassKind(
     loc = next;
   }
 
-  clang::SourceRange range = decl->getSourceRange();
+  clang::SourceRange range =
+      readClangApiValueDefined([&]() { return decl->getSourceRange(); });
+  markClangValueDefined(range);
   if (range.isValid()) {
     clang::SourceLocation begin = range.getBegin();
     clang::SourceLocation end = range.getEnd();
@@ -6401,6 +7664,8 @@ static void appendTemplateInstantiationArg(std::string &result,
                                            const clang::TemplateArgument &arg) {
   auto append_single_arg = [&](const clang::TemplateArgument &single_arg,
                                bool force_pack_ellipsis) {
+    const clang::TemplateArgument &defined_single_arg =
+        markClangTemplateArgumentDefined(single_arg);
     if (need_separator) {
       result += " , ";
     }
@@ -6408,14 +7673,25 @@ static void appendTemplateInstantiationArg(std::string &result,
 
     std::string arg_str;
     llvm::raw_string_ostream arg_stream(arg_str);
-    single_arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
-                     /*IncludeType*/ true);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      defined_single_arg.print(clang::PrintingPolicy(clang::LangOptions()),
+                               arg_stream, /*IncludeType*/ true);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      defined_single_arg.print(clang::PrintingPolicy(clang::LangOptions()),
+                               arg_stream, /*IncludeType*/ true);
+    }
     arg_stream.flush();
+    markClangPrintedStringDefined(arg_str);
 
     arg_str = trimWhitespace(arg_str);
     bool needs_pack_ellipsis =
         force_pack_ellipsis ||
-        template_argument_needs_pack_ellipsis(single_arg);
+        template_argument_needs_pack_ellipsis(defined_single_arg);
     if (needs_pack_ellipsis &&
         (arg_str.size() < 3 ||
          arg_str.compare(arg_str.size() - 3, 3, "...") != 0)) {
@@ -6425,19 +7701,23 @@ static void appendTemplateInstantiationArg(std::string &result,
     result += arg_str;
   };
 
-  if (arg.getKind() == clang::TemplateArgument::Pack) {
-    auto elements = arg.pack_elements();
+  const clang::TemplateArgument &defined_arg =
+      markClangTemplateArgumentDefined(arg);
+  if (defined_arg.getKind() == clang::TemplateArgument::Pack) {
+    auto elements =
+        markClangTemplateArgumentArrayDefined(defined_arg.pack_elements());
     const bool force_pack_ellipsis =
-        elements.size() == 1 && (arg.containsUnexpandedParameterPack() ||
-                                 arg.isInstantiationDependent() ||
-                                 elements.front().isInstantiationDependent());
+        elements.size() == 1 &&
+        (defined_arg.containsUnexpandedParameterPack() ||
+         defined_arg.isInstantiationDependent() ||
+         elements.front().isInstantiationDependent());
     for (const clang::TemplateArgument &pack_arg : elements) {
       append_single_arg(pack_arg, force_pack_ellipsis);
     }
     return;
   }
 
-  append_single_arg(arg, false);
+  append_single_arg(defined_arg, false);
 }
 
 static std::string
@@ -6625,7 +7905,8 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
     const clang::FunctionDecl *decl,
     const clang::ClassTemplateSpecializationDecl *spec_decl_override,
     const clang::CXXRecordDecl *record_decl_override) {
-  const auto *method_decl = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(decl);
+  const auto *method_decl = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(
+      markClangDeclObjectDefinedByKind(decl));
   if (method_decl == nullptr) {
     return nullptr;
   }
@@ -6633,10 +7914,16 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
   const clang::CXXRecordDecl *record_decl = record_decl_override;
   if (record_decl == nullptr) {
     if (spec_decl_override != nullptr) {
-      record_decl = spec_decl_override;
+      record_decl = llvm::cast_or_null<clang::CXXRecordDecl>(
+          markClangDeclObjectDefinedByKind(spec_decl_override));
     } else {
-      record_decl = method_decl->getParent();
+      record_decl = llvm::cast_or_null<clang::CXXRecordDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return method_decl->getParent(); })));
     }
+  } else {
+    record_decl = llvm::cast_or_null<clang::CXXRecordDecl>(
+        markClangDeclObjectDefinedByKind(record_decl));
   }
   if (record_decl == nullptr) {
     return nullptr;
@@ -6652,7 +7939,10 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
     return nullptr;
   }
   const clang::DeclContext *return_context =
-      return_decl != nullptr ? return_decl->getDeclContext() : nullptr;
+      return_decl != nullptr
+          ? markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return return_decl->getDeclContext(); }))
+          : nullptr;
   const clang::CXXRecordDecl *return_record =
       llvm::dyn_cast_or_null<clang::CXXRecordDecl>(return_context);
   if (return_record == nullptr) {
@@ -6799,8 +8089,20 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
           }
           arg_type = SageBuilder::buildTemplateType(SgName(param_name));
         }
-        args.push_back(new SgTemplateArgument(
-            isSgType(SageInterface::deepCopy(arg_type)), false));
+        SgType *arg_type_copy = nullptr;
+        if (SgTemplateType *template_type = isSgTemplateType(arg_type)) {
+          SgTemplateType *template_type_copy =
+              SageBuilder::buildTemplateType(template_type->get_name());
+          template_type_copy->set_template_parameter_position(
+              template_type->get_template_parameter_position());
+          template_type_copy->set_template_parameter_depth(
+              template_type->get_template_parameter_depth());
+          template_type_copy->set_packed(template_type->get_packed());
+          arg_type_copy = template_type_copy;
+        } else {
+          arg_type_copy = isSgType(SageInterface::deepCopy(arg_type));
+        }
+        args.push_back(new SgTemplateArgument(arg_type_copy, false));
         continue;
       }
 
@@ -6858,6 +8160,8 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
   auto build_record_template_arguments =
       [&](const clang::CXXRecordDecl *context_record)
       -> SgTemplateArgumentPtrList {
+    context_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+        markClangDeclObjectDefinedByKind(context_record));
     if (context_record == nullptr) {
       return {};
     }
@@ -6865,7 +8169,10 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
     if (const auto *spec =
             llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
                 context_record)) {
-      return buildTemplateArguments(spec->getTemplateArgs(), 0);
+      const clang::TemplateArgumentList &template_args =
+          spec->getTemplateArgs();
+      return buildTemplateArguments(
+          *markClangTemplateArgumentListDefined(&template_args), 0);
     }
 
     const clang::TemplateParameterList *params =
@@ -6874,11 +8181,14 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
   };
   auto descend_into_record_scope =
       [&](const clang::CXXRecordDecl *context_record) {
+        context_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+            markClangDeclObjectDefinedByKind(context_record));
         if (context_record == nullptr) {
           return;
         }
 
-        std::string record_name = context_record->getNameAsString();
+        std::string record_name = readClangApiValueDefined(
+            [&]() { return context_record->getNameAsString(); });
         if (record_name.empty()) {
           return;
         }
@@ -6897,14 +8207,25 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
       };
 
   std::vector<const clang::DeclContext *> contexts;
-  for (const clang::DeclContext *dc = record_decl->getDeclContext();
-       dc != nullptr && !dc->isTranslationUnit(); dc = dc->getParent()) {
+  for (const clang::DeclContext *dc =
+           markClangDeclContextObjectDefined(readClangApiValueDefined(
+               [&]() { return record_decl->getDeclContext(); }));
+       dc != nullptr &&
+       !readClangApiValueDefined([&]() { return dc->isTranslationUnit(); });
+       dc = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return dc->getParent(); }))) {
     contexts.push_back(dc);
   }
   for (auto it = contexts.rbegin(); it != contexts.rend(); ++it) {
+    const clang::Decl *ctx_decl =
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+          return clang::Decl::castFromDeclContext(
+              const_cast<clang::DeclContext *>(*it));
+        }));
     if (const clang::NamespaceDecl *ns =
-            llvm::dyn_cast<clang::NamespaceDecl>(*it)) {
-      std::string ns_name = ns->getNameAsString();
+            llvm::dyn_cast_or_null<clang::NamespaceDecl>(ctx_decl)) {
+      std::string ns_name =
+          readClangApiValueDefined([&]() { return ns->getNameAsString(); });
       if (!ns_name.empty()) {
         SgNonrealType *ns_type =
             SageBuilder::buildNonrealType(SgName(ns_name), scope, nullptr);
@@ -6914,15 +8235,18 @@ SgType *ClangToSageTranslator::buildSpecializedMemberTypedefReturnType(
         }
       }
     } else if (const clang::CXXRecordDecl *ctx_record =
-                   llvm::dyn_cast<clang::CXXRecordDecl>(*it)) {
+                   llvm::dyn_cast_or_null<clang::CXXRecordDecl>(ctx_decl)) {
       descend_into_record_scope(ctx_record);
     }
   }
 
   descend_into_record_scope(record_decl);
 
-  std::string typedef_name =
-      return_decl != nullptr ? return_decl->getNameAsString() : "";
+  std::string typedef_name = return_decl != nullptr
+                                 ? readClangApiValueDefined([&]() {
+                                     return return_decl->getNameAsString();
+                                   })
+                                 : "";
   if (typedef_name.empty()) {
     return nullptr;
   }
@@ -6986,7 +8310,7 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
           return symbol;
         }
         if (decl_stmt->get_scope() == nullptr) {
-          if (clang::DeclContext *ctx = decl->getDeclContext()) {
+          if (clang::DeclContext *ctx = clangDeclContextDefined(decl)) {
             if (SgScopeStatement *resolved = resolveScopeFromDeclContext(
                     ctx, SageBuilder::topScopeStack())) {
               decl_stmt->set_scope(resolved);
@@ -7065,11 +8389,11 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
   case clang::Decl::TypeAlias: {
     // TypeAlias (C++11 using declarations) are semantically equivalent to
     // Typedef
-    clang::DeclContext *decl_context = decl->getDeclContext();
+    clang::DeclContext *decl_context = clangDeclContextDefined(decl);
     clang::DeclContext *scope_context = decl_context;
     while (scope_context != nullptr &&
            llvm::isa<clang::LinkageSpecDecl>(scope_context)) {
-      scope_context = scope_context->getParent();
+      scope_context = clangDeclContextParentDefined(scope_context);
     }
     if (scope_context != nullptr) {
       if (SgScopeStatement *decl_scope =
@@ -7088,9 +8412,10 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
   case clang::Decl::ParmVar:
   case clang::Decl::Binding: {
     if (auto *var_decl = llvm::dyn_cast<clang::VarDecl>(decl)) {
-      if (var_decl->isStaticDataMember()) {
+      var_decl = markClangSpecificDeclDefined(var_decl);
+      if (clangVarDeclIsStaticDataMemberDefined(var_decl)) {
         auto resolve_member_scope = [&]() -> SgScopeStatement * {
-          clang::DeclContext *ctx = var_decl->getDeclContext();
+          clang::DeclContext *ctx = clangDeclContextDefined(var_decl);
           if (ctx == nullptr) {
             return nullptr;
           }
@@ -7108,9 +8433,12 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
 
           if (clang::CXXRecordDecl *record =
                   llvm::dyn_cast<clang::CXXRecordDecl>(ctx)) {
+            record = markClangSpecificDeclDefined(record);
             clang::CXXRecordDecl *record_def =
-                record->getDefinition() != nullptr ? record->getDefinition()
-                                                   : record;
+                clangCXXRecordDefinitionDefined(record);
+            if (record_def == nullptr) {
+              record_def = record;
+            }
             if (record_def != nullptr) {
               if (SgDeclarationStatement *decl_stmt =
                       lookupSgDeclarationForClangDecl(
@@ -7229,10 +8557,10 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
         }
       }
 
-      clang::DeclContext *decl_context = var_decl->getDeclContext();
+      clang::DeclContext *decl_context = clangDeclContextDefined(var_decl);
       while (decl_context != nullptr &&
              llvm::isa<clang::LinkageSpecDecl>(decl_context)) {
-        decl_context = decl_context->getParent();
+        decl_context = clangDeclContextParentDefined(decl_context);
       }
       if (decl_context != nullptr &&
           (decl_context->isTranslationUnit() || decl_context->isNamespace())) {
@@ -7295,7 +8623,8 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
     }
     clang::CXXRecordDecl *parent_decl =
         llvm::cast_or_null<clang::CXXRecordDecl>(
-            markClangDeclObjectDefinedByKind(method_decl->getParent()));
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return method_decl->getParent(); })));
 
     SgNode *parent_node = nullptr;
     auto normalize_parent_node = [](SgNode *node) -> SgNode * {
@@ -7793,7 +9122,9 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
   case clang::Decl::CXXDeductionGuide:
   case clang::Decl::Function: {
     auto *func_decl = llvm::cast<clang::FunctionDecl>(decl);
-    SgType *tmp_type = buildTypeFromQualifiedType(func_decl->getType());
+    clang::QualType function_type = markClangFunctionTypeBoundaryDefined(
+        readClangApiValueDefined([&]() { return func_decl->getType(); }));
+    SgType *tmp_type = buildTypeFromQualifiedType(function_type);
     SgFunctionType *type = isSgFunctionType(tmp_type);
     SgTemplateArgumentPtrList template_args;
     SgTemplateArgumentPtrList *template_args_ptr = nullptr;
@@ -7827,6 +9158,61 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
           SageBuilder::appendTemplateArgumentsToName(name, *template_args_ptr);
     }
 
+    auto symbol_function_decl =
+        [](SgSymbol *candidate) -> SgFunctionDeclaration * {
+      if (candidate == nullptr) {
+        return nullptr;
+      }
+      if (SgAliasSymbol *alias = isSgAliasSymbol(candidate)) {
+        candidate = alias->get_alias();
+      }
+      if (candidate == nullptr) {
+        return nullptr;
+      }
+      if (SgTemplateFunctionSymbol *tmpl_sym =
+              isSgTemplateFunctionSymbol(candidate)) {
+        return isSgFunctionDeclaration(tmpl_sym->get_declaration());
+      }
+      if (SgFunctionSymbol *func_sym = isSgFunctionSymbol(candidate)) {
+        return func_sym->get_declaration();
+      }
+      return nullptr;
+    };
+    auto function_symbol_matches_current_signature =
+        [&](SgSymbol *candidate_symbol) -> bool {
+      SgFunctionDeclaration *candidate_decl =
+          symbol_function_decl(candidate_symbol);
+      if (candidate_decl == nullptr) {
+        return false;
+      }
+
+      const SgInitializedNamePtrList &candidate_args =
+          candidate_decl->get_args();
+      const bool candidate_is_variadic =
+          candidate_decl->get_type() != nullptr &&
+          candidate_decl->get_type()->get_has_ellipses();
+      if (candidate_args.size() != func_decl->getNumParams() ||
+          candidate_is_variadic != func_decl->isVariadic()) {
+        return false;
+      }
+
+      for (unsigned i = 0; i < func_decl->getNumParams(); ++i) {
+        clang::ParmVarDecl *param_decl = func_decl->getParamDecl(i);
+        param_decl = llvm::dyn_cast_or_null<clang::ParmVarDecl>(
+            markClangDeclObjectDefinedByKind(param_decl));
+        ROSE_ASSERT(param_decl != nullptr);
+        SgType *target_type = buildTypeFromQualifiedType(param_decl->getType());
+        ROSE_ASSERT(target_type != nullptr);
+        SgType *candidate_type = candidate_args[i]->get_type();
+        ROSE_ASSERT(candidate_type != nullptr);
+        if (!same_function_reuse_parameter_type(candidate_type, target_type)) {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
     auto lookup_in_scope = [&](SgScopeStatement *lookup_scope) -> SgSymbol * {
       if (lookup_scope == nullptr) {
         return nullptr;
@@ -7847,6 +9233,10 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
       if (found != nullptr && !symbol_present_in_scope(lookup_scope, found)) {
         found = nullptr;
       }
+      if (found != nullptr &&
+          !function_symbol_matches_current_signature(found)) {
+        found = nullptr;
+      }
       return found;
     };
     auto lookup_in_scope_by_name =
@@ -7862,30 +9252,7 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
         return nullptr;
       }
 
-      auto symbol_function_decl =
-          [](SgSymbol *candidate) -> SgFunctionDeclaration * {
-        if (candidate == nullptr) {
-          return nullptr;
-        }
-        if (SgAliasSymbol *alias = isSgAliasSymbol(candidate)) {
-          candidate = alias->get_alias();
-        }
-        if (candidate == nullptr) {
-          return nullptr;
-        }
-        if (SgTemplateFunctionSymbol *tmpl_sym =
-                isSgTemplateFunctionSymbol(candidate)) {
-          return isSgFunctionDeclaration(tmpl_sym->get_declaration());
-        }
-        if (SgFunctionSymbol *func_sym = isSgFunctionSymbol(candidate)) {
-          return func_sym->get_declaration();
-        }
-        return nullptr;
-      };
-
       const SgName key = template_args_ptr != nullptr ? lookup_name : name;
-      const unsigned target_param_count = func_decl->getNumParams();
-      const bool target_is_variadic = func_decl->isVariadic();
 
       SgSymbol *matched_symbol = nullptr;
       SgFunctionDeclaration *matched_decl = nullptr;
@@ -7903,13 +9270,7 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
           continue;
         }
 
-        const SgInitializedNamePtrList &candidate_args =
-            candidate_decl->get_args();
-        const bool candidate_is_variadic =
-            candidate_decl->get_type() != nullptr &&
-            candidate_decl->get_type()->get_has_ellipses();
-        if (candidate_args.size() != target_param_count ||
-            candidate_is_variadic != target_is_variadic) {
+        if (!function_symbol_matches_current_signature(candidate_symbol)) {
           continue;
         }
 
@@ -8228,7 +9589,16 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
     // field can be variable or ClassDefinition
 
     clang::FieldDecl *field_decl = (clang::FieldDecl *)decl;
-    bool is_dependent_field = field_decl->getType()->isDependentType();
+    field_decl = llvm::cast<clang::FieldDecl>(
+        markClangDeclObjectDefinedByKind(field_decl));
+    clang::QualType field_type = markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return field_decl->getType(); }));
+    const clang::Type *field_type_ptr =
+        markClangTypeObjectDefinedByClass(field_type.getTypePtrOrNull());
+    bool is_dependent_field =
+        field_type_ptr != nullptr && readClangApiValueDefined([&]() {
+          return field_type_ptr->isDependentType();
+        });
 
     // Prefer the translated field declaration when available so we can resolve
     // symbols even while the enclosing class is still under construction.
@@ -8264,7 +9634,8 @@ ClangToSageTranslator::GetSymbolFromSymbolTable(clang::NamedDecl *decl) {
 
     // CLANG FRONTEND FIX: Check if parent has been translated before calling
     // Traverse to avoid infinite recursion during template instantiation
-    clang::Decl *parent_decl = ((clang::FieldDecl *)decl)->getParent();
+    clang::Decl *parent_decl = markClangDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return field_decl->getParent(); }));
     SgNode *parent_node = nullptr;
 
     // First check if parent is already in translation map
@@ -8757,14 +10128,18 @@ ClangToSageTranslator::resolveScopeFromDeclContext(clang::DeclContext *context,
 
   // Linkage specs are not scopes in ROSE; resolve through them to the
   // enclosing namespace/global context.
-  while (context != nullptr && llvm::isa<clang::LinkageSpecDecl>(context)) {
-    context = markClangDeclContextObjectDefined(context->getParent());
+  while (context != nullptr && readClangApiValueDefined([&]() {
+           return llvm::isa<clang::LinkageSpecDecl>(context);
+         })) {
+    context = markClangDeclContextObjectDefined(
+        readClangApiValueDefined([&]() { return context->getParent(); }));
   }
   if (context == nullptr) {
     return fallback;
   }
 
-  if (context->isTranslationUnit()) {
+  if (readClangApiValueDefined(
+          [&]() { return context->isTranslationUnit(); })) {
     return getGlobalScope();
   }
 
@@ -8801,13 +10176,15 @@ ClangToSageTranslator::resolveScopeFromDeclContext(clang::DeclContext *context,
           markClangDeclObjectDefinedByKind(record_decl));
       if (clang::RecordDecl *definition =
               llvm::dyn_cast_or_null<clang::RecordDecl>(
-                  markClangDeclObjectDefinedByKind(
-                      record_decl->getDefinition()))) {
+                  markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                      [&]() { return record_decl->getDefinition(); })))) {
         map_key = definition;
       } else if (clang::RecordDecl *canonical =
                      llvm::dyn_cast<clang::RecordDecl>(
                          markClangDeclObjectDefinedByKind(
-                             record_decl->getCanonicalDecl()))) {
+                             readClangApiValueDefined([&]() {
+                               return record_decl->getCanonicalDecl();
+                             })))) {
         map_key = canonical;
       }
     }
@@ -9959,6 +11336,198 @@ static void copy_real_source_range_from_located_node_if_missing(
     target->set_file_info(new Sg_File_Info(*source_start));
     target->get_file_info()->set_parent(target);
   }
+}
+
+static void copy_real_source_range_from_node_if_missing(SgNode *target,
+                                                        const SgNode *source) {
+  copy_real_source_range_from_located_node_if_missing(
+      isSgLocatedNode(target), isSgLocatedNode(const_cast<SgNode *>(source)));
+}
+
+static SgTemplateParameter *
+clone_template_parameter_surface(const SgTemplateParameter *source,
+                                 bool preserve_defaults);
+
+static SgTemplateParameterPtrList
+clone_template_parameter_list_surface(const SgTemplateParameterPtrList &source,
+                                      bool preserve_defaults,
+                                      bool anchor_nonreals) {
+  SgTemplateParameterPtrList copies;
+  copies.reserve(source.size());
+  for (const SgTemplateParameter *param : source) {
+    if (param == nullptr) {
+      continue;
+    }
+
+    SgTemplateParameter *param_copy =
+        clone_template_parameter_surface(param, preserve_defaults);
+    ROSE_ASSERT(param_copy != nullptr);
+    copies.push_back(param_copy);
+  }
+  if (anchor_nonreals) {
+    anchor_copied_template_parameter_nonreals(copies,
+                                              SageBuilder::topScopeStack());
+  }
+  return copies;
+}
+
+static SgInitializedName *clone_template_parameter_initialized_name_surface(
+    const SgInitializedName *source, SgTemplateParameter *owner) {
+  if (source == nullptr) {
+    return nullptr;
+  }
+
+  SgInitializer *initializer_copy = nullptr;
+  if (source->get_initializer() != nullptr) {
+    initializer_copy = SageInterface::deepCopy(source->get_initializer());
+    if (initializer_copy != nullptr) {
+      initializer_copy->set_parent(nullptr);
+    }
+  }
+
+  SgInitializedName *copy = SageBuilder::buildInitializedName_nfi(
+      source->get_name(), source->get_type(), initializer_copy);
+  ROSE_ASSERT(copy != nullptr);
+  copy->set_parent(owner);
+  copy->set_scope(source->get_scope());
+  copy->set_is_parameter_pack(source->get_is_parameter_pack());
+  copy->set_is_pack_element(source->get_is_pack_element());
+  copy->set_needs_definitions(source->get_needs_definitions());
+  copy->set_name_qualification_length(source->get_name_qualification_length());
+  copy->set_name_qualification_length_for_type(
+      source->get_name_qualification_length_for_type());
+  copy->set_type_elaboration_required(source->get_type_elaboration_required());
+  copy->set_type_elaboration_required_for_type(
+      source->get_type_elaboration_required_for_type());
+  copy->set_global_qualification_required(
+      source->get_global_qualification_required());
+  copy->set_global_qualification_required_for_type(
+      source->get_global_qualification_required_for_type());
+  copy_real_source_range_from_node_if_missing(copy, source);
+  if (initializer_copy != nullptr) {
+    initializer_copy->set_parent(copy);
+  }
+  return copy;
+}
+
+static SgExpression *
+clone_template_parameter_expression_surface(SgExpression *source,
+                                            SgTemplateParameter *owner) {
+  if (source == nullptr) {
+    return nullptr;
+  }
+
+  SgExpression *copy = SageInterface::copyExpression(source);
+  ROSE_ASSERT(copy != nullptr);
+  attach_template_parameter_expression(owner, copy);
+  return copy;
+}
+
+static SgDeclarationScope *clone_detached_nonreal_decl_scope() {
+  SgDeclarationScope *scope = new SgDeclarationScope();
+  ROSE_ASSERT(scope != nullptr);
+  SageInterface::setSourcePosition(scope);
+  if (scope->get_startOfConstruct() != nullptr) {
+    scope->get_startOfConstruct()->setCompilerGenerated();
+  }
+  if (scope->get_endOfConstruct() != nullptr) {
+    scope->get_endOfConstruct()->setCompilerGenerated();
+  }
+  return scope;
+}
+
+static SgNonrealDecl *
+clone_template_parameter_nonreal_decl_surface(const SgNonrealDecl *source,
+                                              bool preserve_defaults) {
+  ROSE_ASSERT(source != nullptr);
+
+  SgNonrealDecl *copy = new SgNonrealDecl(source->get_name());
+  ROSE_ASSERT(copy != nullptr);
+  SageInterface::setSourcePosition(copy);
+  copy_real_source_range_from_node_if_missing(copy, source);
+  copy->set_firstNondefiningDeclaration(copy);
+  copy->set_is_template_param(source->get_is_template_param());
+  copy->set_template_parameter_position(
+      source->get_template_parameter_position());
+  copy->set_suppress_typename(source->get_suppress_typename());
+
+  SgNonrealType *type = new SgNonrealType();
+  ROSE_ASSERT(type != nullptr);
+  type->set_declaration(copy);
+  type->set_parent(copy);
+  copy->set_type(type);
+
+  SgDeclarationScope *decl_scope = clone_detached_nonreal_decl_scope();
+  decl_scope->set_parent(copy);
+  copy->set_nonreal_decl_scope(decl_scope);
+
+  copy->get_tpl_params() = clone_template_parameter_list_surface(
+      source->get_tpl_params(), preserve_defaults, /*anchor_nonreals=*/false);
+  finalize_attached_template_parameters(copy);
+  return copy;
+}
+
+static SgTemplateParameter *
+clone_template_parameter_surface(const SgTemplateParameter *source,
+                                 bool preserve_defaults) {
+  ROSE_ASSERT(source != nullptr);
+  SgType *type = source->get_type();
+  ROSE_ASSERT(type != nullptr);
+
+  SgTemplateParameter *copy =
+      new SgTemplateParameter(source->get_parameterType(), type);
+  ROSE_ASSERT(copy != nullptr);
+  SageInterface::setSourcePosition(copy);
+  copy_real_source_range_from_node_if_missing(copy, source);
+  copy->set_parent(nullptr);
+  copy->set_templateParameterKeyword(source->get_templateParameterKeyword());
+  copy->set_isAbbreviatedFunctionTemplateParameter(
+      source->get_isAbbreviatedFunctionTemplateParameter());
+  copy->set_is_parameter_pack(source->get_is_parameter_pack());
+  copy->set_defaultTypeParameter(
+      preserve_defaults ? source->get_defaultTypeParameter() : nullptr);
+
+  if (SgInitializedName *init_name =
+          clone_template_parameter_initialized_name_surface(
+              source->get_initializedName(), copy)) {
+    copy->set_initializedName(init_name);
+  }
+
+  if (SgExpression *expression = clone_template_parameter_expression_surface(
+          source->get_expression(), copy)) {
+    copy->set_expression(expression);
+  }
+  if (SgExpression *constraint = clone_template_parameter_expression_surface(
+          source->get_typeConstraint(), copy)) {
+    copy->set_typeConstraint(constraint);
+  }
+  if (preserve_defaults) {
+    if (SgExpression *default_expr =
+            clone_template_parameter_expression_surface(
+                source->get_defaultExpressionParameter(), copy)) {
+      copy->set_defaultExpressionParameter(default_expr);
+    }
+    if (SgDeclarationStatement *default_decl =
+            source->get_defaultTemplateDeclarationParameter()) {
+      SgNonrealDecl *default_nonreal = isSgNonrealDecl(default_decl);
+      ROSE_ASSERT(default_nonreal != nullptr);
+      SgNonrealDecl *default_copy =
+          clone_template_parameter_nonreal_decl_surface(default_nonreal, true);
+      default_copy->set_parent(copy);
+      copy->set_defaultTemplateDeclarationParameter(default_copy);
+    }
+  }
+
+  if (source->get_parameterType() == SgTemplateParameter::template_parameter) {
+    SgNonrealDecl *nonreal = isSgNonrealDecl(source->get_templateDeclaration());
+    ROSE_ASSERT(nonreal != nullptr);
+    copy->set_templateDeclaration(clone_template_parameter_nonreal_decl_surface(
+        nonreal, preserve_defaults));
+  } else {
+    copy->set_templateDeclaration(nullptr);
+  }
+
+  return copy;
 }
 
 static bool declaration_has_real_source(SgDeclarationStatement *decl) {
@@ -11684,6 +13253,69 @@ static SgDeclarationStatement *unwrap_template_instantiation_directive_decl(
   return decl_stmt;
 }
 
+static SgScopeStatement *
+scope_to_preserve_for_child_attachment(SgScopeStatement *original_scope,
+                                       SgScopeStatement *attachment_scope) {
+  if (original_scope == nullptr || attachment_scope == nullptr ||
+      original_scope == attachment_scope) {
+    return original_scope;
+  }
+
+  if (isSgNamespaceDefinitionStatement(original_scope) != nullptr &&
+      isSgNamespaceDefinitionStatement(attachment_scope) != nullptr &&
+      normalizeNamespaceScope(original_scope) ==
+          normalizeNamespaceScope(attachment_scope)) {
+    return attachment_scope;
+  }
+
+  return original_scope;
+}
+
+static void
+detach_decl_from_other_namespace_fragments(SgDeclarationStatement *decl,
+                                           SgScopeStatement *attachment_scope) {
+  if (decl == nullptr || attachment_scope == nullptr) {
+    return;
+  }
+
+  SgNamespaceDefinitionStatement *attachment_ns =
+      isSgNamespaceDefinitionStatement(attachment_scope);
+  if (attachment_ns == nullptr) {
+    return;
+  }
+
+  SgScopeStatement *canonical_scope = normalizeNamespaceScope(attachment_ns);
+  SgNamespaceDeclarationStatement *seed_decl =
+      attachment_ns->get_namespaceDeclaration();
+  if (seed_decl == nullptr) {
+    return;
+  }
+
+  SgNamespaceDeclarationStatement *first_nondef =
+      isSgNamespaceDeclarationStatement(
+          seed_decl->get_firstNondefiningDeclaration());
+  if (first_nondef == nullptr) {
+    first_nondef = seed_decl;
+  }
+
+  SgNamespaceDefinitionStatement *chain =
+      first_nondef != nullptr ? first_nondef->get_definition() : nullptr;
+  if (chain == nullptr) {
+    chain = attachment_ns;
+  }
+
+  for (SgNamespaceDefinitionStatement *current = chain; current != nullptr;
+       current = current->get_nextNamespaceDefinition()) {
+    if (current == attachment_ns) {
+      continue;
+    }
+    if (normalizeNamespaceScope(current) != canonical_scope) {
+      continue;
+    }
+    detach_decl_from_scope_child_list(decl, current);
+  }
+}
+
 void insert_decl_in_scope_child_list_by_source_position(
     SgDeclarationStatement *decl, SgScopeStatement *scope, const char *context);
 
@@ -11701,6 +13333,7 @@ void ensure_decl_in_scope_child_list(
     diagnose_null_scope(decl, context);
     return;
   }
+  detach_decl_from_other_namespace_fragments(decl, scope);
 
   if (decl->get_parent() == scope && decl->get_scope() == scope &&
       is_decl_attached_to_scope_child_list(scope, decl)) {
@@ -11759,6 +13392,7 @@ void insert_decl_in_scope_child_list_by_source_position(
     diagnose_null_scope(decl, context);
     return;
   }
+  detach_decl_from_other_namespace_fragments(decl, scope);
 
   if ((std::getenv("REX_DEBUG_BAD_DECLS") != nullptr ||
        std::getenv("REX_DEBUG_REMAINING_2013") != nullptr) &&
@@ -12012,6 +13646,9 @@ void ensure_decl_in_scope_child_list_preserve_scope(
     ensure_decl_in_scope_child_list(decl, scope, context);
     return;
   }
+  SgScopeStatement *scope_to_preserve =
+      scope_to_preserve_for_child_attachment(original_scope, scope);
+  detach_decl_from_other_namespace_fragments(decl, scope);
 
   if (original_scope != scope &&
       is_decl_attached_to_scope_child_list(original_scope, decl)) {
@@ -12049,8 +13686,8 @@ void ensure_decl_in_scope_child_list_preserve_scope(
   if (decl->get_parent() != scope) {
     decl->set_parent(scope);
   }
-  if (decl->get_scope() != original_scope) {
-    decl->set_scope(original_scope);
+  if (decl->get_scope() != scope_to_preserve) {
+    decl->set_scope(scope_to_preserve);
   }
 }
 
@@ -12094,10 +13731,12 @@ void insert_decl_in_parent_child_list_by_source_position_preserve_scope(
   }
 
   SgScopeStatement *original_scope = decl->get_scope();
+  SgScopeStatement *scope_to_preserve =
+      scope_to_preserve_for_child_attachment(original_scope, parent_scope);
   insert_decl_in_scope_child_list_by_source_position(decl, parent_scope,
                                                      context);
-  if (original_scope != nullptr && decl->get_scope() != original_scope) {
-    decl->set_scope(original_scope);
+  if (scope_to_preserve != nullptr && decl->get_scope() != scope_to_preserve) {
+    decl->set_scope(scope_to_preserve);
   }
 }
 
@@ -12109,9 +13748,11 @@ static void insert_decl_in_scope_child_list_by_source_position_preserve_scope(
   }
 
   SgScopeStatement *original_scope = decl->get_scope();
+  SgScopeStatement *scope_to_preserve =
+      scope_to_preserve_for_child_attachment(original_scope, scope);
   insert_decl_in_scope_child_list_by_source_position(decl, scope, context);
-  if (original_scope != nullptr && decl->get_scope() != original_scope) {
-    decl->set_scope(original_scope);
+  if (scope_to_preserve != nullptr && decl->get_scope() != scope_to_preserve) {
+    decl->set_scope(scope_to_preserve);
   }
 }
 
@@ -12175,6 +13816,8 @@ static void insert_decl_before_anchor_in_scope_child_list_preserve_scope(
   align_decl_sort_position_with_anchor(decl, anchor);
 
   SgScopeStatement *original_scope = decl->get_scope();
+  SgScopeStatement *scope_to_preserve =
+      scope_to_preserve_for_child_attachment(original_scope, scope);
   detach_decl_from_known_scope_child_lists(decl, scope);
   if (decl->get_scope() == nullptr) {
     decl->set_scope(scope);
@@ -12195,8 +13838,8 @@ static void insert_decl_before_anchor_in_scope_child_list_preserve_scope(
   index.members.insert(decl);
   index.indexed_count = decls->size();
 
-  if (original_scope != nullptr && decl->get_scope() != original_scope) {
-    decl->set_scope(original_scope);
+  if (scope_to_preserve != nullptr && decl->get_scope() != scope_to_preserve) {
+    decl->set_scope(scope_to_preserve);
   }
 }
 
@@ -12247,6 +13890,30 @@ static void suppress_same_source_placeholder_first_nondefining_class_decl(
   if (!first_nondefining_class_decl_is_same_source_placeholder(first_nondef,
                                                                defining)) {
     return;
+  }
+
+  if (defining != nullptr && defining != first_nondef &&
+      defining->get_definition() != nullptr &&
+      declaration_has_real_source(defining)) {
+    SgScopeStatement *anchor_scope =
+        isSgScopeStatement(first_nondef->get_parent());
+    if (anchor_scope == nullptr) {
+      anchor_scope = first_nondef->get_scope();
+    }
+    if (anchor_scope == nullptr) {
+      anchor_scope = defining->get_scope();
+    }
+
+    if (anchor_scope != nullptr &&
+        is_decl_attached_to_scope_child_list(anchor_scope, first_nondef) &&
+        !is_decl_attached_to_scope_child_list(anchor_scope, defining)) {
+      defining->set_isAutonomousDeclaration(true);
+      mark_source_backed_for_output(defining);
+      mark_source_backed_for_output(defining->get_definition());
+      insert_decl_before_anchor_in_scope_child_list_preserve_scope(
+          defining, first_nondef, anchor_scope,
+          "suppress_same_source_placeholder_first_nondefining_class_decl");
+    }
   }
 
   first_nondef->set_isAutonomousDeclaration(false);
@@ -12849,15 +14516,10 @@ static SgNamespaceDefinitionStatement *selectNamespaceFragmentBySourcePosition(
     chain = namespace_scope;
   }
 
-  SgNamespaceDefinitionStatement *best = namespace_scope;
-  Sg_File_Info *best_fi =
-      best != nullptr ? pick_source_info(best->get_namespaceDeclaration())
-                      : nullptr;
-  SgNamespaceDefinitionStatement *best_source_backed =
-      is_source_backed_namespace_fragment(namespace_scope) ? namespace_scope
-                                                           : nullptr;
-  Sg_File_Info *best_source_backed_fi =
-      best_source_backed != nullptr ? best_fi : nullptr;
+  SgNamespaceDefinitionStatement *best = nullptr;
+  Sg_File_Info *best_fi = nullptr;
+  SgNamespaceDefinitionStatement *best_source_backed = nullptr;
+  Sg_File_Info *best_source_backed_fi = nullptr;
 
   for (SgNamespaceDefinitionStatement *current = chain; current != nullptr;
        current = current->get_nextNamespaceDefinition()) {
@@ -13235,6 +14897,64 @@ SgName function_declaration_base_name(SgFunctionDeclaration *decl) {
   return decl->get_name();
 }
 
+SgType *function_reuse_parameter_identity_type(SgType *type) {
+  if (type == nullptr) {
+    return nullptr;
+  }
+
+  return type->stripType(SgType::STRIP_MODIFIER_TYPE |
+                         SgType::STRIP_TYPEDEF_TYPE);
+}
+
+SgDeclarationStatement *canonical_named_type_declaration(SgType *type) {
+  type = function_reuse_parameter_identity_type(type);
+  if (SgNamedType *named_type = isSgNamedType(type)) {
+    SgDeclarationStatement *decl = named_type->get_declaration();
+    if (decl != nullptr) {
+      if (SgDeclarationStatement *first_nondef = isSgDeclarationStatement(
+              decl->get_firstNondefiningDeclaration())) {
+        return first_nondef;
+      }
+    }
+    return decl;
+  }
+
+  return nullptr;
+}
+
+bool same_function_reuse_parameter_type(SgType *lhs, SgType *rhs) {
+  lhs = function_reuse_parameter_identity_type(lhs);
+  rhs = function_reuse_parameter_identity_type(rhs);
+  if (lhs == rhs) {
+    return true;
+  }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+
+  SgDeclarationStatement *lhs_decl = canonical_named_type_declaration(lhs);
+  SgDeclarationStatement *rhs_decl = canonical_named_type_declaration(rhs);
+  if (lhs_decl != nullptr || rhs_decl != nullptr) {
+    return lhs_decl == rhs_decl;
+  }
+
+  if (lhs->variantT() != rhs->variantT()) {
+    return false;
+  }
+
+  return lhs->get_mangled().getString() == rhs->get_mangled().getString();
+}
+
+bool is_visible_source_function_decl(SgFunctionDeclaration *decl) {
+  if (decl == nullptr) {
+    return false;
+  }
+
+  Sg_File_Info *fi = decl->get_file_info();
+  return fi != nullptr && fi->isOutputInCodeGeneration() &&
+         !fi->isCompilerGenerated() && !fi->isFrontendSpecific();
+}
+
 bool same_function_signature_shape(SgFunctionDeclaration *lhs,
                                    SgFunctionDeclaration *rhs) {
   if (lhs == nullptr || rhs == nullptr) {
@@ -13253,6 +14973,13 @@ bool same_function_signature_shape(SgFunctionDeclaration *lhs,
       rhs_params != nullptr ? rhs_params->get_args().size() : 0;
   if (lhs_count != rhs_count) {
     return false;
+  }
+  for (size_t i = 0; i < lhs_count; ++i) {
+    SgType *lhs_type = lhs_params->get_args()[i]->get_type();
+    SgType *rhs_type = rhs_params->get_args()[i]->get_type();
+    if (!same_function_reuse_parameter_type(lhs_type, rhs_type)) {
+      return false;
+    }
   }
 
   SgFunctionType *lhs_type = lhs->get_type();
@@ -13334,6 +15061,13 @@ bool same_member_function_signature_shape(SgMemberFunctionDeclaration *lhs,
       rhs_params != nullptr ? rhs_params->get_args().size() : 0;
   if (lhs_count != rhs_count) {
     return false;
+  }
+  for (size_t i = 0; i < lhs_count; ++i) {
+    SgType *lhs_type = lhs_params->get_args()[i]->get_type();
+    SgType *rhs_type = rhs_params->get_args()[i]->get_type();
+    if (!same_function_reuse_parameter_type(lhs_type, rhs_type)) {
+      return false;
+    }
   }
 
   SgMemberFunctionType *lhs_type = isSgMemberFunctionType(lhs->get_type());
@@ -14153,9 +15887,16 @@ static bool tagDefinitionWrittenInRange(const clang::TagDecl *tag_decl,
                                         clang::SourceRange range,
                                         clang::SourceManager *source_manager,
                                         bool allow_fallback_loc_compare) {
-  return tag_decl != nullptr && tag_decl->isThisDeclarationADefinition() &&
-         sourceRangeContainsLocation(range, tag_decl->getBeginLoc(),
-                                     source_manager,
+  tag_decl = markClangSpecificDeclDefined(tag_decl);
+  if (tag_decl == nullptr || !readClangApiValueDefined([&]() {
+        return tag_decl->isThisDeclarationADefinition();
+      })) {
+    return false;
+  }
+
+  const clang::SourceLocation tag_begin =
+      readClangApiValueDefined([&]() { return tag_decl->getBeginLoc(); });
+  return sourceRangeContainsLocation(range, tag_begin, source_manager,
                                      allow_fallback_loc_compare);
 }
 
@@ -14163,21 +15904,49 @@ static bool isTagEmbeddedInField(clang::TagDecl *tag_decl,
                                  clang::RecordDecl *parent_decl,
                                  clang::SourceManager *source_manager,
                                  bool allow_fallback_loc_compare) {
+  markClangValueDefined(tag_decl);
+  markClangValueDefined(parent_decl);
   if (tag_decl == nullptr || parent_decl == nullptr) {
     return false;
   }
 
-  clang::SourceLocation tag_begin = tag_decl->getBeginLoc();
-  for (clang::FieldDecl *field_decl : parent_decl->fields()) {
-    clang::QualType field_qual_type = field_decl->getType();
+  tag_decl = markClangSpecificDeclDefined(tag_decl);
+  parent_decl = markClangSpecificDeclDefined(parent_decl);
+  if (tag_decl == nullptr || parent_decl == nullptr) {
+    return false;
+  }
+
+  clang::SourceLocation tag_begin =
+      readClangApiValueDefined([&]() { return tag_decl->getBeginLoc(); });
+  clang::DeclContext::decl_iterator field_it =
+      readClangApiValueDefined([&]() { return parent_decl->decls_begin(); });
+  clang::DeclContext::decl_iterator field_end =
+      readClangApiValueDefined([&]() { return parent_decl->decls_end(); });
+  for (; field_it != field_end; field_it = readClangApiValueDefined([&]() {
+                                  clang::DeclContext::decl_iterator next =
+                                      field_it;
+                                  ++next;
+                                  return next;
+                                })) {
+    clang::Decl *raw_decl = markClangDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return *field_it; }));
+    clang::FieldDecl *field_decl =
+        llvm::dyn_cast_or_null<clang::FieldDecl>(raw_decl);
+    if (field_decl == nullptr) {
+      continue;
+    }
+    clang::QualType field_qual_type = markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return field_decl->getType(); }));
     const clang::Type *field_type = stripFieldType(field_qual_type);
     clang::TagDecl *field_tag = nullptr;
     if (auto *record_type =
             llvm::dyn_cast_or_null<clang::RecordType>(field_type)) {
-      field_tag = record_type->getDecl();
+      field_tag = markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return record_type->getDecl(); }));
     } else if (auto *enum_type =
                    llvm::dyn_cast_or_null<clang::EnumType>(field_type)) {
-      field_tag = enum_type->getDecl();
+      field_tag = markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return enum_type->getDecl(); }));
     }
 
     if (field_tag == nullptr) {
@@ -14199,7 +15968,13 @@ static bool isTagEmbeddedInField(clang::TagDecl *tag_decl,
       }
     }
 
-    if (field_tag->getCanonicalDecl() == tag_decl->getCanonicalDecl() &&
+    clang::TagDecl *field_canonical =
+        markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return field_tag->getCanonicalDecl(); }));
+    const clang::TagDecl *tag_canonical =
+        markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return tag_decl->getCanonicalDecl(); }));
+    if (field_canonical == tag_canonical &&
         sourceRangeContainsLocation(field_range, tag_begin, source_manager,
                                     allow_fallback_loc_compare)) {
       return true;
@@ -15142,9 +16917,11 @@ void ClangToSageTranslator::populateClassDefinition(
           typedef_scope = resolveScopeFromDeclContext(
               clang_typedef->getDeclContext(), nullptr);
         }
-        SgName base_name = typedef_decl != nullptr
-                               ? typedef_decl->get_name()
-                               : sanitize_base_name(base_type.getAsString());
+        SgName base_name =
+            typedef_decl != nullptr
+                ? typedef_decl->get_name()
+                : sanitize_base_name(
+                      clangQualTypeAsStringDefinedForFrontend(base_type));
         SgClassDeclaration *placeholder =
             build_placeholder_base_decl(base_name, typedef_scope);
         if (placeholder != nullptr && !has_class_base(placeholder)) {
@@ -15171,7 +16948,8 @@ void ClangToSageTranslator::populateClassDefinition(
                                                        base.isVirtual(), true);
             }
           } else {
-            SgName base_name = sanitize_base_name(base_type.getAsString());
+            SgName base_name = sanitize_base_name(
+                clangQualTypeAsStringDefinedForFrontend(base_type));
             SgClassDeclaration *placeholder =
                 build_placeholder_base_decl(base_name, nullptr);
             if (placeholder != nullptr && !has_class_base(placeholder)) {
@@ -15229,7 +17007,8 @@ void ClangToSageTranslator::populateClassDefinition(
             }
           }
         } else {
-          SgName base_name = sanitize_base_name(base_type.getAsString());
+          SgName base_name = sanitize_base_name(
+              clangQualTypeAsStringDefinedForFrontend(base_type));
           SgClassDeclaration *placeholder =
               build_placeholder_base_decl(base_name, nullptr);
           if (placeholder != nullptr && !has_class_base(placeholder)) {
@@ -15311,6 +17090,7 @@ void ClangToSageTranslator::populateClassDefinition(
 
     auto is_template_marked_on_demand =
         [&](clang::ClassTemplateDecl *candidate) -> bool {
+      candidate = markClangSpecificDeclDefined(candidate);
       if (candidate == nullptr) {
         return false;
       }
@@ -15320,7 +17100,9 @@ void ClangToSageTranslator::populateClassDefinition(
         return true;
       }
 
-      if (clang::ClassTemplateDecl *canonical = candidate->getCanonicalDecl()) {
+      if (clang::ClassTemplateDecl *canonical =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return candidate->getCanonicalDecl(); }))) {
         if (p_decl_translation_on_demand.find(canonical) !=
             p_decl_translation_on_demand.end()) {
           return true;
@@ -15331,26 +17113,30 @@ void ClangToSageTranslator::populateClassDefinition(
     };
 
     auto is_marked_on_demand = [&](clang::RecordDecl *candidate) -> bool {
+      candidate = markClangSpecificDeclDefined(candidate);
       return candidate != nullptr &&
              p_decl_translation_on_demand.find(candidate) !=
                  p_decl_translation_on_demand.end();
     };
 
+    decl = markClangSpecificDeclDefined(decl);
     if (is_marked_on_demand(decl)) {
       return true;
     }
-    if (clang::RecordDecl *definition = decl->getDefinition()) {
+    if (clang::RecordDecl *definition = clangRecordDefinitionDefined(decl)) {
       if (is_marked_on_demand(definition)) {
         return true;
       }
     }
     if (clang::RecordDecl *canonical =
-            llvm::dyn_cast<clang::RecordDecl>(decl->getCanonicalDecl())) {
+            llvm::dyn_cast_or_null<clang::RecordDecl>(
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return decl->getCanonicalDecl(); })))) {
       if (is_marked_on_demand(canonical)) {
         return true;
       }
       if (clang::RecordDecl *canonical_definition =
-              canonical->getDefinition()) {
+              clangRecordDefinitionDefined(canonical)) {
         if (is_marked_on_demand(canonical_definition)) {
           return true;
         }
@@ -15358,17 +17144,22 @@ void ClangToSageTranslator::populateClassDefinition(
     }
 
     if (clang::CXXRecordDecl *cxx_record =
-            llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
+            llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                markClangDeclObjectDefinedByKind(decl))) {
       if (is_template_marked_on_demand(
-              cxx_record->getDescribedClassTemplate())) {
+              markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+                return cxx_record->getDescribedClassTemplate();
+              })))) {
         return true;
       }
 
       if (clang::ClassTemplateSpecializationDecl *specialization =
-              llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+              llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
                   cxx_record)) {
         if (is_template_marked_on_demand(
-                specialization->getSpecializedTemplate())) {
+                markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+                  return specialization->getSpecializedTemplate();
+                })))) {
           return true;
         }
       }
@@ -15386,8 +17177,10 @@ void ClangToSageTranslator::populateClassDefinition(
       return false;
     }
 
-    clang::RecordDecl *source_record = record_decl;
-    if (clang::RecordDecl *definition = record_decl->getDefinition()) {
+    clang::RecordDecl *source_record =
+        markClangSpecificDeclDefined(record_decl);
+    if (clang::RecordDecl *definition =
+            clangRecordDefinitionDefined(source_record)) {
       source_record = definition;
     }
 
@@ -15538,7 +17331,8 @@ void ClangToSageTranslator::populateClassDefinition(
     if (llvm::isa<clang::AccessSpecDecl>(inner_decl)) {
       clang::AccessSpecDecl *asd =
           llvm::cast<clang::AccessSpecDecl>(inner_decl);
-      clang::AccessSpecifier as = asd->getAccess();
+      clang::AccessSpecifier as =
+          readClangApiValueDefined([&]() { return asd->getAccess(); });
       if (as == clang::AS_public)
         current_access = SgAccessModifier::e_public;
       else if (as == clang::AS_protected)
@@ -15587,7 +17381,10 @@ void ClangToSageTranslator::populateClassDefinition(
             continue;
           }
           if (!tagDefinitionWrittenInRange(
-                  canonical_tag, typedef_decl->getSourceRange(), source_manager,
+                  canonical_tag, readClangApiValueDefined([&]() {
+                    return typedef_decl->getSourceRange();
+                  }),
+                  source_manager,
                   /*allow_fallback_loc_compare=*/
                   false)) {
             continue;
@@ -15635,16 +17432,20 @@ void ClangToSageTranslator::populateClassDefinition(
       }
     }
 
-    if (inner_decl->isImplicit()) {
+    if (readClangApiValueDefined([&]() { return inner_decl->isImplicit(); })) {
       bool allow_implicit = false;
       if (clang::FieldDecl *field_decl =
               llvm::dyn_cast<clang::FieldDecl>(inner_decl)) {
-        if (field_decl->isAnonymousStructOrUnion()) {
+        if (readClangApiValueDefined(
+                [&]() { return field_decl->isAnonymousStructOrUnion(); })) {
           const clang::CXXRecordDecl *parent_record =
               llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                  markClangDeclObjectDefinedByKind(field_decl->getParent()));
+                  markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                      [&]() { return field_decl->getParent(); })));
           bool is_lambda_field =
-              parent_record != nullptr && parent_record->isLambda();
+              parent_record != nullptr && readClangApiValueDefined([&]() {
+                return parent_record->isLambda();
+              });
           // Anonymous unions are spelled in the source but modeled as implicit
           // fields; keep them so the union definition is emitted in-class.
           allow_implicit = !is_lambda_field;
@@ -15692,8 +17493,9 @@ void ClangToSageTranslator::populateClassDefinition(
     // Semantic members can be lexically declared outside the class (e.g.
     // out-of-line nested type definitions and out-of-line member definitions).
     // They must not be appended as in-class members.
-    if (clang::DeclContext *lexical_context = markClangDeclContextObjectDefined(
-            inner_decl->getLexicalDeclContext())) {
+    if (clang::DeclContext *lexical_context =
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return inner_decl->getLexicalDeclContext(); }))) {
       if (lexical_context != record_decl &&
           !llvm::isa<clang::FriendDecl>(inner_decl) &&
           !llvm::isa<clang::FriendTemplateDecl>(inner_decl)) {
@@ -15712,7 +17514,8 @@ void ClangToSageTranslator::populateClassDefinition(
             isSgDeclarationStatement(sg_child)) {
       if (clang::TagDecl *inner_tag =
               llvm::dyn_cast<clang::TagDecl>(inner_decl)) {
-        if (inner_tag->isThisDeclarationADefinition()) {
+        if (readClangApiValueDefined(
+                [&]() { return inner_tag->isThisDeclarationADefinition(); })) {
           if (SgClassDeclaration *class_decl =
                   isSgClassDeclaration(child_decl)) {
             if (SgClassDeclaration *defining_decl = isSgClassDeclaration(
@@ -15799,19 +17602,9 @@ void ClangToSageTranslator::populateClassDefinition(
 
         SgTemplateParameterPtrList template_params;
         if (reuse_translated_syntax) {
-          for (SgTemplateParameter *param :
-               translated_decl->get_templateParameters()) {
-            if (param == nullptr) {
-              continue;
-            }
-            SgTemplateParameter *copied_param =
-                isSgTemplateParameter(SageInterface::deepCopy(param));
-            if (copied_param == nullptr) {
-              cleanup_unused_param_list(nullptr, param_list);
-              return nullptr;
-            }
-            template_params.push_back(copied_param);
-          }
+          template_params = clone_template_parameter_list_surface(
+              translated_decl->get_templateParameters(),
+              /*preserve_defaults=*/true, /*anchor_nonreals=*/true);
         } else {
           std::unique_ptr<SgTemplateParameterPtrList> translated_params =
               translateTemplateParameterList(
@@ -16485,6 +18278,7 @@ SgTemplateParameter *ClangToSageTranslator::translateTemplateParameter(
   if (param_decl == nullptr) {
     return nullptr;
   }
+  markClangTemplateParameterSourceRangeStorageDefined(param_decl);
 
   auto should_translate_template_parameter_detail =
       [&](const clang::NamedDecl *decl) -> bool {
@@ -17656,6 +19450,9 @@ SgNode *ClangToSageTranslator::lookupCachedTranslationForTraverse(
   if (decl == nullptr) {
     return nullptr;
   }
+  if (p_rebuild_translation_cache_depth != 0) {
+    return nullptr;
+  }
 
   clang::Decl *map_key = decl;
   if (clang::NamespaceDecl *ns_decl =
@@ -18265,8 +20062,12 @@ translate_decl:
             hidden_template_inst, /*detach_from_scope_lists=*/true);
       }
     }
-    p_decl_translation_map.insert(
-        std::pair<clang::Decl *, SgNode *>(decl, result));
+    if (p_rebuild_translation_cache_depth != 0) {
+      p_decl_translation_map[decl] = result;
+    } else {
+      p_decl_translation_map.insert(
+          std::pair<clang::Decl *, SgNode *>(decl, result));
+    }
   }
 
 #if DEBUG_TRAVERSE_DECL
@@ -18292,7 +20093,8 @@ translate_decl:
         }
       }
       if (p_compiler_instance != nullptr) {
-        clang::SourceLocation loc = decl->getLocation();
+        clang::SourceLocation loc =
+            readClangApiValueDefined([&]() { return decl->getLocation(); });
         if (loc.isValid()) {
           clang::PresumedLoc ploc =
               p_compiler_instance->getSourceManager().getPresumedLoc(loc);
@@ -18385,7 +20187,8 @@ bool ClangToSageTranslator::TraverseForDeclContext(
           llvm::dyn_cast_or_null<clang::NamespaceDecl>(
               markClangDeclObjectDefinedByKind(
                   llvm::dyn_cast_or_null<clang::Decl>(decl_context)));
-      const clang::DeclContext *lexical_ctx = decl->getLexicalDeclContext();
+      const clang::DeclContext *lexical_ctx = readClangApiValueDefined(
+          [&]() { return decl->getLexicalDeclContext(); });
       lexical_ctx = markClangDeclContextObjectDefined(lexical_ctx);
       if (current_ns != nullptr) {
         bool belongs_to_current_fragment = false;
@@ -18407,9 +20210,11 @@ bool ClangToSageTranslator::TraverseForDeclContext(
 
         if (p_compiler_instance != nullptr) {
           clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-          clang::SourceLocation decl_loc = decl->getBeginLoc();
+          clang::SourceLocation decl_loc =
+              readClangApiValueDefined([&]() { return decl->getBeginLoc(); });
           if (!decl_loc.isValid()) {
-            decl_loc = decl->getLocation();
+            decl_loc =
+                readClangApiValueDefined([&]() { return decl->getLocation(); });
           }
           // Keep namespace-fragment traversal aligned with the source file
           // the user actually wrote. For macro-opened namespaces, the spelling
@@ -18417,35 +20222,18 @@ bool ClangToSageTranslator::TraverseForDeclContext(
           // declarations appear outside the current namespace body, which drops
           // whole nested namespaces from eager traversal.
           decl_loc = resolveLocationForMainFileEmission(decl_loc, sm);
+          clang::SourceRange current_ns_range = readClangApiValueDefined(
+              [&]() { return current_ns->getSourceRange(); });
 
-          if (decl_loc.isValid() && current_ns->getSourceRange().isValid()) {
+          if (decl_loc.isValid() && current_ns_range.isValid()) {
             belongs_to_current_fragment = sourceRangeContainsLocation(
-                current_ns->getSourceRange(), decl_loc, &sm,
+                current_ns_range, decl_loc, &sm,
                 /*allow_fallback_loc_compare=*/false);
           }
         }
 
         if (!belongs_to_current_fragment) {
           continue;
-        }
-      }
-    }
-
-    if (global_scope && SgProject::get_verbose() > 0) {
-      if (clang::NamedDecl *named = llvm::dyn_cast<clang::NamedDecl>(decl)) {
-        std::string n = named->getNameAsString();
-        if (n == "uint8_t" || n == "uint16_t" || n == "uint32_t" ||
-            n == "in_port_t" || n == "in_addr_t" || n == "in6_addr" ||
-            n == "in_addr" || n == "sockaddr_in" || n == "ntohl" ||
-            n == "ntohs" || n == "htonl" || n == "htons") {
-          unsigned line = 0;
-          if (p_compiler_instance != nullptr) {
-            line =
-                p_compiler_instance->getSourceManager().getSpellingLineNumber(
-                    named->getLocation());
-          }
-          std::cerr << "CFE: TU visit '" << n << "' ("
-                    << decl->getDeclKindName() << ") @" << line << std::endl;
         }
       }
     }
@@ -18540,6 +20328,74 @@ bool ClangToSageTranslator::TraverseForDeclContext(
 
       bool preserve_lexical_member = false;
       if (decl_stmt != nullptr) {
+        auto read_semantic_decl_context =
+            [](clang::Decl *clang_decl) -> clang::DeclContext * {
+          clang_decl = markClangDeclObjectDefinedByKind(clang_decl);
+          if (clang_decl == nullptr) {
+            return nullptr;
+          }
+          return markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return clang_decl->getDeclContext(); }));
+        };
+        auto read_lexical_decl_context =
+            [](clang::Decl *clang_decl) -> clang::DeclContext * {
+          clang_decl = markClangDeclObjectDefinedByKind(clang_decl);
+          if (clang_decl == nullptr) {
+            return nullptr;
+          }
+          return markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return clang_decl->getLexicalDeclContext(); }));
+        };
+        auto read_decl_context_parent =
+            [](clang::DeclContext *ctx) -> clang::DeclContext * {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          if (ctx == nullptr) {
+            return nullptr;
+          }
+          return markClangDeclContextObjectDefined(
+              readClangApiValueDefined([&]() { return ctx->getParent(); }));
+        };
+        auto context_decl = [](clang::DeclContext *ctx) -> clang::Decl * {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          if (ctx == nullptr) {
+            return nullptr;
+          }
+          return markClangDeclObjectDefinedByKind(
+              clang::Decl::castFromDeclContext(ctx));
+        };
+        auto strip_linkage_context =
+            [&](clang::DeclContext *ctx) -> clang::DeclContext * {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          while (clang::Decl *ctx_decl = context_decl(ctx)) {
+            if (!llvm::isa<clang::LinkageSpecDecl>(ctx_decl)) {
+              break;
+            }
+            ctx = read_decl_context_parent(ctx);
+          }
+          return ctx;
+        };
+        auto context_is_translation_unit = [](clang::DeclContext *ctx) -> bool {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          return ctx != nullptr && readClangApiValueDefined([&]() {
+                   return ctx->isTranslationUnit();
+                 });
+        };
+        auto context_is_namespace = [](clang::DeclContext *ctx) -> bool {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          return ctx != nullptr &&
+                 readClangApiValueDefined([&]() { return ctx->isNamespace(); });
+        };
+        auto context_is_file_context = [](clang::DeclContext *ctx) -> bool {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          return ctx != nullptr && readClangApiValueDefined(
+                                       [&]() { return ctx->isFileContext(); });
+        };
+        auto context_is_record = [](clang::DeclContext *ctx) -> bool {
+          ctx = markClangDeclContextObjectDefined(ctx);
+          return ctx != nullptr &&
+                 readClangApiValueDefined([&]() { return ctx->isRecord(); });
+        };
+
         auto should_preserve_lexical =
             [&](clang::CXXMethodDecl *method_decl) -> bool {
           if (method_decl == nullptr || !methodDeclIsOutOfLine(method_decl)) {
@@ -18551,33 +20407,30 @@ bool ClangToSageTranslator::TraverseForDeclContext(
         };
         auto should_preserve_lexical_record =
             [&](clang::RecordDecl *record_decl) -> bool {
-          if (record_decl == nullptr ||
-              !record_decl->isThisDeclarationADefinition()) {
+          record_decl = llvm::dyn_cast_or_null<clang::RecordDecl>(
+              markClangDeclObjectDefinedByKind(record_decl));
+          if (record_decl == nullptr || !readClangApiValueDefined([&]() {
+                return record_decl->isThisDeclarationADefinition();
+              })) {
             return false;
           }
 
-          auto strip_linkage_context =
-              [](clang::DeclContext *ctx) -> clang::DeclContext * {
-            while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-              ctx = ctx->getParent();
-            }
-            return ctx;
-          };
-
           clang::DeclContext *semantic_ctx =
-              strip_linkage_context(record_decl->getDeclContext());
+              strip_linkage_context(read_semantic_decl_context(record_decl));
           clang::DeclContext *lexical_ctx =
-              strip_linkage_context(record_decl->getLexicalDeclContext());
+              strip_linkage_context(read_lexical_decl_context(record_decl));
           if (semantic_ctx != nullptr && lexical_ctx != nullptr &&
               semantic_ctx != lexical_ctx &&
-              (lexical_ctx->isTranslationUnit() ||
-               lexical_ctx->isNamespace()) &&
-              (semantic_ctx->isFileContext() || semantic_ctx->isRecord())) {
+              (context_is_translation_unit(lexical_ctx) ||
+               context_is_namespace(lexical_ctx)) &&
+              (context_is_file_context(semantic_ctx) ||
+               context_is_record(semantic_ctx))) {
             return true;
           }
 
           clang::RecordDecl *owner_record =
-              llvm::dyn_cast<clang::RecordDecl>(record_decl->getDeclContext());
+              llvm::dyn_cast_or_null<clang::RecordDecl>(
+                  context_decl(read_semantic_decl_context(record_decl)));
           if (owner_record == nullptr) {
             return false;
           }
@@ -18588,8 +20441,10 @@ bool ClangToSageTranslator::TraverseForDeclContext(
 
           clang::SourceManager &sm = p_compiler_instance->getSourceManager();
           clang::SourceLocation decl_loc =
-              sm.getFileLoc(record_decl->getLocation());
-          clang::SourceRange owner_braces = owner_record->getBraceRange();
+              sm.getFileLoc(readClangApiValueDefined(
+                  [&]() { return record_decl->getLocation(); }));
+          clang::SourceRange owner_braces = readClangApiValueDefined(
+              [&]() { return owner_record->getBraceRange(); });
           if (!decl_loc.isValid() || !owner_braces.isValid()) {
             return false;
           }
@@ -18622,25 +20477,21 @@ bool ClangToSageTranslator::TraverseForDeclContext(
         };
         auto should_preserve_lexical_enum =
             [&](clang::EnumDecl *enum_decl) -> bool {
-          if (enum_decl == nullptr ||
-              !enum_decl->isThisDeclarationADefinition() ||
-              !enum_decl->isCompleteDefinition() ||
+          enum_decl = llvm::dyn_cast_or_null<clang::EnumDecl>(
+              markClangDeclObjectDefinedByKind(enum_decl));
+          if (enum_decl == nullptr || !readClangApiValueDefined([&]() {
+                return enum_decl->isThisDeclarationADefinition();
+              }) ||
+              !readClangApiValueDefined(
+                  [&]() { return enum_decl->isCompleteDefinition(); }) ||
               isSgEnumDeclaration(decl_stmt) == nullptr) {
             return false;
           }
 
-          auto strip_linkage_context =
-              [](clang::DeclContext *ctx) -> clang::DeclContext * {
-            while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-              ctx = ctx->getParent();
-            }
-            return ctx;
-          };
-
           clang::DeclContext *semantic_ctx =
-              strip_linkage_context(enum_decl->getDeclContext());
+              strip_linkage_context(read_semantic_decl_context(enum_decl));
           clang::DeclContext *lexical_ctx =
-              strip_linkage_context(enum_decl->getLexicalDeclContext());
+              strip_linkage_context(read_lexical_decl_context(enum_decl));
           return semantic_ctx != nullptr && lexical_ctx != nullptr &&
                  semantic_ctx != lexical_ctx;
         };
@@ -18819,6 +20670,19 @@ bool ClangToSageTranslator::TraverseForDeclContext(
                   : "TraverseForDeclContext:global");
         }
       } else if (namespace_scope != nullptr) {
+        SgScopeStatement *namespace_attach_scope = namespace_scope;
+        if (SgNamespaceDefinitionStatement *namespace_def =
+                isSgNamespaceDefinitionStatement(namespace_scope)) {
+          if (SgLocatedNode *located_decl =
+                  isSgLocatedNode(scope_attached_decl)) {
+            namespace_attach_scope = selectNamespaceFragmentBySourcePosition(
+                located_decl, namespace_def);
+          }
+        }
+        if (namespace_attach_scope != namespace_scope) {
+          detach_decl_from_scope_child_list(scope_attached_decl,
+                                            namespace_scope);
+        }
         SgScopeStatement *decl_scope = decl_stmt->get_scope();
         if (decl_scope != nullptr && decl_scope != namespace_scope &&
             !preserve_lexical_member) {
@@ -18850,7 +20714,7 @@ bool ClangToSageTranslator::TraverseForDeclContext(
               // the specialization from the emitted AST.
             } else if (namespace_scope->containsOnlyDeclarations()) {
               ensure_decl_in_scope_child_list_preserve_scope(
-                  scope_attached_decl, namespace_scope,
+                  scope_attached_decl, namespace_attach_scope,
                   "TraverseForDeclContext:namespace-keep-existing");
             }
             continue;
@@ -18863,36 +20727,38 @@ bool ClangToSageTranslator::TraverseForDeclContext(
             if (!is_member_decl &&
                 !func_decl->get_declarationModifier().isFriend()) {
               ensure_decl_in_scope_child_list(
-                  scope_attached_decl, namespace_scope,
+                  scope_attached_decl, namespace_attach_scope,
                   "TraverseForDeclContext:namespace-lexical");
               continue;
             }
           }
           ensure_decl_in_scope_child_list_preserve_scope(
-              scope_attached_decl, namespace_scope,
+              scope_attached_decl, namespace_attach_scope,
               "TraverseForDeclContext:namespace-lexical");
-          restore_semantic_outer_record_scope(decl_stmt, namespace_scope);
+          restore_semantic_outer_record_scope(decl_stmt,
+                                              namespace_attach_scope);
           dump_namespace_move("after-preserve");
           continue;
         }
 
         if (preserve_lexical_member) {
           ensure_decl_in_scope_child_list_preserve_scope(
-              scope_attached_decl, namespace_scope,
+              scope_attached_decl, namespace_attach_scope,
               "TraverseForDeclContext:namespace-lexical");
-          restore_semantic_outer_record_scope(decl_stmt, namespace_scope);
+          restore_semantic_outer_record_scope(decl_stmt,
+                                              namespace_attach_scope);
         } else {
           ensure_decl_in_scope_child_list(
-              scope_attached_decl, namespace_scope,
+              scope_attached_decl, namespace_attach_scope,
               isSgUsingDirectiveStatement(decl_stmt) != nullptr
                   ? "TraverseForDeclContext:namespace-using"
                   : "TraverseForDeclContext:namespace");
         }
-        if (scope_attached_decl->get_parent() != namespace_scope) {
-          scope_attached_decl->set_parent(namespace_scope);
+        if (scope_attached_decl->get_parent() != namespace_attach_scope) {
+          scope_attached_decl->set_parent(namespace_attach_scope);
         }
         if (scope_attached_decl->get_scope() == nullptr) {
-          scope_attached_decl->set_scope(namespace_scope);
+          scope_attached_decl->set_scope(namespace_attach_scope);
         }
         restore_semantic_outer_record_scope(decl_stmt, namespace_scope);
       } else {
@@ -19150,7 +21016,17 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
   if (decl != nullptr) {
     int max_alignment = -1;
     bool has_aligned_attr = false;
-    for (const clang::Attr *attr : decl->attrs()) {
+#if ROSE_USE_VALGRIND
+    markClangDeclAttrsDefined(decl);
+    VALGRIND_DISABLE_ERROR_REPORTING;
+#endif
+    const clang::AttrVec &attrs = decl->getAttrs();
+#if ROSE_USE_VALGRIND
+    VALGRIND_ENABLE_ERROR_REPORTING;
+#endif
+    for (size_t attr_index = 0; attr_index < attrs.size(); ++attr_index) {
+      const clang::Attr *attr = markClangAstObjectDefined(
+          readClangApiValueDefined([&]() { return attrs[attr_index]; }));
       const clang::AlignedAttr *aligned_attr =
           llvm::dyn_cast_or_null<clang::AlignedAttr>(attr);
       aligned_attr = markClangAstObjectDefined(aligned_attr);
@@ -19441,13 +21317,20 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
   std::cerr << "FriendDecl::isUnsupportedFriend () "
             << friend_decl->isUnsupportedFriend() << std::endl;
 #endif
+  friend_decl = llvm::cast<clang::FriendDecl>(
+      markClangDeclObjectDefinedByKind(friend_decl));
+  markClangDeclAttrsDefined(friend_decl);
   bool res = true;
   bool explicit_global_friend_decl = false;
 
   auto skip_linkage_context =
       [](const clang::DeclContext *ctx) -> const clang::DeclContext * {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
     return ctx;
   };
@@ -19465,22 +21348,32 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
   auto enclosing_namespace_or_tu =
       [&](const clang::DeclContext *ctx) -> const clang::DeclContext * {
     ctx = skip_linkage_context(ctx);
-    while (ctx != nullptr && !ctx->isNamespace() && !ctx->isTranslationUnit()) {
-      ctx = skip_linkage_context(ctx->getParent());
+    while (
+        ctx != nullptr &&
+        !readClangApiValueDefined([&]() { return ctx->isNamespace(); }) &&
+        !readClangApiValueDefined([&]() { return ctx->isTranslationUnit(); })) {
+      ctx = skip_linkage_context(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
     return ctx;
   };
 
   auto has_explicit_global_qualifier =
       [&](const clang::FunctionDecl *decl) -> bool {
+    decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(decl));
     if (decl == nullptr) {
       return false;
     }
 
-    if (clang::NestedNameSpecifierLoc qual_loc = decl->getQualifierLoc()) {
-      if (qual_loc.getLocalSourceRange().isValid()) {
+    if (clang::NestedNameSpecifierLoc qual_loc =
+            markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                [&]() { return decl->getQualifierLoc(); }))) {
+      if (readClangApiValueDefined(
+              [&]() { return qual_loc.getLocalSourceRange().isValid(); })) {
         if (clang::NestedNameSpecifier qual =
-                qual_loc.getNestedNameSpecifier()) {
+                markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                    [&]() { return qual_loc.getNestedNameSpecifier(); }))) {
           if (has_global_qualifier(qual)) {
             return true;
           }
@@ -19492,21 +21385,30 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
     // without preserving qualifier loc on the synthesized FunctionDecl.
     // Preserve this semantic distinction from the surrounding namespace.
     const clang::DeclContext *friend_ns_or_tu = enclosing_namespace_or_tu(
-        friend_decl != nullptr ? friend_decl->getDeclContext() : nullptr);
-    const clang::DeclContext *function_ns_or_tu =
-        enclosing_namespace_or_tu(decl->getDeclContext());
-    return function_ns_or_tu != nullptr &&
-           function_ns_or_tu->isTranslationUnit() &&
-           friend_ns_or_tu != nullptr && friend_ns_or_tu->isNamespace();
+        friend_decl != nullptr ? readClangApiValueDefined([&]() {
+          return friend_decl->getDeclContext();
+        })
+                               : nullptr);
+    const clang::DeclContext *function_ns_or_tu = enclosing_namespace_or_tu(
+        readClangApiValueDefined([&]() { return decl->getDeclContext(); }));
+    return function_ns_or_tu != nullptr && readClangApiValueDefined([&]() {
+             return function_ns_or_tu->isTranslationUnit();
+           }) &&
+           friend_ns_or_tu != nullptr && readClangApiValueDefined([&]() {
+             return friend_ns_or_tu->isNamespace();
+           });
   };
 
   auto record_explicit_global_friend = [&](clang::NamedDecl *named_decl) {
+    named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+        markClangDeclObjectDefinedByKind(named_decl));
     const clang::FunctionDecl *func_decl = nullptr;
-    if (auto *fd = llvm::dyn_cast<clang::FunctionDecl>(named_decl)) {
+    if (auto *fd = llvm::dyn_cast_or_null<clang::FunctionDecl>(named_decl)) {
       func_decl = fd;
-    } else if (auto *ft =
-                   llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-      func_decl = ft->getTemplatedDecl();
+    } else if (auto *ft = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+                   named_decl)) {
+      func_decl = markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return ft->getTemplatedDecl(); }));
     }
     if (func_decl == nullptr) {
       return;
@@ -19539,21 +21441,28 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
 
   auto friend_function_is_spelled_on_friend_decl =
       [&](const clang::FunctionDecl *func_decl) -> bool {
+    func_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(func_decl));
     if (func_decl == nullptr) {
       return false;
     }
-    return same_spelling_location(func_decl->getLocation(),
-                                  friend_decl->getLocation());
+    return same_spelling_location(
+        readClangApiValueDefined([&]() { return func_decl->getLocation(); }),
+        readClangApiValueDefined([&]() { return friend_decl->getLocation(); }));
   };
 
   auto friend_function_uses_explicit_template_id =
       [&](const clang::FunctionDecl *func_decl) -> bool {
+    func_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(func_decl));
     if (func_decl == nullptr) {
       return false;
     }
     return clangFunctionTemplateSpecializationArgsDefined(
                const_cast<clang::FunctionDecl *>(func_decl)) != nullptr ||
-           func_decl->getTemplateSpecializationArgsAsWritten() != nullptr;
+           readClangApiValueDefined([&]() {
+             return func_decl->getTemplateSpecializationArgsAsWritten();
+           }) != nullptr;
   };
 
   auto same_sage_source_position = [](SgLocatedNode *lhs,
@@ -19663,6 +21572,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
 
   auto lookup_hidden_friend_decl =
       [&](const clang::FunctionDecl *key) -> SgFunctionDeclaration * {
+    key = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(key));
     if (key == nullptr) {
       return nullptr;
     }
@@ -19676,10 +21587,14 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
   SgScopeStatement *current_scope = SageBuilder::topScopeStack();
   auto resolve_friend_scope =
       [&](clang::DeclContext *ctx) -> SgScopeStatement * {
-    clang::DeclContext *scope_ctx = ctx;
-    while (scope_ctx != nullptr && !scope_ctx->isNamespace() &&
-           !scope_ctx->isTranslationUnit()) {
-      scope_ctx = scope_ctx->getParent();
+    clang::DeclContext *scope_ctx = markClangDeclContextObjectDefined(ctx);
+    while (scope_ctx != nullptr && !readClangApiValueDefined([&]() {
+             return scope_ctx->isNamespace();
+           }) &&
+           !readClangApiValueDefined(
+               [&]() { return scope_ctx->isTranslationUnit(); })) {
+      scope_ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return scope_ctx->getParent(); }));
     }
     if (clang::NamespaceDecl *ns_decl =
             llvm::dyn_cast_or_null<clang::NamespaceDecl>(
@@ -19691,16 +21606,25 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
         }
       }
     }
-    if (scope_ctx != nullptr && scope_ctx->isTranslationUnit()) {
+    if (scope_ctx != nullptr && readClangApiValueDefined([&]() {
+          return scope_ctx->isTranslationUnit();
+        })) {
       return getGlobalScope();
     }
     return nullptr;
   };
 
   clang::DeclContext *friend_context =
-      friend_decl != nullptr ? friend_decl->getDeclContext() : nullptr;
-  if (clang::NamedDecl *named_decl = friend_decl->getFriendDecl()) {
-    if (clang::DeclContext *named_context = named_decl->getDeclContext()) {
+      friend_decl != nullptr
+          ? markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return friend_decl->getDeclContext(); }))
+          : nullptr;
+  if (clang::NamedDecl *named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return friend_decl->getFriendDecl(); })))) {
+    if (clang::DeclContext *named_context =
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return named_decl->getDeclContext(); }))) {
       friend_context = named_context;
     }
   }
@@ -20428,13 +22352,24 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
     }
 
     auto namespace_or_tu_context = [](clang::DeclContext *ctx) {
-      while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-        ctx = ctx->getParent();
+      ctx = markClangDeclContextObjectDefined(ctx);
+      while (ctx != nullptr && readClangApiValueDefined([&]() {
+               return llvm::isa<clang::LinkageSpecDecl>(ctx);
+             })) {
+        ctx = markClangDeclContextObjectDefined(
+            readClangApiValueDefined([&]() { return ctx->getParent(); }));
       }
-      return ctx == nullptr || ctx->isNamespace() || ctx->isTranslationUnit();
+      return ctx == nullptr ||
+             readClangApiValueDefined([&]() { return ctx->isNamespace(); }) ||
+             readClangApiValueDefined(
+                 [&]() { return ctx->isTranslationUnit(); });
     };
-    if (!namespace_or_tu_context(function_decl->getDeclContext()) ||
-        !namespace_or_tu_context(function_decl->getLexicalDeclContext())) {
+    if (!namespace_or_tu_context(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getDeclContext(); }))) ||
+        !namespace_or_tu_context(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getLexicalDeclContext(); })))) {
       return nullptr;
     }
 
@@ -20638,19 +22573,9 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
 
     SgTemplateParameterPtrList template_params;
     if (reuse_translated_syntax) {
-      for (SgTemplateParameter *param :
-           translated_decl->get_templateParameters()) {
-        if (param == nullptr) {
-          continue;
-        }
-        SgTemplateParameter *copied_param =
-            isSgTemplateParameter(SageInterface::deepCopy(param));
-        if (copied_param == nullptr) {
-          discard_param_list();
-          return nullptr;
-        }
-        template_params.push_back(copied_param);
-      }
+      template_params = clone_template_parameter_list_surface(
+          translated_decl->get_templateParameters(),
+          /*preserve_defaults=*/true, /*anchor_nonreals=*/true);
     } else {
       std::unique_ptr<SgTemplateParameterPtrList> translated_params =
           translateTemplateParameterList(
@@ -20702,6 +22627,20 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
     }
 
     applySourceRange(lexical_decl, friend_decl->getSourceRange());
+    if (p_compiler_instance != nullptr) {
+      clang::SourceRange friend_range = friend_decl->getSourceRange();
+      if (friend_range.isValid() &&
+          decl_range_should_consume_trailing_semicolon(friend_decl)) {
+        friend_range = extendDeclSourceRangeWithTrailingSemicolon(
+            friend_range, p_compiler_instance->getSourceManager(),
+            p_compiler_instance->getLangOpts());
+      }
+      std::string friend_template_spelling =
+          trimWhitespace(getSourceText(friend_range));
+      if (!friend_template_spelling.empty()) {
+        lexical_decl->set_string(SgName(friend_template_spelling));
+      }
+    }
     lexical_decl->set_firstNondefiningDeclaration(lexical_decl);
     lexical_decl->set_definingDeclaration(nullptr);
     bind_lexical_hidden_friend_decl_to_canonical_chain(lexical_decl,
@@ -20754,9 +22693,16 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
   }
   bool skip_friend_propagation = false;
   clang::NamedDecl *friend_named_decl =
-      sg_decl == nullptr ? friend_decl->getFriendDecl() : nullptr;
+      sg_decl == nullptr
+          ? llvm::dyn_cast_or_null<clang::NamedDecl>(
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return friend_decl->getFriendDecl(); })))
+          : nullptr;
   clang::TypeSourceInfo *friend_type_info =
-      sg_decl == nullptr ? friend_decl->getFriendType() : nullptr;
+      sg_decl == nullptr
+          ? markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return friend_decl->getFriendType(); }))
+          : nullptr;
   auto strip_synthetic_friend_template_class_symbol =
       [&](SgTemplateClassDeclaration *decl) {
         if (decl == nullptr) {
@@ -20876,18 +22822,21 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
         prepare_decl(isSgTemplateClassDeclaration(
             template_class_decl->get_definingDeclaration()));
       };
-  if (clang::NamedDecl *named_decl = friend_named_decl) {
+  if (clang::NamedDecl *named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+          markClangDeclObjectDefinedByKind(friend_named_decl))) {
     record_explicit_global_friend(named_decl);
     if (clang::FunctionDecl *fd =
-            llvm::dyn_cast<clang::FunctionDecl>(named_decl)) {
+            llvm::dyn_cast_or_null<clang::FunctionDecl>(named_decl)) {
       explicit_global_friend_decl = has_explicit_global_qualifier(fd);
     } else if (clang::FunctionTemplateDecl *ft =
-                   llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-      explicit_global_friend_decl =
-          has_explicit_global_qualifier(ft->getTemplatedDecl());
+                   llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+                       named_decl)) {
+      explicit_global_friend_decl = has_explicit_global_qualifier(
+          markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return ft->getTemplatedDecl(); })));
     }
     if (clang::RecordDecl *record_decl =
-            llvm::dyn_cast<clang::RecordDecl>(named_decl)) {
+            llvm::dyn_cast_or_null<clang::RecordDecl>(named_decl)) {
       // Ensure the record declaration is translated so the symbol/type exists.
       clang::RecordDecl *lookup_record =
           recordDeclForTypeOnlyReference(record_decl);
@@ -20897,7 +22846,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
 
       SgClassDeclaration::class_types type_of_class =
           SgClassDeclaration::e_class;
-      switch (record_decl->getTagKind()) {
+      switch (readClangApiValueDefined(
+          [&]() { return record_decl->getTagKind(); })) {
       case clang::TagTypeKind::Struct:
         type_of_class = SgClassDeclaration::e_struct;
         break;
@@ -20914,11 +22864,14 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
         break;
       }
 
-      SgName recordName(record_decl->getNameAsString());
+      SgName recordName(readClangApiValueDefined(
+          [&]() { return record_decl->getNameAsString(); }));
       SgScopeStatement *scope =
           current_scope != nullptr
               ? current_scope
-              : resolve_friend_type_scope(record_decl->getDeclContext());
+              : resolve_friend_type_scope(
+                    markClangDeclContextObjectDefined(readClangApiValueDefined(
+                        [&]() { return record_decl->getDeclContext(); })));
       SgClassDeclaration *sg_friend_class_decl =
           SageBuilder::buildNondefiningClassDeclaration_nfi(
               recordName, type_of_class, scope,
@@ -20936,7 +22889,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
         skip_friend_propagation = true;
       }
     } else if (clang::ClassTemplateDecl *class_template_decl =
-                   llvm::dyn_cast<clang::ClassTemplateDecl>(named_decl)) {
+                   llvm::dyn_cast_or_null<clang::ClassTemplateDecl>(
+                       named_decl)) {
       // Friend class templates are declared in the enclosing namespace, not as
       // members of the class. Override the symbol scope accordingly so the
       // primary template links consistently with its namespace definition.
@@ -20947,7 +22901,7 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
       skip_friend_propagation = true;
     } else {
       if (clang::FunctionDecl *func_decl =
-              llvm::dyn_cast<clang::FunctionDecl>(named_decl)) {
+              llvm::dyn_cast_or_null<clang::FunctionDecl>(named_decl)) {
         const bool
             defer_spelled_friend_template_specialization_to_function_decl =
                 friend_function_is_spelled_on_friend_decl(func_decl) &&
@@ -20958,12 +22912,16 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
           sg_decl = hidden_friend_decl;
           skip_friend_propagation = true;
         } else if (SgFunctionDeclaration *hidden_friend_decl =
-                       lookup_hidden_friend_decl(
-                           func_decl->getCanonicalDecl())) {
+                       lookup_hidden_friend_decl(markClangSpecificDeclDefined(
+                           readClangApiValueDefined([&]() {
+                             return func_decl->getCanonicalDecl();
+                           })))) {
           sg_decl = hidden_friend_decl;
           skip_friend_propagation = true;
         } else if (SgFunctionDeclaration *hidden_friend_decl =
-                       lookup_hidden_friend_decl(func_decl->getFirstDecl())) {
+                       lookup_hidden_friend_decl(markClangSpecificDeclDefined(
+                           readClangApiValueDefined(
+                               [&]() { return func_decl->getFirstDecl(); })))) {
           sg_decl = hidden_friend_decl;
           skip_friend_propagation = true;
         }
@@ -20996,6 +22954,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
                   bool allow_on_demand_translation) -> SgFunctionDeclaration * {
             auto lookup_cached_function_decl =
                 [&](clang::FunctionDecl *decl_key) -> SgFunctionDeclaration * {
+              decl_key = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                  markClangDeclObjectDefinedByKind(decl_key));
               if (decl_key == nullptr) {
                 return nullptr;
               }
@@ -21008,6 +22968,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
               }
               return nullptr;
             };
+            function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                markClangDeclObjectDefinedByKind(function_decl));
             if (function_decl == nullptr) {
               return nullptr;
             }
@@ -21024,7 +22986,11 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
               }
             }
             if (clang::FunctionDecl *first_decl =
-                    function_decl->getFirstDecl()) {
+                    llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                        markClangDeclObjectDefinedByKind(
+                            readClangApiValueDefined([&]() {
+                              return function_decl->getFirstDecl();
+                            })))) {
               if (first_decl != function_decl) {
                 if (SgFunctionDeclaration *mapped_decl =
                         lookup_cached_function_decl(first_decl)) {
@@ -21041,7 +23007,11 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
               }
             }
             if (clang::FunctionDecl *canonical_decl =
-                    function_decl->getCanonicalDecl()) {
+                    llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                        markClangDeclObjectDefinedByKind(
+                            readClangApiValueDefined([&]() {
+                              return function_decl->getCanonicalDecl();
+                            })))) {
               if (canonical_decl != function_decl) {
                 if (SgFunctionDeclaration *mapped_decl =
                         lookup_cached_function_decl(canonical_decl)) {
@@ -21060,7 +23030,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
             return nullptr;
           };
           if (clang::FunctionTemplateDecl *template_decl =
-                  llvm::dyn_cast<clang::FunctionTemplateDecl>(decl)) {
+                  llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+                      markClangDeclObjectDefinedByKind(decl))) {
             auto template_it = p_decl_translation_map.find(template_decl);
             if (template_it != p_decl_translation_map.end()) {
               if (SgFunctionDeclaration *mapped_decl =
@@ -21069,7 +23040,11 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
               }
             }
             if (clang::FunctionDecl *templated_decl =
-                    template_decl->getTemplatedDecl()) {
+                    llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                        markClangDeclObjectDefinedByKind(
+                            readClangApiValueDefined([&]() {
+                              return template_decl->getTemplatedDecl();
+                            })))) {
               if (SgFunctionDeclaration *mapped_decl = lookup_function_decl(
                       templated_decl,
                       /*allow_on_demand_translation=*/false)) {
@@ -21079,19 +23054,28 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
             return nullptr;
           }
           if (clang::FunctionDecl *function_decl =
-                  llvm::dyn_cast<clang::FunctionDecl>(decl)) {
+                  llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                      markClangDeclObjectDefinedByKind(decl))) {
             return lookup_function_decl(function_decl,
                                         /*allow_on_demand_translation=*/true);
           }
           return nullptr;
         };
 
+        clang::NamedDecl *defined_named_decl =
+            llvm::dyn_cast_or_null<clang::NamedDecl>(
+                markClangDeclObjectDefinedByKind(named_decl));
         clang::FunctionDecl *friend_function_decl =
-            llvm::dyn_cast<clang::FunctionDecl>(named_decl);
+            llvm::dyn_cast_or_null<clang::FunctionDecl>(defined_named_decl);
         if (friend_function_decl == nullptr) {
           if (clang::FunctionTemplateDecl *friend_template_decl =
-                  llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-            friend_function_decl = friend_template_decl->getTemplatedDecl();
+                  llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+                      defined_named_decl)) {
+            friend_function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                markClangDeclObjectDefinedByKind(
+                    readClangApiValueDefined([&]() {
+                      return friend_template_decl->getTemplatedDecl();
+                    })));
           }
         }
 
@@ -21103,10 +23087,11 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
                   friend_function_uses_explicit_template_id(
                       friend_function_decl);
           SgFunctionDeclaration *translated_friend_decl =
-              lookup_translated_friend_function(named_decl);
+              lookup_translated_friend_function(defined_named_decl);
           if (!defer_spelled_friend_template_specialization_to_function_decl) {
             if (clang::FunctionTemplateDecl *friend_function_template_decl =
-                    llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
+                    llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
+                        defined_named_decl)) {
               SgTemplateFunctionDeclaration *translated_friend_template_decl =
                   isSgTemplateFunctionDeclaration(translated_friend_decl);
               if (SgTemplateFunctionDeclaration *lexical_friend_template_decl =
@@ -21147,11 +23132,13 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
         }
       }
       if (clang::FunctionDecl *func_decl =
-              llvm::dyn_cast<clang::FunctionDecl>(named_decl)) {
+              llvm::dyn_cast_or_null<clang::FunctionDecl>(
+                  markClangDeclObjectDefinedByKind(named_decl))) {
         if (SgFunctionDeclaration *translated_func =
                 isSgFunctionDeclaration(sg_decl)) {
           if (clang::CXXMethodDecl *method_decl =
-                  llvm::dyn_cast<clang::CXXMethodDecl>(func_decl)) {
+                  llvm::dyn_cast_or_null<clang::CXXMethodDecl>(
+                      markClangDeclObjectDefinedByKind(func_decl))) {
             if (SgMemberFunctionDeclaration *translated_member =
                     isSgMemberFunctionDeclaration(translated_func)) {
               const bool needs_lexical_member_friend_surface =
@@ -21198,72 +23185,116 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
       }
     }
   } else if (clang::TypeSourceInfo *type_info = friend_type_info) {
-    clang::QualType friendQualType = type_info->getType();
-    const clang::Type *friendType = friendQualType.getTypePtr();
+    type_info = markClangTypeSourceInfoDefined(type_info);
+    clang::QualType friendQualType = markClangFunctionTypeBoundaryDefined(
+        readClangApiValueDefined([&]() { return type_info->getType(); }));
+    const clang::Type *friendType =
+        markClangTypeObjectDefinedByClass(friendQualType.getTypePtr());
     auto find_template_specialization_loc =
         [](clang::TypeLoc type_loc) -> clang::TemplateSpecializationTypeLoc {
       markClangTypeLocDataDefined(type_loc);
       while (!type_loc.isNull()) {
         markClangTypeLocDataDefined(type_loc);
-        markClangTypeObjectDefinedByClass(type_loc.getTypePtr());
-        if (auto spec_loc =
-                type_loc.getAs<clang::TemplateSpecializationTypeLoc>()) {
+        markClangTypeObjectDefinedByClass(
+            readClangApiValueDefined([&]() { return type_loc.getTypePtr(); }));
+        clang::TemplateSpecializationTypeLoc spec_loc =
+            readClangApiValueDefined([&]() {
+              return type_loc.getAs<clang::TemplateSpecializationTypeLoc>();
+            });
+        markClangTypeLocDataDefined(spec_loc);
+        if (spec_loc) {
           markClangTypeLocDataDefined(spec_loc);
-          markClangTypeObjectDefinedByClass(spec_loc.getTypePtr());
+          markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+              [&]() { return spec_loc.getTypePtr(); }));
           return spec_loc;
         }
-        type_loc = type_loc.getNextTypeLoc();
+        type_loc = nextClangTypeLocDefined(type_loc);
       }
       return clang::TemplateSpecializationTypeLoc();
     };
 
     auto build_written_template_specialization_type =
         [&](clang::TemplateSpecializationTypeLoc spec_loc) -> SgType * {
+      spec_loc = readClangApiValueDefined([&]() { return spec_loc; });
+      markClangTypeLocDataDefined(spec_loc);
       const clang::TemplateSpecializationType *spec_type =
-          spec_loc.getTypePtr();
+          llvm::dyn_cast_or_null<clang::TemplateSpecializationType>(
+              markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                  [&]() { return spec_loc.getTypePtr(); })));
       if (spec_type == nullptr) {
         return nullptr;
       }
 
-      clang::TemplateName tmpl_name = spec_type->getTemplateName();
+      clang::TemplateName tmpl_name =
+          markClangTemplateNameDefined(readClangApiValueDefined(
+              [&]() { return spec_type->getTemplateName(); }));
       std::string base_name;
-      if (clang::TemplateDecl *template_decl = tmpl_name.getAsTemplateDecl()) {
-        base_name = template_decl->getNameAsString();
+      if (clang::TemplateDecl *template_decl =
+              llvm::dyn_cast_or_null<clang::TemplateDecl>(
+                  markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                      [&]() { return tmpl_name.getAsTemplateDecl(); })))) {
+        base_name = clangNamedDeclNameAsStringDefinedForFrontend(template_decl);
       } else if (const clang::QualifiedTemplateName *qtn =
-                     tmpl_name.getAsQualifiedTemplateName()) {
+                     readClangApiValueDefined([&]() {
+                       return tmpl_name.getAsQualifiedTemplateName();
+                     })) {
         if (clang::TemplateDecl *template_decl =
-                qtn->getUnderlyingTemplate().getAsTemplateDecl()) {
-          base_name = template_decl->getNameAsString();
+                llvm::dyn_cast_or_null<clang::TemplateDecl>(
+                    markClangDeclObjectDefinedByKind(
+                        readClangApiValueDefined([&]() {
+                          return qtn->getUnderlyingTemplate()
+                              .getAsTemplateDecl();
+                        })))) {
+          base_name =
+              clangNamedDeclNameAsStringDefinedForFrontend(template_decl);
         }
       } else if (clang::UsingShadowDecl *using_shadow =
-                     tmpl_name.getAsUsingShadowDecl()) {
-        base_name = using_shadow->getNameAsString();
+                     llvm::dyn_cast_or_null<clang::UsingShadowDecl>(
+                         markClangDeclObjectDefinedByKind(
+                             readClangApiValueDefined([&]() {
+                               return tmpl_name.getAsUsingShadowDecl();
+                             })))) {
+        base_name = clangNamedDeclNameAsStringDefinedForFrontend(using_shadow);
       }
       if (base_name.empty()) {
         return nullptr;
       }
 
       SgTemplateArgumentPtrList tpl_args;
-      for (unsigned i = 0; i < spec_loc.getNumArgs(); ++i) {
-        appendTemplateArguments(tpl_args, spec_loc.getArgLoc(i), true);
+      const unsigned num_args =
+          readClangApiValueDefined([&]() { return spec_loc.getNumArgs(); });
+      for (unsigned i = 0; i < num_args; ++i) {
+        clang::TemplateArgumentLoc arg_loc =
+            readClangApiValueDefined([&]() { return spec_loc.getArgLoc(i); });
+        markClangTemplateArgumentLocDefined(arg_loc);
+        appendTemplateArguments(tpl_args, arg_loc, true);
       }
 
       const bool has_explicit_empty_template_args =
-          spec_loc.getNumArgs() == 0 && spec_loc.getLAngleLoc().isValid() &&
-          spec_loc.getRAngleLoc().isValid();
+          num_args == 0 && readClangApiValueDefined([&]() {
+                             return spec_loc.getLAngleLoc();
+                           }).isValid() &&
+          readClangApiValueDefined([&]() {
+            return spec_loc.getRAngleLoc();
+          }).isValid();
       if (tpl_args.empty() && !has_explicit_empty_template_args) {
         tpl_args = buildTemplateArguments(spec_type);
       }
 
       clang::NestedNameSpecifier qualifier = std::nullopt;
       bool has_template_keyword = false;
-      if (const clang::QualifiedTemplateName *qtn =
-              tmpl_name.getAsQualifiedTemplateName()) {
-        qualifier = qtn->getQualifier();
-        has_template_keyword = qtn->hasTemplateKeyword();
+      if (const clang::QualifiedTemplateName *qtn = readClangApiValueDefined(
+              [&]() { return tmpl_name.getAsQualifiedTemplateName(); })) {
+        qualifier = markClangNestedNameSpecifierDefined(
+            readClangApiValueDefined([&]() { return qtn->getQualifier(); }));
+        has_template_keyword = readClangApiValueDefined(
+            [&]() { return qtn->hasTemplateKeyword(); });
       } else if (const clang::DependentTemplateName *dtn =
-                     tmpl_name.getAsDependentTemplateName()) {
-        qualifier = dtn->getQualifier();
+                     readClangApiValueDefined([&]() {
+                       return tmpl_name.getAsDependentTemplateName();
+                     })) {
+        qualifier = markClangNestedNameSpecifierDefined(
+            readClangApiValueDefined([&]() { return dtn->getQualifier(); }));
         has_template_keyword = true;
       }
 
@@ -21298,27 +23329,38 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
     };
 
     clang::TemplateSpecializationTypeLoc friend_spec_loc =
-        find_template_specialization_loc(type_info->getTypeLoc());
+        find_template_specialization_loc(
+            readClangTypeLocDefined([&]() { return type_info->getTypeLoc(); }));
     if (typeHasElaboratedSpelling(friendType) && friend_spec_loc.isNull()) {
-      friendQualType = friendQualType.getCanonicalType();
-      friendType = friendQualType.getTypePtr();
+      friendQualType =
+          markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+              [&]() { return friendQualType.getCanonicalType(); }));
+      friendType =
+          markClangTypeObjectDefinedByClass(friendQualType.getTypePtr());
     }
 
     clang::TemplateDecl *friend_template_decl = nullptr;
     if (!friend_spec_loc.isNull()) {
-      clang::TemplateName tmpl_name =
-          friend_spec_loc.getTypePtr()->getTemplateName();
-      friend_template_decl = tmpl_name.getAsTemplateDecl();
+      clang::TemplateName tmpl_name = readClangApiValueDefined(
+          [&]() { return friend_spec_loc.getTypePtr()->getTemplateName(); });
+      friend_template_decl = llvm::dyn_cast_or_null<clang::TemplateDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return tmpl_name.getAsTemplateDecl(); })));
     } else if (const clang::TemplateSpecializationType *spec_type =
                    llvm::dyn_cast<clang::TemplateSpecializationType>(
                        friendType)) {
-      clang::TemplateName tmpl_name = spec_type->getTemplateName();
-      friend_template_decl = tmpl_name.getAsTemplateDecl();
+      clang::TemplateName tmpl_name = readClangApiValueDefined(
+          [&]() { return spec_type->getTemplateName(); });
+      friend_template_decl = llvm::dyn_cast_or_null<clang::TemplateDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return tmpl_name.getAsTemplateDecl(); })));
     }
 
     if (const clang::RecordType *record_type =
             llvm::dyn_cast<clang::RecordType>(friendType)) {
-      clang::RecordDecl *recordDecl = record_type->getDecl();
+      clang::RecordDecl *recordDecl = llvm::dyn_cast_or_null<clang::RecordDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return record_type->getDecl(); })));
       if (recordDecl != nullptr) {
         // Ensure the record exists in the translation map before we create a
         // friend entry tied to the current lexical class scope.
@@ -21330,7 +23372,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
 
         SgClassDeclaration::class_types type_of_class =
             SgClassDeclaration::e_class;
-        switch (recordDecl->getTagKind()) {
+        switch (readClangApiValueDefined(
+            [&]() { return recordDecl->getTagKind(); })) {
         case clang::TagTypeKind::Struct:
           type_of_class = SgClassDeclaration::e_struct;
           break;
@@ -21346,11 +23389,13 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
           res = false;
         }
 
-        SgName recordName(recordDecl->getNameAsString());
+        SgName recordName(readClangApiValueDefined(
+            [&]() { return recordDecl->getNameAsString(); }));
         SgScopeStatement *scope =
             current_scope != nullptr
                 ? current_scope
-                : resolve_friend_type_scope(recordDecl->getDeclContext());
+                : resolve_friend_type_scope(readClangApiValueDefined(
+                      [&]() { return recordDecl->getDeclContext(); }));
         SgClassDeclaration *sg_friend_class_decl =
             SageBuilder::buildNondefiningClassDeclaration_nfi(
                 recordName, type_of_class, scope,
@@ -21675,6 +23720,8 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
        isSgTemplateInstantiationDefn(current_scope) != nullptr)) {
     auto record_hidden_friend_decl = [&](const clang::FunctionDecl *key,
                                          SgFunctionDeclaration *decl) {
+      key = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+          markClangDeclObjectDefinedByKind(key));
       if (key != nullptr && decl != nullptr &&
           isSgMemberFunctionDeclaration(decl) == nullptr) {
         p_hidden_friend_function_decl_map[key] = decl;
@@ -21682,15 +23729,21 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
     };
 
     const clang::FunctionDecl *friend_func_decl = nullptr;
-    if (clang::NamedDecl *named_decl = friend_decl->getFriendDecl()) {
+    if (clang::NamedDecl *named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return friend_decl->getFriendDecl(); })))) {
       if (auto *fd = llvm::dyn_cast<clang::FunctionDecl>(named_decl)) {
         friend_func_decl = fd;
       } else if (auto *ft =
                      llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-        friend_func_decl = ft->getTemplatedDecl();
+        friend_func_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return ft->getTemplatedDecl(); })));
       }
     }
 
+    friend_func_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(friend_func_decl));
     if (friend_func_decl != nullptr) {
       SgFunctionDeclaration *lexical_friend_decl =
           isSgFunctionDeclaration(sg_decl);
@@ -21700,9 +23753,13 @@ bool ClangToSageTranslator::VisitFriendDecl(clang::FriendDecl *friend_decl,
               friend_func_decl)] = lexical_friend_decl;
         }
         record_hidden_friend_decl(friend_func_decl, lexical_friend_decl);
-        record_hidden_friend_decl(friend_func_decl->getCanonicalDecl(),
+        record_hidden_friend_decl(readClangApiValueDefined([&]() {
+                                    return friend_func_decl->getCanonicalDecl();
+                                  }),
                                   lexical_friend_decl);
-        record_hidden_friend_decl(friend_func_decl->getFirstDecl(),
+        record_hidden_friend_decl(readClangApiValueDefined([&]() {
+                                    return friend_func_decl->getFirstDecl();
+                                  }),
                                   lexical_friend_decl);
         for (const clang::FunctionDecl *redecl : friend_func_decl->redecls()) {
           record_hidden_friend_decl(redecl, lexical_friend_decl);
@@ -21788,19 +23845,9 @@ bool ClangToSageTranslator::VisitFriendTemplateDecl(
     }
 
     SgTemplateParameterPtrList template_params;
-    for (SgTemplateParameter *param :
-         translated_decl->get_templateParameters()) {
-      if (param == nullptr) {
-        continue;
-      }
-      SgTemplateParameter *copied_param =
-          isSgTemplateParameter(SageInterface::deepCopy(param));
-      if (copied_param == nullptr) {
-        cleanup_unused_param_list(nullptr, param_list);
-        return nullptr;
-      }
-      template_params.push_back(copied_param);
-    }
+    template_params = clone_template_parameter_list_surface(
+        translated_decl->get_templateParameters(),
+        /*preserve_defaults=*/true, /*anchor_nonreals=*/true);
 
     SgTemplateFunctionDeclaration *lexical_decl =
         SageBuilder::buildNondefiningTemplateFunctionDeclaration(
@@ -21843,6 +23890,20 @@ bool ClangToSageTranslator::VisitFriendTemplateDecl(
     }
 
     applySourceRange(lexical_decl, friend_template_decl->getSourceRange());
+    if (p_compiler_instance != nullptr) {
+      clang::SourceRange friend_range = friend_template_decl->getSourceRange();
+      if (friend_range.isValid() &&
+          decl_range_should_consume_trailing_semicolon(friend_template_decl)) {
+        friend_range = extendDeclSourceRangeWithTrailingSemicolon(
+            friend_range, p_compiler_instance->getSourceManager(),
+            p_compiler_instance->getLangOpts());
+      }
+      std::string friend_template_spelling =
+          trimWhitespace(getSourceText(friend_range));
+      if (!friend_template_spelling.empty()) {
+        lexical_decl->set_string(SgName(friend_template_spelling));
+      }
+    }
     lexical_decl->set_firstNondefiningDeclaration(lexical_decl);
     lexical_decl->set_definingDeclaration(nullptr);
     bind_lexical_hidden_friend_decl_to_canonical_chain(lexical_decl,
@@ -23131,13 +25192,33 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
     return nullptr;
   }
 
+  auto count_spelled_default_template_args =
+      [](clang::TemplateParameterList *param_list) -> unsigned {
+    param_list = markClangTemplateParameterListDefined(param_list);
+    if (param_list == nullptr) {
+      return 0;
+    }
+
+    unsigned count = 0;
+    for (clang::NamedDecl *param : *param_list) {
+      if (currentDeclSpellsDefaultTemplateArg(param)) {
+        ++count;
+      }
+    }
+    return count;
+  };
+
   clang::TemplateParameterList *decl_template_params =
       class_template_decl->getTemplateParameters();
   if (const clang::TemplateParameterList *described_params =
           markClangAstObjectDefined(
               templated_decl->getDescribedTemplateParams())) {
-    decl_template_params =
+    clang::TemplateParameterList *mutable_described_params =
         const_cast<clang::TemplateParameterList *>(described_params);
+    if (count_spelled_default_template_args(mutable_described_params) >=
+        count_spelled_default_template_args(decl_template_params)) {
+      decl_template_params = mutable_described_params;
+    }
   }
 
   auto lookup_existing_template_decl =
@@ -23219,12 +25300,14 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
   if (template_name_str.empty()) {
     template_name_str =
         "__anon_template_" +
-        generate_source_position_string(class_template_decl->getBeginLoc());
+        generate_source_position_string(readClangApiValueDefined(
+            [&]() { return class_template_decl->getBeginLoc(); }));
   }
 
   auto clang_decl_precedes_sg_decl =
       [&](const clang::Decl *clang_decl,
           SgDeclarationStatement *sg_decl) -> bool {
+    clang_decl = markClangDeclObjectDefinedByKind(clang_decl);
     if (clang_decl == nullptr || sg_decl == nullptr ||
         p_compiler_instance == nullptr) {
       return false;
@@ -23238,8 +25321,8 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
 
     clang::SourceManager &source_manager =
         p_compiler_instance->getSourceManager();
-    clang::SourceLocation clang_loc =
-        source_manager.getSpellingLoc(clang_decl->getBeginLoc());
+    clang::SourceLocation clang_loc = source_manager.getSpellingLoc(
+        readClangApiValueDefined([&]() { return clang_decl->getBeginLoc(); }));
     if (!clang_loc.isValid()) {
       return false;
     }
@@ -23266,6 +25349,7 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
   auto clang_decl_matches_sg_decl_source =
       [&](const clang::Decl *clang_decl,
           SgDeclarationStatement *sg_decl) -> bool {
+    clang_decl = markClangDeclObjectDefinedByKind(clang_decl);
     if (clang_decl == nullptr || sg_decl == nullptr ||
         p_compiler_instance == nullptr) {
       return false;
@@ -23278,8 +25362,8 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
 
     clang::SourceManager &source_manager =
         p_compiler_instance->getSourceManager();
-    clang::SourceLocation clang_loc =
-        source_manager.getSpellingLoc(clang_decl->getBeginLoc());
+    clang::SourceLocation clang_loc = source_manager.getSpellingLoc(
+        readClangApiValueDefined([&]() { return clang_decl->getBeginLoc(); }));
     if (!clang_loc.isValid()) {
       return false;
     }
@@ -23303,16 +25387,18 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
     if (lhs == rhs) {
       return true;
     }
+    lhs = markClangDeclObjectDefinedByKind(lhs);
+    rhs = markClangDeclObjectDefinedByKind(rhs);
     if (lhs == nullptr || rhs == nullptr || p_compiler_instance == nullptr) {
       return false;
     }
 
     clang::SourceManager &source_manager =
         p_compiler_instance->getSourceManager();
-    clang::SourceLocation lhs_loc =
-        source_manager.getSpellingLoc(lhs->getBeginLoc());
-    clang::SourceLocation rhs_loc =
-        source_manager.getSpellingLoc(rhs->getBeginLoc());
+    clang::SourceLocation lhs_loc = source_manager.getSpellingLoc(
+        readClangApiValueDefined([&]() { return lhs->getBeginLoc(); }));
+    clang::SourceLocation rhs_loc = source_manager.getSpellingLoc(
+        readClangApiValueDefined([&]() { return rhs->getBeginLoc(); }));
     if (!lhs_loc.isValid() || !rhs_loc.isValid()) {
       return false;
     }
@@ -23324,7 +25410,8 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
                source_manager.getSpellingColumnNumber(rhs_loc);
   };
   clang::ClassTemplateDecl *previous_template_decl =
-      class_template_decl->getPreviousDecl();
+      markClangSpecificDeclDefined(readClangApiValueDefined(
+          [&]() { return class_template_decl->getPreviousDecl(); }));
   const bool has_distinct_source_previous_template_decl =
       previous_template_decl != nullptr &&
       !clang_decls_share_spelling_location(previous_template_decl,
@@ -23333,7 +25420,7 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
   const bool current_decl_precedes_existing_exact =
       clang_decl_precedes_sg_decl(source_decl, existing_exact_decl);
   const bool current_decl_is_first_nondef =
-      !is_definition && class_template_decl->getPreviousDecl() == nullptr;
+      !is_definition && previous_template_decl == nullptr;
   const bool existing_exact_matches_current_source =
       clang_decl_matches_sg_decl_source(source_decl, existing_exact_decl);
   const bool can_reuse_existing_exact_decl =
@@ -23592,17 +25679,9 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
       clang_decl_precedes_sg_decl(source_decl, existing_nondefining_decl);
   auto clone_template_params = [](const SgTemplateParameterPtrList &source)
       -> SgTemplateParameterPtrList {
-    SgTemplateParameterPtrList copies;
-    copies.reserve(source.size());
-    for (SgTemplateParameter *param : source) {
-      if (SgTemplateParameter *param_copy =
-              isSgTemplateParameter(SageInterface::deepCopy(param))) {
-        copies.push_back(param_copy);
-      }
-    }
-    anchor_copied_template_parameter_nonreals(copies,
-                                              SageBuilder::topScopeStack());
-    return copies;
+    return clone_template_parameter_list_surface(source,
+                                                 /*preserve_defaults=*/true,
+                                                 /*anchor_nonreals=*/true);
   };
 
   SgTemplateParameterPtrList saved_existing_nondefining_decl_params;
@@ -23969,8 +26048,10 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
 
           if (auto *type_param =
                   llvm::dyn_cast<clang::TemplateTypeParmDecl>(clang_param)) {
+            const bool spells_default =
+                currentDeclSpellsDefaultTemplateArg(type_param);
             if (sg_param->get_defaultTypeParameter() == nullptr &&
-                currentDeclSpellsDefaultTemplateArg(type_param)) {
+                spells_default) {
               const clang::TemplateArgumentLoc &default_loc =
                   type_param->getDefaultArgument();
               const clang::TemplateArgument &default_arg =
@@ -24385,6 +26466,9 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
   SgTemplateClassDeclaration *restore_nondefining_decl =
       first_nondefining_decl != nullptr ? first_nondefining_decl
                                         : nondefining_decl;
+  const bool restored_saved_nondefining_decl_params =
+      !saved_nondefining_decl_params.empty() &&
+      restore_nondefining_decl != nullptr;
   if (!saved_nondefining_decl_params.empty() &&
       restore_nondefining_decl != nullptr) {
     for (SgTemplateParameter *param_copy : saved_nondefining_decl_params) {
@@ -24409,6 +26493,19 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
     attach_nonreal_template_parameters(
         existing_nondefining_decl,
         *SageBuilder::getTemplateParameterList(existing_nondefining_decl));
+  }
+
+  if (restore_nondefining_decl != nullptr &&
+      !restored_saved_nondefining_decl_params) {
+    apply_missing_default_template_args(
+        restore_nondefining_decl->get_templateParameters(),
+        decl_template_params);
+  }
+  if (existing_nondefining_decl != nullptr &&
+      existing_nondefining_decl != restore_nondefining_decl) {
+    apply_missing_default_template_args(
+        existing_nondefining_decl->get_templateParameters(),
+        decl_template_params);
   }
 
   if (!is_definition && nondefining_decl != nullptr) {
@@ -24520,17 +26617,8 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
         continue;
       }
 
-      clang::NamedDecl *clang_param =
-          decl_template_params != nullptr &&
-                  i < static_cast<size_t>(decl_template_params->size())
-              ? decl_template_params->getParam(i)
-              : nullptr;
-
       SgTemplateParameter *param_copy =
-          isSgTemplateParameter(SageInterface::deepCopy(param));
-      if (param_copy == nullptr) {
-        continue;
-      }
+          clone_template_parameter_surface(param, /*preserve_defaults=*/true);
 
       reparent_copied_template_parameter(param_copy, template_decl);
 
@@ -24795,35 +26883,10 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
     auto build_stripped_template_param_copy =
         [&](const SgTemplateParameterPtrList &source)
         -> std::unique_ptr<SgTemplateParameterPtrList> {
-      auto copied_params = std::make_unique<SgTemplateParameterPtrList>();
-      copied_params->reserve(source.size());
-      for (SgTemplateParameter *param : source) {
-        if (param == nullptr) {
-          continue;
-        }
-
-        SgTemplateParameter *param_copy =
-            isSgTemplateParameter(SageInterface::deepCopy(param));
-        if (param_copy == nullptr) {
-          continue;
-        }
-
-        param_copy->set_parent(nullptr);
-        if (param_copy->get_parameterType() !=
-            SgTemplateParameter::template_parameter) {
-          param_copy->set_templateDeclaration(nullptr);
-        }
-        if (SgInitializedName *init_name = param_copy->get_initializedName()) {
-          init_name->set_parent(param_copy);
-        }
-        if (SgExpression *constraint = param_copy->get_typeConstraint()) {
-          attach_template_parameter_expression(param_copy, constraint);
-        }
-        param_copy->set_defaultTypeParameter(nullptr);
-        param_copy->set_defaultExpressionParameter(nullptr);
-        param_copy->set_defaultTemplateDeclarationParameter(nullptr);
-        copied_params->push_back(param_copy);
-      }
+      auto copied_params = std::make_unique<SgTemplateParameterPtrList>(
+          clone_template_parameter_list_surface(source,
+                                                /*preserve_defaults=*/false,
+                                                /*anchor_nonreals=*/true));
       return copied_params;
     };
 
@@ -25298,24 +27361,17 @@ SgTemplateClassDeclaration *ClangToSageTranslator::translateClassTemplateDecl(
                                    p_sage_source_file,
                                    p_sage_preprocessor_recorder);
   if (!template_is_system_only) {
-    clang::ClassTemplateDecl::spec_range specializations =
-        class_template_decl->specializations();
-    for (clang::ClassTemplateDecl::spec_iterator it = specializations.begin(),
-                                                 end = specializations.end();
-         it != end; ++it) {
-      clang::ClassTemplateSpecializationDecl *entry = nullptr;
-#if ROSE_USE_VALGRIND
-      if (RUNNING_ON_VALGRIND) {
-        // Clang's public SpecIterator reaches into its protected FoldingSet and
-        // calls getMostRecentDecl before REX can mark the specialization entry.
-        VALGRIND_DISABLE_ERROR_REPORTING;
-        entry = *it;
-        VALGRIND_ENABLE_ERROR_REPORTING;
-      } else
-#endif
-      {
-        entry = *it;
-      }
+    clang::ClassTemplateDecl::spec_iterator it = readClangApiValueDefined(
+        [&]() { return class_template_decl->spec_begin(); });
+    clang::ClassTemplateDecl::spec_iterator end = readClangApiValueDefined(
+        [&]() { return class_template_decl->spec_end(); });
+    for (; it != end;) {
+      clang::ClassTemplateSpecializationDecl *entry =
+          readClangApiValueDefined([&]() { return *it; });
+      readClangApiValueDefined([&]() {
+        ++it;
+        return true;
+      });
       clang::ClassTemplateSpecializationDecl *spec =
           llvm::cast_or_null<clang::ClassTemplateSpecializationDecl>(
               markClangClassTemplateSpecializationStateDefined(entry));
@@ -25572,24 +27628,32 @@ bool ClangToSageTranslator::VisitFunctionTemplateDecl(
     }
   };
 
-  for (auto it = function_template_decl->spec_begin();
-       it != function_template_decl->spec_end(); ++it) {
-    clang::FunctionDecl *spec = *it;
+  auto spec_begin = readClangApiValueDefined(
+      [&]() { return function_template_decl->spec_begin(); });
+  auto spec_end = readClangApiValueDefined(
+      [&]() { return function_template_decl->spec_end(); });
+  for (auto it = spec_begin; it != spec_end; ++it) {
+    clang::FunctionDecl *spec = readClangApiValueDefined([&]() { return *it; });
+    spec = markClangSpecificDeclDefined(spec);
     if (spec == nullptr) {
       continue;
     }
-    if (spec->isInvalidDecl()) {
+    if (readClangApiValueDefined([&]() { return spec->isInvalidDecl(); })) {
       translate_spec_if_needed(spec);
       continue;
     }
 
-    clang::TemplateSpecializationKind kind =
-        spec->getTemplateSpecializationKind();
+    clang::TemplateSpecializationKind kind = readClangApiValueDefined(
+        [&]() { return spec->getTemplateSpecializationKind(); });
     if (kind == clang::TSK_ExplicitInstantiationDeclaration ||
         kind == clang::TSK_ExplicitInstantiationDefinition) {
+      clang::DeclContext *lexical_context =
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return spec->getLexicalDeclContext(); }));
       const bool needs_member_rehoming =
-          spec->getLexicalDeclContext() != nullptr &&
-          spec->getLexicalDeclContext()->isRecord();
+          lexical_context != nullptr && readClangApiValueDefined([&]() {
+            return lexical_context->isRecord();
+          });
       if (!needs_member_rehoming) {
         SgNode *spec_node = nullptr;
         translate_spec_if_needed(spec);
@@ -26406,12 +28470,14 @@ bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
     if (existing_def_decl == nullptr) {
       existing_def_decl = reused_existing_decl;
     }
-    clang::RecordDecl *def_record = record_decl->getDefinition();
-    if (def_record == nullptr && record_decl->isThisDeclarationADefinition()) {
+    clang::RecordDecl *def_record = clangRecordDefinitionDefined(record_decl);
+    const bool record_decl_is_definition = readClangApiValueDefined(
+        [&]() { return record_decl->isThisDeclarationADefinition(); });
+    if (def_record == nullptr && record_decl_is_definition) {
       def_record = record_decl;
     }
     const bool deferred_definition_needs_completion =
-        !needs_definition && !record_decl->isThisDeclarationADefinition() &&
+        !needs_definition && !record_decl_is_definition &&
         !current_record_on_demand_translation && def_record != nullptr &&
         existing_def_decl != nullptr &&
         existing_def_decl->get_definition() != nullptr &&
@@ -26449,13 +28515,91 @@ bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
                 deferred_definition_needs_completion ? 1 : 0);
       }
     }
+    auto located_node_has_output_source = [](SgLocatedNode *target) -> bool {
+      if (target == nullptr) {
+        return false;
+      }
+      auto output_source_info = [](Sg_File_Info *info) -> bool {
+        return has_real_source_file_info(info) &&
+               info->isOutputInCodeGeneration();
+      };
+      return output_source_info(target->get_startOfConstruct()) ||
+             output_source_info(target->get_file_info()) ||
+             output_source_info(target->get_endOfConstruct());
+    };
+    const bool existing_definition_is_complete_source_surface =
+        !needs_definition && record_decl->isThisDeclarationADefinition() &&
+        !deferred_definition_needs_completion && existing_def_decl != nullptr &&
+        existing_def_decl->get_definition() != nullptr &&
+        p_record_definitions_populated.find(
+            existing_def_decl->get_definition()) !=
+            p_record_definitions_populated.end() &&
+        located_node_has_output_source(existing_def_decl) &&
+        located_node_has_output_source(existing_def_decl->get_definition());
+    if (existing_definition_is_complete_source_surface) {
+      p_decl_translation_map[record_decl] = existing_def_decl;
+      *node = existing_def_decl;
+      return true;
+    }
     if ((!needs_definition && record_decl->isThisDeclarationADefinition()) ||
         deferred_definition_needs_completion) {
       if (existing_def_decl != nullptr &&
           existing_def_decl->get_definition() != nullptr) {
         SgClassDefinition *existing_def = existing_def_decl->get_definition();
-        applySourceRange(existing_def_decl, record_decl->getSourceRange());
-        applySourceRange(existing_def, record_decl->getSourceRange());
+        auto apply_source_range_preserving_existing_real_source =
+            [&](SgLocatedNode *target, clang::SourceRange source_range) {
+              if (target == nullptr) {
+                return;
+              }
+
+              const bool had_real_source = located_node_has_real_source(target);
+              Sg_File_Info *saved_file_info =
+                  had_real_source && target->get_file_info() != nullptr
+                      ? new Sg_File_Info(*target->get_file_info())
+                      : nullptr;
+              Sg_File_Info *saved_start =
+                  had_real_source && target->get_startOfConstruct() != nullptr
+                      ? new Sg_File_Info(*target->get_startOfConstruct())
+                      : nullptr;
+              Sg_File_Info *saved_end =
+                  had_real_source && target->get_endOfConstruct() != nullptr
+                      ? new Sg_File_Info(*target->get_endOfConstruct())
+                      : nullptr;
+
+              applySourceRange(target, source_range);
+
+              if (had_real_source && !located_node_has_real_source(target)) {
+                std::set<Sg_File_Info *> replaced_infos = {
+                    target->get_file_info(), target->get_startOfConstruct(),
+                    target->get_endOfConstruct()};
+                for (Sg_File_Info *info : replaced_infos) {
+                  delete info;
+                }
+
+                target->set_file_info(saved_file_info);
+                if (saved_file_info != nullptr) {
+                  saved_file_info->set_parent(target);
+                }
+                target->set_startOfConstruct(saved_start);
+                if (saved_start != nullptr) {
+                  saved_start->set_parent(target);
+                }
+                target->set_endOfConstruct(saved_end);
+                if (saved_end != nullptr) {
+                  saved_end->set_parent(target);
+                }
+                return;
+              }
+
+              delete saved_file_info;
+              delete saved_start;
+              delete saved_end;
+            };
+        clang::SourceRange record_source_range = record_decl->getSourceRange();
+        apply_source_range_preserving_existing_real_source(existing_def_decl,
+                                                           record_source_range);
+        apply_source_range_preserving_existing_real_source(existing_def,
+                                                           record_source_range);
         if (SgClassDeclaration *def_anchor =
                 isSgClassDeclaration(existing_def->get_declaration())) {
           copy_real_source_range_from_located_node_if_missing(existing_def_decl,
@@ -26810,14 +28954,19 @@ bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
   // incorrectly nest namespace-scope records inside the current class scope
   // (Issue 69).
   clang::DeclContext *semantic_context =
-      markClangDeclContextObjectDefined(record_decl->getDeclContext());
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return record_decl->getDeclContext(); }));
   clang::DeclContext *lexical_context =
-      markClangDeclContextObjectDefined(record_decl->getLexicalDeclContext());
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return record_decl->getLexicalDeclContext(); }));
 
   auto skip_linkage_context = [](clang::DeclContext *ctx) {
     ctx = markClangDeclContextObjectDefined(ctx);
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = markClangDeclContextObjectDefined(ctx->getParent());
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
     return ctx;
   };
@@ -27740,31 +29889,48 @@ bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
       detach_decl_from_known_scope_child_lists(sg_intermediate_class_decl);
     }
   }
+  clang::DeclContext *embedded_semantic_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return record_decl->getDeclContext(); }));
   clang::RecordDecl *parent_decl =
-      llvm::dyn_cast_or_null<clang::RecordDecl>(record_decl->getDeclContext());
+      llvm::dyn_cast_or_null<clang::RecordDecl>(embedded_semantic_context);
+  parent_decl = markClangSpecificDeclDefined(parent_decl);
+  clang::DeclContext *embedded_lexical_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return record_decl->getLexicalDeclContext(); }));
   clang::RecordDecl *lexical_parent_decl =
-      llvm::dyn_cast_or_null<clang::RecordDecl>(
-          record_decl->getLexicalDeclContext());
+      llvm::dyn_cast_or_null<clang::RecordDecl>(embedded_lexical_context);
+  lexical_parent_decl = markClangSpecificDeclDefined(lexical_parent_decl);
   clang::RecordDecl *field_owner_decl =
       parent_decl != nullptr ? parent_decl : lexical_parent_decl;
   clang::SourceManager *embedded_source_manager =
       p_compiler_instance != nullptr ? &p_compiler_instance->getSourceManager()
                                      : nullptr;
-  bool is_inline_tag_decl =
-      p_inline_tag_decls.find(record_decl->getCanonicalDecl()) !=
-      p_inline_tag_decls.end();
-  const bool embedded_by_declarator = record_decl->isEmbeddedInDeclarator();
+  clang::TagDecl *canonical_record_decl =
+      markClangSpecificDeclDefined(readClangApiValueDefined(
+          [&]() { return record_decl->getCanonicalDecl(); }));
+  bool is_inline_tag_decl = p_inline_tag_decls.find(canonical_record_decl) !=
+                            p_inline_tag_decls.end();
+  const bool embedded_by_declarator = readClangApiValueDefined(
+      [&]() { return record_decl->isEmbeddedInDeclarator(); });
   const bool embedded_declarator_needs_suppression =
-      embedded_by_declarator && record_decl->isThisDeclarationADefinition();
+      embedded_by_declarator && readClangApiValueDefined([&]() {
+        return record_decl->isThisDeclarationADefinition();
+      });
   bool embedded_in_field = isTagEmbeddedInField(record_decl, field_owner_decl,
                                                 embedded_source_manager, true);
   const bool embedded_field_forward_decl =
-      embedded_in_field && !record_decl->isThisDeclarationADefinition();
+      embedded_in_field && !readClangApiValueDefined([&]() {
+        return record_decl->isThisDeclarationADefinition();
+      });
   const bool semantic_outer_embedded_tag = semantic_outer_named_definition;
   const bool inline_tag_definition_needs_suppression =
-      is_inline_tag_decl && record_decl->isThisDeclarationADefinition();
+      is_inline_tag_decl && readClangApiValueDefined([&]() {
+        return record_decl->isThisDeclarationADefinition();
+      });
   bool non_standalone_forward_tag_decl = false;
-  if (!record_decl->isThisDeclarationADefinition() &&
+  if (!readClangApiValueDefined(
+          [&]() { return record_decl->isThisDeclarationADefinition(); }) &&
       embedded_source_manager != nullptr && p_compiler_instance != nullptr) {
     non_standalone_forward_tag_decl = !tagForwardDeclHasStandaloneSemicolon(
         record_decl, *embedded_source_manager,
@@ -27774,7 +29940,9 @@ bool ClangToSageTranslator::VisitRecordDecl(clang::RecordDecl *record_decl,
       embedded_field_forward_decl || non_standalone_forward_tag_decl ||
       (!semantic_outer_embedded_tag && embedded_declarator_needs_suppression) ||
       (!semantic_outer_embedded_tag &&
-       record_decl->getTypedefNameForAnonDecl() != nullptr) ||
+       readClangApiValueDefined([&]() {
+         return record_decl->getTypedefNameForAnonDecl();
+       }) != nullptr) ||
       (!semantic_outer_embedded_tag &&
        inline_tag_definition_needs_suppression) ||
       embedded_in_field;
@@ -28587,7 +30755,9 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
   };
 
   clang::TemplateSpecializationKind specialization_kind =
-      class_tpl_spec_decl->getTemplateSpecializationKind();
+      readClangApiValueDefined([&]() {
+        return class_tpl_spec_decl->getTemplateSpecializationKind();
+      });
   bool is_explicit_instantiation =
       specialization_kind == clang::TSK_ExplicitInstantiationDeclaration ||
       specialization_kind == clang::TSK_ExplicitInstantiationDefinition;
@@ -28595,33 +30765,38 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
       specialization_kind == clang::TSK_ExplicitInstantiationDeclaration;
   clang::CXXRecordDecl *definition_decl =
       llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-          markClangDeclObjectDefinedByKind(
-              class_tpl_spec_decl->getDefinition()));
-  if (definition_decl == nullptr &&
-      class_tpl_spec_decl->isThisDeclarationADefinition()) {
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return class_tpl_spec_decl->getDefinition(); })));
+  if (definition_decl == nullptr && readClangApiValueDefined([&]() {
+        return class_tpl_spec_decl->isThisDeclarationADefinition();
+      })) {
     definition_decl = class_tpl_spec_decl;
   }
   definition_decl = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
       markClangDeclObjectDefinedByKind(definition_decl));
   const bool has_definition = definition_decl != nullptr;
-  const bool is_definition_decl =
-      class_tpl_spec_decl->isThisDeclarationADefinition();
-  clang::SourceRange specialization_source_range =
-      class_tpl_spec_decl->getSourceRange();
+  const bool is_definition_decl = readClangApiValueDefined(
+      [&]() { return class_tpl_spec_decl->isThisDeclarationADefinition(); });
+  clang::SourceRange specialization_source_range = readClangApiValueDefined(
+      [&]() { return class_tpl_spec_decl->getSourceRange(); });
   markClangValueDefined(specialization_source_range);
   clang::SourceRange defining_source_range =
-      definition_decl != nullptr ? definition_decl->getSourceRange()
+      definition_decl != nullptr ? readClangApiValueDefined([&]() {
+        return definition_decl->getSourceRange();
+      })
                                  : specialization_source_range;
   markClangValueDefined(defining_source_range);
 
   clang::TemplateDecl *specialized_template =
       llvm::dyn_cast_or_null<clang::TemplateDecl>(
-          markClangDeclObjectDefinedByKind(
-              class_tpl_spec_decl->getSpecializedTemplate()));
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+            return class_tpl_spec_decl->getSpecializedTemplate();
+          })));
 
   // Resolve class kind early so fallback template declarations can use it.
   SgClassDeclaration::class_types class_kind = SgClassDeclaration::e_class;
-  switch (class_tpl_spec_decl->getTagKind()) {
+  switch (readClangApiValueDefined(
+      [&]() { return class_tpl_spec_decl->getTagKind(); })) {
   case clang::TagTypeKind::Struct:
     class_kind = SgClassDeclaration::e_struct;
     break;
@@ -28653,7 +30828,9 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
   };
 
   if (specialized_template == nullptr) {
-    auto specialized = class_tpl_spec_decl->getSpecializedTemplateOrPartial();
+    auto specialized = readClangApiValueDefined([&]() {
+      return class_tpl_spec_decl->getSpecializedTemplateOrPartial();
+    });
     if (auto *class_template =
             specialized.dyn_cast<clang::ClassTemplateDecl *>()) {
       specialized_template = llvm::dyn_cast_or_null<clang::TemplateDecl>(
@@ -28962,24 +31139,31 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
     }
   }
 
-  clang::DeclContext *decl_context = class_tpl_spec_decl->getDeclContext();
+  clang::DeclContext *decl_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return class_tpl_spec_decl->getDeclContext(); }));
   clang::DeclContext *lexical_context =
-      class_tpl_spec_decl->getLexicalDeclContext();
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return class_tpl_spec_decl->getLexicalDeclContext(); }));
   clang::DeclContext *instantiation_context = decl_context;
   if (is_explicit_instantiation && lexical_context != nullptr) {
     instantiation_context = lexical_context;
   }
+  instantiation_context =
+      markClangDeclContextObjectDefined(instantiation_context);
+  const bool instantiation_context_is_translation_unit =
+      instantiation_context != nullptr && readClangApiValueDefined([&]() {
+        return instantiation_context->isTranslationUnit();
+      });
 
   SgScopeStatement *instantiation_scope =
-      (instantiation_context != nullptr &&
-       instantiation_context->isTranslationUnit())
-          ? getGlobalScope()
-          : SageBuilder::topScopeStack();
+      instantiation_context_is_translation_unit ? getGlobalScope()
+                                                : SageBuilder::topScopeStack();
 
   // Check if we can get a better scope from the DeclContext
-  if (instantiation_context && !instantiation_context->isTranslationUnit()) {
-    clang::Decl *context_decl =
-        llvm::dyn_cast<clang::Decl>(instantiation_context);
+  if (instantiation_context && !instantiation_context_is_translation_unit) {
+    clang::Decl *context_decl = markClangDeclObjectDefinedByKind(
+        llvm::dyn_cast<clang::Decl>(instantiation_context));
     if (context_decl) {
       SgNode *context_node = nullptr;
       auto it = p_decl_translation_map.find(context_decl);
@@ -29015,6 +31199,26 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
     instantiation_scope = getGlobalScope();
   }
 
+  auto make_namespace_scope_reachable =
+      [&](SgScopeStatement *candidate,
+          clang::DeclContext *context) -> SgScopeStatement * {
+    if (candidate == nullptr || scopeReachableFromCurrentFile(candidate)) {
+      return candidate;
+    }
+    if (isSgGlobal(candidate) == nullptr &&
+        isSgNamespaceDefinitionStatement(candidate) == nullptr) {
+      return candidate;
+    }
+
+    if (SgScopeStatement *reachable = resolveReachableNamespaceScope(context)) {
+      return reachable;
+    }
+    return getGlobalScope();
+  };
+
+  instantiation_scope = make_namespace_scope_reachable(instantiation_scope,
+                                                       instantiation_context);
+
   SgScopeStatement *class_scope = nullptr;
   if (specialized_template != nullptr) {
     clang::DeclContext *template_context =
@@ -29043,12 +31247,15 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
       (decl_context == nullptr || !decl_context->isRecord())) {
     class_scope = instantiation_scope;
   }
+  class_scope = make_namespace_scope_reachable(class_scope, decl_context);
 
   SgScopeStatement *lexical_scope =
       resolveScopeFromDeclContext(lexical_context, nullptr);
   if (lexical_scope == nullptr) {
     lexical_scope = instantiation_scope;
   }
+  lexical_scope =
+      make_namespace_scope_reachable(lexical_scope, lexical_context);
 
   if (instantiation_scope == nullptr) {
     instantiation_scope = getGlobalScope();
@@ -29061,6 +31268,7 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
   if (symbol_scope == nullptr) {
     symbol_scope = getGlobalScope();
   }
+  symbol_scope = make_namespace_scope_reachable(symbol_scope, decl_context);
 
   SgScopeStatement *scope = symbol_scope;
   SgScopeStatement *parent_scope = class_scope;
@@ -29155,8 +31363,8 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
     return stub;
   };
 
-  auto specialized_or_partial =
-      class_tpl_spec_decl->getSpecializedTemplateOrPartial();
+  auto specialized_or_partial = readClangApiValueDefined(
+      [&]() { return class_tpl_spec_decl->getSpecializedTemplateOrPartial(); });
   const bool specialization_is_partial =
       specialized_or_partial
           .dyn_cast<clang::ClassTemplatePartialSpecializationDecl *>() !=
@@ -30092,8 +32300,7 @@ bool ClangToSageTranslator::VisitClassTemplateSpecializationDecl(
       instantiation_directive->set_declaration(nondef_decl);
       instantiation_directive->set_scope(instantiation_scope);
       instantiation_directive->set_parent(instantiation_scope);
-      applySourceRange(instantiation_directive,
-                       class_tpl_spec_decl->getSourceRange());
+      applySourceRange(instantiation_directive, specialization_source_range);
       nondef_decl->set_parent(instantiation_directive);
       if (nondef_decl->get_scope() == nullptr) {
         SgScopeStatement *decl_scope = scope;
@@ -30580,24 +32787,27 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
     if (result == nullptr) {
       return;
     }
-    p_decl_translation_map[class_tpl_part_spec_decl] = result;
-    if (clang::CXXRecordDecl *definition_decl =
-            class_tpl_part_spec_decl->getDefinition()) {
-      p_decl_translation_map[definition_decl] = result;
-    }
-    if (clang::CXXRecordDecl *canonical =
-            class_tpl_part_spec_decl->getCanonicalDecl()) {
-      p_decl_translation_map[canonical] = result;
-    }
+    auto cache_key = [&](clang::CXXRecordDecl *key) {
+      key = markClangSpecificDeclDefined(key);
+      if (key != nullptr) {
+        p_decl_translation_map[key] = result;
+      }
+    };
+
+    cache_key(class_tpl_part_spec_decl);
+    cache_key(clangCXXRecordDefinitionDefined(class_tpl_part_spec_decl));
+    cache_key(clangCXXRecordCanonicalDeclDefined(class_tpl_part_spec_decl));
     for (clang::CXXRecordDecl *prev =
-             class_tpl_part_spec_decl->getPreviousDecl();
-         prev != nullptr; prev = prev->getPreviousDecl()) {
-      p_decl_translation_map[prev] = result;
+             clangCXXRecordPreviousDeclDefined(class_tpl_part_spec_decl);
+         prev != nullptr; prev = clangCXXRecordPreviousDeclDefined(prev)) {
+      cache_key(prev);
     }
   };
 
   auto existing_partial_translation = [&]() -> SgTemplateClassDeclaration * {
-    auto lookup = [&](clang::Decl *key) -> SgTemplateClassDeclaration * {
+    auto lookup =
+        [&](clang::CXXRecordDecl *key) -> SgTemplateClassDeclaration * {
+      key = markClangSpecificDeclDefined(key);
       if (key == nullptr) {
         return nullptr;
       }
@@ -30612,16 +32822,16 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
       return decl;
     }
     if (SgTemplateClassDeclaration *decl =
-            lookup(class_tpl_part_spec_decl->getDefinition())) {
+            lookup(clangCXXRecordDefinitionDefined(class_tpl_part_spec_decl))) {
       return decl;
     }
-    if (SgTemplateClassDeclaration *decl =
-            lookup(class_tpl_part_spec_decl->getCanonicalDecl())) {
+    if (SgTemplateClassDeclaration *decl = lookup(
+            clangCXXRecordCanonicalDeclDefined(class_tpl_part_spec_decl))) {
       return decl;
     }
     for (clang::CXXRecordDecl *prev =
-             class_tpl_part_spec_decl->getPreviousDecl();
-         prev != nullptr; prev = prev->getPreviousDecl()) {
+             clangCXXRecordPreviousDeclDefined(class_tpl_part_spec_decl);
+         prev != nullptr; prev = clangCXXRecordPreviousDeclDefined(prev)) {
       if (SgTemplateClassDeclaration *decl = lookup(prev)) {
         return decl;
       }
@@ -30729,9 +32939,20 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
       }
       unsigned index = parm_type->getIndex();
       if (clang::TemplateParameterList *params =
-              class_tpl_part_spec_decl->getTemplateParameters()) {
-        if (index < params->size()) {
-          std::string param_name = params->getParam(index)->getNameAsString();
+              markClangTemplateParameterListDefined(
+                  readClangApiValueDefined([&]() {
+                    return class_tpl_part_spec_decl->getTemplateParameters();
+                  }))) {
+        if (index <
+            readClangApiValueDefined([&]() { return params->size(); })) {
+          clang::NamedDecl *param_decl =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return params->getParam(index); }));
+          std::string param_name = param_decl != nullptr
+                                       ? readClangApiValueDefined([&]() {
+                                           return param_decl->getNameAsString();
+                                         })
+                                       : std::string();
           if (!param_name.empty()) {
             name = param_name;
           }
@@ -30747,23 +32968,33 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
     };
     auto append_arg_loc =
         [&](const clang::TemplateArgumentLoc &arg_loc) -> void {
-      const clang::TemplateArgument &arg = arg_loc.getArgument();
-      if (arg.getKind() == clang::TemplateArgument::Pack) {
-        for (const clang::TemplateArgument &pack_arg : arg.pack_elements()) {
+      const clang::TemplateArgumentLoc &defined_arg_loc =
+          markClangTemplateArgumentLocDefined(arg_loc);
+      const clang::TemplateArgument &arg =
+          markClangTemplateArgumentDefined(defined_arg_loc.getArgument());
+      if (readClangApiValueDefined([&]() { return arg.getKind(); }) ==
+          clang::TemplateArgument::Pack) {
+        for (const clang::TemplateArgument &pack_arg :
+             markClangTemplateArgumentArrayDefined(readClangApiValueDefined(
+                 [&]() { return arg.pack_elements(); }))) {
           append_arg(pack_arg, append_arg);
         }
         return;
       }
 
       size_t before = target_list.size();
-      appendTemplateArguments(target_list, arg_loc, true);
+      appendTemplateArguments(target_list, defined_arg_loc, true);
 
-      if (arg.getKind() != clang::TemplateArgument::Type ||
+      if (readClangApiValueDefined([&]() { return arg.getKind(); }) !=
+              clang::TemplateArgument::Type ||
           target_list.size() == before) {
         return;
       }
 
-      const clang::Type *type_ptr = arg.getAsType().getTypePtr();
+      const clang::Type *type_ptr =
+          markClangQualTypeDefined(readClangApiValueDefined([&]() {
+            return arg.getAsType();
+          })).getTypePtr();
       const clang::TemplateTypeParmType *parm_type =
           findTemplateParamType(type_ptr);
       if (parm_type == nullptr) {
@@ -30771,14 +33002,29 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
       }
 
       std::string name;
-      if (clang::TemplateTypeParmDecl *decl = parm_type->getDecl()) {
-        name = decl->getNameAsString();
+      if (clang::TemplateTypeParmDecl *decl =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return parm_type->getDecl(); }))) {
+        name =
+            readClangApiValueDefined([&]() { return decl->getNameAsString(); });
       }
-      unsigned index = parm_type->getIndex();
+      unsigned index =
+          readClangApiValueDefined([&]() { return parm_type->getIndex(); });
       if (clang::TemplateParameterList *params =
-              class_tpl_part_spec_decl->getTemplateParameters()) {
-        if (index < params->size()) {
-          std::string param_name = params->getParam(index)->getNameAsString();
+              markClangTemplateParameterListDefined(
+                  readClangApiValueDefined([&]() {
+                    return class_tpl_part_spec_decl->getTemplateParameters();
+                  }))) {
+        if (index <
+            readClangApiValueDefined([&]() { return params->size(); })) {
+          clang::NamedDecl *param_decl =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return params->getParam(index); }));
+          std::string param_name = param_decl != nullptr
+                                       ? readClangApiValueDefined([&]() {
+                                           return param_decl->getNameAsString();
+                                         })
+                                       : std::string();
           if (!param_name.empty()) {
             name = param_name;
           }
@@ -30794,19 +33040,29 @@ bool ClangToSageTranslator::VisitClassTemplatePartialSpecializationDecl(
     };
 
     const clang::ASTTemplateArgumentListInfo *args_written =
-        class_tpl_part_spec_decl->getTemplateArgsAsWritten();
+        markClangAstObjectDefined(readClangApiValueDefined([&]() {
+          return class_tpl_part_spec_decl->getTemplateArgsAsWritten();
+        }));
     if (args_written == nullptr) {
       if (auto *first =
               llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
-                  class_tpl_part_spec_decl->getFirstDecl())) {
-        args_written = first->getTemplateArgsAsWritten();
+                  markClangDeclObjectDefinedByKind(
+                      readClangApiValueDefined([&]() {
+                        return class_tpl_part_spec_decl->getFirstDecl();
+                      })))) {
+        args_written = markClangAstObjectDefined(readClangApiValueDefined(
+            [&]() { return first->getTemplateArgsAsWritten(); }));
       }
     }
     if (args_written == nullptr) {
       if (auto *recent =
               llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
-                  class_tpl_part_spec_decl->getMostRecentDecl())) {
-        args_written = recent->getTemplateArgsAsWritten();
+                  markClangDeclObjectDefinedByKind(
+                      readClangApiValueDefined([&]() {
+                        return class_tpl_part_spec_decl->getMostRecentDecl();
+                      })))) {
+        args_written = markClangAstObjectDefined(readClangApiValueDefined(
+            [&]() { return recent->getTemplateArgsAsWritten(); }));
       }
     }
 
@@ -31580,9 +33836,16 @@ bool ClangToSageTranslator::VisitEnumDecl(clang::EnumDecl *enum_decl,
       if (var_decl == nullptr || var_decl->isInvalidDecl()) {
         continue;
       }
-      clang::SourceRange var_range = var_decl->getSourceRange();
-      if (clang::TypeSourceInfo *tsi = var_decl->getTypeSourceInfo()) {
-        clang::SourceRange type_range = tsi->getTypeLoc().getSourceRange();
+      clang::SourceRange var_range = readClangApiValueDefined(
+          [&]() { return var_decl->getSourceRange(); });
+      if (clang::TypeSourceInfo *tsi =
+              markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                  [&]() { return var_decl->getTypeSourceInfo(); }))) {
+        clang::TypeLoc type_loc =
+            readClangApiValueDefined([&]() { return tsi->getTypeLoc(); });
+        markClangTypeLocDataDefined(type_loc);
+        clang::SourceRange type_range = readClangApiValueDefined(
+            [&]() { return type_loc.getSourceRange(); });
         if (type_range.isValid()) {
           var_range = type_range;
         }
@@ -32146,6 +34409,9 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
 #if DEBUG_VISIT_DECL
   std::cerr << "ClangToSageTranslator::VisitTypedefDecl" << std::endl;
 #endif
+  typedef_decl = markClangSpecificDeclDefined(typedef_decl);
+  ROSE_ASSERT(typedef_decl != nullptr);
+
   bool res = true;
 
   SgScopeStatement *structural_scope = SageBuilder::topScopeStack();
@@ -32276,12 +34542,16 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   // Definitions embedded in a declarator are not autonomous.
   bool isAutonomousDeclaration = true;
   auto isEmbeddedInThisTypedef = [&](clang::TagDecl *tag) -> bool {
+    tag = llvm::cast_or_null<clang::TagDecl>(
+        markClangDeclObjectDefinedByKind(tag));
     if (tag == nullptr || p_compiler_instance == nullptr) {
       return false;
     }
     clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-    clang::SourceLocation decl_loc = tag->getBeginLoc();
-    clang::SourceRange typedef_range = typedef_decl->getSourceRange();
+    clang::SourceLocation decl_loc =
+        readClangApiValueDefined([&]() { return tag->getBeginLoc(); });
+    clang::SourceRange typedef_range = readClangApiValueDefined(
+        [&]() { return typedef_decl->getSourceRange(); });
     if (!decl_loc.isValid() || !typedef_range.isValid()) {
       return isembedded;
     }
@@ -32727,8 +34997,11 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   clang::TagDecl *ownedTagDecl = nullptr;
   clang::RecordDecl *embeddedRecordDecl = nullptr;
   clang::EnumDecl *embeddedEnumDecl = nullptr;
-  if (clang::TypeSourceInfo *type_info = typedef_decl->getTypeSourceInfo()) {
-    ownedTagDecl = typeLocSpellsDirectTagDecl(type_info->getTypeLoc());
+  if (clang::TypeSourceInfo *type_info =
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return typedef_decl->getTypeSourceInfo(); }))) {
+    ownedTagDecl = typeLocSpellsDirectTagDecl(
+        readClangTypeLocDefined([&]() { return type_info->getTypeLoc(); }));
   }
   if (ownedTagDecl == nullptr) {
     underlyingQualType = stripQualifiedPointerArrayType(underlyingQualType,
@@ -32738,10 +35011,14 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   }
   underlyingType = underlyingQualType.getTypePtr();
   auto written_typedef_base_qualifier = [&]() -> clang::NestedNameSpecifier {
-    if (clang::TypeSourceInfo *type_info = typedef_decl->getTypeSourceInfo()) {
+    if (clang::TypeSourceInfo *type_info =
+            markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return typedef_decl->getTypeSourceInfo(); }))) {
       if (clang::NestedNameSpecifierLoc qualifier_loc =
-              typeLocQualifierLoc(type_info->getTypeLoc())) {
-        return qualifier_loc.getNestedNameSpecifier();
+              typeLocQualifierLoc(readClangTypeLocDefined(
+                  [&]() { return type_info->getTypeLoc(); }))) {
+        return markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
       }
     }
     return std::nullopt;
@@ -32750,12 +35027,18 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   clang::NestedNameSpecifier qualifiedEnumDefinitionQualifier = std::nullopt;
   auto prior_sibling_typedef_owning_written_tag =
       [&](clang::TagDecl *tag) -> clang::TypedefNameDecl * {
-    if (tag == nullptr || !tag->isThisDeclarationADefinition() ||
+    tag = llvm::dyn_cast_or_null<clang::TagDecl>(
+        markClangDeclObjectDefinedByKind(tag));
+    if (tag == nullptr || !readClangApiValueDefined([&]() {
+          return tag->isThisDeclarationADefinition();
+        }) ||
         p_compiler_instance == nullptr) {
       return nullptr;
     }
 
-    clang::DeclContext *decl_context = typedef_decl->getDeclContext();
+    clang::DeclContext *decl_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return typedef_decl->getDeclContext(); }));
     if (decl_context == nullptr) {
       return nullptr;
     }
@@ -32771,41 +35054,70 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
       return sm.getFileLoc(loc);
     };
 
-    clang::SourceLocation current_begin = file_loc(typedef_decl->getBeginLoc());
+    clang::SourceLocation current_begin = file_loc(readClangApiValueDefined(
+        [&]() { return typedef_decl->getBeginLoc(); }));
     if (!current_begin.isValid()) {
       return nullptr;
     }
 
-    clang::TagDecl *canonical_tag = tag->getCanonicalDecl();
-    for (clang::Decl *sibling_decl : decl_context->decls()) {
+    clang::TagDecl *canonical_tag = llvm::dyn_cast_or_null<clang::TagDecl>(
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+            [&]() { return tag->getCanonicalDecl(); })));
+    clang::DeclContext::decl_iterator sibling_it =
+        readClangApiValueDefined([&]() { return decl_context->decls_begin(); });
+    clang::DeclContext::decl_iterator sibling_end =
+        readClangApiValueDefined([&]() { return decl_context->decls_end(); });
+    for (; sibling_it != sibling_end;
+         sibling_it = readClangApiValueDefined([&]() {
+           clang::DeclContext::decl_iterator next = sibling_it;
+           ++next;
+           return next;
+         })) {
+      clang::Decl *sibling_decl = markClangDeclObjectDefinedByKind(
+          readClangApiValueDefined([&]() { return *sibling_it; }));
       if (sibling_decl == typedef_decl) {
         break;
       }
 
       clang::TypedefNameDecl *prior_typedef =
-          llvm::dyn_cast<clang::TypedefNameDecl>(sibling_decl);
-      if (prior_typedef == nullptr ||
-          file_loc(prior_typedef->getBeginLoc()) != current_begin ||
-          !tagDefinitionWrittenInRange(canonical_tag,
-                                       prior_typedef->getSourceRange(), &sm,
-                                       /*allow_fallback_loc_compare=*/false)) {
+          llvm::dyn_cast_or_null<clang::TypedefNameDecl>(
+              markClangDeclObjectDefinedByKind(sibling_decl));
+      if (prior_typedef == nullptr || file_loc(readClangApiValueDefined([&]() {
+                                        return prior_typedef->getBeginLoc();
+                                      })) != current_begin ||
+          !tagDefinitionWrittenInRange(
+              canonical_tag, readClangApiValueDefined([&]() {
+                return prior_typedef->getSourceRange();
+              }),
+              &sm, /*allow_fallback_loc_compare=*/false)) {
         continue;
       }
 
       clang::TagDecl *prior_owned_tag = nullptr;
       clang::QualType prior_underlying = stripQualifiedPointerArrayType(
-          prior_typedef->getUnderlyingType(), nullptr, &prior_owned_tag);
+          markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+              [&]() { return prior_typedef->getUnderlyingType(); })),
+          nullptr, &prior_owned_tag);
       if (prior_owned_tag == nullptr) {
+        const clang::Type *prior_underlying_type =
+            markClangTypeObjectDefinedByClass(
+                prior_underlying.getTypePtrOrNull());
         const clang::TypeDecl *prior_type_decl =
-            prior_underlying.getTypePtrOrNull() != nullptr
-                ? prior_underlying.getTypePtrOrNull()->getAsTagDecl()
+            prior_underlying_type != nullptr
+                ? llvm::dyn_cast_or_null<clang::TypeDecl>(
+                      markClangDeclObjectDefinedByKind(
+                          readClangApiValueDefined([&]() {
+                            return prior_underlying_type->getAsTagDecl();
+                          })))
                 : nullptr;
         prior_owned_tag = llvm::dyn_cast_or_null<clang::TagDecl>(
             const_cast<clang::TypeDecl *>(prior_type_decl));
       }
 
       if (prior_owned_tag != nullptr &&
-          prior_owned_tag->getCanonicalDecl() == canonical_tag) {
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+            return prior_owned_tag->getCanonicalDecl();
+          })) == canonical_tag) {
         return prior_typedef;
       }
     }
@@ -33108,23 +35420,33 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   if (llvm::isa<clang::RecordType>(underlyingType)) {
     clang::RecordType *underlyingRecordType =
         (clang::RecordType *)underlyingType;
-    clang::RecordDecl *recordDeclaration = underlyingRecordType->getDecl();
+    clang::RecordDecl *recordDeclaration =
+        llvm::cast_or_null<clang::RecordDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return underlyingRecordType->getDecl(); })));
     if (clang::RecordDecl *writtenRecord =
             llvm::dyn_cast_or_null<clang::RecordDecl>(ownedTagDecl)) {
       if (isEmbeddedInThisTypedef(writtenRecord) ||
-          writtenRecord->getTypedefNameForAnonDecl() == typedef_decl) {
+          readClangApiValueDefined([&]() {
+            return writtenRecord->getTypedefNameForAnonDecl();
+          }) == typedef_decl) {
         recordDeclaration = writtenRecord;
       }
     }
-    if (clang::RecordDecl *definition = recordDeclaration->getDefinition()) {
+    if (clang::RecordDecl *definition = llvm::cast_or_null<clang::RecordDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return recordDeclaration->getDefinition(); })))) {
       if (isEmbeddedInThisTypedef(definition) ||
-          definition->getTypedefNameForAnonDecl() == typedef_decl) {
+          readClangApiValueDefined([&]() {
+            return definition->getTypedefNameForAnonDecl();
+          }) == typedef_decl) {
         recordDeclaration = definition;
       }
     }
-    bool is_definition = recordDeclaration->isThisDeclarationADefinition();
-    clang::TypedefNameDecl *anonymous_owner =
-        recordDeclaration->getTypedefNameForAnonDecl();
+    bool is_definition = readClangApiValueDefined(
+        [&]() { return recordDeclaration->isThisDeclarationADefinition(); });
+    clang::TypedefNameDecl *anonymous_owner = readClangApiValueDefined(
+        [&]() { return recordDeclaration->getTypedefNameForAnonDecl(); });
     bool embedded_by_location = isEmbeddedInThisTypedef(recordDeclaration);
     if (anonymous_owner != nullptr && anonymous_owner != typedef_decl) {
       embedded_by_location = false;
@@ -33161,10 +35483,12 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
       !typedef_requires_semantic_underlying_type(typedef_decl) &&
       !written_type_owned_by_sibling_typedef;
   if (preserve_written_underlying_type) {
-    if (clang::TypeSourceInfo *type_info = typedef_decl->getTypeSourceInfo()) {
+    if (clang::TypeSourceInfo *type_info =
+            markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return typedef_decl->getTypeSourceInfo(); }))) {
       ++p_force_written_template_specialization_depth;
-      if (SgType *written_type =
-              buildTypeFromTypeLoc(type_info->getTypeLoc())) {
+      if (SgType *written_type = buildTypeFromTypeLoc(readClangTypeLocDefined(
+              [&]() { return type_info->getTypeLoc(); }))) {
         sg_underlyingType = written_type;
         type = written_type;
       }
@@ -33184,7 +35508,9 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     sg_underlyingType = buildTypeFromQualifiedType(underlyingQualType);
   }
   if (type == nullptr) {
-    type = buildTypeFromQualifiedType(typedef_decl->getUnderlyingType());
+    type = buildTypeFromQualifiedType(
+        markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+            [&]() { return typedef_decl->getUnderlyingType(); })));
   }
 
   if (!preserve_written_underlying_type && SgProject::get_verbose() > 0) {
@@ -33226,9 +35552,15 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     return false;
   };
 
+  const clang::Type *underlying_type_ptr =
+      markClangTypeObjectDefinedByClass(underlyingQualType.getTypePtrOrNull());
+  const bool underlying_is_dependent =
+      underlying_type_ptr != nullptr && readClangApiValueDefined([&]() {
+        return underlying_type_ptr->isDependentType();
+      });
   if ((isSgNonrealType(type) != nullptr || isSgClassType(type) != nullptr) &&
       !preserves_written_template_specialization(type) &&
-      !underlyingQualType->isDependentType()) {
+      !underlying_is_dependent) {
     if (SgType *canonical_underlying =
             buildTypeFromQualifiedType(underlyingQualType)) {
       if ((isSgNonrealType(canonical_underlying) == nullptr ||
@@ -33244,7 +35576,8 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
   if (type_has_unknown && SgProject::get_verbose() > 0) {
     std::cerr << "CFE: Typedef with unknown underlying type '" << name
               << "' spelled as '"
-              << typedef_decl->getUnderlyingType().getAsString()
+              << clangQualTypeAsStringDefinedForFrontend(
+                     typedef_decl->getUnderlyingType())
               << "' (sg_type="
               << (type != nullptr ? type->class_name() : "null") << ", base="
               << (type != nullptr && type->findBaseType() != nullptr
@@ -33253,7 +35586,8 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
               << ")" << std::endl;
   }
   if (type_has_unknown) {
-    std::string spelled = typedef_decl->getUnderlyingType().getAsString();
+    std::string spelled = clangQualTypeAsStringDefinedForFrontend(
+        typedef_decl->getUnderlyingType());
     SgScopeStatement *opaque_scope = getSafeOpaqueTypeInsertionScope();
     type = SageBuilder::buildOpaqueType(spelled, opaque_scope);
     sg_underlyingType = type;
@@ -33275,12 +35609,7 @@ bool ClangToSageTranslator::VisitTypedefDecl(clang::TypedefDecl *typedef_decl,
     }
   }
 
-  // finding the bottom base type and check
-  while (type->findBaseType() != type) {
-    type = type->findBaseType();
-    if (type == sg_underlyingType)
-      break;
-  }
+  type = stripSageDeclaratorBaseType(type);
 
   // Only treat base-type declarations as embedded when Clang marks them as
   // embedded-in-declarator (e.g., `typedef struct { ... } T;`).  Named types
@@ -33884,8 +36213,11 @@ bool ClangToSageTranslator::VisitTypeAliasDecl(
   if (const clang::TemplateSpecializationType *spec =
           llvm::dyn_cast<clang::TemplateSpecializationType>(named)) {
     if (!spec->isDependentType()) {
-      clang::TemplateName tname = spec->getTemplateName();
-      if (clang::TemplateDecl *clang_tpl = tname.getAsTemplateDecl()) {
+      clang::TemplateName tname = markClangTemplateNameDefined(
+          readClangApiValueDefined([&]() { return spec->getTemplateName(); }));
+      if (clang::TemplateDecl *clang_tpl =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return tname.getAsTemplateDecl(); }))) {
         if (SgNode *tpl_node = Traverse(clang_tpl)) {
           if (SgTemplateClassDeclaration *tpl_decl =
                   isSgTemplateClassDeclaration(tpl_node)) {
@@ -33898,14 +36230,16 @@ bool ClangToSageTranslator::VisitTypeAliasDecl(
     }
     if (spec->isTypeAlias()) {
       ++p_force_written_template_specialization_depth;
-      (void)buildTypeFromQualifiedType(spec->getAliasedType());
+      (void)buildTypeFromQualifiedType(markClangQualTypeDefined(
+          readClangApiValueDefined([&]() { return spec->getAliasedType(); })));
       ROSE_ASSERT(p_force_written_template_specialization_depth > 0);
       --p_force_written_template_specialization_depth;
     }
   }
 
   if (underlying_type_info != nullptr && preserve_written_alias_type) {
-    clang::TypeLoc written_type_loc = underlying_type_info->getTypeLoc();
+    clang::TypeLoc written_type_loc = readClangTypeLocDefined(
+        [&]() { return underlying_type_info->getTypeLoc(); });
     bool use_written_type_loc = true;
 
     if (use_written_type_loc) {
@@ -34617,6 +36951,23 @@ bool ClangToSageTranslator::VisitUsingDecl(clang::UsingDecl *using_decl,
   // map every shadow back to it.
 
   // Reuse an already-built translation if any shadow has been visited first.
+  auto retire_redundant_using_shadow_translation =
+      [&](SgUsingDeclarationStatement *redundant,
+          SgUsingDeclarationStatement *canonical) {
+        if (redundant == nullptr || redundant == canonical) {
+          return;
+        }
+
+        suppress_unparse_output(redundant);
+        detach_decl_from_known_scope_child_lists(redundant);
+        if (redundant->get_scope() == current_scope) {
+          redundant->set_scope(nullptr);
+        }
+        if (redundant->get_parent() == current_scope) {
+          redundant->set_parent(nullptr);
+        }
+      };
+
   for (clang::UsingShadowDecl *shadow : using_decl->shadows()) {
     if (shadow == nullptr) {
       continue;
@@ -34638,6 +36989,11 @@ bool ClangToSageTranslator::VisitUsingDecl(clang::UsingDecl *using_decl,
       p_decl_translation_map[using_decl] = existing;
       for (clang::UsingShadowDecl *s : using_decl->shadows()) {
         if (s != nullptr) {
+          auto mapped_shadow = p_decl_translation_map.find(s);
+          if (mapped_shadow != p_decl_translation_map.end()) {
+            retire_redundant_using_shadow_translation(
+                isSgUsingDeclarationStatement(mapped_shadow->second), existing);
+          }
           p_decl_translation_map[s] = existing;
         }
       }
@@ -34832,6 +37188,7 @@ bool ClangToSageTranslator::VisitUsingDecl(clang::UsingDecl *using_decl,
 SgNamespaceDeclarationStatement *
 ClangToSageTranslator::ensureNamespaceDeclaration(
     clang::NamespaceDecl *ns_decl) {
+  ns_decl = markClangSpecificDeclDefined(ns_decl);
   if (ns_decl == nullptr)
     return nullptr;
 
@@ -34840,13 +37197,16 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
     return isSgNamespaceDeclarationStatement(exact_it->second);
   }
 
-  clang::NamespaceDecl *canonical_ns = getCanonicalNamespaceDecl(ns_decl);
+  clang::NamespaceDecl *canonical_ns =
+      markClangSpecificDeclDefined(getCanonicalNamespaceDecl(ns_decl));
 
   // Inline namespaces are transparent for name lookup; map them to their
   // enclosing namespace to keep qualification stable.
-  if (ns_decl->isInline()) {
-    if (clang::NamespaceDecl *parent_ns =
-            llvm::dyn_cast<clang::NamespaceDecl>(ns_decl->getDeclContext())) {
+  if (readClangApiValueDefined([&]() { return ns_decl->isInline(); })) {
+    clang::DeclContext *decl_context = markClangDeclContextObjectDefined(
+        readClangApiValueDefined([&]() { return ns_decl->getDeclContext(); }));
+    if (clang::NamespaceDecl *parent_ns = markClangSpecificDeclDefined(
+            llvm::dyn_cast<clang::NamespaceDecl>(decl_context))) {
       if (SgNamespaceDeclarationStatement *parent_sg_decl =
               ensureNamespaceDeclaration(parent_ns)) {
         p_decl_translation_map[ns_decl] = parent_sg_decl;
@@ -34868,12 +37228,15 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
 
   // Not found, create a stub
   SgScopeStatement *scope = nullptr;
-  clang::DeclContext *parent_ctx = ns_decl->getDeclContext();
+  clang::DeclContext *parent_ctx = markClangDeclContextObjectDefined(
+      readClangApiValueDefined([&]() { return ns_decl->getDeclContext(); }));
 
-  if (parent_ctx->isTranslationUnit()) {
+  if (parent_ctx != nullptr && readClangApiValueDefined([&]() {
+        return parent_ctx->isTranslationUnit();
+      })) {
     scope = p_global_scope;
-  } else if (clang::NamespaceDecl *parent_ns =
-                 llvm::dyn_cast<clang::NamespaceDecl>(parent_ctx)) {
+  } else if (clang::NamespaceDecl *parent_ns = markClangSpecificDeclDefined(
+                 llvm::dyn_cast<clang::NamespaceDecl>(parent_ctx))) {
     // Recursively ensure parent namespace exists
     SgNamespaceDeclarationStatement *parent_sg_decl =
         ensureNamespaceDeclaration(parent_ns);
@@ -34889,15 +37252,18 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
   }
 
   // Construct the name
-  SgName name(ns_decl->getNameAsString());
-  bool isAnonymous = ns_decl->isAnonymousNamespace();
+  SgName name(
+      readClangApiValueDefined([&]() { return ns_decl->getNameAsString(); }));
+  bool isAnonymous = readClangApiValueDefined(
+      [&]() { return ns_decl->isAnonymousNamespace(); });
   if (isAnonymous || name.getString().empty()) {
     clang::NamespaceDecl *name_source_decl =
         canonical_ns != nullptr ? canonical_ns : ns_decl;
     // Use the canonical anonymous namespace spelling so reopenings share the
     // same logical namespace chain without collapsing onto one ROSE fragment.
     name = "__anonymous_namespace_" +
-           generate_source_position_string(name_source_decl->getBeginLoc());
+           generate_source_position_string(readClangApiValueDefined(
+               [&]() { return name_source_decl->getBeginLoc(); }));
   }
 
   // Create the namespace stub using SageBuilder
@@ -34917,9 +37283,11 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
     first_nondef = sg_ns_decl;
   }
   sg_ns_decl->set_firstNondefiningDeclaration(first_nondef);
-  sg_ns_decl->set_isInlinedNamespace(ns_decl->isInline());
+  sg_ns_decl->set_isInlinedNamespace(
+      readClangApiValueDefined([&]() { return ns_decl->isInline(); }));
 
-  clang::SourceRange namespace_decl_range = ns_decl->getSourceRange();
+  clang::SourceRange namespace_decl_range =
+      readClangApiValueDefined([&]() { return ns_decl->getSourceRange(); });
   clang::SourceRange namespace_body_range;
   if (p_compiler_instance != nullptr) {
     namespace_body_range = namespaceDefinitionSourceRange(
@@ -34967,6 +37335,7 @@ bool ClangToSageTranslator::VisitUsingDirectiveDecl(
 #if DEBUG_VISIT_DECL
   std::cerr << "ClangToSageTranslator::VisitUsingDirectiveDecl" << std::endl;
 #endif
+  using_directive_decl = markClangSpecificDeclDefined(using_directive_decl);
   bool res = true;
 
   // ROOT CAUSE FIX: Implement proper support for using directives (e.g., using
@@ -34975,7 +37344,8 @@ bool ClangToSageTranslator::VisitUsingDirectiveDecl(
 
   // Get the namespace being imported
   clang::NamespaceDecl *clang_ns_decl =
-      using_directive_decl->getNominatedNamespace();
+      markClangSpecificDeclDefined(readClangApiValueDefined(
+          [&]() { return using_directive_decl->getNominatedNamespace(); }));
 
   // Ensure the namespace exists in the AST (creating stubs if needed,
   // supporting nested namespaces)
@@ -35885,7 +38255,8 @@ bool ClangToSageTranslator::VisitFieldDecl(clang::FieldDecl *field_decl,
   bool type_has_unknown = SageInterface::containsUnknownType(type);
   if (type_has_unknown && SgProject::get_verbose() > 0) {
     std::cerr << "CFE: Field with unknown type '" << name << "' spelled as '"
-              << field_decl->getType().getAsString() << "' (sg_type="
+              << clangQualTypeAsStringDefinedForFrontend(field_decl->getType())
+              << "' (sg_type="
               << (type != nullptr ? type->class_name() : "null") << ", base="
               << (type != nullptr && type->findBaseType() != nullptr
                       ? type->findBaseType()->class_name()
@@ -35895,8 +38266,9 @@ bool ClangToSageTranslator::VisitFieldDecl(clang::FieldDecl *field_decl,
 
   if (type_has_unknown) {
     SgScopeStatement *opaque_scope = getSafeOpaqueTypeInsertionScope();
-    type = SageBuilder::buildOpaqueType(field_decl->getType().getAsString(),
-                                        opaque_scope);
+    type = SageBuilder::buildOpaqueType(
+        clangQualTypeAsStringDefinedForFrontend(field_decl->getType()),
+        opaque_scope);
     sg_fieldType = type;
   }
 
@@ -35991,12 +38363,7 @@ bool ClangToSageTranslator::VisitFieldDecl(clang::FieldDecl *field_decl,
     }
   }
 
-  // finding the bottom base type and check
-  while (type->findBaseType() != type) {
-    type = type->findBaseType();
-    if (type == sg_fieldType)
-      break;
-  }
+  type = stripSageDeclaratorBaseType(type);
 
   auto class_definition_is_source_scope_owned =
       [](SgClassDeclaration *decl) -> bool {
@@ -37917,8 +40284,8 @@ ClangToSageTranslator::lookupSgDeclarationForClangDecl(clang::Decl *key,
       // declaration. Falling back to the canonical in-class declaration here
       // collapses the definition and prevents the real TU/namespace node from
       // being built.
-      if (var_decl->isStaticDataMember() &&
-          var_decl->getPreviousDecl() != nullptr) {
+      if (clangVarDeclIsStaticDataMemberDefined(var_decl) &&
+          clangVarPreviousDeclDefined(var_decl) != nullptr) {
         return nullptr;
       }
     }
@@ -38206,8 +40573,8 @@ ClangToSageTranslator::buildInProgressMemberFunctionPlaceholder(
 
   SgMemberFunctionDeclaration *placeholder =
       SageBuilder::buildNondefiningMemberFunctionDeclaration(
-          SgName(function_decl->getNameAsString()), ret_type, param_list,
-          class_def, functionConstVolatileFlags,
+          SgName(clangNamedDeclNameAsStringDefinedForFrontend(function_decl)),
+          ret_type, param_list, class_def, functionConstVolatileFlags,
           /*buildTemplateInstantiation=*/false,
           /*templateArgumentsList=*/nullptr);
   if (placeholder == nullptr) {
@@ -38929,14 +41296,17 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   }
   function_decl = llvm::cast<clang::FunctionDecl>(
       markClangFunctionTemplateStateDefined(function_decl));
+  function_decl = markClangSpecificDeclDefined(function_decl);
   template_decl = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(
       markClangDeclObjectDefinedByKind(template_decl));
   const clang::TemplateSpecializationKind specialization_kind_early =
-      function_decl->getTemplateSpecializationKind();
+      readClangApiValueDefined(
+          [&]() { return function_decl->getTemplateSpecializationKind(); });
   const bool is_explicit_instantiation_early =
       specialization_kind_early == clang::TSK_ExplicitInstantiationDefinition ||
       specialization_kind_early == clang::TSK_ExplicitInstantiationDeclaration;
-  const bool invalid_decl = function_decl->isInvalidDecl();
+  const bool invalid_decl = readClangApiValueDefined(
+      [&]() { return function_decl->isInvalidDecl(); });
   const bool has_template_instantiation_context =
       clangFunctionTemplateInstantiationPatternDefined(function_decl) !=
           nullptr ||
@@ -39004,28 +41374,36 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     ~TranslationGuard() { in_progress.erase(decl); }
   } translation_guard(p_decl_translation_in_progress, function_decl);
 
-  const clang::QualType funcQualType =
-      markClangFunctionTypeBoundaryDefined(function_decl->getType());
+  markClangDeclAttrsDefined(function_decl);
+  const clang::QualType funcQualType = markClangFunctionTypeBoundaryDefined(
+      readClangApiValueDefined([&]() { return function_decl->getType(); }));
   const clang::FunctionType::ExtInfo func_ext_info =
       clang::getFunctionExtInfo(funcQualType);
   const bool has_regparm_attr = func_ext_info.getHasRegParm();
   const unsigned regparm_value = func_ext_info.getRegParm();
   const clang::CallingConv calling_conv = func_ext_info.getCC();
-  const bool has_stdcall_attr = function_decl->hasAttr<clang::StdCallAttr>();
-  const bool has_cdecl_attr = function_decl->hasAttr<clang::CDeclAttr>();
+  const bool has_stdcall_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::StdCallAttr>(); });
+  const bool has_cdecl_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::CDeclAttr>(); });
   const bool has_noreturn_attr = func_ext_info.getNoReturn();
-  const bool has_constructor_attr =
-      function_decl->hasAttr<clang::ConstructorAttr>();
-  const bool has_destructor_attr =
-      function_decl->hasAttr<clang::DestructorAttr>();
-  const bool has_pure_attr = function_decl->hasAttr<clang::PureAttr>();
-  const bool has_const_attr = function_decl->hasAttr<clang::ConstAttr>();
-  const bool has_weak_attr = function_decl->hasAttr<clang::WeakAttr>();
-  const bool has_unused_attr = function_decl->hasAttr<clang::UnusedAttr>();
-  const bool has_used_attr = function_decl->hasAttr<clang::UsedAttr>();
-  const bool has_deprecated_attr =
-      function_decl->hasAttr<clang::DeprecatedAttr>();
-  const bool has_malloc_attr = [&]() {
+  const bool has_constructor_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::ConstructorAttr>(); });
+  const bool has_destructor_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::DestructorAttr>(); });
+  const bool has_pure_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::PureAttr>(); });
+  const bool has_const_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::ConstAttr>(); });
+  const bool has_weak_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::WeakAttr>(); });
+  const bool has_unused_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::UnusedAttr>(); });
+  const bool has_used_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::UsedAttr>(); });
+  const bool has_deprecated_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::DeprecatedAttr>(); });
+  const bool has_malloc_attr = readClangApiValueDefined([&]() {
     for (const clang::RestrictAttr *attr :
          function_decl->specific_attrs<clang::RestrictAttr>()) {
       if (attr == nullptr) {
@@ -39040,36 +41418,40 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     }
     return false;
-  }();
-  const bool has_naked_attr = function_decl->hasAttr<clang::NakedAttr>();
-  const bool has_noinline_attr = function_decl->hasAttr<clang::NoInlineAttr>();
-  const bool has_always_inline_attr =
-      function_decl->hasAttr<clang::AlwaysInlineAttr>();
-  const bool has_weakref_attr = function_decl->hasAttr<clang::WeakRefAttr>();
-  const bool has_warn_unused_result_attr =
-      function_decl->hasAttr<clang::WarnUnusedResultAttr>();
+  });
+  const bool has_naked_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::NakedAttr>(); });
+  const bool has_noinline_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::NoInlineAttr>(); });
+  const bool has_always_inline_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::AlwaysInlineAttr>(); });
+  const bool has_weakref_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::WeakRefAttr>(); });
+  const bool has_warn_unused_result_attr = readClangApiValueDefined(
+      [&]() { return function_decl->hasAttr<clang::WarnUnusedResultAttr>(); });
   typedef SgFunctionModifier::gnu_attribute_parameter_index_list_t
       GnuAttributeParameterIndexList;
   typedef SgFunctionModifier::gnu_attribute_parameter_index_list_list_t
       GnuAttributeParameterIndexListList;
-  const GnuAttributeParameterIndexListList nonnull_argument_sets = [&]() {
-    GnuAttributeParameterIndexListList sets;
-    for (const clang::NonNullAttr *attr :
-         function_decl->specific_attrs<clang::NonNullAttr>()) {
-      if (attr == nullptr) {
-        continue;
-      }
-      GnuAttributeParameterIndexList indices;
-      for (const clang::ParamIdx &idx : attr->args()) {
-        if (idx.isValid()) {
-          indices.push_back(idx.getSourceIndex());
+  const GnuAttributeParameterIndexListList nonnull_argument_sets =
+      readClangApiValueDefined([&]() {
+        GnuAttributeParameterIndexListList sets;
+        for (const clang::NonNullAttr *attr :
+             function_decl->specific_attrs<clang::NonNullAttr>()) {
+          if (attr == nullptr) {
+            continue;
+          }
+          GnuAttributeParameterIndexList indices;
+          for (const clang::ParamIdx &idx : attr->args()) {
+            if (idx.isValid()) {
+              indices.push_back(idx.getSourceIndex());
+            }
+          }
+          sets.push_back(std::move(indices));
         }
-      }
-      sets.push_back(std::move(indices));
-    }
-    return sets;
-  }();
-  const std::string asm_label = [&]() -> std::string {
+        return sets;
+      });
+  const std::string asm_label = readClangApiValueDefined([&]() -> std::string {
     for (const clang::AsmLabelAttr *attr :
          function_decl->specific_attrs<clang::AsmLabelAttr>()) {
       if (attr != nullptr && !attr->isInherited()) {
@@ -39077,8 +41459,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     }
     return std::string();
-  }();
-  const std::string alias_name = [&]() -> std::string {
+  });
+  const std::string alias_name = readClangApiValueDefined([&]() -> std::string {
     for (const clang::AliasAttr *attr :
          function_decl->specific_attrs<clang::AliasAttr>()) {
       if (attr != nullptr && !attr->isInherited()) {
@@ -39086,12 +41468,13 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     }
     return std::string();
-  }();
-  const bool is_constexpr_function = function_decl->isConstexprSpecified() ||
-                                     function_decl->isConstexpr() ||
-                                     function_decl->isConsteval() ||
-                                     function_decl->getConstexprKind() !=
-                                         clang::ConstexprSpecKind::Unspecified;
+  });
+  const bool is_constexpr_function = readClangApiValueDefined([&]() {
+    return function_decl->isConstexprSpecified() ||
+           function_decl->isConstexpr() || function_decl->isConsteval() ||
+           function_decl->getConstexprKind() !=
+               clang::ConstexprSpecKind::Unspecified;
+  });
   const bool is_inline_function =
       function_decl->isInlineSpecified() && !is_explicit_instantiation_early;
   const bool is_explicit_special_member_function = [&]() {
@@ -39249,6 +41632,44 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
              isSgTemplateClassDefinition(parent_scope) != nullptr ||
              isSgTemplateInstantiationDefn(parent_scope) != nullptr;
     };
+    auto signature_matches_key = [&](SgFunctionDeclaration *mapped_decl,
+                                     clang::FunctionDecl *candidate) -> bool {
+      if (mapped_decl == nullptr || candidate == nullptr) {
+        return false;
+      }
+
+      SgFunctionParameterList *params = mapped_decl->get_parameterList();
+      ROSE_ASSERT(params != nullptr);
+      const SgInitializedNamePtrList &sage_args = params->get_args();
+      if (sage_args.size() != candidate->getNumParams()) {
+        return false;
+      }
+
+      SgFunctionType *function_type = mapped_decl->get_type();
+      const bool sage_has_ellipses =
+          function_type != nullptr && function_type->get_has_ellipses();
+      if (sage_has_ellipses != candidate->isVariadic()) {
+        return false;
+      }
+
+      for (unsigned i = 0; i < candidate->getNumParams(); ++i) {
+        clang::ParmVarDecl *param_decl = candidate->getParamDecl(i);
+        param_decl = llvm::dyn_cast_or_null<clang::ParmVarDecl>(
+            markClangDeclObjectDefinedByKind(param_decl));
+        ROSE_ASSERT(param_decl != nullptr);
+        SgType *clang_param_type =
+            buildTypeFromQualifiedType(param_decl->getType());
+        ROSE_ASSERT(clang_param_type != nullptr);
+        SgType *sage_param_type = sage_args[i]->get_type();
+        ROSE_ASSERT(sage_param_type != nullptr);
+        if (!same_function_reuse_parameter_type(sage_param_type,
+                                                clang_param_type)) {
+          return false;
+        }
+      }
+
+      return true;
+    };
 
     SgFunctionDeclaration *hidden_friend_decl = lookup_hidden_friend_decl(key);
     auto it = p_decl_translation_map.find(key);
@@ -39264,6 +41685,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     if (hidden_friend_decl != nullptr &&
         has_class_like_lexical_parent(hidden_friend_decl) &&
         !has_class_like_lexical_parent(mapped_decl)) {
+      return hidden_friend_decl;
+    }
+    if (!signature_matches_key(mapped_decl, key)) {
       return hidden_friend_decl;
     }
     return mapped_decl;
@@ -39346,16 +41770,39 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   };
 
   int same_source_decl_rank = -1;
+  auto collect_function_redecls =
+      [&](clang::FunctionDecl *decl) -> std::vector<clang::FunctionDecl *> {
+    std::vector<clang::FunctionDecl *> redecls;
+    decl = markClangSpecificDeclDefined(decl);
+    if (decl == nullptr) {
+      return redecls;
+    }
+    for (auto it = readClangApiValueDefined(
+                  [&]() { return decl->redecls_begin(); }),
+              end = readClangApiValueDefined(
+                  [&]() { return decl->redecls_end(); });
+         it != end; readClangApiValueDefined([&]() {
+           ++it;
+           return true;
+         })) {
+      if (clang::FunctionDecl *redecl = markClangSpecificDeclDefined(
+              readClangApiValueDefined([&]() { return *it; }))) {
+        redecls.push_back(redecl);
+      }
+    }
+    return redecls;
+  };
   auto lookup_same_source_decl =
       [&](clang::FunctionDecl *reference) -> SgFunctionDeclaration * {
     same_source_decl_rank = -1;
+    reference = markClangSpecificDeclDefined(reference);
     if (reference == nullptr) {
       return nullptr;
     }
 
     SgFunctionDeclaration *best_decl = nullptr;
     int best_rank = -1;
-    for (clang::FunctionDecl *redecl : reference->redecls()) {
+    for (clang::FunctionDecl *redecl : collect_function_redecls(reference)) {
       if (redecl == nullptr ||
           !same_function_decl_source_location(reference, redecl)) {
         continue;
@@ -39366,7 +41813,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         continue;
       }
 
-      int rank = specialization_rank(redecl->getTemplateSpecializationKind());
+      int rank = specialization_rank(readClangApiValueDefined(
+          [&]() { return redecl->getTemplateSpecializationKind(); }));
       if (is_hidden_frontend_placeholder(mapped) ||
           mapped_function_decl_is_suppressed(mapped)) {
         rank = -1;
@@ -39383,21 +41831,22 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   };
   auto find_stronger_same_source_redecl =
       [&](clang::FunctionDecl *reference) -> clang::FunctionDecl * {
+    reference = markClangSpecificDeclDefined(reference);
     if (reference == nullptr) {
       return nullptr;
     }
 
     clang::FunctionDecl *best_redecl = nullptr;
-    int best_rank =
-        specialization_rank(reference->getTemplateSpecializationKind());
-    for (clang::FunctionDecl *redecl : reference->redecls()) {
+    int best_rank = specialization_rank(readClangApiValueDefined(
+        [&]() { return reference->getTemplateSpecializationKind(); }));
+    for (clang::FunctionDecl *redecl : collect_function_redecls(reference)) {
       if (redecl == nullptr || redecl == reference ||
           !same_function_decl_source_location(reference, redecl)) {
         continue;
       }
 
-      int redecl_rank =
-          specialization_rank(redecl->getTemplateSpecializationKind());
+      int redecl_rank = specialization_rank(readClangApiValueDefined(
+          [&]() { return redecl->getTemplateSpecializationKind(); }));
       if (redecl_rank > best_rank) {
         best_redecl = redecl;
         best_rank = redecl_rank;
@@ -39411,18 +41860,23 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   SgFunctionDeclaration *same_source_decl =
       lookup_same_source_decl(function_decl);
   const int current_specialization_rank =
-      specialization_rank(function_decl->getTemplateSpecializationKind());
+      specialization_rank(readClangApiValueDefined(
+          [&]() { return function_decl->getTemplateSpecializationKind(); }));
   auto redecl_chain_contains_friend_object =
       [&](clang::FunctionDecl *decl) -> bool {
+    decl = markClangSpecificDeclDefined(decl);
     if (decl == nullptr) {
       return false;
     }
-    if (decl->getFriendObjectKind() != clang::Decl::FOK_None) {
+    if (readClangApiValueDefined([&]() {
+          return decl->getFriendObjectKind();
+        }) != clang::Decl::FOK_None) {
       return true;
     }
-    for (clang::FunctionDecl *redecl : decl->redecls()) {
-      if (redecl != nullptr &&
-          redecl->getFriendObjectKind() != clang::Decl::FOK_None) {
+    for (clang::FunctionDecl *redecl : collect_function_redecls(decl)) {
+      if (redecl != nullptr && readClangApiValueDefined([&]() {
+                                 return redecl->getFriendObjectKind();
+                               }) != clang::Decl::FOK_None) {
         return true;
       }
     }
@@ -39434,12 +41888,20 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         isSgTemplateInstantiationDefn(SageBuilder::topScopeStack()) !=
             nullptr) &&
       !llvm::isa<clang::CXXMethodDecl>(function_decl) &&
-      context_is_namespace_or_tu(function_decl->getDeclContext()) &&
-      (function_decl->getLexicalDeclContext() == nullptr ||
-       context_is_namespace_or_tu(function_decl->getLexicalDeclContext())) &&
+      context_is_namespace_or_tu(
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return function_decl->getDeclContext(); }))) &&
+      (readClangApiValueDefined([&]() {
+         return function_decl->getLexicalDeclContext();
+       }) == nullptr ||
+       context_is_namespace_or_tu(
+           markClangDeclContextObjectDefined(readClangApiValueDefined(
+               [&]() { return function_decl->getLexicalDeclContext(); })))) &&
       (clangFunctionTemplateInstantiationPatternDefined(function_decl) !=
            nullptr ||
-       function_decl->getTemplateSpecializationKind() != clang::TSK_Undeclared);
+       readClangApiValueDefined([&]() {
+         return function_decl->getTemplateSpecializationKind();
+       }) != clang::TSK_Undeclared);
   if (same_source_decl != nullptr && namespace_level_friend_redecl_artifact &&
       redecl_chain_contains_friend_object(function_decl)) {
     if (p_decl_translation_map.find(function_decl) ==
@@ -39469,22 +41931,28 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   }
   const bool current_is_out_of_line_member_definition =
       is_out_of_line_member_function_definition(function_decl) &&
-      function_decl->getPreviousDecl() != nullptr;
+      readClangApiValueDefined(
+          [&]() { return function_decl->getPreviousDecl(); }) != nullptr;
   if (existing_decl == nullptr && !current_is_out_of_line_member_definition) {
-    if (clang::FunctionDecl *canonical = function_decl->getCanonicalDecl()) {
+    if (clang::FunctionDecl *canonical =
+            markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getCanonicalDecl(); }))) {
       existing_decl = lookup_existing_decl(canonical);
     }
   }
   if (existing_decl == nullptr && !current_is_out_of_line_member_definition) {
-    if (clang::FunctionDecl *first = function_decl->getFirstDecl()) {
+    if (clang::FunctionDecl *first =
+            markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getFirstDecl(); }))) {
       existing_decl = lookup_existing_decl(first);
     }
   }
 
   clang::FunctionDecl *clang_first_function_decl =
-      function_decl->getFirstDecl();
+      markClangSpecificDeclDefined(readClangApiValueDefined(
+          [&]() { return function_decl->getFirstDecl(); }));
   bool current_has_same_source_redecl = false;
-  for (clang::FunctionDecl *redecl : function_decl->redecls()) {
+  for (clang::FunctionDecl *redecl : collect_function_redecls(function_decl)) {
     if (redecl == nullptr || redecl == function_decl) {
       continue;
     }
@@ -39501,11 +41969,13 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     current_matches_first_source_decl = true;
   }
   if (!current_matches_first_source_decl &&
-      function_decl->getTemplateSpecializationKind() ==
-          clang::TSK_ExplicitSpecialization &&
+      readClangApiValueDefined([&]() {
+        return function_decl->getTemplateSpecializationKind();
+      }) == clang::TSK_ExplicitSpecialization &&
       clang_first_function_decl != nullptr &&
-      clang_first_function_decl->getTemplateSpecializationKind() !=
-          clang::TSK_ExplicitSpecialization) {
+      readClangApiValueDefined([&]() {
+        return clang_first_function_decl->getTemplateSpecializationKind();
+      }) != clang::TSK_ExplicitSpecialization) {
     current_matches_first_source_decl = true;
   }
   // On-demand translation can materialize a ROSE declaration chain for this
@@ -39513,24 +41983,38 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   // the current clang::FunctionDecl. Reuse the existing symbol-backed chain
   // instead of asking SageBuilder to synthesize another first declaration.
   if (existing_decl == nullptr && current_matches_first_source_decl &&
-      function_decl->isThisDeclarationADefinition()) {
+      readClangApiValueDefined(
+          [&]() { return function_decl->isThisDeclarationADefinition(); })) {
     if (SgSymbol *existing_symbol = GetSymbolFromSymbolTable(function_decl)) {
       existing_decl = function_declaration_from_symbol(existing_symbol);
     }
   }
-  clang::FunctionTemplateDecl *templateDecl =
+  clang::FunctionTemplateDecl *templateDecl = markClangSpecificDeclDefined(
       template_decl != nullptr ? template_decl
-                               : findOwningFunctionTemplateDecl(function_decl);
+                               : findOwningFunctionTemplateDecl(function_decl));
   const clang::SourceRange declaration_source_range = [&]() {
+    clang::FunctionDecl *templated_decl =
+        templateDecl != nullptr
+            ? markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return templateDecl->getTemplatedDecl(); }))
+            : nullptr;
+    const clang::TemplateSpecializationKind function_tsk =
+        readClangApiValueDefined(
+            [&]() { return function_decl->getTemplateSpecializationKind(); });
+    clang::SourceRange template_source_range =
+        templateDecl != nullptr ? readClangApiValueDefined([&]() {
+          return templateDecl->getSourceRange();
+        })
+                                : clang::SourceRange();
     const bool use_template_decl_range =
-        templateDecl != nullptr &&
-        templateDecl->getTemplatedDecl() == function_decl &&
-        function_decl->getTemplateSpecializationKind() ==
-            clang::TSK_Undeclared &&
-        templateDecl->getSourceRange().isValid();
+        templated_decl == function_decl &&
+        function_tsk == clang::TSK_Undeclared &&
+        template_source_range.isValid();
     clang::SourceRange range = use_template_decl_range
-                                   ? templateDecl->getSourceRange()
-                                   : function_decl->getSourceRange();
+                                   ? template_source_range
+                                   : readClangApiValueDefined([&]() {
+                                       return function_decl->getSourceRange();
+                                     });
 
     auto maybe_set_range_begin = [&](clang::SourceLocation loc) {
       if (!loc.isValid()) {
@@ -39545,19 +42029,27 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     };
 
     const clang::DeclaratorDecl *declarator_decl =
-        llvm::dyn_cast<clang::DeclaratorDecl>(function_decl);
+        llvm::dyn_cast<clang::DeclaratorDecl>(
+            markClangDeclObjectDefinedByKind(function_decl));
     if (declarator_decl != nullptr &&
-        declarator_decl->getNumTemplateParameterLists() > 0) {
+        readClangApiValueDefined([&]() {
+          return declarator_decl->getNumTemplateParameterLists();
+        }) > 0) {
       if (const clang::TemplateParameterList
               *outermost_written_template_params =
-                  declarator_decl->getTemplateParameterList(0)) {
-        maybe_set_range_begin(
-            outermost_written_template_params->getTemplateLoc());
+                  markClangTemplateParameterListDefined(
+                      readClangApiValueDefined([&]() {
+                        return declarator_decl->getTemplateParameterList(0);
+                      }))) {
+        maybe_set_range_begin(readClangApiValueDefined([&]() {
+          return outermost_written_template_params->getTemplateLoc();
+        }));
       }
     }
 
     if (llvm::isa<clang::CXXDestructorDecl>(function_decl)) {
-      maybe_set_range_begin(function_decl->getNameInfo().getBeginLoc());
+      maybe_set_range_begin(readClangApiValueDefined(
+          [&]() { return function_decl->getNameInfo().getBeginLoc(); }));
     }
 
     return range;
@@ -39567,8 +42059,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   const bool isMethodDecl = llvm::isa<clang::CXXMethodDecl>(function_decl);
   clang::CXXRecordDecl *method_parent_record = nullptr;
   if (isMethodDecl) {
-    method_parent_record =
-        llvm::cast<clang::CXXMethodDecl>(function_decl)->getParent();
+    clang::CXXMethodDecl *method_decl = llvm::cast<clang::CXXMethodDecl>(
+        markClangDeclObjectDefinedByKind(function_decl));
+    method_parent_record = markClangSpecificDeclDefined(
+        readClangApiValueDefined([&]() { return method_decl->getParent(); }));
   }
   const bool method_parent_is_class_specialization =
       method_parent_record != nullptr &&
@@ -39577,16 +42071,20 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           method_parent_record);
   const bool method_parent_is_explicit_class_specialization =
       method_parent_is_class_specialization &&
-      method_parent_record->getTemplateSpecializationKind() ==
-          clang::TSK_ExplicitSpecialization;
+      readClangApiValueDefined([&]() {
+        return method_parent_record->getTemplateSpecializationKind();
+      }) == clang::TSK_ExplicitSpecialization;
   const bool method_parent_is_primary_class_template =
       method_parent_record != nullptr &&
       templateParametersForDeclContext(method_parent_record) != nullptr &&
       !method_parent_is_class_specialization;
   const clang::DeclContext *method_enclosing_template_context = nullptr;
   if (method_parent_record != nullptr) {
-    for (const clang::DeclContext *ctx = method_parent_record; ctx != nullptr;
-         ctx = ctx->getParent()) {
+    for (const clang::DeclContext *ctx =
+             markClangDeclContextObjectDefined(method_parent_record);
+         ctx != nullptr;
+         ctx = markClangDeclContextObjectDefined(
+             readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
       if (ctx == method_parent_record &&
           method_parent_is_class_specialization) {
         continue;
@@ -39662,8 +42160,11 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   };
   auto skip_linkage_context = [](clang::DeclContext *ctx) {
     ctx = markClangDeclContextObjectDefined(ctx);
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = markClangDeclContextObjectDefined(ctx->getParent());
+    while (ctx != nullptr && readClangApiValueDefined([&]() {
+             return llvm::isa<clang::LinkageSpecDecl>(ctx);
+           })) {
+      ctx = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return ctx->getParent(); }));
     }
     return ctx;
   };
@@ -39720,9 +42221,15 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   }
   SgScopeStatement *expected_hidden_friend_owner_scope = nullptr;
   if (!isMethodDecl) {
+    clang::DeclContext *function_decl_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return function_decl->getDeclContext(); }));
+    clang::DeclContext *function_lexical_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return function_decl->getLexicalDeclContext(); }));
     if (clang::CXXRecordDecl *lexical_record =
             llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                skip_linkage_context(function_decl->getLexicalDeclContext()))) {
+                skip_linkage_context(function_lexical_context))) {
       expected_hidden_friend_owner_scope =
           resolve_record_owner_scope(lexical_record);
       if (expected_hidden_friend_owner_scope == nullptr) {
@@ -39735,9 +42242,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     }
     if (expected_hidden_friend_owner_scope == nullptr &&
-        context_is_namespace_or_tu(function_decl->getDeclContext()) &&
-        (function_decl->getLexicalDeclContext() == nullptr ||
-         context_is_namespace_or_tu(function_decl->getLexicalDeclContext()))) {
+        context_is_namespace_or_tu(function_decl_context) &&
+        (function_lexical_context == nullptr ||
+         context_is_namespace_or_tu(function_lexical_context))) {
       expected_hidden_friend_owner_scope =
           extract_class_like_scope(SageBuilder::topScopeStack());
     }
@@ -39894,6 +42401,359 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
     return isSgTemplateFunctionDeclaration(candidate) != nullptr;
   };
+  auto source_location_matches_file_info =
+      [&](clang::SourceLocation loc, const Sg_File_Info *file_info) -> bool {
+    if (file_info == nullptr ||
+        !has_real_source_file_info(const_cast<Sg_File_Info *>(file_info)) ||
+        p_compiler_instance == nullptr) {
+      return false;
+    }
+
+    clang::SourceManager &sm = p_compiler_instance->getSourceManager();
+    if (loc.isMacroID()) {
+      loc = sm.getSpellingLoc(loc);
+    }
+    if (!loc.isValid()) {
+      return false;
+    }
+
+    bool invalid_line = false;
+    bool invalid_col = false;
+    const unsigned line = sm.getSpellingLineNumber(loc, &invalid_line);
+    const unsigned col = sm.getSpellingColumnNumber(loc, &invalid_col);
+    if (invalid_line || invalid_col || line == 0 || col == 0 ||
+        line != static_cast<unsigned>(file_info->get_line()) ||
+        col != static_cast<unsigned>(file_info->get_col())) {
+      return false;
+    }
+
+    const std::string clang_file = sourceLocationFilename(loc, sm);
+    const std::string &sage_file = file_info->get_filenameString();
+    if (clang_file.empty() || sage_file.empty()) {
+      return false;
+    }
+    if (clang_file == sage_file) {
+      return true;
+    }
+
+    Sg_File_Info clang_file_info(clang_file, static_cast<int>(line),
+                                 static_cast<int>(col));
+    return clang_file_info.get_physical_file_id() ==
+           file_info->get_physical_file_id();
+  };
+  auto current_source_match_location = [&]() -> clang::SourceLocation {
+    clang::SourceLocation match_loc = declaration_source_range.getBegin();
+    if (!match_loc.isValid()) {
+      match_loc = function_decl->getBeginLoc();
+    }
+    if (!match_loc.isValid()) {
+      match_loc = function_decl->getLocation();
+    }
+    return match_loc;
+  };
+  auto build_source_file_info_for_location =
+      [&](clang::SourceLocation loc) -> std::unique_ptr<Sg_File_Info> {
+    if (p_compiler_instance == nullptr || !loc.isValid()) {
+      return nullptr;
+    }
+    clang::SourceManager &sm = p_compiler_instance->getSourceManager();
+    if (loc.isMacroID()) {
+      loc = sm.getSpellingLoc(loc);
+    }
+    if (!loc.isValid()) {
+      return nullptr;
+    }
+
+    bool invalid_line = false;
+    bool invalid_col = false;
+    const unsigned line = sm.getSpellingLineNumber(loc, &invalid_line);
+    const unsigned col = sm.getSpellingColumnNumber(loc, &invalid_col);
+    if (invalid_line || invalid_col || line == 0 || col == 0) {
+      return nullptr;
+    }
+
+    const std::string file = sourceLocationFilename(loc, sm);
+    if (file.empty()) {
+      return nullptr;
+    }
+
+    return std::unique_ptr<Sg_File_Info>(
+        new Sg_File_Info(file, static_cast<int>(line), static_cast<int>(col)));
+  };
+  std::unique_ptr<Sg_File_Info> current_source_match_file_info =
+      build_source_file_info_for_location(current_source_match_location());
+  auto function_decl_matches_current_source_range =
+      [&](SgFunctionDeclaration *candidate) -> bool {
+    if (candidate == nullptr) {
+      return false;
+    }
+    return source_location_matches_file_info(
+        current_source_match_location(), primary_real_source_start(candidate));
+  };
+  auto function_arity_matches_current =
+      [&](SgFunctionDeclaration *candidate) -> bool {
+    if (candidate == nullptr) {
+      return false;
+    }
+
+    SgFunctionParameterList *params = candidate->get_parameterList();
+    ROSE_ASSERT(params != nullptr);
+    const SgInitializedNamePtrList &sage_args = params->get_args();
+    if (sage_args.size() != function_decl->getNumParams()) {
+      return false;
+    }
+
+    SgFunctionType *function_type = candidate->get_type();
+    const bool sage_has_ellipses =
+        function_type != nullptr && function_type->get_has_ellipses();
+    if (sage_has_ellipses != function_decl->isVariadic()) {
+      return false;
+    }
+
+    return true;
+  };
+  const clang::FunctionDecl *current_source_definition_decl = nullptr;
+  const bool current_decl_is_defined = readClangApiValueDefined([&]() {
+    return function_decl->isDefined(current_source_definition_decl);
+  });
+  current_source_definition_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+      markClangDeclObjectDefinedByKind(current_source_definition_decl));
+  const bool current_decl_spells_own_body =
+      (current_decl_is_defined &&
+       current_source_definition_decl == function_decl) ||
+      readClangApiValueDefined(
+          [&]() { return function_decl->isThisDeclarationADefinition(); });
+  auto lookup_visible_same_source_member_definition_in_scope =
+      [&](SgScopeStatement *seed_scope) -> SgFunctionDeclaration * {
+    if (seed_scope == nullptr || !isMethodDecl ||
+        !current_decl_spells_own_body ||
+        readClangApiValueDefined([&]() {
+          return function_decl->getTemplateSpecializationKind();
+        }) != clang::TSK_Undeclared) {
+      return nullptr;
+    }
+
+    std::vector<SgScopeStatement *> scopes;
+    std::set<SgScopeStatement *> seen_scopes;
+    auto add_scope = [&](SgScopeStatement *scope) {
+      if (scope != nullptr && seen_scopes.insert(scope).second) {
+        scopes.push_back(scope);
+      }
+    };
+
+    if (SgNamespaceDefinitionStatement *ns =
+            isSgNamespaceDefinitionStatement(seed_scope)) {
+      SgNamespaceDeclarationStatement *ns_decl = ns->get_namespaceDeclaration();
+      SgNamespaceDeclarationStatement *first_nondef =
+          ns_decl != nullptr ? isSgNamespaceDeclarationStatement(
+                                   ns_decl->get_firstNondefiningDeclaration())
+                             : nullptr;
+      if (first_nondef == nullptr) {
+        first_nondef = ns_decl;
+      }
+      SgNamespaceDefinitionStatement *chain =
+          first_nondef != nullptr ? first_nondef->get_definition() : nullptr;
+      if (chain == nullptr) {
+        chain = ns;
+      }
+      for (SgNamespaceDefinitionStatement *current = chain; current != nullptr;
+           current = current->get_nextNamespaceDefinition()) {
+        if (sameLogicalNamespace(current, ns)) {
+          add_scope(current);
+        }
+      }
+      add_scope(ns);
+    } else {
+      add_scope(normalizeNamespaceScope(seed_scope));
+      add_scope(seed_scope);
+    }
+
+    SgFunctionDeclaration *best = nullptr;
+    auto consider_decl = [&](SgFunctionDeclaration *candidate) {
+      if (candidate == nullptr || candidate == best) {
+        return;
+      }
+      const bool same_name = function_declaration_base_name(candidate) ==
+                             SgName(function_decl->getNameAsString());
+      const bool visible = is_visible_source_function_decl(candidate);
+      const bool has_definition = candidate->get_definition() != nullptr;
+      const bool method_context =
+          function_decl_matches_current_method_context(candidate);
+      const bool template_wrapper =
+          function_decl_matches_current_template_wrapper_kind(candidate);
+      const bool source_range =
+          function_decl_matches_current_source_range(candidate);
+      const bool arity = function_arity_matches_current(candidate);
+      if (!same_name || !visible || !has_definition || !method_context ||
+          !template_wrapper || !source_range || !arity) {
+        return;
+      }
+
+      best = candidate;
+    };
+
+    for (SgScopeStatement *scope : scopes) {
+      if (SgDeclarationStatementPtrList *decls =
+              get_scope_declaration_list(scope)) {
+        const std::vector<SgDeclarationStatement *> *same_line_decls =
+            lookup_decls_on_same_source_line(
+                decls, current_source_match_file_info.get());
+        if (same_line_decls == nullptr) {
+          continue;
+        }
+        for (SgDeclarationStatement *decl_stmt : *same_line_decls) {
+          SgFunctionDeclaration *decl = isSgFunctionDeclaration(decl_stmt);
+          consider_decl(decl);
+          consider_decl(isSgFunctionDeclaration(
+              decl != nullptr ? decl->get_definingDeclaration() : nullptr));
+          if (best != nullptr) {
+            return best;
+          }
+        }
+      }
+    }
+
+    return best;
+  };
+  auto lookup_visible_same_source_decl_in_scope =
+      [&](SgScopeStatement *seed_scope) -> SgFunctionDeclaration * {
+    if (seed_scope == nullptr || isMethodDecl ||
+        !current_decl_spells_own_body ||
+        readClangApiValueDefined([&]() {
+          return function_decl->getTemplateSpecializationKind();
+        }) != clang::TSK_Undeclared) {
+      return nullptr;
+    }
+
+    std::vector<SgScopeStatement *> scopes;
+    std::set<SgScopeStatement *> seen_scopes;
+    auto add_scope = [&](SgScopeStatement *scope) {
+      if (scope != nullptr && seen_scopes.insert(scope).second) {
+        scopes.push_back(scope);
+      }
+    };
+    auto add_namespace_chain = [&](SgNamespaceDefinitionStatement *ns) {
+      if (ns == nullptr) {
+        return;
+      }
+      SgNamespaceDeclarationStatement *ns_decl = ns->get_namespaceDeclaration();
+      SgNamespaceDeclarationStatement *first_nondef =
+          ns_decl != nullptr ? isSgNamespaceDeclarationStatement(
+                                   ns_decl->get_firstNondefiningDeclaration())
+                             : nullptr;
+      if (first_nondef == nullptr) {
+        first_nondef = ns_decl;
+      }
+      SgNamespaceDefinitionStatement *chain =
+          first_nondef != nullptr ? first_nondef->get_definition() : nullptr;
+      if (chain == nullptr) {
+        chain = ns;
+      }
+      for (SgNamespaceDefinitionStatement *current = chain; current != nullptr;
+           current = current->get_nextNamespaceDefinition()) {
+        if (sameLogicalNamespace(current, ns)) {
+          add_scope(current);
+        }
+      }
+      add_scope(ns);
+    };
+
+    if (SgNamespaceDefinitionStatement *ns =
+            isSgNamespaceDefinitionStatement(seed_scope)) {
+      add_namespace_chain(ns);
+    } else {
+      add_scope(normalizeNamespaceScope(seed_scope));
+      add_scope(seed_scope);
+    }
+
+    SgFunctionDeclaration *best = nullptr;
+    auto consider_decl = [&](SgFunctionDeclaration *candidate) {
+      if (candidate == nullptr || candidate == best) {
+        return;
+      }
+      if (function_declaration_base_name(candidate) !=
+              SgName(function_decl->getNameAsString()) ||
+          !is_visible_source_function_decl(candidate) ||
+          !function_decl_matches_current_method_context(candidate) ||
+          !function_decl_matches_current_template_wrapper_kind(candidate) ||
+          !function_decl_matches_current_source_range(candidate) ||
+          !function_arity_matches_current(candidate)) {
+        return;
+      }
+
+      SgScopeStatement *candidate_scope = candidate->get_scope();
+      if (candidate_scope == nullptr) {
+        candidate_scope = isSgScopeStatement(candidate->get_parent());
+      }
+      if (!scopeMatchesForDeclarationReuse(seed_scope, candidate_scope)) {
+        return;
+      }
+
+      if (current_decl_spells_own_body &&
+          candidate->get_definition() == nullptr) {
+        return;
+      }
+
+      if (best == nullptr || (best->get_definition() == nullptr &&
+                              candidate->get_definition() != nullptr)) {
+        best = candidate;
+      }
+    };
+
+    for (SgScopeStatement *scope : scopes) {
+      if (SgDeclarationStatementPtrList *decls =
+              get_scope_declaration_list(scope)) {
+        const std::vector<SgDeclarationStatement *> *same_line_decls =
+            lookup_decls_on_same_source_line(
+                decls, current_source_match_file_info.get());
+        if (same_line_decls == nullptr) {
+          continue;
+        }
+        for (SgDeclarationStatement *decl_stmt : *same_line_decls) {
+          SgFunctionDeclaration *decl = isSgFunctionDeclaration(decl_stmt);
+          consider_decl(decl);
+          consider_decl(isSgFunctionDeclaration(
+              decl != nullptr ? decl->get_firstNondefiningDeclaration()
+                              : nullptr));
+          consider_decl(isSgFunctionDeclaration(
+              decl != nullptr ? decl->get_definingDeclaration() : nullptr));
+        }
+      }
+    }
+
+    return best;
+  };
+  if (same_source_decl == nullptr && existing_decl == nullptr &&
+      current_decl_spells_own_body) {
+    if (isMethodDecl) {
+      SgScopeStatement *lexical_scope = resolveScopeFromDeclContext(
+          skip_linkage_context(function_decl->getLexicalDeclContext()),
+          nullptr);
+      same_source_decl =
+          lookup_visible_same_source_member_definition_in_scope(lexical_scope);
+    } else {
+      SgScopeStatement *semantic_scope = resolveScopeFromDeclContext(
+          skip_linkage_context(function_decl->getDeclContext()), nullptr);
+      same_source_decl =
+          lookup_visible_same_source_decl_in_scope(semantic_scope);
+      if (same_source_decl == nullptr) {
+        SgScopeStatement *lexical_scope = resolveScopeFromDeclContext(
+            skip_linkage_context(function_decl->getLexicalDeclContext()),
+            semantic_scope);
+        same_source_decl =
+            lookup_visible_same_source_decl_in_scope(lexical_scope);
+      }
+    }
+    if (same_source_decl != nullptr) {
+      same_source_decl_rank = current_specialization_rank;
+    }
+  }
+  if (same_source_decl != nullptr &&
+      (existing_decl == nullptr ||
+       (is_hidden_frontend_placeholder(existing_decl) &&
+        !is_hidden_frontend_placeholder(same_source_decl)))) {
+    existing_decl = same_source_decl;
+  }
 
   const bool is_template_instantiation =
       clangFunctionTemplateSpecializationArgsDefined(function_decl) !=
@@ -39924,10 +42784,16 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         isSgTemplateClassDefinition(existing_lexical_scope) != nullptr ||
         isSgTemplateInstantiationDefn(existing_lexical_scope) != nullptr;
     const bool decl_context_is_namespace_or_tu_here =
-        context_is_namespace_or_tu(function_decl->getDeclContext());
+        context_is_namespace_or_tu(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getDeclContext(); })));
     const bool lexical_context_is_namespace_or_tu_here =
-        function_decl->getLexicalDeclContext() == nullptr ||
-        context_is_namespace_or_tu(function_decl->getLexicalDeclContext());
+        readClangApiValueDefined([&]() {
+          return function_decl->getLexicalDeclContext();
+        }) == nullptr ||
+        context_is_namespace_or_tu(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getLexicalDeclContext(); })));
     if (existing_lexically_in_class && decl_context_is_namespace_or_tu_here &&
         lexical_context_is_namespace_or_tu_here) {
       existing_decl = nullptr;
@@ -40002,7 +42868,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       exact_decl_mapped = false;
     }
   }
-  auto function_decl_is_suppressed_for_unparse =
+  auto function_decl_surface_is_suppressed_for_unparse =
       [](SgFunctionDeclaration *decl) -> bool {
     if (decl == nullptr) {
       return true;
@@ -40016,14 +42882,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       return true;
     }
 
-    if (SgFunctionDeclaration *first_nondef =
-            isSgFunctionDeclaration(decl->get_firstNondefiningDeclaration())) {
-      if (is_suppressed(first_nondef->get_file_info())) {
-        return true;
-      }
-    }
-
-    return false;
+    return is_suppressed(decl->get_file_info());
   };
   if (roseShouldTraceFunctionDeclChain(function_decl)) {
     roseTraceDeclarationChain("function-prebuild-existing", "existing",
@@ -40052,16 +42911,20 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             "has_builtin_prefix=%d has_builtin_attr=%d\n",
             phase, debug_function_name.c_str(), function_decl, decl,
             exact_decl_mapped ? 1 : 0,
-            function_decl_is_suppressed_for_unparse(decl) ? 1 : 0,
+            function_decl_surface_is_suppressed_for_unparse(decl) ? 1 : 0,
             (!function_decl->isImplicit() &&
              clangDeclHasNonBuiltinSourceLocation(p_compiler_instance,
                                                   function_decl))
                 ? 1
                 : 0,
             function_decl->isImplicit() ? 1 : 0,
-            function_decl->getBuiltinID() != clang::Builtin::NotBuiltin ? 1 : 0,
+            readClangApiValueDefined([&]() {
+              return function_decl->getBuiltinID();
+            }) != clang::Builtin::NotBuiltin
+                ? 1
+                : 0,
             debug_function_name.rfind("__builtin_", 0) == 0 ? 1 : 0,
-            function_decl->hasAttr<clang::BuiltinAttr>() ? 1 : 0);
+            clangDeclHasBuiltinAttrDefinedForFrontend(function_decl) ? 1 : 0);
 
     if (decl != nullptr) {
       const SgInitializedNamePtrList &decl_args = decl->get_args();
@@ -40128,7 +42991,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       !function_decl->isImplicit() &&
       clangDeclHasNonBuiltinSourceLocation(p_compiler_instance,
                                            function_decl) &&
-      function_decl_is_suppressed_for_unparse(existing_decl)) {
+      function_decl_surface_is_suppressed_for_unparse(existing_decl)) {
     debug_operator_delete_state("drop-suppressed-existing", existing_decl);
     existing_decl = nullptr;
     same_source_decl = nullptr;
@@ -40214,7 +43077,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   if (existing_decl != nullptr && !on_demand_translation &&
       current_decl_has_real_source_location &&
       current_matches_first_source_decl && current_decl_is_class_scoped &&
-      function_decl_is_suppressed_for_unparse(existing_decl)) {
+      function_decl_surface_is_suppressed_for_unparse(existing_decl)) {
     placeholder_decl_to_replace_in_scope = existing_decl;
     if (same_source_decl == existing_decl) {
       same_source_decl = nullptr;
@@ -40314,19 +43177,43 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   }
   if (existing_decl != nullptr) {
+    const bool same_source_definition_duplicate =
+        existing_decl == same_source_decl && current_decl_spells_own_body &&
+        existing_decl->get_definition() != nullptr &&
+        function_decl_matches_current_source_range(existing_decl) &&
+        function_arity_matches_current(existing_decl);
     const bool stronger_same_source_decl =
         existing_decl == same_source_decl &&
         same_source_decl_rank > current_specialization_rank;
     const bool existing_decl_wrapped =
         isSgTemplateInstantiationDirectiveStatement(
             existing_decl->get_parent()) != nullptr;
-    const clang::FunctionDecl *current_definition_decl = nullptr;
-    const bool current_decl_spells_own_body =
-        (function_decl->isDefined(current_definition_decl) &&
-         current_definition_decl == function_decl) ||
-        function_decl->isThisDeclarationADefinition();
     const bool needs_definition = current_decl_spells_own_body &&
                                   existing_decl->get_definition() == nullptr;
+    if (same_source_definition_duplicate) {
+      if (p_decl_translation_map.find(function_decl) ==
+          p_decl_translation_map.end()) {
+        p_decl_translation_map.insert(
+            std::make_pair(function_decl, existing_decl));
+      }
+      apply_function_ext_info(existing_decl);
+      if (SgFunctionDeclaration *first_nondef = isSgFunctionDeclaration(
+              existing_decl->get_firstNondefiningDeclaration())) {
+        apply_function_ext_info(first_nondef,
+                                /*include_decl_local_attrs=*/false);
+      }
+      if (SgFunctionDeclaration *def_decl = isSgFunctionDeclaration(
+              existing_decl->get_definingDeclaration())) {
+        apply_function_ext_info(def_decl, /*include_decl_local_attrs=*/false);
+      }
+      reattach_existing_decl_to_lexical_namespace(existing_decl);
+      reattach_existing_decl_to_lexical_namespace(isSgFunctionDeclaration(
+          existing_decl->get_firstNondefiningDeclaration()));
+      reattach_existing_decl_to_lexical_namespace(
+          isSgFunctionDeclaration(existing_decl->get_definingDeclaration()));
+      *node = existing_decl;
+      return true;
+    }
     clang::DeclContext *function_semantic_context =
         markClangDeclContextObjectDefined(function_decl->getDeclContext());
     clang::DeclContext *function_lexical_context =
@@ -40338,7 +43225,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         (function_lexical_context != nullptr &&
          llvm::isa<clang::CXXRecordDecl>(function_lexical_context));
     const bool needs_distinct_class_scoped_source_decl =
-        !exact_decl_mapped && current_matches_first_source_decl &&
+        !on_demand_translation && !exact_decl_mapped &&
+        current_matches_first_source_decl &&
         !function_decl->isThisDeclarationADefinition() &&
         current_decl_is_class_scoped &&
         existing_decl->get_definition() != nullptr;
@@ -40649,8 +43537,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     }
     if (converted_name.empty()) {
-      converted_name =
-          trimWhitespace(conversion_decl->getConversionType().getAsString());
+      converted_name = trimWhitespace(clangQualTypeAsStringDefinedForFrontend(
+          conversion_decl->getConversionType()));
     }
 
     converted_name = normalizeClangTemplateParamName(converted_name);
@@ -40711,12 +43599,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   auto resolve_parent_class_name =
       [&](clang::CXXRecordDecl *parentClassDecl) -> SgName {
+    parentClassDecl = markClangSpecificDeclDefined(parentClassDecl);
     if (parentClassDecl == nullptr) {
       return SgName();
     }
     SgClassDeclaration *CxxRecordDeclaration = nullptr;
     auto lookup_class_decl = [&](clang::CXXRecordDecl *record,
                                  bool allow_on_demand) -> SgClassDeclaration * {
+      record = markClangSpecificDeclDefined(record);
       if (record == nullptr) {
         return nullptr;
       }
@@ -40742,8 +43632,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           markClangCXXRecordDefinitionStateDefined(parentClassDecl));
       if (clang::CXXRecordDecl *definition =
               llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                  static_cast<clang::RecordDecl *>(parentClassDecl)
-                      ->getDefinition())) {
+                  clangRecordDefinitionDefined(
+                      static_cast<clang::RecordDecl *>(parentClassDecl)))) {
         check_in_progress(llvm::cast_or_null<clang::CXXRecordDecl>(
             markClangCXXRecordDefinitionStateDefined(definition)));
       }
@@ -40752,7 +43642,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       if (clang::CXXRecordDecl *canonical =
               llvm::cast_or_null<clang::CXXRecordDecl>(
                   markClangDeclObjectDefinedByKind(
-                      parentClassDecl->getCanonicalDecl()))) {
+                      readClangApiValueDefined([&]() {
+                        return parentClassDecl->getCanonicalDecl();
+                      })))) {
         check_in_progress(canonical);
       }
     }
@@ -40777,7 +43669,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   if (llvm::isa<clang::CXXConstructorDecl>(function_decl)) {
     clang::CXXRecordDecl *parentClassDecl =
-        static_cast<clang::CXXConstructorDecl *>(function_decl)->getParent();
+        markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+          return static_cast<clang::CXXConstructorDecl *>(function_decl)
+              ->getParent();
+        }));
     SgName class_name = resolve_parent_class_name(parentClassDecl);
     std::string base_name = strip_template_args(class_name.getString());
     if (!base_name.empty()) {
@@ -40785,7 +43680,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   } else if (llvm::isa<clang::CXXDestructorDecl>(function_decl)) {
     clang::CXXRecordDecl *parentClassDecl =
-        static_cast<clang::CXXDestructorDecl *>(function_decl)->getParent();
+        markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+          return static_cast<clang::CXXDestructorDecl *>(function_decl)
+              ->getParent();
+        }));
     SgName class_name = resolve_parent_class_name(parentClassDecl);
     std::string base_name = strip_template_args(class_name.getString());
     if (!base_name.empty()) {
@@ -40793,8 +43691,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   }
 
-  const bool has_builtin_id =
-      (function_decl->getBuiltinID() != clang::Builtin::NotBuiltin);
+  const bool has_builtin_id = (readClangApiValueDefined([&]() {
+                                 return function_decl->getBuiltinID();
+                               }) != clang::Builtin::NotBuiltin);
   const bool has_builtin_name_prefix = func_name.rfind("__builtin_", 0) == 0;
   auto is_builtin_support_function_decl = [&](clang::FunctionDecl *candidate) {
     if (candidate == nullptr) {
@@ -40831,8 +43730,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     return false;
   };
 
-  bool is_builtin_decl = has_builtin_name_prefix || has_builtin_id ||
-                         function_decl->hasAttr<clang::BuiltinAttr>();
+  bool is_builtin_decl =
+      has_builtin_name_prefix || has_builtin_id ||
+      clangDeclHasBuiltinAttrDefinedForFrontend(function_decl);
   if (!is_builtin_decl) {
     is_builtin_decl = is_builtin_support_function_decl(function_decl);
   }
@@ -41113,47 +44013,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           return;
         }
 
-        auto detached_params = std::make_unique<SgTemplateParameterPtrList>();
-        detached_params->reserve(templateParams->size());
-        for (SgTemplateParameter *param : *templateParams) {
-          if (param == nullptr) {
-            continue;
-          }
-
-          SgTemplateParameter *param_copy =
-              isSgTemplateParameter(SageInterface::deepCopy(param));
-          if (param_copy == nullptr) {
-            continue;
-          }
-
-          param_copy->set_parent(nullptr);
-          if (param_copy->get_parameterType() !=
-              SgTemplateParameter::template_parameter) {
-            param_copy->set_templateDeclaration(nullptr);
-          }
-          if (SgInitializedName *init_name =
-                  param_copy->get_initializedName()) {
-            init_name->set_parent(param_copy);
-          }
-          if (SgExpression *constraint = param_copy->get_typeConstraint()) {
-            attach_template_parameter_expression(param_copy, constraint);
-          }
-          if (SgExpression *default_expr =
-                  param_copy->get_defaultExpressionParameter()) {
-            attach_template_parameter_expression(param_copy, default_expr);
-          }
-          if (SgDeclarationStatement *default_decl =
-                  param_copy->get_defaultTemplateDeclarationParameter()) {
-            default_decl->set_parent(param_copy);
-          }
-
-          detached_params->push_back(param_copy);
-        }
+        auto detached_params = std::make_unique<SgTemplateParameterPtrList>(
+            clone_template_parameter_list_surface(
+                *templateParams,
+                /*preserve_defaults=*/preserve_spelled_defaults,
+                /*anchor_nonreals=*/true));
 
         normalize_function_template_parameter_defaults(
             *detached_params, preserve_spelled_defaults);
-        anchor_copied_template_parameter_nonreals(*detached_params,
-                                                  SageBuilder::topScopeStack());
 
         if (translated_template_param_list != nullptr) {
           register_function_template_parameter_mappings(
@@ -41162,6 +44029,29 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
         templateParams = std::move(detached_params);
       };
+
+  auto current_declarator_decl =
+      [&](const clang::FunctionDecl *decl) -> const clang::DeclaratorDecl * {
+    return llvm::dyn_cast_or_null<clang::DeclaratorDecl>(
+        markClangDeclObjectDefinedByKind(decl));
+  };
+  auto declarator_template_parameter_list_count =
+      [&](const clang::DeclaratorDecl *declarator_decl) -> unsigned {
+    if (declarator_decl == nullptr) {
+      return 0;
+    }
+    return readClangApiValueDefined(
+        [&]() { return declarator_decl->getNumTemplateParameterLists(); });
+  };
+  auto declarator_template_parameter_list =
+      [&](const clang::DeclaratorDecl *declarator_decl,
+          unsigned index) -> const clang::TemplateParameterList * {
+    if (declarator_decl == nullptr) {
+      return nullptr;
+    }
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return declarator_decl->getTemplateParameterList(index); }));
+  };
 
   auto current_written_outer_template_parameters =
       [&](const clang::FunctionDecl *decl)
@@ -41173,9 +44063,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       return nullptr;
     }
     const clang::DeclaratorDecl *declarator_decl =
-        llvm::dyn_cast<clang::DeclaratorDecl>(decl);
-    if (declarator_decl == nullptr ||
-        declarator_decl->getNumTemplateParameterLists() == 0) {
+        current_declarator_decl(decl);
+    const unsigned written_template_levels =
+        declarator_template_parameter_list_count(declarator_decl);
+    if (declarator_decl == nullptr || written_template_levels == 0) {
       return nullptr;
     }
 
@@ -41185,8 +44076,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                 .size()) +
         countEnclosingClassTemplateSpecializationLevels(method_parent_record);
     if (enclosing_class_template_levels == 0 ||
-        declarator_decl->getNumTemplateParameterLists() <
-            enclosing_class_template_levels) {
+        written_template_levels < enclosing_class_template_levels) {
       return nullptr;
     }
 
@@ -41194,8 +44084,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     // declarations from outermost to innermost. ROSE models the immediate
     // owning class-template header on the member declaration itself; enclosing
     // outer class headers are emitted from the associated class chain.
-    return declarator_decl->getTemplateParameterList(
-        enclosing_class_template_levels - 1);
+    return declarator_template_parameter_list(
+        declarator_decl, enclosing_class_template_levels - 1);
   };
   auto current_written_outer_template_parameter_lists =
       [&](const clang::FunctionDecl *decl)
@@ -41206,9 +44096,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     const clang::DeclaratorDecl *declarator_decl =
-        llvm::dyn_cast<clang::DeclaratorDecl>(decl);
-    if (declarator_decl == nullptr ||
-        declarator_decl->getNumTemplateParameterLists() == 0) {
+        current_declarator_decl(decl);
+    const unsigned written_template_levels =
+        declarator_template_parameter_list_count(declarator_decl);
+    if (declarator_decl == nullptr || written_template_levels == 0) {
       return result;
     }
 
@@ -41218,15 +44109,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                 .size()) +
         countEnclosingClassTemplateSpecializationLevels(method_parent_record);
     if (enclosing_class_template_levels == 0 ||
-        declarator_decl->getNumTemplateParameterLists() <
-            enclosing_class_template_levels) {
+        written_template_levels < enclosing_class_template_levels) {
       return result;
     }
 
     result.reserve(enclosing_class_template_levels);
     for (unsigned i = 0; i < enclosing_class_template_levels; ++i) {
       if (const clang::TemplateParameterList *params =
-              declarator_decl->getTemplateParameterList(i)) {
+              declarator_template_parameter_list(declarator_decl, i)) {
         result.push_back(params);
       }
     }
@@ -41240,13 +44130,13 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     const clang::DeclaratorDecl *declarator_decl =
-        llvm::dyn_cast<clang::DeclaratorDecl>(decl);
+        current_declarator_decl(decl);
     if (declarator_decl == nullptr) {
       return nullptr;
     }
 
     const unsigned written_template_levels =
-        declarator_decl->getNumTemplateParameterLists();
+        declarator_template_parameter_list_count(declarator_decl);
     if (written_template_levels == 0) {
       return nullptr;
     }
@@ -41264,8 +44154,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     // declarations from outermost to innermost. Any list beyond the enclosing
     // class-template headers is therefore the member function template's own
     // header.
-    return declarator_decl->getTemplateParameterList(
-        enclosing_class_template_levels);
+    return declarator_template_parameter_list(declarator_decl,
+                                              enclosing_class_template_levels);
   };
   const clang::TemplateParameterList *written_function_template_params =
       templateDecl == nullptr && isMethodDecl
@@ -41300,14 +44190,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       if (outer_template_params == outer_template_lists.back()) {
         translated_outer_template_param_list = mutable_outer_template_params;
         writtenOuterTemplateParams =
-            std::make_unique<SgTemplateParameterPtrList>();
-        for (SgTemplateParameter *param : *written_params) {
-          SgTemplateParameter *param_copy =
-              isSgTemplateParameter(SageInterface::deepCopy(param));
-          if (param_copy != nullptr) {
-            writtenOuterTemplateParams->push_back(param_copy);
-          }
-        }
+            std::make_unique<SgTemplateParameterPtrList>(
+                clone_template_parameter_list_surface(
+                    *written_params, /*preserve_defaults=*/true,
+                    /*anchor_nonreals=*/true));
       }
       writtenOuterTemplateParamLists.push_back(std::move(written_params));
       ++outer_template_level;
@@ -41523,26 +44409,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       return true;
     }
 
-    auto has_global_qualifier = [](clang::NestedNameSpecifier qual) -> bool {
-      for (clang::NestedNameSpecifier cur = qual; cur;
-           cur = nestedNameSpecifierPrefix(cur)) {
-        if (cur.getKind() == clang::NestedNameSpecifier::Kind::Global) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    if (clang::NestedNameSpecifierLoc qual_loc =
-            function_decl->getQualifierLoc()) {
-      if (qual_loc.getLocalSourceRange().isValid()) {
-        if (clang::NestedNameSpecifier qual =
-                qual_loc.getNestedNameSpecifier()) {
-          if (has_global_qualifier(qual)) {
-            return true;
-          }
-        }
-      }
+    if (nestedNameSpecifierHasGlobal(writtenFunctionQualifier(function_decl))) {
+      return true;
     }
 
     if (isFriendFreeFunction) {
@@ -41843,6 +44711,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   auto resolve_or_translate_class_definition =
       [&](clang::CXXRecordDecl *record,
           bool populate_definition = true) -> SgClassDefinition * {
+    record = markClangSpecificDeclDefined(record);
     if (record == nullptr) {
       return nullptr;
     }
@@ -41854,12 +44723,15 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       auto rose_decl_matches_specialization_kind =
           [&](clang::CXXRecordDecl *record_decl,
               SgClassDefinition *class_def) -> bool {
+        record_decl = markClangSpecificDeclDefined(record_decl);
         if (record_decl == nullptr || class_def == nullptr) {
           return true;
         }
 
         clang::ClassTemplateSpecializationDecl *spec_decl =
-            llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(record_decl);
+            markClangSpecificDeclDefined(
+                llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+                    record_decl));
         if (spec_decl == nullptr ||
             llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(
                 spec_decl)) {
@@ -41879,8 +44751,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         }
 
         const bool clang_is_explicit_specialization =
-            spec_decl->getTemplateSpecializationKind() ==
-            clang::TSK_ExplicitSpecialization;
+            readClangApiValueDefined([&]() {
+              return spec_decl->getTemplateSpecializationKind();
+            }) == clang::TSK_ExplicitSpecialization;
         const bool rose_is_explicit_specialization =
             inst_decl->get_specialization() ==
             SgDeclarationStatement::e_specialization;
@@ -41890,6 +44763,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       auto rose_enclosing_scope_matches_record_context =
           [&](clang::CXXRecordDecl *record_decl,
               SgClassDefinition *class_def) -> bool {
+        record_decl = markClangSpecificDeclDefined(record_decl);
         if (record_decl == nullptr || class_def == nullptr) {
           return true;
         }
@@ -41899,43 +44773,57 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           return true;
         }
 
-        clang::CXXRecordDecl *parent_record =
-            llvm::dyn_cast<clang::CXXRecordDecl>(record_decl->getDeclContext());
+        clang::DeclContext *decl_context =
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return record_decl->getDeclContext(); }));
+        clang::CXXRecordDecl *parent_record = markClangSpecificDeclDefined(
+            llvm::dyn_cast<clang::CXXRecordDecl>(decl_context));
         if (parent_record == nullptr) {
           return true;
         }
 
         if (clang::ClassTemplateSpecializationDecl *parent_spec =
-                llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
-                    parent_record)) {
+                markClangSpecificDeclDefined(
+                    llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+                        parent_record))) {
           if (!llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(
                   parent_spec)) {
-            if (parent_spec->getTemplateSpecializationKind() ==
-                clang::TSK_Undeclared) {
+            if (readClangApiValueDefined([&]() {
+                  return parent_spec->getTemplateSpecializationKind();
+                }) == clang::TSK_Undeclared) {
               return isSgTemplateClassDefinition(rose_parent_scope) != nullptr;
             }
             return isSgTemplateInstantiationDefn(rose_parent_scope) != nullptr;
           }
         }
 
-        if (parent_record->getDescribedClassTemplate() != nullptr) {
+        if (markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+              return parent_record->getDescribedClassTemplate();
+            })) != nullptr) {
           return isSgTemplateClassDefinition(rose_parent_scope) != nullptr;
         }
 
         return true;
       };
-      if (llvm::isa<clang::ClassTemplateSpecializationDecl>(decl) &&
-          !llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
-        clang::ClassTemplateSpecializationDecl *spec_decl =
-            llvm::cast<clang::ClassTemplateSpecializationDecl>(decl);
-        if (spec_decl->getTemplateSpecializationKind() ==
-            clang::TSK_Undeclared) {
+      decl = markClangSpecificDeclDefined(decl);
+      if (clang::ClassTemplateSpecializationDecl *spec_decl =
+              markClangSpecificDeclDefined(
+                  llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+                      decl))) {
+        if (llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
+          return true;
+        }
+        if (readClangApiValueDefined([&]() {
+              return spec_decl->getTemplateSpecializationKind();
+            }) == clang::TSK_Undeclared) {
           return isSgTemplateClassDefinition(def) != nullptr;
         }
         return isSgTemplateInstantiationDefn(def) != nullptr &&
                rose_decl_matches_specialization_kind(decl, def);
       }
-      if (decl->getDescribedClassTemplate() != nullptr) {
+      if (markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+            return decl->getDescribedClassTemplate();
+          })) != nullptr) {
         return isSgTemplateClassDefinition(def) != nullptr;
       }
       return isSgClassDefinition(def) != nullptr &&
@@ -41954,9 +44842,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           p_record_definitions_populated.end()) {
         return def;
       }
-      clang::CXXRecordDecl *def_decl = decl->getDefinition();
+      clang::CXXRecordDecl *def_decl = clangCXXRecordDefinitionDefined(decl);
       if (def_decl == nullptr) {
-        if (!decl->isThisDeclarationADefinition()) {
+        if (!readClangApiValueDefined(
+                [&]() { return decl->isThisDeclarationADefinition(); })) {
           return def;
         }
         def_decl = decl;
@@ -41972,8 +44861,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         return nullptr;
       }
 
-      clang::TemplateSpecializationKind tsk =
-          decl->getTemplateSpecializationKind();
+      decl = markClangSpecificDeclDefined(decl);
+      clang::TemplateSpecializationKind tsk = readClangApiValueDefined(
+          [&]() { return decl->getTemplateSpecializationKind(); });
       const bool allow_template_pattern =
           tsk == clang::TSK_ImplicitInstantiation ||
           tsk == clang::TSK_ExplicitInstantiationDeclaration ||
@@ -41993,7 +44883,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         return ensure_definition_populated(pattern, existing);
       }
 
-      clang::CXXRecordDecl *pattern_def = pattern->getDefinition();
+      clang::CXXRecordDecl *pattern_def =
+          clangCXXRecordDefinitionDefined(pattern);
       if (pattern_def != nullptr && pattern_def != pattern) {
         if (SgClassDefinition *existing =
                 resolve_class_definition(pattern_def)) {
@@ -42094,6 +44985,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   auto mapped_parent_record_chain_is_hidden =
       [&](clang::CXXRecordDecl *record) -> bool {
     auto check_record = [&](clang::CXXRecordDecl *candidate) -> bool {
+      candidate = markClangSpecificDeclDefined(candidate);
       if (candidate == nullptr) {
         return false;
       }
@@ -42106,11 +44998,13 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     if (check_record(record)) {
       return true;
     }
-    if (check_record(record != nullptr ? record->getDefinition() : nullptr)) {
+    if (check_record(record != nullptr ? clangCXXRecordDefinitionDefined(record)
+                                       : nullptr)) {
       return true;
     }
-    if (check_record(record != nullptr ? record->getCanonicalDecl()
-                                       : nullptr)) {
+    if (check_record(record != nullptr
+                         ? clangCXXRecordCanonicalDeclDefined(record)
+                         : nullptr)) {
       return true;
     }
     if (record != nullptr) {
@@ -42119,8 +45013,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         return true;
       }
       if (clang::ClassTemplateDecl *templ =
-              record->getDescribedClassTemplate()) {
-        if (check_record(templ->getTemplatedDecl())) {
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return record->getDescribedClassTemplate(); }))) {
+        if (check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return templ->getTemplatedDecl(); })))) {
           return true;
         }
       }
@@ -42130,29 +45026,34 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   // For member functions (including friend methods), use the class definition
   // as scope
-  if (!scope_assigned && llvm::isa<clang::CXXMethodDecl>(function_decl)) {
-    clang::CXXMethodDecl *method_decl =
-        llvm::cast<clang::CXXMethodDecl>(function_decl);
-    clang::CXXRecordDecl *parent_class = method_decl->getParent();
+  clang::CXXMethodDecl *function_method_decl =
+      markClangSpecificDeclDefined(llvm::dyn_cast<clang::CXXMethodDecl>(
+          markClangDeclObjectDefinedByKind(function_decl)));
+  if (!scope_assigned && function_method_decl != nullptr) {
+    clang::CXXRecordDecl *parent_class =
+        markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return function_method_decl->getParent(); }));
     if (parent_class) {
       SgClassDefinition *class_def =
           resolve_or_translate_class_definition(parent_class,
                                                 /*populate_definition=*/false);
-      clang::CXXRecordDecl *definition_decl = parent_class->getDefinition();
+      clang::CXXRecordDecl *definition_decl =
+          clangCXXRecordDefinitionDefined(parent_class);
       if (class_def == nullptr && definition_decl != nullptr &&
           definition_decl != parent_class) {
         class_def = resolve_or_translate_class_definition(
             definition_decl, /*populate_definition=*/false);
       }
-      clang::CXXRecordDecl *canonical_decl = parent_class->getCanonicalDecl();
+      clang::CXXRecordDecl *canonical_decl =
+          clangCXXRecordCanonicalDeclDefined(parent_class);
       if (class_def == nullptr && canonical_decl != nullptr &&
           canonical_decl != parent_class) {
         class_def = resolve_or_translate_class_definition(
             canonical_decl, /*populate_definition=*/false);
       }
       if (class_def == nullptr) {
-        clang::TemplateSpecializationKind tsk =
-            parent_class->getTemplateSpecializationKind();
+        clang::TemplateSpecializationKind tsk = readClangApiValueDefined(
+            [&]() { return parent_class->getTemplateSpecializationKind(); });
         bool allow_template_pattern =
             tsk == clang::TSK_ImplicitInstantiation ||
             tsk == clang::TSK_ExplicitInstantiationDeclaration ||
@@ -42169,8 +45070,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
       if (class_def == nullptr) {
         if (clang::ClassTemplateDecl *templ =
-                parent_class->getDescribedClassTemplate()) {
-          clang::CXXRecordDecl *templated = templ->getTemplatedDecl();
+                markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+                  return parent_class->getDescribedClassTemplate();
+                }))) {
+          clang::CXXRecordDecl *templated =
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return templ->getTemplatedDecl(); }));
           if (templated != nullptr && templated != parent_class) {
             class_def = resolve_or_translate_class_definition(
                 templated, /*populate_definition=*/false);
@@ -42221,13 +45126,18 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
               std::cerr << "  " << label << ": <null>" << std::endl;
               return;
             }
-            std::string name = record->getQualifiedNameAsString();
+            record = markClangSpecificDeclDefined(record);
+            std::string name = readClangApiValueDefined(
+                [&]() { return record->getQualifiedNameAsString(); });
             std::cerr << "  " << label << ": "
                       << (name.empty() ? "<unnamed>" : name) << " ("
                       << static_cast<clang::Decl *>(record)->getDeclKindName()
                       << ")"
-                      << " def=" << (record->getDefinition() != nullptr)
-                      << " tsk=" << record->getTemplateSpecializationKind()
+                      << " def="
+                      << (clangCXXRecordDefinitionDefined(record) != nullptr)
+                      << " tsk=" << readClangApiValueDefined([&]() {
+                           return record->getTemplateSpecializationKind();
+                         })
                       << std::endl;
             auto it = p_decl_translation_map.find(record);
             std::cerr << "    map="
@@ -42246,8 +45156,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             dump_record("pattern", pattern);
           }
           if (clang::ClassTemplateDecl *templ =
-                  parent_class->getDescribedClassTemplate()) {
-            dump_record("templated", templ->getTemplatedDecl());
+                  markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+                    return parent_class->getDescribedClassTemplate();
+                  }))) {
+            dump_record("templated",
+                        markClangSpecificDeclDefined(readClangApiValueDefined(
+                            [&]() { return templ->getTemplatedDecl(); })));
           }
         }
         if (node != nullptr) {
@@ -42346,13 +45260,17 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   }
 
-  if (isMethodDecl) {
-    auto *method_decl = llvm::cast<clang::CXXMethodDecl>(function_decl);
+  if (isMethodDecl && function_method_decl != nullptr) {
+    clang::CXXMethodDecl *method_decl = function_method_decl;
     if (methodDeclIsOutOfLine(method_decl)) {
-      clang::DeclContext *target_ctx = method_decl->getLexicalDeclContext();
-      while (target_ctx != nullptr &&
-             llvm::isa<clang::CXXRecordDecl>(target_ctx)) {
-        target_ctx = target_ctx->getParent();
+      clang::DeclContext *target_ctx =
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return method_decl->getLexicalDeclContext(); }));
+      while (target_ctx != nullptr && readClangApiValueDefined([&]() {
+               return llvm::isa<clang::CXXRecordDecl>(target_ctx);
+             })) {
+        target_ctx = markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return target_ctx->getParent(); }));
       }
       if (target_ctx != nullptr) {
         if (SgScopeStatement *out_of_line_scope =
@@ -42400,10 +45318,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   if (isFriendFreeFunction && friend_lexically_inside_class) {
     auto resolve_enclosing_namespace_scope =
         [&](clang::DeclContext *ctx) -> SgScopeStatement * {
-      clang::DeclContext *cursor = ctx;
-      while (cursor != nullptr && !cursor->isNamespace() &&
-             !cursor->isTranslationUnit()) {
-        cursor = cursor->getParent();
+      clang::DeclContext *cursor = markClangDeclContextObjectDefined(ctx);
+      while (cursor != nullptr && !readClangApiValueDefined([&]() {
+               return cursor->isNamespace();
+             }) &&
+             !readClangApiValueDefined(
+                 [&]() { return cursor->isTranslationUnit(); })) {
+        cursor = markClangDeclContextObjectDefined(
+            readClangApiValueDefined([&]() { return cursor->getParent(); }));
       }
       if (cursor == nullptr) {
         return nullptr;
@@ -42526,13 +45448,17 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     p_template_parameter_decl_context_stack.push_back(function_decl);
 
     clang::FunctionTypeLoc written_function_type_loc;
-    if (clang::TypeSourceInfo *type_info = markClangTypeSourceInfoDefined(
-            function_decl->getTypeSourceInfo())) {
-      for (clang::TypeLoc type_loc = type_info->getTypeLoc();
-           !type_loc.isNull(); type_loc = type_loc.getNextTypeLoc()) {
+    if (clang::TypeSourceInfo *type_info =
+            markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getTypeSourceInfo(); }))) {
+      for (clang::TypeLoc type_loc = readClangTypeLocDefined(
+               [&]() { return type_info->getTypeLoc(); });
+           !type_loc.isNull(); type_loc = nextClangTypeLocDefined(type_loc)) {
         markClangTypeLocDataDefined(type_loc);
-        markClangTypeObjectDefinedByClass(type_loc.getTypePtr());
-        if (auto func_loc = type_loc.getAs<clang::FunctionTypeLoc>()) {
+        markClangTypeObjectDefinedByClass(
+            readClangApiValueDefined([&]() { return type_loc.getTypePtr(); }));
+        if (auto func_loc = readClangTypeLocDefined(
+                [&]() { return type_loc.getAs<clang::FunctionTypeLoc>(); })) {
           markClangTypeLocDataDefined(func_loc);
           written_function_type_loc = func_loc;
           break;
@@ -42561,7 +45487,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     {
       ++p_force_nonlocal_injected_class_name_depth;
       if (!written_function_type_loc.isNull()) {
-        clang::TypeLoc return_loc = written_function_type_loc.getReturnLoc();
+        clang::TypeLoc return_loc = readClangTypeLocDefined(
+            [&]() { return written_function_type_loc.getReturnLoc(); });
         written_return_type_has_explicit_qualifier =
             static_cast<bool>(typeLocQualifierLoc(return_loc));
         written_return_type_spells_elaborated_keyword =
@@ -42647,7 +45574,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           return clang::SourceRange(l_paren, r_paren);
         }
       }
-      return function_decl->getParametersSourceRange();
+      return readClangApiValueDefined(
+          [&]() { return function_decl->getParametersSourceRange(); });
     };
 
     param_list = SageBuilder::buildFunctionParameterList_nfi();
@@ -42904,8 +45832,15 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       }
     };
 
+    const unsigned function_num_params = readClangApiValueDefined(
+        [&]() { return function_decl->getNumParams(); });
+    const unsigned prototype_num_params =
+        funcProtoType != nullptr ? readClangApiValueDefined([&]() {
+          return funcProtoType->getNumParams();
+        })
+                                 : 0;
     if (funcProtoType != nullptr &&
-        funcProtoType->getNumParams() != function_decl->getNumParams()) {
+        prototype_num_params != function_num_params) {
       diffInProtoType = true;
     }
 
@@ -42913,23 +45848,30 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     declScope->set_parent(SageBuilder::topScopeStack());
     SageBuilder::pushScopeStack(declScope);
 
-    for (unsigned i = 0; i < function_decl->getNumParams(); i++) {
-      clang::ParmVarDecl *param_decl = function_decl->getParamDecl(i);
+    for (unsigned i = 0; i < function_num_params; i++) {
+      clang::ParmVarDecl *param_decl = readClangApiValueDefined(
+          [&]() { return function_decl->getParamDecl(i); });
       clang::TypeLoc param_type_loc;
       param_decl = llvm::cast<clang::ParmVarDecl>(
           markClangDeclObjectDefinedByKind(param_decl));
       if (clang::TypeSourceInfo *param_type_info =
-              markClangTypeSourceInfoDefined(param_decl->getTypeSourceInfo())) {
-        param_type_loc = param_type_info->getTypeLoc();
+              markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                  [&]() { return param_decl->getTypeSourceInfo(); }))) {
+        param_type_loc = readClangApiValueDefined(
+            [&]() { return param_type_info->getTypeLoc(); });
       }
+      const clang::QualType declared_param_qual_type =
+          markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+              [&]() { return param_decl->getType(); }));
+      const clang::SourceRange param_source_range = readClangApiValueDefined(
+          [&]() { return param_decl->getSourceRange(); });
       (void)materialize_inline_tag_definition_for_qual_type(
-          param_type_loc, param_decl->getType(), param_decl->getSourceRange());
+          param_type_loc, declared_param_qual_type, param_source_range);
       if (funcProtoType != nullptr) {
-        const clang::QualType declared_param_type =
-            markClangFunctionTypeBoundaryDefined(param_decl->getType());
+        const clang::QualType declared_param_type = declared_param_qual_type;
         const clang::QualType proto_param_type =
-            markClangFunctionTypeBoundaryDefined(
-                funcProtoType->getParamType(i));
+            markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                [&]() { return funcProtoType->getParamType(i); }));
         bool differs = false;
         if (p_compiler_instance != nullptr) {
           differs = !p_compiler_instance->getASTContext().hasSameType(
@@ -42940,9 +45882,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         }
         if (differs) {
 #if DEBUG_VISIT_DECL
-          std::cout << "Func arg type :" << declared_param_type.getAsString()
+          std::cout << "Func arg type :"
+                    << clangQualTypeAsStringDefinedForFrontend(
+                           declared_param_type)
                     << " funcProtoType arg type:"
-                    << proto_param_type.getAsString() << std::endl;
+                    << clangQualTypeAsStringDefinedForFrontend(proto_param_type)
+                    << std::endl;
 #endif
           diffInProtoType = true;
         }
@@ -43396,6 +46341,48 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         register_decl(redecl);
       }
     }
+
+    if (template_decl != nullptr && readClangApiValueDefined([&]() {
+                                      return template_decl->getTemplatedDecl();
+                                    }) == clang_decl &&
+        specialization_kind == clang::TSK_Undeclared) {
+      SgDeclarationStatement *template_sage_decl =
+          isSgTemplateFunctionDeclaration(sage_decl);
+      if (template_sage_decl == nullptr) {
+        template_sage_decl = isSgTemplateMemberFunctionDeclaration(sage_decl);
+      }
+      if (template_sage_decl == nullptr) {
+        template_sage_decl = isSgTemplateFunctionDeclaration(
+            sage_decl->get_firstNondefiningDeclaration());
+      }
+      if (template_sage_decl == nullptr) {
+        template_sage_decl = isSgTemplateMemberFunctionDeclaration(
+            sage_decl->get_firstNondefiningDeclaration());
+      }
+      if (template_sage_decl == nullptr) {
+        template_sage_decl = isSgTemplateFunctionDeclaration(
+            sage_decl->get_definingDeclaration());
+      }
+      if (template_sage_decl == nullptr) {
+        template_sage_decl = isSgTemplateMemberFunctionDeclaration(
+            sage_decl->get_definingDeclaration());
+      }
+
+      auto register_template_decl = [&](clang::FunctionTemplateDecl *key) {
+        if (key == nullptr || template_sage_decl == nullptr) {
+          return;
+        }
+        auto it = p_decl_translation_map.find(key);
+        if (it == p_decl_translation_map.end() || it->second == nullptr ||
+            (is_hidden_frontend_placeholder(it->second) &&
+             !is_hidden_frontend_placeholder(template_sage_decl))) {
+          p_decl_translation_map[key] = template_sage_decl;
+        }
+      };
+
+      register_template_decl(template_decl);
+      register_template_decl(template_decl->getCanonicalDecl());
+    }
   };
 
   // REX FIX: Check if this is a function template pattern
@@ -43537,7 +46524,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       is_explicitly_defaulted || is_explicitly_deleted;
 
   auto resolve_function_body_decl =
-      [](clang::FunctionDecl *decl) -> clang::FunctionDecl * {
+      [&](clang::FunctionDecl *decl) -> clang::FunctionDecl * {
     decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
         markClangDeclObjectDefinedByKind(decl));
     if (decl == nullptr) {
@@ -43564,7 +46551,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
     if (clang::FunctionDecl *canonical =
             llvm::dyn_cast_or_null<clang::FunctionDecl>(
-                markClangDeclObjectDefinedByKind(decl->getCanonicalDecl()))) {
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return decl->getCanonicalDecl(); })))) {
       if (clang::FunctionDecl *def_decl =
               llvm::dyn_cast_or_null<clang::FunctionDecl>(
                   markClangDeclObjectDefinedByKind(readClangApiValueDefined(
@@ -43578,19 +46566,25 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
     if (clang::FunctionDecl *first =
             llvm::dyn_cast_or_null<clang::FunctionDecl>(
-                markClangDeclObjectDefinedByKind(decl->getFirstDecl()))) {
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return decl->getFirstDecl(); })))) {
       if (clang::FunctionDecl *def_decl =
               llvm::dyn_cast_or_null<clang::FunctionDecl>(
-                  markClangDeclObjectDefinedByKind(first->getDefinition()))) {
-        return def_decl->getBody() != nullptr ? def_decl : nullptr;
+                  markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                      [&]() { return first->getDefinition(); })))) {
+        return readClangApiValueDefined(
+                   [&]() { return def_decl->getBody(); }) != nullptr
+                   ? def_decl
+                   : nullptr;
       }
     }
 
-    for (clang::FunctionDecl *redecl : decl->redecls()) {
-      redecl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
-          markClangDeclObjectDefinedByKind(redecl));
-      if (redecl != nullptr && redecl->doesThisDeclarationHaveABody() &&
-          redecl->getBody() != nullptr) {
+    for (clang::FunctionDecl *redecl : collect_function_redecls(decl)) {
+      if (redecl != nullptr && readClangApiValueDefined([&]() {
+            return redecl->doesThisDeclarationHaveABody();
+          }) &&
+          readClangApiValueDefined([&]() { return redecl->getBody(); }) !=
+              nullptr) {
         return redecl;
       }
     }
@@ -43607,18 +46601,24 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
     clang::FunctionDecl *body_decl = resolve_function_body_decl(function_decl);
     clang::CXXMethodDecl *body_method_decl =
-        llvm::dyn_cast_or_null<clang::CXXMethodDecl>(body_decl);
+        llvm::dyn_cast_or_null<clang::CXXMethodDecl>(
+            markClangDeclObjectDefinedByKind(body_decl));
     if (body_method_decl == nullptr) {
       return false;
     }
 
     clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-    if (!shouldSuppressDeclNotWrittenInMainFile(body_decl->getLocation(), sm) ||
+    if (!shouldSuppressDeclNotWrittenInMainFile(
+            readClangApiValueDefined(
+                [&]() { return body_decl->getLocation(); }),
+            sm) ||
         !isSystemOrBuiltinFunctionDecl(body_decl, sm)) {
       return false;
     }
 
-    clang::CXXRecordDecl *parent_record = body_method_decl->getParent();
+    clang::CXXRecordDecl *parent_record =
+        markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return body_method_decl->getParent(); }));
     if (parent_record == nullptr) {
       return false;
     }
@@ -43846,6 +46846,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           }
         }
       };
+      bool rebuild_body_translation_cache = false;
       if (body_stmt != nullptr) {
         bool old_body_is_placeholder = false;
         if (old_body != nullptr) {
@@ -43872,59 +46873,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
              specialization_kind ==
                  clang::TSK_ExplicitInstantiationDeclaration);
 
-        std::function<void(clang::Decl *)> recursive_invalidate_decl;
-        std::function<void(clang::Stmt *)> recursive_invalidate_stmt;
-
-        recursive_invalidate_decl = [&](clang::Decl *d) {
-          if (!d)
-            return;
-          d = markClangDeclObjectDefinedByKind(d);
-          auto it = p_decl_translation_map.find(d);
-          if (it != p_decl_translation_map.end()) {
-            p_decl_translation_map.erase(it);
-          }
-
-          // Recurse into DeclContext (e.g. structs)
-          if (auto *ctx = llvm::dyn_cast<clang::DeclContext>(d)) {
-            for (auto *child : ctx->decls()) {
-              recursive_invalidate_decl(child);
-            }
-          }
-
-          // Handle FunctionDecl body
-          if (auto *fd = llvm::dyn_cast<clang::FunctionDecl>(d)) {
-            if (fd->hasBody())
-              recursive_invalidate_stmt(fd->getBody());
-          }
-          // Handle VarDecl init
-          if (auto *vd = llvm::dyn_cast<clang::VarDecl>(d)) {
-            if (vd->getInit())
-              recursive_invalidate_stmt(vd->getInit());
-          }
-        };
-
-        recursive_invalidate_stmt = [&](clang::Stmt *s) {
-          if (!s)
-            return;
-          s = markClangStmtObjectDefinedByClass(s);
-          auto it = p_stmt_translation_map.find(s);
-          if (it != p_stmt_translation_map.end()) {
-            p_stmt_translation_map.erase(it);
-          }
-
-          // Handle DeclStmt specifically to descend into Decls
-          if (auto *ds = llvm::dyn_cast<clang::DeclStmt>(s)) {
-            for (auto *d : ds->decls()) {
-              recursive_invalidate_decl(d);
-            }
-          }
-
-          // Handle Stmt children
-          for (auto *child : s->children()) {
-            child = markClangStmtObjectDefinedByClass(child);
-            recursive_invalidate_stmt(child);
-          }
-        };
+        rebuild_body_translation_cache =
+            need_invalidate || isolate_template_body;
 
         if (need_invalidate) {
           if (old_body != nullptr) {
@@ -43994,9 +46944,6 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                 SageInterface::DeleteAstMode::kSkipExternalReferences);
             old_body = nullptr;
           }
-          recursive_invalidate_stmt(body_stmt);
-        } else if (isolate_template_body) {
-          recursive_invalidate_stmt(body_stmt);
         } else if (old_body != nullptr) {
           placeholder_body = old_body;
         }
@@ -44011,7 +46958,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         p_template_parameter_decl_context_stack.push_back(body_decl);
       }
 
-      SgNode *tmp_body = Traverse(body_stmt);
+      SgNode *tmp_body = nullptr;
+      {
+        ScopedTranslationCacheRebuild rebuild_translation_cache(
+            p_rebuild_translation_cache_depth, rebuild_body_translation_cache);
+        tmp_body = Traverse(body_stmt);
+      }
       SgBasicBlock *body = isSgBasicBlock(tmp_body);
       if (body == nullptr) {
         if (SgTryStmt *try_stmt = isSgTryStmt(tmp_body)) {
@@ -44171,11 +47123,18 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         clang::FunctionDecl *deduced_specialization = nullptr;
         clang::sema::TemplateDeductionInfo deduction_info(
             function_decl->getLocation());
+        clang::QualType function_type =
+            markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getType(); }));
         clang::TemplateDeductionResult deduction_result =
-            p_compiler_instance->getSema().DeduceTemplateArguments(
-                primary, /*ExplicitTemplateArgs=*/nullptr,
-                function_decl->getType(), deduced_specialization,
-                deduction_info, /*IsAddressOfFunction=*/false);
+            readClangApiValueDefined([&]() {
+              return p_compiler_instance->getSema().DeduceTemplateArguments(
+                  primary, /*ExplicitTemplateArgs=*/nullptr, function_type,
+                  deduced_specialization, deduction_info,
+                  /*IsAddressOfFunction=*/false);
+            });
+        deduced_specialization =
+            markClangSpecificDeclDefined(deduced_specialization);
         if (deduction_result != clang::TemplateDeductionResult::Success ||
             deduced_specialization == nullptr) {
           return true;
@@ -44953,7 +47912,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           }
 
           apply_template_instantiation_info(
-              sg_function_decl, /*preserve_existing_explicit=*/false);
+              sg_function_decl,
+              /*preserve_existing_explicit=*/false);
 
           register_function_translation(function_decl, sg_function_decl);
           if (!skip_function_body_translation) {
@@ -44996,7 +47956,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         if (sg_function_decl != nullptr &&
             sg_function_decl != inst_symbol_decl) {
           apply_template_instantiation_info(
-              sg_function_decl, /*preserve_existing_explicit=*/false);
+              sg_function_decl,
+              /*preserve_existing_explicit=*/false);
         }
 
         // Only implicit instantiations should be emitted as ordinary scope
@@ -45582,20 +48543,11 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             !template_parameter_lists_match(
                 defining_template->get_templateParameters(),
                 *effective_template_params)) {
-          SgTemplateParameterPtrList adjusted_template_params;
-          adjusted_template_params.reserve(effective_template_params->size());
-          for (SgTemplateParameter *param : *effective_template_params) {
-            if (param == nullptr) {
-              continue;
-            }
-            SgTemplateParameter *param_copy =
-                isSgTemplateParameter(SageInterface::deepCopy(param));
-            if (param_copy == nullptr) {
-              continue;
-            }
-            param_copy->set_defaultTypeParameter(nullptr);
-            param_copy->set_defaultExpressionParameter(nullptr);
-            param_copy->set_defaultTemplateDeclarationParameter(nullptr);
+          SgTemplateParameterPtrList adjusted_template_params =
+              clone_template_parameter_list_surface(*effective_template_params,
+                                                    /*preserve_defaults=*/false,
+                                                    /*anchor_nonreals=*/true);
+          for (SgTemplateParameter *param_copy : adjusted_template_params) {
             param_copy->set_parent(defining_template);
             if (param_copy->get_parameterType() !=
                     SgTemplateParameter::template_parameter &&
@@ -45606,7 +48558,6 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                     param_copy->get_initializedName()) {
               init_name->set_parent(param_copy);
             }
-            adjusted_template_params.push_back(param_copy);
           }
           defining_template->get_templateParameters() =
               adjusted_template_params;
@@ -46983,8 +49934,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     auto function_build_chain_repair_start = std::chrono::steady_clock::now();
 
     auto skip_linkage_context = [](clang::DeclContext *ctx) {
+      ctx = markClangDeclContextObjectDefined(ctx);
       while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-        ctx = ctx->getParent();
+        ctx = markClangDeclContextObjectDefined(
+            readClangApiValueDefined([&]() { return ctx->getParent(); }));
       }
       return ctx;
     };
@@ -46994,10 +49947,11 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         return false;
       }
 
-      clang::DeclContext *decl_ctx =
-          skip_linkage_context(decl->getDeclContext());
+      clang::DeclContext *decl_ctx = skip_linkage_context(
+          readClangApiValueDefined([&]() { return decl->getDeclContext(); }));
       clang::DeclContext *lex_ctx =
-          skip_linkage_context(decl->getLexicalDeclContext());
+          skip_linkage_context(readClangApiValueDefined(
+              [&]() { return decl->getLexicalDeclContext(); }));
       return (decl_ctx != nullptr &&
               llvm::isa<clang::CXXRecordDecl>(decl_ctx)) ||
              (lex_ctx != nullptr && llvm::isa<clang::CXXRecordDecl>(lex_ctx));
@@ -47168,7 +50122,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     auto promote_lexical_class_member_over_same_source_duplicate = [&]() {
       if (sg_function_decl == nullptr || !isMethodDecl ||
           isFriendFreeFunction || !current_matches_first_source_decl ||
-          !current_decl_has_real_source_location ||
+          !current_decl_has_real_source_location || on_demand_translation ||
           sg_function_decl->get_definition() != nullptr) {
         return;
       }
@@ -47490,7 +50444,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   auto preserve_visible_first_decl_over_hidden_builtin_support_decl =
       [&](SgFunctionDeclaration *decl) -> SgFunctionDeclaration * {
     if (decl == nullptr || has_builtin_id || has_builtin_name_prefix ||
-        function_decl->hasAttr<clang::BuiltinAttr>()) {
+        clangDeclHasBuiltinAttrDefinedForFrontend(function_decl)) {
       return nullptr;
     }
 
@@ -47650,11 +50604,17 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     return symbol != nullptr &&
            symbol_present_in_scope(decl->get_scope(), symbol);
   };
+  clang::DeclContext *function_decl_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return function_decl->getDeclContext(); }));
+  clang::DeclContext *function_lexical_decl_context =
+      markClangDeclContextObjectDefined(readClangApiValueDefined(
+          [&]() { return function_decl->getLexicalDeclContext(); }));
   const bool use_builder_member_symbol_fast_path =
-      !isFriendFreeFunction && function_decl->getDeclContext() != nullptr &&
-      function_decl->getDeclContext()->isRecord() &&
-      function_decl->getLexicalDeclContext() ==
-          function_decl->getDeclContext() &&
+      !isFriendFreeFunction && function_decl_context != nullptr &&
+      readClangApiValueDefined(
+          [&]() { return function_decl_context->isRecord(); }) &&
+      function_lexical_decl_context == function_decl_context &&
       has_authoritative_builder_member_symbol(sg_function_decl) &&
       has_authoritative_builder_member_symbol(isSgFunctionDeclaration(
           sg_function_decl->get_firstNondefiningDeclaration())) &&
@@ -47673,24 +50633,6 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       return isSgMemberFunctionDeclaration(candidate) != nullptr ||
              isSgTemplateMemberFunctionDeclaration(candidate) != nullptr;
     };
-    if (roseShouldTraceFunctionDeclChain(function_decl)) {
-      fprintf(stderr,
-              "ROSECHAINDBG phase=ensure-function-symbol decl=%p class=%s "
-              "isFriendFreeFunction=%d isDefinition=%d "
-              "current_matches_first_source_decl=%d "
-              "current_decl_has_real_source_location=%d "
-              "on_demand_translation=%d "
-              "decl_is_hidden_placeholder=%d decl_has_definition=%d "
-              "decl_is_member=%d\n",
-              decl, decl->class_name().c_str(), isFriendFreeFunction ? 1 : 0,
-              isDefinition ? 1 : 0, current_matches_first_source_decl ? 1 : 0,
-              current_decl_has_real_source_location ? 1 : 0,
-              on_demand_translation ? 1 : 0,
-              is_hidden_frontend_placeholder(decl) ? 1 : 0,
-              decl->get_definition() != nullptr ? 1 : 0,
-              is_member_like(decl) ? 1 : 0);
-      fflush(stderr);
-    }
 
     auto scopes_match = [&](SgScopeStatement *lhs,
                             SgScopeStatement *rhs) -> bool {
@@ -48343,10 +51285,14 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           nestedNameSpecifierNeedsTemplateParameterTranslation(
               explicit_source_qualifier)) {
         if (clang::NestedNameSpecifierLoc qual_loc =
-                function_decl->getQualifierLoc()) {
-          if (qual_loc.getLocalSourceRange().isValid()) {
+                markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                    [&]() { return function_decl->getQualifierLoc(); }))) {
+          const clang::SourceRange local_range = readClangApiValueDefined(
+              [&]() { return qual_loc.getLocalSourceRange(); });
+          if (local_range.isValid()) {
             std::string qualifier_string =
-                trimWhitespace(getSourceText(qual_loc.getSourceRange()));
+                trimWhitespace(getSourceText(readClangApiValueDefined(
+                    [&]() { return qual_loc.getSourceRange(); })));
             if (!qualifier_string.empty()) {
               int qualifier_length =
                   nestedNameSpecifierComponentCount(explicit_source_qualifier);
@@ -49170,6 +52116,13 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         if (first_nondef == nullptr || first_nondef == defining) {
           return;
         }
+        if (declaration_has_real_source(first_nondef) &&
+            !is_hidden_frontend_placeholder(first_nondef)) {
+          return;
+        }
+        if (is_visible_source_function_decl(first_nondef)) {
+          return;
+        }
 
         // Only suppress the extra non-defining declaration when it is
         // synthetic. If Clang has a prior declaration in the redecl chain, that
@@ -49305,6 +52258,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     if (first_nondef == source_first || first_nondef == source_first_nondef) {
+      return;
+    }
+    if (is_visible_source_function_decl(first_nondef)) {
       return;
     }
 
@@ -49561,8 +52517,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         nullptr) {
       return;
     }
-    if (!function_decl->hasBody() ||
-        function_decl->doesThisDeclarationHaveABody()) {
+    if (!readClangApiValueDefined([&]() { return function_decl->hasBody(); }) ||
+        readClangApiValueDefined(
+            [&]() { return function_decl->doesThisDeclarationHaveABody(); })) {
       return;
     }
 
@@ -50104,8 +53061,17 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     if (lexical_decl != nullptr &&
         !(on_demand_translation &&
           explicit_instantiation_directive == nullptr)) {
+      SgScopeStatement *lexical_attach_scope = lexical_scope;
+      if (SgNamespaceDefinitionStatement *lexical_ns =
+              isSgNamespaceDefinitionStatement(lexical_attach_scope)) {
+        if (SgLocatedNode *located_decl = isSgLocatedNode(lexical_decl)) {
+          lexical_attach_scope =
+              selectNamespaceFragmentBySourcePosition(located_decl, lexical_ns);
+        }
+      }
       ensure_decl_in_scope_child_list_preserve_scope(
-          lexical_decl, lexical_scope, "translateFunctionDeclCommon:lexical");
+          lexical_decl, lexical_attach_scope,
+          "translateFunctionDeclCommon:lexical");
     }
   }
 
@@ -50118,8 +53084,16 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       bool is_member_decl =
           isSgMemberFunctionDeclaration(decl) != nullptr ||
           isSgTemplateMemberFunctionDeclaration(decl) != nullptr;
-      if (!is_member_decl && decl->get_scope() != lexical_scope) {
-        decl->set_scope(lexical_scope);
+      if (!is_member_decl) {
+        SgScopeStatement *decl_lexical_scope = lexical_scope;
+        if (SgNamespaceDefinitionStatement *lexical_ns =
+                isSgNamespaceDefinitionStatement(decl_lexical_scope)) {
+          decl_lexical_scope =
+              selectNamespaceFragmentBySourcePosition(decl, lexical_ns);
+        }
+        if (decl->get_scope() != decl_lexical_scope) {
+          decl->set_scope(decl_lexical_scope);
+        }
       }
     };
     enforce_lexical_namespace_scope(isSgFunctionDeclaration(sg_function_decl));
@@ -50326,13 +53300,24 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
     SgFunctionDeclaration *source_first = lookup_existing_decl(clang_first);
     if (source_first == nullptr) {
+      if (SgSymbol *tmp_symbol = GetSymbolFromSymbolTable(clang_first)) {
+        source_first = function_declaration_from_symbol(tmp_symbol);
+      }
+    }
+    if (source_first == nullptr &&
+        p_decl_translation_in_progress.find(clang_first) ==
+            p_decl_translation_in_progress.end()) {
+      source_first = isSgFunctionDeclaration(TraverseOnDemand(clang_first));
+    }
+    if (source_first == nullptr) {
       return false;
     }
     if (SgFunctionDeclaration *first_nondef = isSgFunctionDeclaration(
             source_first->get_firstNondefiningDeclaration())) {
       source_first = first_nondef;
     }
-    return declaration_has_real_source(source_first) &&
+    return (declaration_has_real_source(source_first) ||
+            is_visible_source_function_decl(source_first)) &&
            decl_output_enabled(source_first);
   }();
   const bool member_is_spelled_in_parent_class_body =
@@ -50341,8 +53326,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   bool suppress_hidden_parent_member = false;
   if (isMethodDecl) {
-    auto *method_decl = llvm::cast<clang::CXXMethodDecl>(function_decl);
-    clang::CXXRecordDecl *parent_record = method_decl->getParent();
+    auto *method_decl = llvm::cast<clang::CXXMethodDecl>(
+        markClangDeclObjectDefinedByKind(function_decl));
+    clang::CXXRecordDecl *parent_record =
+        llvm::cast_or_null<clang::CXXRecordDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return method_decl->getParent(); })));
     if (parent_record != nullptr) {
       SgClassDefinition *parent_def =
           resolve_or_translate_class_definition(parent_record,
@@ -50455,9 +53444,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   if (SgMemberFunctionDeclaration *member_decl =
           isSgMemberFunctionDeclaration(sg_function_decl)) {
-    if (clang::CXXMethodDecl *method_decl =
-            llvm::dyn_cast<clang::CXXMethodDecl>(function_decl)) {
-      clang::CXXRecordDecl *parent_decl = method_decl->getParent();
+    if (clang::CXXMethodDecl *method_decl = markClangSpecificDeclDefined(
+            llvm::dyn_cast<clang::CXXMethodDecl>(function_decl))) {
+      clang::CXXRecordDecl *parent_decl = markClangSpecificDeclDefined(
+          readClangApiValueDefined([&]() { return method_decl->getParent(); }));
 
       auto node_to_class_decl = [](SgNode *node) -> SgClassDeclaration * {
         if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
@@ -50486,6 +53476,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
       auto lookup_class_decl =
           [&](clang::CXXRecordDecl *record) -> SgClassDeclaration * {
+        record = markClangSpecificDeclDefined(record);
         if (record == nullptr) {
           return nullptr;
         }
@@ -50517,18 +53508,24 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           return assoc_from_parent;
         }
 
-        if (clang::CXXRecordDecl *def = parent_decl->getDefinition()) {
+        if (clang::CXXRecordDecl *def =
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return parent_decl->getDefinition(); }))) {
           if (SgClassDeclaration *assoc_from_def = lookup_class_decl(def)) {
             return assoc_from_def;
           }
         }
 
-        if (clang::CXXRecordDecl *canonical = parent_decl->getCanonicalDecl()) {
+        if (clang::CXXRecordDecl *canonical =
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return parent_decl->getCanonicalDecl(); }))) {
           if (SgClassDeclaration *assoc_from_canonical =
                   lookup_class_decl(canonical)) {
             return assoc_from_canonical;
           }
-          if (clang::CXXRecordDecl *def = canonical->getDefinition()) {
+          if (clang::CXXRecordDecl *def =
+                  markClangSpecificDeclDefined(readClangApiValueDefined(
+                      [&]() { return canonical->getDefinition(); }))) {
             if (SgClassDeclaration *assoc_from_canonical_def =
                     lookup_class_decl(def)) {
               return assoc_from_canonical_def;
@@ -50537,7 +53534,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         }
 
         clang::CXXRecordDecl *to_translate = parent_decl;
-        if (clang::CXXRecordDecl *def = parent_decl->getDefinition()) {
+        if (clang::CXXRecordDecl *def =
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return parent_decl->getDefinition(); }))) {
           to_translate = def;
         }
         if (p_decl_translation_map.find(to_translate) ==
@@ -50551,18 +53550,27 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       };
       auto lookup_associated_class_from_written_qualifier =
           [&]() -> SgClassDeclaration * {
-        clang::NestedNameSpecifier qualifier = function_decl->getQualifier();
+        clang::NestedNameSpecifier qualifier =
+            markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                [&]() { return function_decl->getQualifier(); }));
         if (!qualifier) {
           return nullptr;
         }
 
         clang::CXXRecordDecl *qualified_record = nullptr;
-        for (clang::NestedNameSpecifier current = qualifier; current;
-             current = nestedNameSpecifierPrefix(current)) {
-          if (current.getKind() != clang::NestedNameSpecifier::Kind::Type) {
+        for (clang::NestedNameSpecifier current =
+                 markClangNestedNameSpecifierDefined(qualifier);
+             current; current = markClangNestedNameSpecifierDefined(
+                          readClangApiValueDefined([&]() {
+                            return nestedNameSpecifierPrefix(current);
+                          }))) {
+          if (readClangApiValueDefined([&]() { return current.getKind(); }) !=
+              clang::NestedNameSpecifier::Kind::Type) {
             continue;
           }
-          if (clang::CXXRecordDecl *record = current.getAsRecordDecl()) {
+          if (clang::CXXRecordDecl *record =
+                  markClangSpecificDeclDefined(readClangApiValueDefined(
+                      [&]() { return current.getAsRecordDecl(); }))) {
             qualified_record = record;
             break;
           }
@@ -50575,18 +53583,23 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                 lookup_class_decl(qualified_record)) {
           return assoc_from_qualifier;
         }
-        if (clang::CXXRecordDecl *def = qualified_record->getDefinition()) {
+        if (clang::CXXRecordDecl *def =
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return qualified_record->getDefinition(); }))) {
           if (SgClassDeclaration *assoc_from_def = lookup_class_decl(def)) {
             return assoc_from_def;
           }
         }
         if (clang::CXXRecordDecl *canonical =
-                qualified_record->getCanonicalDecl()) {
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return qualified_record->getCanonicalDecl(); }))) {
           if (SgClassDeclaration *assoc_from_canonical =
                   lookup_class_decl(canonical)) {
             return assoc_from_canonical;
           }
-          if (clang::CXXRecordDecl *def = canonical->getDefinition()) {
+          if (clang::CXXRecordDecl *def =
+                  markClangSpecificDeclDefined(readClangApiValueDefined(
+                      [&]() { return canonical->getDefinition(); }))) {
             if (SgClassDeclaration *assoc_from_canonical_def =
                     lookup_class_decl(def)) {
               return assoc_from_canonical_def;
@@ -50626,36 +53639,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         auto build_stripped_template_param_copy =
             [&](const SgTemplateParameterPtrList &params)
             -> std::unique_ptr<SgTemplateParameterPtrList> {
-          auto copied_params = std::make_unique<SgTemplateParameterPtrList>();
-          copied_params->reserve(params.size());
-          for (SgTemplateParameter *param : params) {
-            if (param == nullptr) {
-              continue;
-            }
-
-            SgTemplateParameter *param_copy =
-                isSgTemplateParameter(SageInterface::deepCopy(param));
-            if (param_copy == nullptr) {
-              continue;
-            }
-
-            param_copy->set_parent(nullptr);
-            if (param_copy->get_parameterType() !=
-                SgTemplateParameter::template_parameter) {
-              param_copy->set_templateDeclaration(nullptr);
-            }
-            if (SgInitializedName *init_name =
-                    param_copy->get_initializedName()) {
-              init_name->set_parent(param_copy);
-            }
-            if (SgExpression *constraint = param_copy->get_typeConstraint()) {
-              attach_template_parameter_expression(param_copy, constraint);
-            }
-            param_copy->set_defaultTypeParameter(nullptr);
-            param_copy->set_defaultExpressionParameter(nullptr);
-            param_copy->set_defaultTemplateDeclarationParameter(nullptr);
-            copied_params->push_back(param_copy);
-          }
+          auto copied_params = std::make_unique<SgTemplateParameterPtrList>(
+              clone_template_parameter_list_surface(params,
+                                                    /*preserve_defaults=*/false,
+                                                    /*anchor_nonreals=*/true));
           return copied_params;
         };
         auto template_parameter_name =
@@ -50983,6 +53970,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
         auto record_has_template_header =
             [](const clang::CXXRecordDecl *record) -> bool {
+          record = markClangCXXRecordTemplateOrInstantiationStateDefined(
+              const_cast<clang::CXXRecordDecl *>(record));
           if (record == nullptr) {
             return false;
           }
@@ -50990,7 +53979,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
             return true;
           }
           if (const clang::CXXRecordDecl *canonical =
-                  record->getCanonicalDecl()) {
+                  markClangCXXRecordTemplateOrInstantiationStateDefined(
+                      const_cast<clang::CXXRecordDecl *>(
+                          readClangApiValueDefined(
+                              [&]() { return record->getCanonicalDecl(); })))) {
             if (canonical != record &&
                 templateParametersForDeclContext(canonical) != nullptr) {
               return true;
@@ -51022,7 +54014,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           }
 
           clang::NestedNameSpecifierLoc qualifier_loc =
-              function_decl->getQualifierLoc();
+              markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                  [&]() { return function_decl->getQualifierLoc(); }));
           if (!qualifier_loc) {
             return nullptr;
           }
@@ -51035,19 +54028,39 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           auto build_template_arguments_from_qualifier_segment =
               [&](clang::NestedNameSpecifierLoc segment_loc)
               -> std::unique_ptr<SgTemplateArgumentPtrList> {
-            if (!segment_loc ||
-                segment_loc.getNestedNameSpecifier().getKind() !=
-                    clang::NestedNameSpecifier::Kind::Type) {
+            segment_loc = markClangNestedNameSpecifierLocDefined(segment_loc);
+            if (!segment_loc) {
+              return nullptr;
+            }
+            clang::NestedNameSpecifier segment_specifier =
+                markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                    [&]() { return segment_loc.getNestedNameSpecifier(); }));
+            if (!segment_specifier ||
+                readClangApiValueDefined([&]() {
+                  return segment_specifier.getKind();
+                }) != clang::NestedNameSpecifier::Kind::Type) {
               return nullptr;
             }
 
-            for (clang::TypeLoc current = segment_loc.getAsTypeLoc();
-                 !current.isNull(); current = current.getNextTypeLoc()) {
-              if (auto spec_loc =
-                      current.getAs<clang::TemplateSpecializationTypeLoc>()) {
+            for (clang::TypeLoc current = readClangTypeLocDefined(
+                     [&]() { return segment_loc.getAsTypeLoc(); });
+                 !current.isNull();
+                 current = nextClangTypeLocDefined(current)) {
+              clang::TemplateSpecializationTypeLoc spec_loc =
+                  readClangApiValueDefined([&]() {
+                    return current
+                        .getAs<clang::TemplateSpecializationTypeLoc>();
+                  });
+              markClangTypeLocDataDefined(spec_loc);
+              if (spec_loc) {
                 auto args = std::make_unique<SgTemplateArgumentPtrList>();
-                for (unsigned i = 0; i < spec_loc.getNumArgs(); ++i) {
-                  appendTemplateArguments(*args, spec_loc.getArgLoc(i), true);
+                const unsigned num_args = readClangApiValueDefined(
+                    [&]() { return spec_loc.getNumArgs(); });
+                for (unsigned i = 0; i < num_args; ++i) {
+                  clang::TemplateArgumentLoc arg_loc = readClangApiValueDefined(
+                      [&]() { return spec_loc.getArgLoc(i); });
+                  markClangTemplateArgumentLocDefined(arg_loc);
+                  appendTemplateArguments(*args, arg_loc, true);
                 }
                 ensureTemplateArgumentParents(*args);
                 return args;
@@ -51058,10 +54071,16 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           };
 
           std::vector<QualifierRecordSegment> qualifier_records;
-          for (clang::NestedNameSpecifierLoc current = qualifier_loc; current;
-               current = nestedNameSpecifierLocPrefix(current)) {
-            if (current.getNestedNameSpecifier().getKind() !=
-                clang::NestedNameSpecifier::Kind::Type) {
+          for (clang::NestedNameSpecifierLoc current =
+                   markClangNestedNameSpecifierLocDefined(qualifier_loc);
+               current; current = nestedNameSpecifierLocPrefix(current)) {
+            clang::NestedNameSpecifier current_specifier =
+                markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                    [&]() { return current.getNestedNameSpecifier(); }));
+            if (!current_specifier ||
+                readClangApiValueDefined([&]() {
+                  return current_specifier.getKind();
+                }) != clang::NestedNameSpecifier::Kind::Type) {
               continue;
             }
             clang::CXXRecordDecl *record =
@@ -51089,13 +54108,18 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
             SgClassDeclaration *segment_decl = lookup_class_decl(record);
             if (segment_decl == nullptr) {
-              if (clang::CXXRecordDecl *def = record->getDefinition()) {
+              if (clang::CXXRecordDecl *def =
+                      markClangCXXRecordTemplateOrInstantiationStateDefined(
+                          readClangApiValueDefined(
+                              [&]() { return record->getDefinition(); }))) {
                 segment_decl = lookup_class_decl(def);
               }
             }
             if (segment_decl == nullptr) {
               if (clang::CXXRecordDecl *canonical =
-                      record->getCanonicalDecl()) {
+                      markClangCXXRecordTemplateOrInstantiationStateDefined(
+                          readClangApiValueDefined(
+                              [&]() { return record->getCanonicalDecl(); }))) {
                 segment_decl = lookup_class_decl(canonical);
               }
             }
@@ -51173,7 +54197,9 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         const bool prefer_direct_associated_class =
             method_is_out_of_line ||
             specialization_kind == clang::TSK_ExplicitSpecialization ||
-            static_cast<bool>(function_decl->getQualifier());
+            static_cast<bool>(
+                markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                    [&]() { return function_decl->getQualifier(); })));
         auto apply_associated_class = [&](SgFunctionDeclaration *decl_to_fix) {
           if (SgMemberFunctionDeclaration *member_to_fix =
                   isSgMemberFunctionDeclaration(decl_to_fix)) {
@@ -51232,19 +54258,12 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
           return;
         }
 
-        SgTemplateParameterPtrList copied_params;
-        copied_params.reserve(templateParams->size());
-        for (SgTemplateParameter *param : *templateParams) {
-          if (param == nullptr) {
-            continue;
-          }
-
-          SgTemplateParameter *param_copy =
-              isSgTemplateParameter(SageInterface::deepCopy(param));
-          if (param_copy == nullptr) {
-            continue;
-          }
-
+        SgTemplateParameterPtrList copied_params =
+            clone_template_parameter_list_surface(
+                *templateParams,
+                /*preserve_defaults=*/preserve_spelled_defaults,
+                /*anchor_nonreals=*/true);
+        for (SgTemplateParameter *param_copy : copied_params) {
           param_copy->set_parent(decl);
           if (param_copy->get_parameterType() !=
               SgTemplateParameter::template_parameter) {
@@ -51261,8 +54280,6 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
                   param_copy->get_defaultExpressionParameter()) {
             attach_template_parameter_expression(param_copy, default_expr);
           }
-
-          copied_params.push_back(param_copy);
         }
 
         normalize_function_template_parameter_defaults(
@@ -51387,11 +54404,283 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       is_template_function_decl(sg_function_decl) ||
       is_template_function_decl(first_nondef_decl) ||
       is_template_function_decl(defining_decl);
-  const bool force_template_ast_unparse =
+  bool force_template_ast_unparse =
       has_template_ast_unparse_target &&
       shouldForceTemplateAstUnparse(p_compiler_instance, function_decl,
                                     p_sage_source_file, on_demand_translation,
                                     specialization_kind_early);
+
+  auto decl_context_is_class_like = [](clang::DeclContext *ctx) {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
+      ctx = markClangDeclContextObjectDefined(ctx->getParent());
+    }
+    return ctx != nullptr && llvm::isa<clang::CXXRecordDecl>(ctx);
+  };
+
+  auto source_text_has_conditional_control = [](llvm::StringRef text) {
+    auto line_spells_directive = [](llvm::StringRef line,
+                                    llvm::StringRef directive) {
+      line = line.trim(" \t\r\n");
+      if (!line.consume_front("#")) {
+        return false;
+      }
+      line = line.ltrim(" \t");
+      if (!line.consume_front(directive)) {
+        return false;
+      }
+      return line.empty() || line.front() == ' ' || line.front() == '\t' ||
+             line.front() == '\r' || line.front() == '\n';
+    };
+
+    size_t cursor = 0;
+    while (cursor <= text.size()) {
+      size_t line_end = text.find_first_of("\r\n", cursor);
+      llvm::StringRef line = line_end == llvm::StringRef::npos
+                                 ? text.substr(cursor)
+                                 : text.substr(cursor, line_end - cursor);
+      if (line_spells_directive(line, "if") ||
+          line_spells_directive(line, "ifdef") ||
+          line_spells_directive(line, "ifndef") ||
+          line_spells_directive(line, "elif") ||
+          line_spells_directive(line, "else") ||
+          line_spells_directive(line, "endif")) {
+        return true;
+      }
+      if (line_end == llvm::StringRef::npos) {
+        break;
+      }
+      cursor = line_end + 1;
+    }
+    return false;
+  };
+
+  auto source_text_for_template_function = [&](clang::SourceRange range,
+                                               const clang::Decl *source_decl) {
+    if (p_compiler_instance == nullptr || source_decl == nullptr ||
+        !range.isValid()) {
+      return std::string();
+    }
+
+    const bool range_spells_macro_definition =
+        declSourceRangeSpellsMacroDefinition(
+            p_compiler_instance, const_cast<clang::Decl *>(source_decl), range);
+    if (range_spells_macro_definition) {
+      return std::string();
+    }
+
+    clang::SourceRange normalized_range =
+        normalizeDeclSourceRangeForMacroExpansion(
+            p_compiler_instance, const_cast<clang::Decl *>(source_decl), range);
+    if (normalized_range.isValid() &&
+        decl_range_should_consume_trailing_semicolon(source_decl)) {
+      normalized_range = extendDeclSourceRangeWithTrailingSemicolon(
+          normalized_range, p_compiler_instance->getSourceManager(),
+          p_compiler_instance->getLangOpts());
+    }
+    if (!normalized_range.isValid()) {
+      return std::string();
+    }
+
+    clang::SourceManager &sm = p_compiler_instance->getSourceManager();
+    const clang::LangOptions &lang_opts = p_compiler_instance->getLangOpts();
+    clang::SourceLocation begin = normalized_range.getBegin();
+    clang::SourceLocation end = normalized_range.getEnd();
+    if (begin.isMacroID()) {
+      begin = sm.getSpellingLoc(begin);
+    }
+    if (end.isMacroID()) {
+      end = sm.getSpellingLoc(end);
+    }
+    begin = sm.getFileLoc(begin);
+    end = sm.getFileLoc(end);
+    if (!begin.isValid() || !end.isValid()) {
+      return std::string();
+    }
+
+    clang::FileID begin_file = sm.getFileID(begin);
+    clang::FileID end_file = sm.getFileID(end);
+    if (!begin_file.isValid() || begin_file != end_file) {
+      return trimWhitespace(getSourceText(normalized_range));
+    }
+
+    clang::SourceLocation after_end =
+        clang::Lexer::getLocForEndOfToken(end, 0, sm, lang_opts);
+    if (!after_end.isValid()) {
+      after_end = end;
+    }
+
+    auto buffer = sm.getBufferDataOrNone(begin_file);
+    if (!buffer) {
+      return trimWhitespace(getSourceText(normalized_range));
+    }
+
+    unsigned begin_offset = sm.getFileOffset(begin);
+    unsigned end_offset = sm.getFileOffset(after_end);
+    if (begin_offset >= end_offset || end_offset > buffer->size()) {
+      return trimWhitespace(getSourceText(normalized_range));
+    }
+
+    auto line_start_for = [&](unsigned offset) -> unsigned {
+      offset = std::min<unsigned>(offset, buffer->size());
+      while (offset > 0 && (*buffer)[offset - 1] != '\n' &&
+             (*buffer)[offset - 1] != '\r') {
+        --offset;
+      }
+      return offset;
+    };
+
+    auto previous_line_bounds = [&](unsigned line_start, unsigned &prev_start,
+                                    unsigned &prev_end) -> bool {
+      if (line_start == 0) {
+        return false;
+      }
+      unsigned cursor = line_start - 1;
+      while (cursor > 0 &&
+             ((*buffer)[cursor] == '\n' || (*buffer)[cursor] == '\r')) {
+        --cursor;
+      }
+      prev_end = cursor + 1;
+      prev_start = line_start_for(cursor);
+      return prev_start < prev_end;
+    };
+
+    auto line_spells_directive = [](llvm::StringRef line,
+                                    llvm::StringRef directive) {
+      line = line.trim(" \t\r\n");
+      if (!line.consume_front("#")) {
+        return false;
+      }
+      line = line.ltrim(" \t");
+      if (!line.consume_front(directive)) {
+        return false;
+      }
+      return line.empty() || line.front() == ' ' || line.front() == '\t' ||
+             line.front() == '\r' || line.front() == '\n';
+    };
+
+    auto line_spells_opening_conditional = [&](llvm::StringRef line) {
+      return line_spells_directive(line, "if") ||
+             line_spells_directive(line, "ifdef") ||
+             line_spells_directive(line, "ifndef");
+    };
+
+    auto text_has_conditional_continuation = [&](llvm::StringRef text) {
+      size_t cursor = 0;
+      while (cursor <= text.size()) {
+        size_t line_end = text.find_first_of("\r\n", cursor);
+        llvm::StringRef line = line_end == llvm::StringRef::npos
+                                   ? text.substr(cursor)
+                                   : text.substr(cursor, line_end - cursor);
+        if (line_spells_directive(line, "elif") ||
+            line_spells_directive(line, "else") ||
+            line_spells_directive(line, "endif")) {
+          return true;
+        }
+        if (line_end == llvm::StringRef::npos) {
+          break;
+        }
+        cursor = line_end + 1;
+      }
+      return false;
+    };
+
+    llvm::StringRef initial_slice =
+        buffer->substr(begin_offset, end_offset - begin_offset);
+    if (text_has_conditional_continuation(initial_slice)) {
+      unsigned current_line_start = line_start_for(begin_offset);
+      unsigned prev_start = 0;
+      unsigned prev_end = 0;
+      while (previous_line_bounds(current_line_start, prev_start, prev_end)) {
+        llvm::StringRef previous_line =
+            buffer->substr(prev_start, prev_end - prev_start);
+        llvm::StringRef trimmed = previous_line.trim(" \t\r\n");
+        if (trimmed.empty() || trimmed.starts_with("//")) {
+          current_line_start = prev_start;
+          continue;
+        }
+        if (line_spells_opening_conditional(previous_line)) {
+          begin_offset = prev_start;
+        }
+        break;
+      }
+    }
+
+    return trimWhitespace(
+        buffer->substr(begin_offset, end_offset - begin_offset).str());
+  };
+
+  auto set_template_function_saved_spelling = [&](SgFunctionDeclaration *decl,
+                                                  const std::string &spelling) {
+    if (decl == nullptr || spelling.empty()) {
+      return;
+    }
+    if (SgTemplateFunctionDeclaration *tmpl_func =
+            isSgTemplateFunctionDeclaration(decl)) {
+      tmpl_func->set_string(SgName(spelling));
+    } else if (SgTemplateMemberFunctionDeclaration *tmpl_member =
+                   isSgTemplateMemberFunctionDeclaration(decl)) {
+      tmpl_member->set_string(SgName(spelling));
+    }
+  };
+
+  auto set_current_template_function_saved_spelling =
+      [&](const std::string &spelling) {
+        set_template_function_saved_spelling(sg_function_decl, spelling);
+        if (node != nullptr) {
+          set_template_function_saved_spelling(isSgFunctionDeclaration(*node),
+                                               spelling);
+        }
+        if (sg_function_decl == nullptr || sg_function_decl->isForward()) {
+          return;
+        }
+        auto set_empty_nonforward_template_alias =
+            [&](SgFunctionDeclaration *decl) {
+              if (decl == nullptr || decl->isForward()) {
+                return;
+              }
+              SgName saved_template_name;
+              if (SgTemplateFunctionDeclaration *tmpl_func =
+                      isSgTemplateFunctionDeclaration(decl)) {
+                saved_template_name = tmpl_func->get_string();
+              } else if (SgTemplateMemberFunctionDeclaration *tmpl_member =
+                             isSgTemplateMemberFunctionDeclaration(decl)) {
+                saved_template_name = tmpl_member->get_string();
+              } else {
+                return;
+              }
+              const char *saved_template_string = saved_template_name.str();
+              if (saved_template_name.is_null() ||
+                  saved_template_string == nullptr ||
+                  saved_template_string[0] == '\0') {
+                set_template_function_saved_spelling(decl, spelling);
+              }
+            };
+        set_empty_nonforward_template_alias(first_nondef_decl);
+        set_empty_nonforward_template_alias(defining_decl);
+      };
+
+  std::string template_function_saved_spelling;
+  bool template_function_saved_spelling_overrides_ast = false;
+  if (current_decl_is_primary_function_template && !isMethodDecl &&
+      !decl_context_is_class_like(function_decl->getLexicalDeclContext()) &&
+      !decl_context_is_class_like(function_decl->getDeclContext())) {
+    const clang::Decl *source_decl =
+        templateDecl != nullptr
+            ? static_cast<const clang::Decl *>(templateDecl)
+            : static_cast<const clang::Decl *>(function_decl);
+    std::string spelled_template_text = source_text_for_template_function(
+        declaration_source_range, source_decl);
+    if (!spelled_template_text.empty() &&
+        (!force_template_ast_unparse ||
+         source_text_has_conditional_control(spelled_template_text))) {
+      template_function_saved_spelling = spelled_template_text;
+      if (source_text_has_conditional_control(spelled_template_text)) {
+        force_template_ast_unparse = false;
+        template_function_saved_spelling_overrides_ast = true;
+      }
+    }
+  }
   auto enable_template_ast_unparse = [&](SgFunctionDeclaration *decl) {
     if (decl == nullptr) {
       return;
@@ -51439,13 +54728,18 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     size_t param_count = params->get_args().size();
-    size_t clang_param_count =
-        static_cast<size_t>(function_decl->getNumParams());
+    size_t clang_param_count = static_cast<size_t>(readClangApiValueDefined(
+        [&]() { return function_decl->getNumParams(); }));
     size_t shared = std::min(param_count, clang_param_count);
     for (size_t idx = 0; idx < shared; ++idx) {
       clang::ParmVarDecl *clang_param =
-          function_decl->getParamDecl(static_cast<unsigned>(idx));
-      if (clang_param == nullptr || !clang_param->isParameterPack()) {
+          llvm::dyn_cast_or_null<clang::ParmVarDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
+                return function_decl->getParamDecl(static_cast<unsigned>(idx));
+              })));
+      if (clang_param == nullptr || !readClangApiValueDefined([&]() {
+            return clang_param->isParameterPack();
+          })) {
         continue;
       }
       SgInitializedName *param = params->get_args()[idx];
@@ -51536,7 +54830,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
     clang::CXXRecordDecl *parent_record =
         llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-            markClangDeclObjectDefinedByKind(method_decl->getParent()));
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return method_decl->getParent(); })));
     if (parent_record == nullptr) {
       return false;
     }
@@ -51545,8 +54840,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         specialization_kind == clang::TSK_ImplicitInstantiation ||
         specialization_kind == clang::TSK_ExplicitInstantiationDeclaration ||
         specialization_kind == clang::TSK_ExplicitInstantiationDefinition;
-    clang::TemplateSpecializationKind parent_tsk =
-        parent_record->getTemplateSpecializationKind();
+    clang::TemplateSpecializationKind parent_tsk = readClangApiValueDefined(
+        [&]() { return parent_record->getTemplateSpecializationKind(); });
     const bool parent_is_instantiation =
         parent_tsk == clang::TSK_ImplicitInstantiation ||
         parent_tsk == clang::TSK_ExplicitInstantiationDeclaration ||
@@ -51563,7 +54858,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-    clang::SourceLocation loc = defined_function_decl->getLocation();
+    clang::SourceLocation loc = readClangApiValueDefined(
+        [&]() { return defined_function_decl->getLocation(); });
     if (loc.isMacroID()) {
       loc = sm.getSpellingLoc(loc);
     }
@@ -51578,8 +54874,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
               llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
                   parent_record)) {
         if (clang::ClassTemplateDecl *primary =
-                parent_spec->getSpecializedTemplate()) {
-          pattern = primary->getTemplatedDecl();
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return parent_spec->getSpecializedTemplate(); }))) {
+          pattern = markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return primary->getTemplatedDecl(); }));
         }
       }
     }
@@ -51654,6 +54952,29 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
   }
 
+  if (!template_function_saved_spelling.empty()) {
+    set_current_template_function_saved_spelling(
+        template_function_saved_spelling);
+    if (template_function_saved_spelling_overrides_ast) {
+      std::set<SgFunctionDeclaration *> visited;
+      std::function<void(SgFunctionDeclaration *)> enable_chain =
+          [&](SgFunctionDeclaration *decl) {
+            if (decl == nullptr || !visited.insert(decl).second) {
+              return;
+            }
+            enable_template_ast_unparse(decl);
+            enable_chain(isSgFunctionDeclaration(
+                decl->get_firstNondefiningDeclaration()));
+            enable_chain(
+                isSgFunctionDeclaration(decl->get_definingDeclaration()));
+          };
+      enable_chain(sg_function_decl);
+      if (node != nullptr) {
+        enable_chain(isSgFunctionDeclaration(*node));
+      }
+    }
+  }
+
   auto is_instantiated_member_from_template_pattern = [&]() -> bool {
     if (p_compiler_instance == nullptr) {
       return false;
@@ -51666,13 +54987,16 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       return false;
     }
 
-    clang::CXXMethodDecl *method_decl =
-        llvm::dyn_cast<clang::CXXMethodDecl>(function_decl);
+    clang::CXXMethodDecl *method_decl = llvm::dyn_cast<clang::CXXMethodDecl>(
+        markClangDeclObjectDefinedByKind(function_decl));
     if (method_decl == nullptr) {
       return false;
     }
 
-    clang::CXXRecordDecl *parent_record = method_decl->getParent();
+    clang::CXXRecordDecl *parent_record =
+        llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return method_decl->getParent(); })));
     if (parent_record == nullptr) {
       return false;
     }
@@ -51688,8 +55012,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         specialization_kind == clang::TSK_ImplicitInstantiation ||
         specialization_kind == clang::TSK_ExplicitInstantiationDeclaration ||
         specialization_kind == clang::TSK_ExplicitInstantiationDefinition;
-    clang::TemplateSpecializationKind parent_tsk =
-        parent_record->getTemplateSpecializationKind();
+    clang::TemplateSpecializationKind parent_tsk = readClangApiValueDefined(
+        [&]() { return parent_record->getTemplateSpecializationKind(); });
     const bool parent_is_instantiation =
         parent_tsk == clang::TSK_ImplicitInstantiation ||
         parent_tsk == clang::TSK_ExplicitInstantiationDeclaration ||
@@ -51708,7 +55032,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     }
 
     clang::SourceManager &sm = p_compiler_instance->getSourceManager();
-    clang::SourceLocation loc = function_decl->getLocation();
+    clang::SourceLocation loc = readClangApiValueDefined(
+        [&]() { return function_decl->getLocation(); });
     if (loc.isMacroID()) {
       loc = sm.getSpellingLoc(loc);
     }
@@ -52010,7 +55335,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   };
 
   auto select_visible_source_decl_in_function_chain =
-      [&](SgFunctionDeclaration *root) -> SgFunctionDeclaration * {
+      [&](SgFunctionDeclaration *root, SgFunctionDeclaration *exclude_decl =
+                                           nullptr) -> SgFunctionDeclaration * {
     if (root == nullptr) {
       return nullptr;
     }
@@ -52041,7 +55367,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     SgFunctionDeclaration *best = nullptr;
     int best_rank = -1;
     auto consider_decl = [&](SgFunctionDeclaration *candidate) {
-      if (candidate == nullptr || !declaration_has_real_source(candidate)) {
+      if (candidate == nullptr || candidate == exclude_decl) {
         return;
       }
 
@@ -52051,19 +55377,27 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
         return;
       }
 
-      if (!sageDeclShouldRemainVisibleInGeneratedSurface(candidate,
-                                                         p_sage_source_file)) {
-        return;
-      }
-
       SgScopeStatement *parent_scope =
           isSgScopeStatement(candidate->get_parent());
       int rank = scope_rank(parent_scope);
       if (rank < 0) {
         return;
       }
-      if (parent_scope != nullptr &&
-          !is_decl_attached_to_scope_child_list(parent_scope, candidate)) {
+      const bool attached_to_parent =
+          parent_scope != nullptr &&
+          is_decl_attached_to_scope_child_list(parent_scope, candidate);
+      if (parent_scope != nullptr && !attached_to_parent) {
+        return;
+      }
+
+      const bool source_visible_on_surface =
+          declaration_has_real_source(candidate) &&
+          sageDeclShouldRemainVisibleInGeneratedSurface(candidate,
+                                                        p_sage_source_file);
+      const bool visible_member_in_visible_class =
+          is_visible_source_function_decl(candidate) && attached_to_parent &&
+          class_like_scope_is_visible_for_unparse(parent_scope);
+      if (!source_visible_on_surface && !visible_member_in_visible_class) {
         return;
       }
 
@@ -52154,7 +55488,7 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
     // suppression after VisitDecl so source-range normalization cannot move
     // them back into the generated statement stream.
     if (!has_builtin_id && !has_builtin_name_prefix &&
-        !function_decl->hasAttr<clang::BuiltinAttr>()) {
+        !clangDeclHasBuiltinAttrDefinedForFrontend(function_decl)) {
       if (preserve_visible_decl == nullptr) {
         preserve_visible_decl =
             select_visible_source_decl_in_function_chain(sg_function_decl);
@@ -52231,7 +55565,10 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       clang::CXXMethodDecl *method_decl =
           llvm::dyn_cast<clang::CXXMethodDecl>(function_decl);
       clang::CXXRecordDecl *parent_record =
-          method_decl != nullptr ? method_decl->getParent() : nullptr;
+          method_decl != nullptr
+              ? markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return method_decl->getParent(); }))
+              : nullptr;
       if (parent_record != nullptr) {
         if (SgClassDefinition *parent_def =
                 resolve_or_translate_class_definition(
@@ -52258,9 +55595,19 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
 
   if (visit_res && suppress_header_function) {
     SgFunctionDeclaration *preserve_visible_decl =
-        select_visible_source_decl_in_function_chain(sg_function_decl);
+        select_visible_source_decl_in_function_chain(sg_function_decl,
+                                                     sg_function_decl);
     if (preserve_visible_decl == sg_function_decl) {
       preserve_visible_decl = nullptr;
+    }
+    if (preserve_visible_decl != nullptr) {
+      restore_single_function_decl_output(preserve_visible_decl);
+      if (SgScopeStatement *visible_scope =
+              isSgScopeStatement(preserve_visible_decl->get_parent())) {
+        ensure_decl_in_scope_child_list(
+            preserve_visible_decl, visible_scope,
+            "translateFunctionDeclCommon:preserve-visible-header-chain");
+      }
     }
 
     suppress_function_decl_chain(sg_function_decl,
@@ -52307,7 +55654,20 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
   }
 
   if (suppress_instantiated_member) {
-    suppress_function_decl_chain(sg_function_decl, false, true);
+    SgFunctionDeclaration *preserve_visible_decl =
+        select_visible_source_decl_in_function_chain(sg_function_decl,
+                                                     sg_function_decl);
+    if (preserve_visible_decl != nullptr) {
+      restore_single_function_decl_output(preserve_visible_decl);
+      if (SgScopeStatement *visible_scope =
+              isSgScopeStatement(preserve_visible_decl->get_parent())) {
+        ensure_decl_in_scope_child_list(
+            preserve_visible_decl, visible_scope,
+            "translateFunctionDeclCommon:preserve-visible-instantiated-member");
+      }
+    }
+    suppress_function_decl_chain(sg_function_decl, false, true,
+                                 preserve_visible_decl);
     if (explicit_instantiation_directive != nullptr) {
       suppress_unparse_output(explicit_instantiation_directive);
       detach_decl_from_known_scope_child_lists(
@@ -52760,14 +56120,21 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
                  kind == clang::TSK_ExplicitInstantiationDefinition;
         };
 
-    bool isolate_ctor_initializer_cache = is_template_instantiation_kind(
-        cxx_constructor_decl->getTemplateSpecializationKind());
+    bool isolate_ctor_initializer_cache =
+        is_template_instantiation_kind(readClangApiValueDefined([&]() {
+          return cxx_constructor_decl->getTemplateSpecializationKind();
+        }));
     if (!isolate_ctor_initializer_cache) {
+      clang::CXXRecordDecl *ctor_parent =
+          markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return cxx_constructor_decl->getParent(); }));
       if (clang::ClassTemplateSpecializationDecl *parent_spec =
               llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
-                  cxx_constructor_decl->getParent())) {
-        isolate_ctor_initializer_cache = is_template_instantiation_kind(
-            parent_spec->getTemplateSpecializationKind());
+                  ctor_parent)) {
+        isolate_ctor_initializer_cache =
+            is_template_instantiation_kind(readClangApiValueDefined([&]() {
+              return parent_spec->getTemplateSpecializationKind();
+            }));
       }
     }
 
@@ -52781,72 +56148,26 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
 
     if (!reuse_existing_ctor_initializer_list) {
 
-      std::function<void(clang::Decl *)> recursive_invalidate_decl;
-      std::function<void(clang::Stmt *)> recursive_invalidate_stmt;
-
-      recursive_invalidate_decl = [&](clang::Decl *decl) {
-        if (decl == nullptr) {
-          return;
-        }
-
-        if (auto it = p_decl_translation_map.find(decl);
-            it != p_decl_translation_map.end()) {
-          p_decl_translation_map.erase(it);
-        }
-
-        if (auto *ctx = llvm::dyn_cast<clang::DeclContext>(decl)) {
-          for (clang::Decl *child : ctx->decls()) {
-            recursive_invalidate_decl(child);
-          }
-        }
-
-        if (auto *function_decl = llvm::dyn_cast<clang::FunctionDecl>(decl)) {
-          if (function_decl->hasBody()) {
-            recursive_invalidate_stmt(function_decl->getBody());
-          }
-        }
-        if (auto *var_decl = llvm::dyn_cast<clang::VarDecl>(decl)) {
-          if (var_decl->getInit() != nullptr) {
-            recursive_invalidate_stmt(var_decl->getInit());
-          }
-        }
-      };
-
-      recursive_invalidate_stmt = [&](clang::Stmt *stmt) {
-        if (stmt == nullptr) {
-          return;
-        }
-        stmt = markClangStmtObjectDefinedByClass(stmt);
-
-        if (auto it = p_stmt_translation_map.find(stmt);
-            it != p_stmt_translation_map.end()) {
-          p_stmt_translation_map.erase(it);
-        }
-
-        if (auto *decl_stmt = llvm::dyn_cast<clang::DeclStmt>(stmt)) {
-          for (clang::Decl *decl : decl_stmt->decls()) {
-            recursive_invalidate_decl(decl);
-          }
-        }
-
-        for (clang::Stmt *child : stmt->children()) {
-          child = markClangStmtObjectDefinedByClass(child);
-          recursive_invalidate_stmt(child);
-        }
-      };
-
       auto same_canonical_base_type = [](const clang::Type *lhs,
                                          const clang::Type *rhs) -> bool {
         if (lhs == nullptr || rhs == nullptr) {
           return false;
         }
 
-        clang::QualType lhs_qt(lhs, 0);
-        clang::QualType rhs_qt(rhs, 0);
-        const clang::Type *lhs_canonical =
-            lhs_qt.getCanonicalType().getTypePtrOrNull();
-        const clang::Type *rhs_canonical =
-            rhs_qt.getCanonicalType().getTypePtrOrNull();
+        clang::QualType lhs_qt =
+            markClangFunctionTypeBoundaryDefined(clang::QualType(lhs, 0));
+        clang::QualType rhs_qt =
+            markClangFunctionTypeBoundaryDefined(clang::QualType(rhs, 0));
+        clang::QualType lhs_canonical_qt =
+            markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                [&]() { return lhs_qt.getCanonicalType(); }));
+        clang::QualType rhs_canonical_qt =
+            markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                [&]() { return rhs_qt.getCanonicalType(); }));
+        const clang::Type *lhs_canonical = markClangTypeObjectDefinedByClass(
+            lhs_canonical_qt.getTypePtrOrNull());
+        const clang::Type *rhs_canonical = markClangTypeObjectDefinedByClass(
+            rhs_canonical_qt.getTypePtrOrNull());
         return lhs_canonical != nullptr && lhs_canonical == rhs_canonical;
       };
 
@@ -52946,23 +56267,36 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
             llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
                 markClangDeclObjectDefinedByKind(readClangApiValueDefined(
                     [&]() { return cxx_constructor_decl->getParent(); })));
+        parent_record = markClangCXXRecordDefinitionStateDefined(parent_record);
         if (initializer_base_type == nullptr || parent_record == nullptr) {
           return initializer_type_info;
         }
 
-        for (const clang::CXXBaseSpecifier &raw_base_spec :
-             parent_record->bases()) {
+        clang::CXXRecordDecl::base_class_const_range base_range =
+            readClangApiValueDefined([&]() { return parent_record->bases(); });
+        const clang::CXXBaseSpecifier *base_it =
+            readClangApiValueDefined([&]() { return base_range.begin(); });
+        const clang::CXXBaseSpecifier *base_end =
+            readClangApiValueDefined([&]() { return base_range.end(); });
+        markClangValueDefined(base_it);
+        markClangValueDefined(base_end);
+        for (; base_it != base_end; ++base_it) {
+          markClangValueDefined(base_it);
           const clang::CXXBaseSpecifier &base_spec =
-              makeDefinedClangCXXBaseSpecifier(raw_base_spec);
-          const clang::Type *base_spec_type = base_spec.getType().getTypePtr();
+              makeDefinedClangCXXBaseSpecifier(*base_it);
+          const clang::QualType base_spec_qual_type =
+              markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                  [&]() { return base_spec.getType(); }));
+          const clang::Type *base_spec_type = markClangTypeObjectDefinedByClass(
+              base_spec_qual_type.getTypePtr());
           if (!same_canonical_base_type(initializer_base_type,
                                         base_spec_type)) {
             continue;
           }
 
           if (clang::TypeSourceInfo *base_type_info =
-                  markClangTypeSourceInfoDefined(
-                      base_spec.getTypeSourceInfo())) {
+                  markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                      [&]() { return base_spec.getTypeSourceInfo(); }))) {
             return base_type_info;
           }
         }
@@ -52972,13 +56306,20 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
 
       auto get_existing_base_initializer_type =
           [&](clang::CXXCtorInitializer *initializer) -> SgType * {
-        if (initializer == nullptr || !initializer->isBaseInitializer()) {
+        if (initializer == nullptr || !readClangApiValueDefined([&]() {
+              return initializer->isBaseInitializer();
+            })) {
           return nullptr;
         }
 
-        const clang::Type *initializer_base_type = initializer->getBaseClass();
+        const clang::Type *initializer_base_type =
+            markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                [&]() { return initializer->getBaseClass(); }));
         const clang::CXXRecordDecl *parent_record =
-            cxx_constructor_decl->getParent();
+            llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return cxx_constructor_decl->getParent(); })));
+        parent_record = markClangCXXRecordDefinitionStateDefined(parent_record);
         SgClassDefinition *class_definition =
             get_ctor_initializer_class_definition();
         if (initializer_base_type == nullptr || parent_record == nullptr ||
@@ -52988,11 +56329,23 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
 
         size_t base_index = 0;
         bool found_matching_base = false;
-        for (const clang::CXXBaseSpecifier &raw_base_spec :
-             parent_record->bases()) {
+        clang::CXXRecordDecl::base_class_const_range base_range =
+            readClangApiValueDefined([&]() { return parent_record->bases(); });
+        const clang::CXXBaseSpecifier *base_it =
+            readClangApiValueDefined([&]() { return base_range.begin(); });
+        const clang::CXXBaseSpecifier *base_end =
+            readClangApiValueDefined([&]() { return base_range.end(); });
+        markClangValueDefined(base_it);
+        markClangValueDefined(base_end);
+        for (; base_it != base_end; ++base_it) {
+          markClangValueDefined(base_it);
           const clang::CXXBaseSpecifier &base_spec =
-              makeDefinedClangCXXBaseSpecifier(raw_base_spec);
-          const clang::Type *base_spec_type = base_spec.getType().getTypePtr();
+              makeDefinedClangCXXBaseSpecifier(*base_it);
+          const clang::QualType base_spec_qual_type =
+              markClangFunctionTypeBoundaryDefined(readClangApiValueDefined(
+                  [&]() { return base_spec.getType(); }));
+          const clang::Type *base_spec_type = markClangTypeObjectDefinedByClass(
+              base_spec_qual_type.getTypePtr());
           if (same_canonical_base_type(initializer_base_type, base_spec_type)) {
             found_matching_base = true;
             break;
@@ -53047,7 +56400,9 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
 
       auto build_written_base_initializer_type =
           [&](clang::TypeLoc type_loc) -> SgType * {
-        type_loc = type_loc.getUnqualifiedLoc();
+        markClangTypeLocDataDefined(type_loc);
+        type_loc = readClangTypeLocDefined(
+            [&]() { return type_loc.getUnqualifiedLoc(); });
 
         std::function<SgType *(clang::TypeLoc, clang::NestedNameSpecifier,
                                bool)>
@@ -53055,20 +56410,32 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
                 [&](clang::TypeLoc current_loc,
                     clang::NestedNameSpecifier inherited_qualifier,
                     bool inherited_template_keyword) -> SgType * {
+          current_loc = readClangTypeLocDefined([&]() { return current_loc; });
+          inherited_qualifier =
+              markClangNestedNameSpecifierDefined(inherited_qualifier);
           while (!current_loc.isNull()) {
-            if (clang::ParenTypeLoc paren_loc =
-                    current_loc.getAs<clang::ParenTypeLoc>()) {
-              current_loc = paren_loc.getInnerLoc();
+            markClangTypeLocDataDefined(current_loc);
+            if (clang::ParenTypeLoc paren_loc = readClangTypeLocDefined([&]() {
+                  return current_loc.getAs<clang::ParenTypeLoc>();
+                })) {
+              current_loc = readClangTypeLocDefined(
+                  [&]() { return paren_loc.getInnerLoc(); });
               continue;
             }
             if (clang::AttributedTypeLoc attr_loc =
-                    current_loc.getAs<clang::AttributedTypeLoc>()) {
-              current_loc = attr_loc.getModifiedLoc();
+                    readClangTypeLocDefined([&]() {
+                      return current_loc.getAs<clang::AttributedTypeLoc>();
+                    })) {
+              current_loc = readClangTypeLocDefined(
+                  [&]() { return attr_loc.getModifiedLoc(); });
               continue;
             }
             if (clang::AdjustedTypeLoc adjusted_loc =
-                    current_loc.getAs<clang::AdjustedTypeLoc>()) {
-              current_loc = adjusted_loc.getOriginalLoc();
+                    readClangTypeLocDefined([&]() {
+                      return current_loc.getAs<clang::AdjustedTypeLoc>();
+                    })) {
+              current_loc = readClangTypeLocDefined(
+                  [&]() { return adjusted_loc.getOriginalLoc(); });
               continue;
             }
             break;
@@ -53114,65 +56481,130 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
             return nrtype;
           };
 
+          auto nested_qualifier_from_loc =
+              [&](clang::NestedNameSpecifierLoc qualifier_loc)
+              -> clang::NestedNameSpecifier {
+            qualifier_loc =
+                markClangNestedNameSpecifierLocDefined(qualifier_loc);
+            if (!qualifier_loc) {
+              return std::nullopt;
+            }
+            return markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
+          };
+
           if (clang::TemplateSpecializationTypeLoc spec_loc =
-                  current_loc.getAs<clang::TemplateSpecializationTypeLoc>()) {
+                  readClangTypeLocDefined([&]() {
+                    return current_loc
+                        .getAs<clang::TemplateSpecializationTypeLoc>();
+                  })) {
             const clang::TemplateSpecializationType *tst =
-                spec_loc.getTypePtr();
+                readClangApiValueDefined(
+                    [&]() { return spec_loc.getTypePtr(); });
+            markClangTypeObjectDefinedByClass(tst);
             if (tst == nullptr) {
               return nullptr;
             }
 
-            clang::TemplateName template_name = tst->getTemplateName();
+            clang::TemplateName template_name =
+                markClangTemplateNameDefined(readClangApiValueDefined(
+                    [&]() { return tst->getTemplateName(); }));
             clang::NestedNameSpecifier qualifier =
-                spec_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return spec_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
 
             bool has_template_keyword =
                 inherited_template_keyword ||
-                spec_loc.getTemplateKeywordLoc().isValid();
+                readClangApiValueDefined([&]() {
+                  return spec_loc.getTemplateKeywordLoc();
+                }).isValid();
             std::string base_name;
 
             if (const clang::QualifiedTemplateName *qualified =
-                    template_name.getAsQualifiedTemplateName()) {
+                    readClangApiValueDefined([&]() {
+                      return template_name.getAsQualifiedTemplateName();
+                    })) {
+              markClangAstObjectDefined(qualified);
               if (!qualifier) {
-                qualifier = qualified->getQualifier();
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return qualified->getQualifier(); }));
               }
               has_template_keyword =
-                  has_template_keyword || qualified->hasTemplateKeyword();
+                  has_template_keyword || readClangApiValueDefined([&]() {
+                    return qualified->hasTemplateKeyword();
+                  });
               if (clang::TemplateDecl *template_decl =
-                      qualified->getUnderlyingTemplate().getAsTemplateDecl()) {
-                base_name = template_decl->getNameAsString();
+                      markClangSpecificDeclDefined(
+                          readClangApiValueDefined([&]() {
+                            return markClangTemplateNameDefined(
+                                       readClangApiValueDefined([&]() {
+                                         return qualified
+                                             ->getUnderlyingTemplate();
+                                       }))
+                                .getAsTemplateDecl();
+                          }))) {
+                base_name = readClangApiValueDefined(
+                    [&]() { return template_decl->getNameAsString(); });
               }
             } else if (const clang::DependentTemplateName *dependent =
-                           template_name.getAsDependentTemplateName()) {
+                           readClangApiValueDefined([&]() {
+                             return template_name.getAsDependentTemplateName();
+                           })) {
+              markClangAstObjectDefined(dependent);
               if (!qualifier) {
-                qualifier = dependent->getQualifier();
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return dependent->getQualifier(); }));
               }
               has_template_keyword = true;
-              clang::IdentifierOrOverloadedOperator name = dependent->getName();
+              clang::IdentifierOrOverloadedOperator name =
+                  readClangApiValueDefined(
+                      [&]() { return dependent->getName(); });
               if (const clang::IdentifierInfo *identifier =
-                      name.getIdentifier()) {
+                      readClangApiValueDefined(
+                          [&]() { return name.getIdentifier(); })) {
                 base_name = identifier->getName().str();
               } else {
-                base_name = buildOverloadedOperatorName(name.getOperator());
+                base_name =
+                    buildOverloadedOperatorName(readClangApiValueDefined(
+                        [&]() { return name.getOperator(); }));
               }
             } else if (clang::TemplateDecl *template_decl =
-                           template_name.getAsTemplateDecl()) {
-              base_name = template_decl->getNameAsString();
+                           markClangSpecificDeclDefined(
+                               readClangApiValueDefined([&]() {
+                                 return template_name.getAsTemplateDecl();
+                               }))) {
+              base_name = readClangApiValueDefined(
+                  [&]() { return template_decl->getNameAsString(); });
             } else if (clang::UsingShadowDecl *using_shadow =
-                           template_name.getAsUsingShadowDecl()) {
-              base_name = using_shadow->getNameAsString();
+                           markClangSpecificDeclDefined(
+                               readClangApiValueDefined([&]() {
+                                 return template_name.getAsUsingShadowDecl();
+                               }))) {
+              base_name = readClangApiValueDefined(
+                  [&]() { return using_shadow->getNameAsString(); });
             }
 
             SgTemplateArgumentPtrList tpl_args;
-            for (unsigned i = 0; i < spec_loc.getNumArgs(); ++i) {
-              appendTemplateArguments(tpl_args, spec_loc.getArgLoc(i), true);
+            const unsigned num_args = readClangApiValueDefined(
+                [&]() { return spec_loc.getNumArgs(); });
+            for (unsigned i = 0; i < num_args; ++i) {
+              clang::TemplateArgumentLoc arg_loc =
+                  readClangApiValueDefined([&]() -> clang::TemplateArgumentLoc {
+                    return spec_loc.getArgLoc(i);
+                  });
+              markClangTemplateArgumentLocDefined(arg_loc);
+              appendTemplateArguments(tpl_args, arg_loc, true);
             }
             const bool has_template_args =
-                !tpl_args.empty() || (spec_loc.getNumArgs() == 0 &&
-                                      spec_loc.getLAngleLoc().isValid());
+                !tpl_args.empty() ||
+                (num_args == 0 && readClangApiValueDefined([&]() {
+                                    return spec_loc.getLAngleLoc();
+                                  }).isValid());
 
             return build_named_nonreal_type(
                 base_name, qualifier, has_template_args ? &tpl_args : nullptr,
@@ -53182,83 +56614,117 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
           auto build_nonreal_for_named_decl =
               [&](const clang::NamedDecl *decl,
                   clang::NestedNameSpecifier qualifier) -> SgType * {
+            decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+                markClangDeclObjectDefinedByKind(decl));
+            qualifier = markClangNestedNameSpecifierDefined(qualifier);
             if (decl == nullptr) {
               return nullptr;
             }
-            return build_named_nonreal_type(decl->getNameAsString(), qualifier,
-                                            nullptr,
+            return build_named_nonreal_type(readClangApiValueDefined([&]() {
+                                              return decl->getNameAsString();
+                                            }),
+                                            qualifier, nullptr,
                                             inherited_template_keyword);
           };
 
           if (clang::TypedefTypeLoc typedef_loc =
-                  current_loc.getAs<clang::TypedefTypeLoc>()) {
+                  readClangTypeLocDefined([&]() {
+                    return current_loc.getAs<clang::TypedefTypeLoc>();
+                  })) {
             clang::NestedNameSpecifier qualifier =
-                typedef_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return typedef_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
+            const clang::TypedefType *typedef_type = readClangApiValueDefined(
+                [&]() { return typedef_loc.getTypePtr(); });
+            markClangTypeObjectDefinedByClass(typedef_type);
             if (!qualifier) {
-              if (const clang::TypedefType *typedef_type =
-                      typedef_loc.getTypePtr()) {
-                qualifier = typedef_type->getQualifier();
+              if (typedef_type != nullptr) {
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return typedef_type->getQualifier(); }));
               }
             }
             return build_nonreal_for_named_decl(
-                typedef_loc.getTypePtr() != nullptr
-                    ? typedef_loc.getTypePtr()->getDecl()
+                typedef_type != nullptr
+                    ? markClangSpecificDeclDefined(readClangApiValueDefined(
+                          [&]() { return typedef_type->getDecl(); }))
                     : nullptr,
                 qualifier);
           }
 
-          if (clang::UsingTypeLoc using_loc =
-                  current_loc.getAs<clang::UsingTypeLoc>()) {
+          if (clang::UsingTypeLoc using_loc = readClangTypeLocDefined(
+                  [&]() { return current_loc.getAs<clang::UsingTypeLoc>(); })) {
             clang::NestedNameSpecifier qualifier =
-                using_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return using_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
+            const clang::UsingType *using_type = readClangApiValueDefined(
+                [&]() { return using_loc.getTypePtr(); });
+            markClangTypeObjectDefinedByClass(using_type);
             if (!qualifier) {
-              if (const clang::UsingType *using_type = using_loc.getTypePtr()) {
-                qualifier = using_type->getQualifier();
+              if (using_type != nullptr) {
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return using_type->getQualifier(); }));
               }
             }
             return build_nonreal_for_named_decl(
-                using_loc.getTypePtr() != nullptr
-                    ? using_loc.getTypePtr()->getDecl()
+                using_type != nullptr
+                    ? markClangSpecificDeclDefined(readClangApiValueDefined(
+                          [&]() { return using_type->getDecl(); }))
                     : nullptr,
                 qualifier);
           }
 
           if (clang::UnresolvedUsingTypeLoc unresolved_using_loc =
-                  current_loc.getAs<clang::UnresolvedUsingTypeLoc>()) {
+                  readClangTypeLocDefined([&]() {
+                    return current_loc.getAs<clang::UnresolvedUsingTypeLoc>();
+                  })) {
             clang::NestedNameSpecifier qualifier =
-                unresolved_using_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return unresolved_using_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
-            return build_nonreal_for_named_decl(unresolved_using_loc.getDecl(),
-                                                qualifier);
+            return build_nonreal_for_named_decl(
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return unresolved_using_loc.getDecl(); })),
+                qualifier);
           }
 
-          if (clang::TagTypeLoc tag_loc =
-                  current_loc.getAs<clang::TagTypeLoc>()) {
+          if (clang::TagTypeLoc tag_loc = readClangTypeLocDefined(
+                  [&]() { return current_loc.getAs<clang::TagTypeLoc>(); })) {
             clang::NestedNameSpecifier qualifier =
-                tag_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return tag_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
-            return build_nonreal_for_named_decl(tag_loc.getDecl(), qualifier);
+            return build_nonreal_for_named_decl(
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return tag_loc.getDecl(); })),
+                qualifier);
           }
 
           if (clang::InjectedClassNameTypeLoc injected_loc =
-                  current_loc.getAs<clang::InjectedClassNameTypeLoc>()) {
+                  readClangTypeLocDefined([&]() {
+                    return current_loc.getAs<clang::InjectedClassNameTypeLoc>();
+                  })) {
             clang::NestedNameSpecifier qualifier =
-                injected_loc.getQualifierLoc().getNestedNameSpecifier();
+                nested_qualifier_from_loc(readClangApiValueDefined(
+                    [&]() { return injected_loc.getQualifierLoc(); }));
             if (!qualifier) {
               qualifier = inherited_qualifier;
             }
-            return build_nonreal_for_named_decl(injected_loc.getDecl(),
-                                                qualifier);
+            return build_nonreal_for_named_decl(
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return injected_loc.getDecl(); })),
+                qualifier);
           }
 
           return nullptr;
@@ -53283,6 +56749,9 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
                        cxx_constructor_decl->getSourceRange());
       auto translate_ctor_initializer_args =
           [&](clang::Expr *clang_init) -> SgExpression * {
+        ScopedTranslationCacheRebuild rebuild_translation_cache(
+            p_rebuild_translation_cache_depth,
+            isolate_ctor_initializer_cache && clang_init != nullptr);
         if (clang_init == nullptr) {
           return nullptr;
         }
@@ -53346,9 +56815,6 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
           SgType *fieldType = fieldInitializedName->get_type();
 
           clang::Expr *clang_init = clang_ctor_initializer->getInit();
-          if (isolate_ctor_initializer_cache) {
-            recursive_invalidate_stmt(clang_init);
-          }
 
           SgExpression *initExpr = translate_ctor_initializer_args(clang_init);
           SgInitializer *sgCtorInitializer = isSgInitializer(initExpr);
@@ -53448,9 +56914,6 @@ bool ClangToSageTranslator::VisitCXXConstructorDecl(
           }
 
           clang::Expr *clang_init = clang_ctor_initializer->getInit();
-          if (isolate_ctor_initializer_cache) {
-            recursive_invalidate_stmt(clang_init);
-          }
 
           SgExpression *initExpr = translate_ctor_initializer_args(clang_init);
           if (initExpr == nullptr) {
@@ -53746,7 +57209,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
 
   // Create the SAGE node: SgVariableDeclaration
 
-  SgName name(var_decl->getNameAsString());
+  SgName name(
+      readClangApiValueDefined([&]() { return var_decl->getNameAsString(); }));
   if (name.getString().empty() &&
       llvm::isa<clang::DecompositionDecl>(var_decl)) {
     SgScopeStatement *scope = SageBuilder::topScopeStack();
@@ -53755,8 +57219,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         SageInterface::generateUniqueVariableName(scope, "structured_binding"));
   }
 
-  clang::QualType varQualType = var_decl->getType();
-  markClangValueDefined(varQualType);
+  clang::QualType varQualType = markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return var_decl->getType(); }));
 
   const clang::Type *varType =
       markClangTypeObjectDefinedByClass(varQualType.getTypePtr());
@@ -53792,10 +57256,16 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     if (tag_decl == nullptr || p_compiler_instance == nullptr) {
       return false;
     }
-    clang::SourceRange decl_range = var_decl->getSourceRange();
-    if (clang::TypeSourceInfo *tsi = var_decl->getTypeSourceInfo()) {
+    clang::SourceRange decl_range =
+        readClangApiValueDefined([&]() { return var_decl->getSourceRange(); });
+    if (clang::TypeSourceInfo *tsi =
+            markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return var_decl->getTypeSourceInfo(); }))) {
       tsi = markClangTypeSourceInfoDefined(tsi);
-      clang::SourceRange type_range = tsi->getTypeLoc().getSourceRange();
+      clang::TypeLoc type_loc =
+          readClangTypeLocDefined([&]() { return tsi->getTypeLoc(); });
+      clang::SourceRange type_range =
+          readClangApiValueDefined([&]() { return type_loc.getSourceRange(); });
       if (type_range.isValid()) {
         decl_range = type_range;
       }
@@ -53919,11 +57389,23 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   // base-type defining declarations.
   isDefinitionRequired = iscompleteDefined;
 
-  bool isStaticDataMember = var_decl->isStaticDataMember();
+  bool isStaticDataMember = readClangApiValueDefined(
+      [&]() { return var_decl->isStaticDataMember(); });
   bool isOutOfLineStaticMember = is_out_of_line_static_data_member(var_decl);
+  const bool var_is_file_var_decl =
+      readClangApiValueDefined([&]() { return var_decl->isFileVarDecl(); });
+  const bool var_is_constexpr =
+      readClangApiValueDefined([&]() { return var_decl->isConstexpr(); });
+  const bool var_is_direct_init =
+      readClangApiValueDefined([&]() { return var_decl->isDirectInit(); });
+  const clang::VarDecl::InitializationStyle var_init_style =
+      readClangApiValueDefined([&]() { return var_decl->getInitStyle(); });
 
   const clang::DeclContext *var_type_decl_context =
-      isOutOfLineStaticMember ? var_decl->getDeclContext() : nullptr;
+      isOutOfLineStaticMember
+          ? markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return var_decl->getDeclContext(); }))
+          : nullptr;
   if (var_type_decl_context != nullptr) {
     ++p_preserve_current_class_qualifier_depth;
     p_template_parameter_decl_context_stack.push_back(var_type_decl_context);
@@ -53934,13 +57416,13 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   bool written_type_spells_elaborated_keyword = false;
   clang::TagDecl *written_variable_tag_decl = nullptr;
   clang::NestedNameSpecifierLoc written_type_qualifier_loc;
-  clang::QualType original_var_type = var_decl->getType();
-  markClangValueDefined(original_var_type);
-  markClangTypeObjectDefinedByClass(original_var_type.getTypePtrOrNull());
+  clang::QualType original_var_type = markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return var_decl->getType(); }));
   if (clang::TypeSourceInfo *type_info =
-          markClangAstObjectDefined(var_decl->getTypeSourceInfo())) {
-    clang::TypeLoc type_loc = type_info->getTypeLoc();
-    markClangTypeLocDataDefined(type_loc);
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return var_decl->getTypeSourceInfo(); }))) {
+    clang::TypeLoc type_loc =
+        readClangTypeLocDefined([&]() { return type_info->getTypeLoc(); });
     markClangTypeObjectDefinedByClass(type_loc.getTypePtr());
     written_type_spells_elaborated_keyword =
         typeLocSpellsElaboratedKeyword(type_loc);
@@ -54073,11 +57555,14 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     }
   }
   if (type == nullptr) {
-    type = buildTypeFromQualifiedType(var_decl->getType());
+    type = buildTypeFromQualifiedType(markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return var_decl->getType(); })));
   }
   if (!written_type_spells_elaborated_keyword) {
-    written_type_spells_elaborated_keyword =
-        typeSpellsElaboratedKeyword(var_decl->getType().getTypePtrOrNull());
+    written_type_spells_elaborated_keyword = typeSpellsElaboratedKeyword(
+        markClangQualTypeDefined(readClangApiValueDefined([&]() {
+          return var_decl->getType();
+        })).getTypePtrOrNull());
   }
 
   if (var_type_decl_context != nullptr) {
@@ -54403,7 +57888,29 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   }
 
   const clang::TemplateSpecializationKind var_specialization_kind =
-      var_decl->getTemplateSpecializationKind();
+      readClangApiValueDefined(
+          [&]() { return var_decl->getTemplateSpecializationKind(); });
+
+  auto defined_var_decl_context = [&]() -> clang::DeclContext * {
+    return const_cast<clang::DeclContext *>(
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return var_decl->getDeclContext(); })));
+  };
+  auto defined_var_record_context = [&]() -> clang::RecordDecl * {
+    clang::DeclContext *ctx = defined_var_decl_context();
+    auto *record_ctx = llvm::dyn_cast_or_null<clang::RecordDecl>(ctx);
+    return llvm::dyn_cast_or_null<clang::RecordDecl>(
+        markClangDeclObjectDefinedByKind(record_ctx));
+  };
+  auto defined_record_definition =
+      [&](clang::RecordDecl *record_decl) -> clang::RecordDecl * {
+    if (record_decl == nullptr) {
+      return nullptr;
+    }
+    return llvm::dyn_cast_or_null<clang::RecordDecl>(
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+            [&]() { return record_decl->getDefinition(); })));
+  };
 
   auto build_var_declaration =
       [&](SgScopeStatement *decl_scope) -> SgVariableDeclaration * {
@@ -54414,8 +57921,7 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     if (!isStaticDataMember) {
       return nullptr;
     }
-    clang::DeclContext *ctx = var_decl->getDeclContext();
-    auto *record_ctx = llvm::dyn_cast_or_null<clang::RecordDecl>(ctx);
+    clang::RecordDecl *record_ctx = defined_var_record_context();
     if (record_ctx == nullptr) {
       return nullptr;
     }
@@ -54428,8 +57934,10 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         class_def = class_decl->get_definition();
       }
     }
-    if (class_def == nullptr && record_ctx->getDefinition() != nullptr) {
-      if (SgNode *def_node = TraverseOnDemand(record_ctx->getDefinition())) {
+    clang::RecordDecl *record_definition =
+        defined_record_definition(record_ctx);
+    if (class_def == nullptr && record_definition != nullptr) {
+      if (SgNode *def_node = TraverseOnDemand(record_definition)) {
         if (SgClassDeclaration *def_decl = isSgClassDeclaration(def_node)) {
           class_def = def_decl->get_definition();
         } else if (SgClassDefinition *def_def = isSgClassDefinition(def_node)) {
@@ -54461,8 +57969,12 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   // set_prev_decl_item to point to its first static data member declaration
   // inside the class. buildVariableDeclaration_nfi will take care of the
   // details by looking up the SgSymbol in the symbol table of the class.
-  if (isStaticDataMember && var_decl->getPreviousDecl() != nullptr) {
-    clang::VarDecl *prevDecl = var_decl->getPreviousDecl();
+  clang::VarDecl *previous_static_data_member_decl =
+      llvm::dyn_cast_or_null<clang::VarDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return var_decl->getPreviousDecl(); })));
+  if (isStaticDataMember && previous_static_data_member_decl != nullptr) {
+    clang::VarDecl *prevDecl = previous_static_data_member_decl;
     SgVariableDeclaration *sgPrevDecl = nullptr;
     auto it_prev = p_decl_translation_map.find(prevDecl);
     if (it_prev != p_decl_translation_map.end()) {
@@ -54470,8 +57982,11 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     }
     if (sgPrevDecl == nullptr) {
       SgScopeStatement *saved_scope = SageBuilder::topScopeStack();
+      clang::DeclContext *prev_decl_context =
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return prevDecl->getDeclContext(); }));
       SgScopeStatement *decl_scope_hint =
-          resolveScopeFromDeclContext(prevDecl->getDeclContext(), saved_scope);
+          resolveScopeFromDeclContext(prev_decl_context, saved_scope);
       if (decl_scope_hint != nullptr && decl_scope_hint != saved_scope) {
         SageBuilder::pushScopeStack(decl_scope_hint);
       }
@@ -54512,8 +58027,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     }
   } else {
     SgScopeStatement *decl_scope = SageBuilder::topScopeStack();
-    if (!isStaticDataMember && var_decl->isFileVarDecl()) {
-      if (clang::DeclContext *ctx = var_decl->getDeclContext()) {
+    if (!isStaticDataMember && var_is_file_var_decl) {
+      if (clang::DeclContext *ctx = defined_var_decl_context()) {
         if (SgScopeStatement *resolved =
                 resolveScopeFromDeclContext(ctx, decl_scope)) {
           decl_scope = resolved;
@@ -54526,10 +58041,10 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     sg_var_decl = build_var_declaration(decl_scope);
   }
   const bool ordinary_variable_redeclaration =
-      var_decl->getPreviousDecl() != nullptr && !isStaticDataMember;
+      previous_static_data_member_decl != nullptr && !isStaticDataMember;
   sg_var_decl->set_isAssociatedWithDeclarationList(
       !implicit_anonymous_aggregate_var && !ordinary_variable_redeclaration);
-  if (var_decl->isConstexpr()) {
+  if (var_is_constexpr) {
     sg_var_decl->set_is_constexpr(true);
   }
   if (var_decl->getASTContext().getLangOpts().CPlusPlus &&
@@ -54548,8 +58063,10 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   }
 
   // CLANG FRONTEND FIX: Check if variable has an initializer before traversing
-  clang::Expr *init_expr = markClangExprObjectDefinedByClass(
-      var_decl->isExceptionVariable() ? nullptr : var_decl->getInit());
+  clang::Expr *init_expr =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined([&]() {
+        return var_decl->isExceptionVariable() ? nullptr : var_decl->getInit();
+      }));
   SgExpression *expr = nullptr;
   SgExprListExp *expr_list_expr = nullptr;
   SgInitializer *init = nullptr;
@@ -54569,8 +58086,7 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     if (expr != nullptr) {
       expr_list_expr = isSgExprListExp(expr);
       if (expr_list_expr != nullptr) {
-        if (var_decl->isDirectInit() &&
-            var_decl->getInitStyle() != clang::VarDecl::ListInit) {
+        if (var_is_direct_init && var_init_style != clang::VarDecl::ListInit) {
           const bool class_unknown =
               constructorInitializerAssociatedClassUnknown(type);
           SgConstructorInitializer *ctor_init =
@@ -54582,8 +58098,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
                   class_unknown);
           ctor_init->set_is_braced_initialized(false);
           init = ctor_init;
-        } else if (var_decl->isDirectInit() &&
-                   var_decl->getInitStyle() == clang::VarDecl::ListInit) {
+        } else if (var_is_direct_init &&
+                   var_init_style == clang::VarDecl::ListInit) {
           const bool class_unknown =
               constructorInitializerAssociatedClassUnknown(type);
           SgConstructorInitializer *ctor_init =
@@ -54600,7 +58116,7 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         }
       } else if (SgConstructorInitializer *ctor_init =
                      isSgConstructorInitializer(expr)) {
-        if (var_decl->getInitStyle() == clang::VarDecl::CInit) {
+        if (var_init_style == clang::VarDecl::CInit) {
           init = SageBuilder::buildAssignInitializer_nfi(ctor_init,
                                                          ctor_init->get_type());
         } else {
@@ -54609,8 +58125,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       } else if (SgInitializer *existing_init = isSgInitializer(expr)) {
         init = existing_init;
       } else if (var_decl->getASTContext().getLangOpts().CPlusPlus &&
-                 var_decl->isDirectInit() &&
-                 var_decl->getInitStyle() != clang::VarDecl::ListInit) {
+                 var_is_direct_init &&
+                 var_init_style != clang::VarDecl::ListInit) {
         SgExprListExp *args = SageBuilder::buildExprListExp_nfi();
         args->append_expression(expr);
         applySourceRange(args, init_expr->getSourceRange());
@@ -54639,8 +58155,7 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   }
 
   if (SgConstructorInitializer *ctor_init = isSgConstructorInitializer(init)) {
-    if (var_decl->isDirectInit() &&
-        var_decl->getInitStyle() != clang::VarDecl::ListInit) {
+    if (var_is_direct_init && var_init_style != clang::VarDecl::ListInit) {
       // Preserve the direct-init constructor form so the unparser can
       // reintroduce disambiguating parentheses for cases like `T x((U()))`
       // without affecting true function declarations, which do not come
@@ -54667,12 +58182,7 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     }
   }
 
-  // finding the bottom base type and check
-  while (type->findBaseType() != type) {
-    type = type->findBaseType();
-    if (type == sg_varType)
-      break;
-  }
+  type = stripSageDeclaratorBaseType(type);
 
   if (isSgClassType(type) && isDefinitionRequired) {
     SgClassDeclaration *classDecl =
@@ -54824,8 +58334,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     init_name->set_prev_decl_item(nullptr);
   }
   if (isStaticDataMember && init_name->get_prev_decl_item() == nullptr) {
-    clang::DeclContext *ctx = var_decl->getDeclContext();
-    if (ctx != nullptr && llvm::isa<clang::RecordDecl>(ctx)) {
+    clang::RecordDecl *record_ctx = defined_var_record_context();
+    if (record_ctx != nullptr) {
       // Ensure we link the out-of-line definition to the in-class declaration
       // so name qualification is preserved.
       auto find_member_init =
@@ -54849,7 +58359,9 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       };
 
       SgInitializedName *prev_init = nullptr;
-      clang::VarDecl *first_decl = var_decl->getFirstDecl();
+      clang::VarDecl *first_decl = llvm::dyn_cast_or_null<clang::VarDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return var_decl->getFirstDecl(); })));
       if (first_decl != nullptr && first_decl != var_decl) {
         auto it_prev = p_decl_translation_map.find(first_decl);
         SgVariableDeclaration *prev_decl_node = nullptr;
@@ -54858,8 +58370,11 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         }
         if (prev_decl_node == nullptr) {
           SgScopeStatement *saved_scope = SageBuilder::topScopeStack();
-          SgScopeStatement *decl_scope = resolveScopeFromDeclContext(
-              first_decl->getDeclContext(), saved_scope);
+          clang::DeclContext *first_decl_context =
+              markClangDeclContextObjectDefined(readClangApiValueDefined(
+                  [&]() { return first_decl->getDeclContext(); }));
+          SgScopeStatement *decl_scope =
+              resolveScopeFromDeclContext(first_decl_context, saved_scope);
           if (decl_scope != nullptr && decl_scope != saved_scope) {
             SageBuilder::pushScopeStack(decl_scope);
           }
@@ -54875,8 +58390,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       }
 
       if (prev_init == nullptr) {
-        if (auto *parent_record =
-                llvm::dyn_cast_or_null<clang::CXXRecordDecl>(ctx)) {
+        if (auto *parent_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                markClangDeclObjectDefinedByKind(record_ctx))) {
           SgScopeStatement *scope = resolveScopeFromDeclContext(
               parent_record, SageBuilder::topScopeStack());
           SgClassDefinition *class_def = isSgClassDefinition(scope);
@@ -54885,10 +58400,10 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
               class_def = class_decl->get_definition();
             }
           }
-          if (class_def == nullptr &&
-              parent_record->getDefinition() != nullptr) {
-            if (SgNode *def_node =
-                    TraverseOnDemand(parent_record->getDefinition())) {
+          clang::RecordDecl *parent_definition =
+              defined_record_definition(parent_record);
+          if (class_def == nullptr && parent_definition != nullptr) {
+            if (SgNode *def_node = TraverseOnDemand(parent_definition)) {
               if (SgClassDeclaration *def_decl =
                       isSgClassDeclaration(def_node)) {
                 class_def = def_decl->get_definition();
@@ -54908,41 +58423,38 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
     }
   }
   if (isStaticDataMember && isOutOfLineStaticMember) {
-    clang::DeclContext *ctx = var_decl->getDeclContext();
-    if (ctx != nullptr && llvm::isa<clang::RecordDecl>(ctx)) {
+    clang::RecordDecl *record_ctx = defined_var_record_context();
+    if (record_ctx != nullptr) {
       SgScopeStatement *member_scope = nullptr;
       if (init_name->get_prev_decl_item() != nullptr) {
         member_scope = init_name->get_prev_decl_item()->get_scope();
       }
       if (member_scope == nullptr) {
-        if (auto *record_ctx = llvm::dyn_cast_or_null<clang::RecordDecl>(
-                var_decl->getDeclContext())) {
-          SgScopeStatement *resolved_scope = resolveScopeFromDeclContext(
-              record_ctx, SageBuilder::topScopeStack());
-          SgClassDefinition *class_def = isSgClassDefinition(resolved_scope);
-          if (class_def == nullptr) {
-            if (SgClassDeclaration *class_decl =
-                    isSgClassDeclaration(resolved_scope)) {
-              class_def = class_decl->get_definition();
+        SgScopeStatement *resolved_scope = resolveScopeFromDeclContext(
+            record_ctx, SageBuilder::topScopeStack());
+        SgClassDefinition *class_def = isSgClassDefinition(resolved_scope);
+        if (class_def == nullptr) {
+          if (SgClassDeclaration *class_decl =
+                  isSgClassDeclaration(resolved_scope)) {
+            class_def = class_decl->get_definition();
+          }
+        }
+        clang::RecordDecl *record_definition =
+            defined_record_definition(record_ctx);
+        if (class_def == nullptr && record_definition != nullptr) {
+          if (SgNode *def_node = TraverseOnDemand(record_definition)) {
+            if (SgClassDeclaration *def_decl = isSgClassDeclaration(def_node)) {
+              class_def = def_decl->get_definition();
+            } else if (SgClassDefinition *def_def =
+                           isSgClassDefinition(def_node)) {
+              class_def = def_def;
             }
           }
-          if (class_def == nullptr && record_ctx->getDefinition() != nullptr) {
-            if (SgNode *def_node =
-                    TraverseOnDemand(record_ctx->getDefinition())) {
-              if (SgClassDeclaration *def_decl =
-                      isSgClassDeclaration(def_node)) {
-                class_def = def_decl->get_definition();
-              } else if (SgClassDefinition *def_def =
-                             isSgClassDefinition(def_node)) {
-                class_def = def_def;
-              }
-            }
-          }
-          if (class_def != nullptr) {
-            member_scope = class_def;
-          } else {
-            member_scope = resolved_scope;
-          }
+        }
+        if (class_def != nullptr) {
+          member_scope = class_def;
+        } else {
+          member_scope = resolved_scope;
         }
       }
       if (member_scope != nullptr) {
@@ -54974,9 +58486,9 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   } else if (init_name->get_scope() == nullptr) {
     init_name->set_scope(SageBuilder::topScopeStack());
   }
-  if (!isStaticDataMember && var_decl->isFileVarDecl()) {
+  if (!isStaticDataMember && var_is_file_var_decl) {
     SgScopeStatement *resolved_scope = nullptr;
-    if (clang::DeclContext *ctx = var_decl->getDeclContext()) {
+    if (clang::DeclContext *ctx = defined_var_decl_context()) {
       resolved_scope =
           resolveScopeFromDeclContext(ctx, SageBuilder::topScopeStack());
     }
@@ -54987,7 +58499,10 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         isSgClassDefinition(init_name->get_scope()) != nullptr) {
       init_name->set_scope(resolved_scope);
     }
-    if (var_decl->getPreviousDecl() == nullptr) {
+    clang::VarDecl *previous_decl = llvm::dyn_cast_or_null<clang::VarDecl>(
+        markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+            [&]() { return var_decl->getPreviousDecl(); })));
+    if (previous_decl == nullptr) {
       if (SgInitializedName *prev_init = init_name->get_prev_decl_item()) {
         SgScopeStatement *prev_scope = prev_init->get_scope();
         if (isSgClassDefinition(prev_scope) != nullptr) {
@@ -54996,17 +58511,21 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       }
     }
   }
-  if (var_decl->getInitStyle() == clang::VarDecl::ListInit) {
+  if (var_init_style == clang::VarDecl::ListInit) {
     init_name->set_is_braced_initialized(true);
-    if (!var_decl->isDirectInit()) {
+    if (!var_is_direct_init) {
       init_name->set_using_assignment_copy_constructor_syntax(true);
     }
   }
-  if (var_decl->isConstexpr()) {
+  if (var_is_constexpr) {
     bool explicit_const = true;
     if (const clang::TypeSourceInfo *type_info =
-            var_decl->getTypeSourceInfo()) {
-      explicit_const = type_info->getType().isLocalConstQualified();
+            markClangTypeSourceInfoDefined(readClangApiValueDefined(
+                [&]() { return var_decl->getTypeSourceInfo(); }))) {
+      explicit_const = readClangApiValueDefined([&]() {
+        return markClangQualTypeDefined(type_info->getType())
+            .isLocalConstQualified();
+      });
     }
     init_name->set_is_constexpr_const_implicit(!explicit_const);
   }
@@ -55020,8 +58539,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
   applySourceRange(init_name, var_decl->getSourceRange());
 
   // CLANG FRONTEND FIX: The declptr should already be set by
-  // SgVariableDeclaration constructor to point to the SgVariableDefinition. If
-  // it's null, we need to check why.
+  // SgVariableDeclaration constructor to point to the SgVariableDefinition.
+  // If it's null, we need to check why.
   SgVariableDefinition *var_def =
       isSgVariableDefinition(init_name->get_declptr());
   if (var_def == nullptr) {
@@ -55231,7 +58750,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       suppress_var = shouldSuppressDeclNotWrittenInMainFile(loc, sm);
     }
     auto keep_visible_non_main_file_leaf_var = [&]() -> bool {
-      if (var_decl->isImplicit() || var_decl->isStaticDataMember()) {
+      if (readClangApiValueDefined([&]() { return var_decl->isImplicit(); }) ||
+          isStaticDataMember) {
         return false;
       }
 
@@ -55251,13 +58771,14 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       suppress_var = false;
     }
     auto is_instantiated_static_member_pattern = [&]() -> bool {
-      if (!var_decl->isStaticDataMember()) {
+      if (!isStaticDataMember) {
         return false;
       }
 
       const clang::ClassTemplateSpecializationDecl *parent_spec =
           find_enclosing_class_template_specialization(
-              var_decl->getDeclContext());
+              defined_var_decl_context());
+      parent_spec = markClangSpecificDeclDefined(parent_spec);
       if (parent_spec == nullptr) {
         return false;
       }
@@ -55268,7 +58789,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
               clang::TSK_ExplicitInstantiationDeclaration ||
           var_specialization_kind == clang::TSK_ExplicitInstantiationDefinition;
       const clang::TemplateSpecializationKind parent_tsk =
-          parent_spec->getTemplateSpecializationKind();
+          readClangApiValueDefined(
+              [&]() { return parent_spec->getTemplateSpecializationKind(); });
       const bool parent_is_instantiation =
           parent_tsk == clang::TSK_ImplicitInstantiation ||
           parent_tsk == clang::TSK_ExplicitInstantiationDeclaration ||
@@ -55281,7 +58803,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         return true;
       }
 
-      clang::SourceLocation member_loc = var_decl->getLocation();
+      clang::SourceLocation member_loc =
+          readClangApiValueDefined([&]() { return var_decl->getLocation(); });
       if (member_loc.isMacroID()) {
         member_loc = sm.getSpellingLoc(member_loc);
       }
@@ -55295,19 +58818,22 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
                   parent_spec));
       if (pattern == nullptr) {
         if (clang::ClassTemplateDecl *primary =
-                parent_spec->getSpecializedTemplate()) {
-          pattern = primary->getTemplatedDecl();
+                markClangSpecificDeclDefined(readClangApiValueDefined(
+                    [&]() { return parent_spec->getSpecializedTemplate(); }))) {
+          pattern = markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return primary->getTemplatedDecl(); }));
         }
       }
       if (pattern == nullptr) {
         return false;
       }
 
-      return sourceRangeContainsLocation(pattern->getSourceRange(), member_loc,
-                                         &sm, true);
+      clang::SourceRange pattern_range =
+          readClangApiValueDefined([&]() { return pattern->getSourceRange(); });
+      return sourceRangeContainsLocation(pattern_range, member_loc, &sm, true);
     };
     auto static_member_parent_chain_is_hidden = [&]() -> bool {
-      if (!var_decl->isStaticDataMember()) {
+      if (!isStaticDataMember) {
         return false;
       }
 
@@ -55321,7 +58847,8 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       }
 
       const clang::CXXRecordDecl *record_ctx =
-          find_enclosing_cxx_record_decl(var_decl->getDeclContext());
+          find_enclosing_cxx_record_decl(defined_var_decl_context());
+      record_ctx = markClangSpecificDeclDefined(record_ctx);
       if (record_ctx == nullptr) {
         return false;
       }
@@ -55347,10 +58874,12 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       if (check_record(record_ctx)) {
         return true;
       }
-      if (check_record(record_ctx->getDefinition())) {
+      if (check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return record_ctx->getDefinition(); })))) {
         return true;
       }
-      if (check_record(record_ctx->getCanonicalDecl())) {
+      if (check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return record_ctx->getCanonicalDecl(); })))) {
         return true;
       }
       if (check_record(clangCXXRecordTemplateInstantiationPatternDefined(
@@ -55358,33 +58887,46 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
         return true;
       }
       if (clang::ClassTemplateDecl *templ =
-              record_ctx->getDescribedClassTemplate()) {
-        if (check_record(templ->getTemplatedDecl())) {
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return record_ctx->getDescribedClassTemplate(); }))) {
+        if (check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return templ->getTemplatedDecl(); })))) {
           return true;
         }
       }
 
-      for (const clang::DeclContext *ctx = record_ctx->getParent();
-           ctx != nullptr; ctx = ctx->getParent()) {
+      for (const clang::DeclContext *ctx =
+               markClangDeclContextObjectDefined(readClangApiValueDefined(
+                   [&]() { return record_ctx->getParent(); }));
+           ctx != nullptr;
+           ctx = markClangDeclContextObjectDefined(
+               readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
         const clang::Decl *decl = llvm::dyn_cast_or_null<clang::Decl>(
             const_cast<clang::DeclContext *>(ctx));
         const auto *parent_record =
             llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                const_cast<clang::Decl *>(decl));
+                markClangDeclObjectDefinedByKind(
+                    const_cast<clang::Decl *>(decl)));
         if (parent_record == nullptr) {
           continue;
         }
 
         if (check_record(parent_record) ||
-            check_record(parent_record->getDefinition()) ||
-            check_record(parent_record->getCanonicalDecl()) ||
+            check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return parent_record->getDefinition(); }))) ||
+            check_record(markClangSpecificDeclDefined(readClangApiValueDefined(
+                [&]() { return parent_record->getCanonicalDecl(); }))) ||
             check_record(clangCXXRecordTemplateInstantiationPatternDefined(
                 const_cast<clang::CXXRecordDecl *>(parent_record)))) {
           return true;
         }
         if (clang::ClassTemplateDecl *templ =
-                parent_record->getDescribedClassTemplate()) {
-          if (check_record(templ->getTemplatedDecl())) {
+                markClangSpecificDeclDefined(readClangApiValueDefined([&]() {
+                  return parent_record->getDescribedClassTemplate();
+                }))) {
+          if (check_record(
+                  markClangSpecificDeclDefined(readClangApiValueDefined(
+                      [&]() { return templ->getTemplatedDecl(); })))) {
             return true;
           }
         }
@@ -55393,12 +58935,13 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       return false;
     };
     auto is_source_visible_static_member_specialization = [&]() -> bool {
-      if (!var_decl->isStaticDataMember() || !isOutOfLineStaticMember ||
+      if (!isStaticDataMember || !isOutOfLineStaticMember ||
           var_specialization_kind != clang::TSK_ExplicitSpecialization) {
         return false;
       }
 
-      clang::SourceLocation member_loc = var_decl->getLocation();
+      clang::SourceLocation member_loc =
+          readClangApiValueDefined([&]() { return var_decl->getLocation(); });
       if (member_loc.isMacroID()) {
         member_loc = sm.getSpellingLoc(member_loc);
       }
@@ -55415,9 +58958,9 @@ bool ClangToSageTranslator::VisitVarDecl(clang::VarDecl *var_decl,
       return !shouldSuppressDeclNotWrittenInMainFile(member_loc, sm);
     };
 
-    if (suppress_var && !var_decl->isImplicit() &&
-        var_decl->isStaticDataMember() &&
-        !static_member_parent_chain_is_hidden()) {
+    if (suppress_var &&
+        !readClangApiValueDefined([&]() { return var_decl->isImplicit(); }) &&
+        isStaticDataMember && !static_member_parent_chain_is_hidden()) {
       if (static_member_owner_scope == SageBuilder::topScopeStack()) {
         suppress_var = false;
       } else if (class_like_scope_is_visible_for_unparse(
@@ -55553,6 +59096,7 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
 
   param_var_decl = llvm::cast<clang::ParmVarDecl>(
       markClangDeclObjectDefinedByKind(param_var_decl));
+  markClangParmVarDeclDefaultArgSourceRangeStorageDefined(param_var_decl);
   SgName name(param_var_decl->getNameAsString());
   clang::DeclContext *owning_context =
       markClangDeclContextObjectDefined(param_var_decl->getDeclContext());
@@ -55574,13 +59118,16 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
   int written_type_qualification_length = 0;
   bool written_type_has_explicit_global_qualifier = false;
   if (clang::TypeSourceInfo *type_info =
-          markClangTypeSourceInfoDefined(param_var_decl->getTypeSourceInfo())) {
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return param_var_decl->getTypeSourceInfo(); }))) {
+    clang::TypeLoc type_loc =
+        readClangApiValueDefined([&]() { return type_info->getTypeLoc(); });
+    markClangTypeLocDataDefined(type_loc);
     written_type_spells_elaborated_keyword =
-        typeLocSpellsElaboratedKeyword(type_info->getTypeLoc());
-    written_parameter_tag_decl =
-        typeLocSpellsDirectTagDecl(type_info->getTypeLoc());
+        typeLocSpellsElaboratedKeyword(type_loc);
+    written_parameter_tag_decl = typeLocSpellsDirectTagDecl(type_loc);
     if (clang::NestedNameSpecifierLoc qualifier_loc =
-            typeLocQualifierLoc(type_info->getTypeLoc())) {
+            typeLocQualifierLoc(type_loc)) {
       auto next_qualifier_loc = [](clang::NestedNameSpecifierLoc current)
           -> clang::NestedNameSpecifierLoc {
         current = markClangNestedNameSpecifierLocDefined(current);
@@ -55634,8 +59181,12 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
 
       clang::TagDecl *tag_decl = owned_tag_decl;
       if (tag_decl == nullptr && !stripped_type.isNull()) {
-        tag_decl = const_cast<clang::TagDecl *>(stripped_type->getAsTagDecl());
+        stripped_type = markClangQualTypeDefined(stripped_type);
+        tag_decl = markClangSpecificDeclDefined(
+            const_cast<clang::TagDecl *>(readClangApiValueDefined(
+                [&]() { return stripped_type->getAsTagDecl(); })));
       }
+      tag_decl = markClangSpecificDeclDefined(tag_decl);
       if (tag_decl == nullptr) {
         return false;
       }
@@ -55646,10 +59197,14 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
         return false;
       }
 
-      if (!p_inline_tag_decls.insert(tag_decl->getCanonicalDecl()).second) {
+      clang::TagDecl *canonical_tag =
+          markClangSpecificDeclDefined(readClangApiValueDefined(
+              [&]() { return tag_decl->getCanonicalDecl(); }));
+      if (!p_inline_tag_decls.insert(canonical_tag).second) {
         return true;
       }
-      (void)lookupSgDeclarationForClangDecl(tag_decl, /*allow_on_demand=*/true);
+      (void)lookupSgDeclarationForClangDecl(tag_decl,
+                                            /*allow_on_demand=*/true);
       return true;
     };
     auto translated_inline_tag_type_for_qual_type =
@@ -55660,8 +59215,8 @@ bool ClangToSageTranslator::VisitParmVarDecl(clang::ParmVarDecl *param_var_decl,
 
       // Preserve the full written type shape. The inline-tag materialization
       // above ensures the referenced tag declaration exists; rebuilding the
-      // type from the whole QualType keeps pointer/array layers intact instead
-      // of collapsing `struct T *` to `struct T`.
+      // type from the whole QualType keeps pointer/array layers intact
+      // instead of collapsing `struct T *` to `struct T`.
       return buildTypeFromQualifiedType(qual_type);
     };
 
@@ -56095,8 +59650,8 @@ bool ClangToSageTranslator::VisitVarTemplateSpecializationDecl(
     return false;
   }
 
-  // ROOT CAUSE FIX: Variable template specializations should be represented as
-  // SgTemplateVariableDeclaration with specialization arguments so name
+  // ROOT CAUSE FIX: Variable template specializations should be represented
+  // as SgTemplateVariableDeclaration with specialization arguments so name
   // qualification and symbol table logic can distinguish instantiations.
 
   // Get variable name and type
@@ -56182,8 +59737,10 @@ bool ClangToSageTranslator::VisitVarTemplateSpecializationDecl(
   clang::TemplateSpecializationKind specialization_kind =
       var_template_specialization_decl->getTemplateSpecializationKind();
   const bool specialization_is_partial =
-      var_template_specialization_decl->getSpecializedTemplateOrPartial()
-          .dyn_cast<clang::VarTemplatePartialSpecializationDecl *>() != nullptr;
+      readClangApiValueDefined([&]() {
+        return var_template_specialization_decl
+            ->getSpecializedTemplateOrPartial();
+      }).dyn_cast<clang::VarTemplatePartialSpecializationDecl *>() != nullptr;
 
   const clang::TemplateArgumentList *args_ptr =
       markClangTemplateArgumentListDefined(
@@ -56285,8 +59842,9 @@ bool ClangToSageTranslator::VisitVarTemplateSpecializationDecl(
   // Record the specialized template declaration chosen by Clang.
   SgDeclarationStatement *specialized_template_decl = nullptr;
   clang::Decl *specialized_key = nullptr;
-  auto specialized =
-      var_template_specialization_decl->getSpecializedTemplateOrPartial();
+  auto specialized = readClangApiValueDefined([&]() {
+    return var_template_specialization_decl->getSpecializedTemplateOrPartial();
+  });
   if (auto *partial =
           specialized
               .dyn_cast<clang::VarTemplatePartialSpecializationDecl *>()) {
@@ -56506,6 +60064,9 @@ bool ClangToSageTranslator::VisitEnumConstantDecl(
 #endif
   bool res = true;
 
+  enum_constant_decl = llvm::cast<clang::EnumConstantDecl>(
+      markClangDeclObjectDefinedByKind(enum_constant_decl));
+
   // Safely get the name - check if the declaration name is valid first
   SgName name;
   if (enum_constant_decl && enum_constant_decl->getDeclName().isIdentifier()) {
@@ -56524,19 +60085,25 @@ bool ClangToSageTranslator::VisitEnumConstantDecl(
   p_decl_translation_map.insert(std::pair<clang::Decl *, SgNode *>(
       enum_constant_decl, init_name_placeholder));
 
-  // Get the enum constant's type - this should be the enum type itself, not the
-  // underlying integer type This is critical for type safety, especially for
-  // scoped enums (enum class) where the enumerator must have the enum type, not
-  // int
-  SgType *type = buildTypeFromQualifiedType(enum_constant_decl->getType());
+  // Get the enum constant's type - this should be the enum type itself, not
+  // the underlying integer type This is critical for type safety, especially
+  // for scoped enums (enum class) where the enumerator must have the enum
+  // type, not int
+  clang::QualType enum_constant_type =
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return enum_constant_decl->getType(); }));
+  SgType *type = buildTypeFromQualifiedType(enum_constant_type);
 
   // Update the placeholder with the actual type
   init_name_placeholder->set_type(type);
 
   SgInitializer *init = nullptr;
 
-  if (enum_constant_decl->getInitExpr() != nullptr) {
-    SgNode *tmp_expr = Traverse(enum_constant_decl->getInitExpr());
+  clang::Expr *init_expr =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return enum_constant_decl->getInitExpr(); }));
+  if (init_expr != nullptr) {
+    SgNode *tmp_expr = Traverse(init_expr);
     SgExpression *expr = isSgExpression(tmp_expr);
     if (tmp_expr != nullptr && expr == nullptr) {
       std::cerr << "Runtime error: tmp_expr != nullptr && expr == nullptr"
@@ -56544,10 +60111,13 @@ bool ClangToSageTranslator::VisitEnumConstantDecl(
       res = false;
     } else {
       init = SageBuilder::buildAssignInitializer_nfi(expr, expr->get_type());
+      clang::SourceRange enum_constant_range = readClangApiValueDefined(
+          [&]() { return enum_constant_decl->getSourceRange(); });
+      clang::SourceRange init_expr_range = readClangApiValueDefined(
+          [&]() { return init_expr->getSourceRange(); });
       clang::SourceRange init_range = computeInitializerLexicalRange(
-          p_compiler_instance->getSourceManager(),
-          enum_constant_decl->getSourceRange(),
-          enum_constant_decl->getInitExpr()->getSourceRange());
+          p_compiler_instance->getSourceManager(), enum_constant_range,
+          init_expr_range);
       applySourceRange(init, init_range);
     }
   }
@@ -56688,19 +60258,38 @@ bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
             << std::endl;
 #endif
   bool res = true;
+  unresolved_using_value_decl =
+      llvm::dyn_cast_or_null<clang::UnresolvedUsingValueDecl>(
+          markClangDeclObjectDefinedByKind(unresolved_using_value_decl));
+  ROSE_ASSERT(unresolved_using_value_decl != nullptr);
 
-  std::string name_str = unresolved_using_value_decl->getNameAsString();
+  auto existing_it = p_decl_translation_map.find(unresolved_using_value_decl);
+  if (existing_it != p_decl_translation_map.end()) {
+    if (node != nullptr) {
+      *node = existing_it->second;
+    }
+    return true;
+  }
+
+  std::string name_str = readClangApiValueDefined(
+      [&]() { return unresolved_using_value_decl->getNameAsString(); });
+  clang::DeclarationName decl_name = readClangApiValueDefined(
+      [&]() { return unresolved_using_value_decl->getDeclName(); });
   bool is_inheriting_constructor =
-      unresolved_using_value_decl->getDeclName().getNameKind() ==
+      readClangApiValueDefined([&]() { return decl_name.getNameKind(); }) ==
       clang::DeclarationName::CXXConstructorName;
   SgScopeStatement *current_scope = SageBuilder::topScopeStack();
 
   SgScopeStatement *target_scope = current_scope;
   clang::NestedNameSpecifier qualifier =
-      unresolved_using_value_decl->getQualifier();
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return unresolved_using_value_decl->getQualifier(); }));
   if (!qualifier) {
-    qualifier =
-        unresolved_using_value_decl->getQualifierLoc().getNestedNameSpecifier();
+    clang::NestedNameSpecifierLoc qualifier_loc =
+        markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+            [&]() { return unresolved_using_value_decl->getQualifierLoc(); }));
+    qualifier = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+        [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
   }
   auto strip_template_args = [&](const std::string &raw) -> std::string {
     std::string name = trimWhitespace(raw);
@@ -56712,56 +60301,88 @@ bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
   };
   auto qualifier_terminal_name =
       [&](clang::NestedNameSpecifier nns) -> std::string {
+    nns = markClangNestedNameSpecifierDefined(nns);
     if (!nns) {
       return "";
     }
-    switch (nns.getKind()) {
+    switch (readClangApiValueDefined([&]() { return nns.getKind(); })) {
     case clang::NestedNameSpecifier::Kind::Null:
     case clang::NestedNameSpecifier::Kind::Global:
       return "";
     case clang::NestedNameSpecifier::Kind::Namespace:
       if (const clang::NamespaceDecl *ns = nestedNameSpecifierNamespace(nns)) {
-        return ns->getNameAsString();
+        ns = llvm::dyn_cast_or_null<clang::NamespaceDecl>(
+            markClangDeclObjectDefinedByKind(ns));
+        return readClangApiValueDefined(
+            [&]() { return ns->getNameAsString(); });
       }
       return "";
     case clang::NestedNameSpecifier::Kind::Type: {
       if (const clang::NamespaceAliasDecl *alias =
               nestedNameSpecifierNamespaceAlias(nns)) {
-        return alias->getNameAsString();
+        alias = llvm::dyn_cast_or_null<clang::NamespaceAliasDecl>(
+            markClangDeclObjectDefinedByKind(alias));
+        return readClangApiValueDefined(
+            [&]() { return alias->getNameAsString(); });
       }
-      const clang::Type *type = nns.getAsType();
+      const clang::Type *type = markClangTypeObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return nns.getAsType(); }));
       if (type == nullptr) {
         return "";
       }
       if (const clang::TemplateSpecializationType *spec =
               llvm::dyn_cast<clang::TemplateSpecializationType>(type)) {
+        clang::TemplateName template_name =
+            markClangTemplateNameDefined(readClangApiValueDefined(
+                [&]() { return spec->getTemplateName(); }));
         if (clang::TemplateDecl *tmpl =
-                spec->getTemplateName().getAsTemplateDecl()) {
-          return tmpl->getNameAsString();
+                llvm::dyn_cast_or_null<clang::TemplateDecl>(
+                    markClangDeclObjectDefinedByKind(
+                        readClangApiValueDefined([&]() {
+                          return template_name.getAsTemplateDecl();
+                        })))) {
+          return readClangApiValueDefined(
+              [&]() { return tmpl->getNameAsString(); });
         }
       }
       if (const clang::RecordType *record =
               llvm::dyn_cast<clang::RecordType>(type)) {
-        if (record->getDecl() != nullptr) {
-          return record->getDecl()->getNameAsString();
+        if (clang::RecordDecl *record_decl =
+                llvm::dyn_cast_or_null<clang::RecordDecl>(
+                    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                        [&]() { return record->getDecl(); })))) {
+          return readClangApiValueDefined(
+              [&]() { return record_decl->getNameAsString(); });
         }
       }
       if (const clang::InjectedClassNameType *inj =
               llvm::dyn_cast<clang::InjectedClassNameType>(type)) {
-        if (inj->getDecl() != nullptr) {
-          return inj->getDecl()->getNameAsString();
+        if (clang::CXXRecordDecl *record_decl =
+                llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                        [&]() { return inj->getDecl(); })))) {
+          return readClangApiValueDefined(
+              [&]() { return record_decl->getNameAsString(); });
         }
       }
       if (const clang::TypedefType *tdef =
               llvm::dyn_cast<clang::TypedefType>(type)) {
-        if (tdef->getDecl() != nullptr) {
-          return tdef->getDecl()->getNameAsString();
+        if (clang::TypedefNameDecl *typedef_decl =
+                llvm::dyn_cast_or_null<clang::TypedefNameDecl>(
+                    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                        [&]() { return tdef->getDecl(); })))) {
+          return readClangApiValueDefined(
+              [&]() { return typedef_decl->getNameAsString(); });
         }
       }
       if (const clang::TemplateTypeParmType *type_param =
               llvm::dyn_cast<clang::TemplateTypeParmType>(type)) {
-        if (type_param->getDecl() != nullptr) {
-          return type_param->getDecl()->getNameAsString();
+        if (clang::TemplateTypeParmDecl *type_param_decl =
+                llvm::dyn_cast_or_null<clang::TemplateTypeParmDecl>(
+                    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                        [&]() { return type_param->getDecl(); })))) {
+          return readClangApiValueDefined(
+              [&]() { return type_param_decl->getNameAsString(); });
         }
       }
       return "";
@@ -56774,8 +60395,13 @@ bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
   };
   auto qualifier_is_template_type_param =
       [](clang::NestedNameSpecifier nns) -> bool {
-    return nns && nns.getKind() == clang::NestedNameSpecifier::Kind::Type &&
-           llvm::isa<clang::TemplateTypeParmType>(nns.getAsType());
+    nns = markClangNestedNameSpecifierDefined(nns);
+    return nns &&
+           readClangApiValueDefined([&]() { return nns.getKind(); }) ==
+               clang::NestedNameSpecifier::Kind::Type &&
+           llvm::isa<clang::TemplateTypeParmType>(
+               markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                   [&]() { return nns.getAsType(); })));
   };
   auto is_type_parameter_placeholder_name = [&](const std::string &raw_name) {
     std::string stripped_name = strip_template_args(raw_name);
@@ -56813,6 +60439,84 @@ bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
     }
   }
 
+  auto clang_decl_matches_using_source =
+      [&](SgUsingDeclarationStatement *candidate) -> bool {
+    if (candidate == nullptr || p_compiler_instance == nullptr) {
+      return false;
+    }
+
+    Sg_File_Info *candidate_fi = get_decl_sort_file_info(candidate);
+    if (candidate_fi == nullptr || candidate_fi->get_line() <= 0 ||
+        candidate_fi->get_col() <= 0) {
+      return false;
+    }
+
+    clang::SourceManager &source_manager =
+        p_compiler_instance->getSourceManager();
+    clang::SourceLocation clang_loc = readClangApiValueDefined(
+        [&]() { return unresolved_using_value_decl->getBeginLoc(); });
+    if (!clang_loc.isValid()) {
+      clang_loc = readClangApiValueDefined(
+          [&]() { return unresolved_using_value_decl->getLocation(); });
+    }
+    clang_loc = source_manager.getSpellingLoc(clang_loc);
+    if (!clang_loc.isValid()) {
+      return false;
+    }
+
+    unsigned clang_line = source_manager.getSpellingLineNumber(clang_loc);
+    unsigned clang_col = source_manager.getSpellingColumnNumber(clang_loc);
+    if (clang_line != static_cast<unsigned>(candidate_fi->get_line()) ||
+        clang_col != static_cast<unsigned>(candidate_fi->get_col())) {
+      return false;
+    }
+
+    llvm::StringRef clang_file_ref = source_manager.getFilename(clang_loc);
+    if (clang_file_ref.empty() || candidate_fi->get_filenameString().empty()) {
+      return true;
+    }
+
+    return clang_file_ref == candidate_fi->get_filenameString();
+  };
+
+  auto find_existing_unresolved_using = [&]() -> SgUsingDeclarationStatement * {
+    if (current_scope == nullptr) {
+      return nullptr;
+    }
+
+    SgDeclarationStatementPtrList *decls =
+        get_scope_declaration_list(current_scope);
+    if (decls == nullptr) {
+      return nullptr;
+    }
+
+    for (SgDeclarationStatement *decl : *decls) {
+      SgUsingDeclarationStatement *candidate =
+          isSgUsingDeclarationStatement(decl);
+      if (candidate == nullptr) {
+        continue;
+      }
+      SgInitializedName *candidate_name = candidate->get_initializedName();
+      if (candidate_name == nullptr ||
+          candidate_name->get_name().getString() != name_str) {
+        continue;
+      }
+      if (!clang_decl_matches_using_source(candidate)) {
+        continue;
+      }
+      return candidate;
+    }
+
+    return nullptr;
+  };
+
+  if (SgUsingDeclarationStatement *existing =
+          find_existing_unresolved_using()) {
+    p_decl_translation_map[unresolved_using_value_decl] = existing;
+    *node = existing;
+    return VisitValueDecl(unresolved_using_value_decl, node) && res;
+  }
+
   SgType *unknown_type = SageBuilder::buildUnknownType();
   SgInitializedName *init_name =
       SageBuilder::buildInitializedName(SgName(name_str), unknown_type);
@@ -56833,7 +60537,9 @@ bool ClangToSageTranslator::VisitUnresolvedUsingValueDecl(
     using_stmt->set_scope(current_scope);
     using_stmt->set_parent(current_scope);
   }
-  applySourceRange(using_stmt, unresolved_using_value_decl->getSourceRange());
+  applySourceRange(using_stmt, readClangApiValueDefined([&]() {
+                     return unresolved_using_value_decl->getSourceRange();
+                   }));
   diagnose_null_scope(using_stmt, "UnresolvedUsingValueDecl");
 
   *node = using_stmt;
@@ -56915,7 +60621,9 @@ bool ClangToSageTranslator::VisitStaticAssertDecl(
 #endif
   bool res = true;
 
-  SgNode *tmp_condition = Traverse(pragma_static_assert_decl->getAssertExpr());
+  SgNode *tmp_condition =
+      Traverse(markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return pragma_static_assert_decl->getAssertExpr(); })));
   SgExpression *condition = isSgExpression(tmp_condition);
   if (tmp_condition != nullptr && condition == nullptr) {
     std::cerr
@@ -56925,9 +60633,14 @@ bool ClangToSageTranslator::VisitStaticAssertDecl(
   } else {
     // getMessage() returns Expr*, need to cast to StringLiteral
     std::string message_str = "";
-    if (auto *msg_expr = pragma_static_assert_decl->getMessage()) {
+    if (auto *msg_expr =
+            markClangExprObjectDefinedByClass(readClangApiValueDefined(
+                [&]() { return pragma_static_assert_decl->getMessage(); }))) {
       if (auto *str_lit = clang::dyn_cast<clang::StringLiteral>(msg_expr)) {
-        message_str = str_lit->getString().str();
+        str_lit = markClangStringLiteralStorageDefined(str_lit);
+        message_str = readClangApiValueDefined([&]() {
+                        return str_lit->getString();
+                      }).str();
       }
     }
     *node =
@@ -56935,7 +60648,8 @@ bool ClangToSageTranslator::VisitStaticAssertDecl(
     if (SgStaticAssertionDeclaration *sg_static_assert =
             isSgStaticAssertionDeclaration(*node)) {
       if (isSgClassDefinition(SageBuilder::topScopeStack())) {
-        clang::AccessSpecifier access = pragma_static_assert_decl->getAccess();
+        clang::AccessSpecifier access = readClangApiValueDefined(
+            [&]() { return pragma_static_assert_decl->getAccess(); });
         if (access == clang::AS_public) {
           sg_static_assert->get_declarationModifier()
               .get_accessModifier()
@@ -57059,13 +60773,12 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
         if (auto *record = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
           record = llvm::cast_or_null<clang::CXXRecordDecl>(
               markClangDeclObjectDefinedByKind(record));
-          clang::RecordDecl *definition = record->getDefinition();
-          markClangValueDefined(definition);
+          clang::RecordDecl *definition = clangRecordDefinitionDefined(record);
           spec = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
               markClangDeclObjectDefinedByKind(definition));
           if (spec == nullptr) {
-            clang::CXXRecordDecl *canonical = record->getCanonicalDecl();
-            markClangValueDefined(canonical);
+            clang::CXXRecordDecl *canonical =
+                clangCXXRecordCanonicalDeclDefined(record);
             spec = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
                 markClangDeclObjectDefinedByKind(canonical));
           }
@@ -57097,11 +60810,10 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
       if (auto *record = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
         record = llvm::cast_or_null<clang::CXXRecordDecl>(
             markClangDeclObjectDefinedByKind(record));
-        clang::RecordDecl *definition = record->getDefinition();
-        markClangValueDefined(definition);
+        clang::RecordDecl *definition = clangRecordDefinitionDefined(record);
         maybe_queue_exact_specialization(definition);
-        clang::CXXRecordDecl *canonical = record->getCanonicalDecl();
-        markClangValueDefined(canonical);
+        clang::CXXRecordDecl *canonical =
+            clangCXXRecordCanonicalDeclDefined(record);
         maybe_queue_exact_specialization(canonical);
       }
     }
@@ -57113,11 +60825,11 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
   // specializations after the TU decl pass so the primary template definition
   // is fully materialized before generic AST traversals can observe the
   // specialization. Do not structurally reattach these queued implicit
-  // specializations to scope child lists here: VisitClassTemplateSpecialization
-  // already decides whether a specialization is source-visible. Reattaching
-  // semantic-only instantiations here bounces them back into generated output
-  // as stray `template<> class ...;` declarations and perturbs later symbol
-  // ownership.
+  // specializations to scope child lists here:
+  // VisitClassTemplateSpecialization already decides whether a specialization
+  // is source-visible. Reattaching semantic-only instantiations here bounces
+  // them back into generated output as stray `template<> class ...;`
+  // declarations and perturbs later symbol ownership.
   {
     roseClangPhaseTrace(
         "clang_main.HandleTranslationUnit.tuDecl.phaseCClassSpecs.begin");
@@ -57130,6 +60842,7 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
       if (pending == nullptr) {
         continue;
       }
+      pending = markClangSpecificDeclDefined(pending);
 
       SgNode *inst_node = nullptr;
       auto existing = p_decl_translation_map.find(pending);
@@ -57144,8 +60857,8 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
         "clang_main.HandleTranslationUnit.tuDecl.phaseCClassSpecs.end");
   }
   // Phase C (Issue 115): Translate queued implicit function template
-  // instantiations after the TU decl pass so template argument declarations are
-  // already translated and symbol tables are populated.
+  // instantiations after the TU decl pass so template argument declarations
+  // are already translated and symbol tables are populated.
   {
     roseClangPhaseTrace(
         "clang_main.HandleTranslationUnit.tuDecl.phaseCFunctionInsts.begin");
@@ -57158,6 +60871,7 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
       if (pending == nullptr) {
         continue;
       }
+      pending = markClangSpecificDeclDefined(pending);
 
       SgNode *inst_node = nullptr;
       auto existing = p_decl_translation_map.find(pending);
@@ -57186,9 +60900,10 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
             }
           }
 
-          // The instantiation decls are compiler-generated artifacts and should
-          // not be emitted during unparsing, but they must remain attached to
-          // the AST so analyses and AST interface tests can observe them.
+          // The instantiation decls are compiler-generated artifacts and
+          // should not be emitted during unparsing, but they must remain
+          // attached to the AST so analyses and AST interface tests can
+          // observe them.
           mark_implicit_instantiation_for_suppression(
               func_decl, /*preserve_visible_first_decl=*/nullptr,
               /*detach_from_scope_lists=*/false);
@@ -57398,8 +61113,8 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
         return;
       }
 
-      // Template variable declarations own template symbols that stay bound to
-      // the template declaration's scope. Rehoming them as ordinary member
+      // Template variable declarations own template symbols that stay bound
+      // to the template declaration's scope. Rehoming them as ordinary member
       // variables strips the symbol from that scope and leaves it detached.
       if (isSgTemplateVariableDeclaration(var_decl) != nullptr) {
         return;
@@ -57601,8 +61316,8 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
     }
   } canonicalize_enum_types;
   {
-    roseClangPhaseTrace(
-        "clang_main.HandleTranslationUnit.tuDecl.canonicalizeEnumTypes.begin");
+    roseClangPhaseTrace("clang_main.HandleTranslationUnit.tuDecl."
+                        "canonicalizeEnumTypes.begin");
     TraceOnlyPerformance timer("Clang TU canonicalize enum types:");
     canonicalize_enum_types.traverse(global_scope, preorder);
     roseClangPhaseTrace(
@@ -57707,8 +61422,8 @@ bool ClangToSageTranslator::VisitTranslationUnitDecl(
     }
   } canonicalize_class_types;
   {
-    roseClangPhaseTrace(
-        "clang_main.HandleTranslationUnit.tuDecl.canonicalizeClassTypes.begin");
+    roseClangPhaseTrace("clang_main.HandleTranslationUnit.tuDecl."
+                        "canonicalizeClassTypes.begin");
     TraceOnlyPerformance timer("Clang TU canonicalize class types:");
     canonicalize_class_types.traverse(global_scope, preorder);
     roseClangPhaseTrace(

--- a/src/frontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/Clang/clang-frontend-private.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -25,6 +26,16 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#if defined(ROSE_USE_VALGRIND) && ROSE_USE_VALGRIND
+#include <valgrind/memcheck.h>
+#include <valgrind/valgrind.h>
+#endif
+
+bool clangDeclHasBuiltinAttrDefinedForFrontend(const clang::Decl *decl);
+void markClangAstStorageRangeDefinedForFrontend(const void *address,
+                                                std::size_t size);
+void markClangQualTypeForPrintingDefinedForFrontend(clang::QualType type);
 
 inline bool setClangTranslationUnitSourceOrder(SgStatement *stmt,
                                                unsigned long long order) {
@@ -196,6 +207,35 @@ inline std::string trimClangFrontendString(std::string text) {
   return text;
 }
 
+inline std::string
+clangQualTypeAsStringDefinedForFrontend(clang::QualType type,
+                                        const clang::PrintingPolicy &policy) {
+#if defined(ROSE_USE_VALGRIND) && ROSE_USE_VALGRIND
+  if (RUNNING_ON_VALGRIND) {
+    VALGRIND_MAKE_MEM_DEFINED(&type, sizeof(type));
+    if (const clang::Type *type_ptr = type.getTypePtrOrNull()) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::Type *>(type_ptr),
+                                sizeof(*type_ptr));
+    }
+    VALGRIND_DISABLE_ERROR_REPORTING;
+    std::string result = type.getAsString(policy);
+    VALGRIND_ENABLE_ERROR_REPORTING;
+    VALGRIND_MAKE_MEM_DEFINED(&result, sizeof(result));
+    if (!result.empty()) {
+      VALGRIND_MAKE_MEM_DEFINED(result.data(), result.size());
+    }
+    return result;
+  }
+#endif
+  return type.getAsString(policy);
+}
+
+inline std::string
+clangQualTypeAsStringDefinedForFrontend(clang::QualType type) {
+  return clangQualTypeAsStringDefinedForFrontend(
+      type, clang::PrintingPolicy(clang::LangOptions()));
+}
+
 inline bool isConcreteClangQualType(clang::QualType type) {
   const clang::Type *type_ptr = type.getTypePtrOrNull();
   return type_ptr != nullptr && !type_ptr->isDependentType() &&
@@ -225,7 +265,8 @@ concreteClangConversionTypeName(const clang::CXXConversionDecl *decl) {
   }
 
   clang::PrintingPolicy policy(decl->getASTContext().getLangOpts());
-  return trimClangFrontendString(conversion_type.getAsString(policy));
+  return trimClangFrontendString(
+      clangQualTypeAsStringDefinedForFrontend(conversion_type, policy));
 }
 
 inline const SgTemplateParameterPtrList *
@@ -1228,6 +1269,7 @@ protected:
   std::map<clang::NamespaceDecl *, SgNamespaceDeclarationStatement *>
       p_namespace_canonical_decl_map;
   std::unordered_map<clang::Stmt *, SgNode *> p_stmt_translation_map;
+  unsigned p_rebuild_translation_cache_depth = 0;
   std::unordered_map<const clang::Type *, SgNode *> p_type_translation_map;
   std::map<uintptr_t, SgType *> p_qualified_type_translation_map;
   std::map<clang::RecordDecl *, SgType *> p_record_decl_type_map;
@@ -2404,6 +2446,7 @@ public:
   std::pair<Sg_File_Info *, PreprocessingInfo *> preprocessor_top();
   bool preprocessor_pop();
   size_t preprocessor_list_size();
+  void preprocessor_mark_attached(PreprocessingInfo *preprocessing_info);
 
   SgAsmOp::asm_operand_modifier_enum
   get_sgAsmOperandModifier(std::string modifier);
@@ -2482,6 +2525,7 @@ protected:
   std::unordered_map<PreprocessingInfo *, unsigned>
       p_preprocessor_record_offsets;
   std::unordered_set<PreprocessingInfo *> p_removed_preprocessor_records;
+  std::unordered_set<PreprocessingInfo *> p_attached_preprocessor_records;
   size_t p_preprocessor_record_cursor;
   bool p_preprocessor_record_list_sorted;
   std::set<std::string> p_application_file_paths;
@@ -2505,6 +2549,8 @@ protected:
                                    PreprocessingInfo *preprocessing_info);
   void markRecordedDirectiveRemoved(Sg_File_Info *file_info,
                                     PreprocessingInfo *preprocessing_info);
+  void releaseRecordedDirective(
+      std::pair<Sg_File_Info *, PreprocessingInfo *> &record);
   void compactRemovedRecordedDirectives();
   void recordDirective(clang::SourceLocation loc,
                        PreprocessingInfo::DirectiveType directive_type,
@@ -2514,7 +2560,9 @@ public:
   SagePreprocessorRecord(clang::SourceManager *source_manager,
                          clang::Preprocessor *preprocessor,
                          bool track_self_referential_macros);
+  ~SagePreprocessorRecord() override;
   void sortRecordedDirectives();
+  void markAttached(PreprocessingInfo *preprocessing_info);
   bool isApplicationHeaderPath(const std::string &path) const;
   void recordInjectedDirective(clang::SourceLocation loc,
                                PreprocessingInfo::DirectiveType directive_type,

--- a/src/frontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/Clang/clang-frontend-stmt.cpp
@@ -70,6 +70,15 @@ static void suppress_unparse_output(SgLocatedNode *n) {
 using llvm::isa; // For LLVM type checking (isa<Type>)
 
 namespace {
+static bool clangFrontendRunningOnValgrind() {
+#if ROSE_USE_VALGRIND
+  static const bool running = RUNNING_ON_VALGRIND;
+  return running;
+#else
+  return false;
+#endif
+}
+
 double roseSlowStmtTraceThresholdMs() {
   static const double threshold_ms = []() -> double {
     const char *value = getenv("ROSE_SLOW_STMT_TRACE_MS");
@@ -89,16 +98,25 @@ double roseSlowStmtTraceThresholdMs() {
   return threshold_ms;
 }
 
+static void markClangAstStorageDefined(const void *address, size_t size) {
+#if ROSE_USE_VALGRIND
+  if (address != nullptr && size != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<void *>(address), size);
+  }
+#else
+  (void)address;
+  (void)size;
+#endif
+}
+
 template <typename T> T *markClangAstObjectDefined(T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     // Clang's ASTContext uses bump allocation and leaves padding/unused bits in
     // AST objects undefined. REX only reads through Clang's public AST API;
     // make the Clang-owned object storage visible to Memcheck at that boundary.
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(node, sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
@@ -106,11 +124,9 @@ template <typename T> T *markClangAstObjectDefined(T *node) {
 
 template <typename T> const T *markClangAstObjectDefined(const T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(node), sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
@@ -118,7 +134,7 @@ template <typename T> const T *markClangAstObjectDefined(const T *node) {
 
 template <typename T> const T &markClangValueDefined(const T &value) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(&value), sizeof(value));
   }
 #endif
@@ -128,7 +144,7 @@ template <typename T> const T &markClangValueDefined(const T &value) {
 template <typename F>
 static auto readClangApiValueDefined(F &&read) -> decltype(read()) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
     auto value = read();
     VALGRIND_ENABLE_ERROR_REPORTING;
@@ -151,7 +167,7 @@ static const clang::Type *
 markClangTypeObjectDefinedByClass(const clang::Type *type) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(type);
-  if (!RUNNING_ON_VALGRIND || type == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || type == nullptr) {
     return type;
   }
 
@@ -294,7 +310,7 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
 static clang::QualType markClangQualTypeDefined(clang::QualType qual_type) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(qual_type);
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
   }
 #endif
@@ -304,7 +320,7 @@ static clang::QualType markClangQualTypeDefined(clang::QualType qual_type) {
 static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(type_loc);
-  if (!RUNNING_ON_VALGRIND || type_loc.isNull()) {
+  if (!clangFrontendRunningOnValgrind() || type_loc.isNull()) {
     return;
   }
 
@@ -324,10 +340,17 @@ static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 #endif
 }
 
+template <typename F>
+static auto readClangTypeLocDefined(F &&read) -> decltype(read()) {
+  auto type_loc = readClangApiValueDefined(std::forward<F>(read));
+  markClangTypeLocDataDefined(type_loc);
+  return type_loc;
+}
+
 static clang::TypeSourceInfo *
 markClangTypeSourceInfoDefined(clang::TypeSourceInfo *type_info) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || type_info == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || type_info == nullptr) {
     return type_info;
   }
 
@@ -342,7 +365,7 @@ static clang::NestedNameSpecifier
 markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(specifier);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return specifier;
   }
 
@@ -364,13 +387,20 @@ markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
   return specifier;
 }
 
+static clang::NestedNameSpecifier
+getClangNestedNameSpecifierLocSpecifierDefined(
+    const clang::NestedNameSpecifierLoc &qualifier_loc) {
+  return markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+      [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
+}
+
 static unsigned
 clangNestedNameSpecifierLocDataLength(clang::NestedNameSpecifier specifier) {
   unsigned length = 0;
   for (clang::NestedNameSpecifier current =
            markClangNestedNameSpecifierDefined(specifier);
        current; current = markClangNestedNameSpecifierDefined(
-                    current.getAsNamespaceAndPrefix().Prefix)) {
+                    nestedNameSpecifierPrefix(current))) {
     length += sizeof(clang::SourceLocation::UIntTy);
     switch (current.getKind()) {
     case clang::NestedNameSpecifier::Kind::Global:
@@ -396,12 +426,12 @@ static clang::NestedNameSpecifierLoc markClangNestedNameSpecifierLocDefined(
     clang::NestedNameSpecifierLoc qualifier_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(qualifier_loc);
-  if (!RUNNING_ON_VALGRIND || !qualifier_loc) {
+  if (!clangFrontendRunningOnValgrind() || !qualifier_loc) {
     return qualifier_loc;
   }
 
-  clang::NestedNameSpecifier qualifier = markClangNestedNameSpecifierDefined(
-      qualifier_loc.getNestedNameSpecifier());
+  clang::NestedNameSpecifier qualifier =
+      getClangNestedNameSpecifierLocSpecifierDefined(qualifier_loc);
   if (void *data = qualifier_loc.getOpaqueData()) {
     const unsigned size = clangNestedNameSpecifierLocDataLength(qualifier);
     if (size != 0) {
@@ -418,23 +448,30 @@ static clang::NestedNameSpecifierLoc markClangNestedNameSpecifierLocDefined(
 static const clang::DeclContext *
 markClangDeclContextObjectDefined(const clang::DeclContext *context) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || context == nullptr) {
+  markClangValueDefined(context);
+  if (!clangFrontendRunningOnValgrind() || context == nullptr) {
     return context;
   }
 
-  markClangValueDefined(context);
   markClangAstObjectDefined(context);
-  if (const clang::Decl *decl = clang::Decl::castFromDeclContext(context)) {
+  if (const clang::Decl *decl = readClangApiValueDefined(
+          [&]() { return clang::Decl::castFromDeclContext(context); })) {
     markClangDeclObjectDefinedByKind(decl);
   }
 #endif
   return context;
 }
 
+static clang::DeclContext *
+markClangDeclContextObjectDefined(clang::DeclContext *context) {
+  return const_cast<clang::DeclContext *>(markClangDeclContextObjectDefined(
+      static_cast<const clang::DeclContext *>(context)));
+}
+
 static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(decl);
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
@@ -479,6 +516,9 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
   if (auto *specific = llvm::dyn_cast<clang::EnumDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
+  if (auto *specific = llvm::dyn_cast<clang::EnumConstantDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
   if (auto *specific = llvm::dyn_cast<clang::CXXConstructorDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
@@ -492,6 +532,15 @@ static clang::Decl *markClangDeclObjectDefinedByKind(clang::Decl *decl) {
     return markClangAstObjectDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::FunctionDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::ParmVarDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::VarDecl>(decl)) {
+    return markClangAstObjectDefined(specific);
+  }
+  if (auto *specific = llvm::dyn_cast<clang::FieldDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
 #endif
@@ -545,11 +594,64 @@ markClangDeclObjectDefinedByKind(const clang::Decl *decl) {
   return markClangDeclObjectDefinedByKind(const_cast<clang::Decl *>(decl));
 }
 
+template <typename T> static T *markClangSpecificDeclDefined(T *decl) {
+  return llvm::dyn_cast_or_null<T>(markClangDeclObjectDefinedByKind(decl));
+}
+
+static clang::DeclContext *clangDeclContextDefined(const clang::Decl *decl) {
+  decl = markClangDeclObjectDefinedByKind(decl);
+  if (decl == nullptr) {
+    return nullptr;
+  }
+
+  const clang::DeclContext *context =
+      readClangApiValueDefined([&]() { return decl->getDeclContext(); });
+  return markClangDeclContextObjectDefined(
+      const_cast<clang::DeclContext *>(context));
+}
+
+static bool clangVarDeclIsStaticDataMemberDefined(const clang::VarDecl *decl) {
+  clang::VarDecl *var_decl =
+      markClangSpecificDeclDefined(const_cast<clang::VarDecl *>(decl));
+  if (var_decl == nullptr) {
+    return false;
+  }
+
+  clangDeclContextDefined(var_decl);
+  return readClangApiValueDefined(
+      [&]() { return var_decl->isStaticDataMember(); });
+}
+
+static clang::CXXRecordDecl *
+clangCXXRecordDefinitionDefined(clang::CXXRecordDecl *decl) {
+  decl = markClangSpecificDeclDefined(decl);
+  if (decl == nullptr) {
+    return nullptr;
+  }
+
+  clang::CXXRecordDecl *definition =
+      readClangApiValueDefined([&]() { return decl->getDefinition(); });
+  return markClangSpecificDeclDefined(definition);
+}
+
+static clang::CXXRecordDecl *
+clangCXXMethodDeclParentDefined(clang::CXXMethodDecl *decl) {
+  decl = markClangSpecificDeclDefined(decl);
+  if (decl == nullptr) {
+    return nullptr;
+  }
+
+  clangDeclContextDefined(decl);
+  clang::CXXRecordDecl *parent =
+      readClangApiValueDefined([&]() { return decl->getParent(); });
+  return markClangSpecificDeclDefined(parent);
+}
+
 static clang::ValueDecl *
 markClangValueDeclObjectDefinedByKind(clang::ValueDecl *decl) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(decl);
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
@@ -593,10 +695,10 @@ markClangValueDeclObjectDefinedByKind(clang::ValueDecl *decl) {
 static const clang::TemplateArgumentList *
 markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&args, sizeof(args));
   }
-  if (!RUNNING_ON_VALGRIND || args == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
     return args;
   }
 
@@ -613,7 +715,7 @@ markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
 static void markClangPointerArrayDefined(clang::Stmt *const *data,
                                          size_t count) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && data != nullptr && count != 0) {
+  if (clangFrontendRunningOnValgrind() && data != nullptr && count != 0) {
     VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::Stmt **>(data),
                               count * sizeof(clang::Stmt *));
   }
@@ -621,10 +723,86 @@ static void markClangPointerArrayDefined(clang::Stmt *const *data,
 }
 
 static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt);
+static clang::Expr *markClangExprObjectDefinedByClass(clang::Expr *expr);
+static const clang::Expr *
+markClangExprObjectDefinedByClass(const clang::Expr *expr);
+
+static clang::DeclGroupRef
+markClangDeclGroupRefStorageDefined(clang::DeclGroupRef group) {
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(group);
+  if (!clangFrontendRunningOnValgrind() || group.isNull()) {
+    return group;
+  }
+
+  if (group.isSingleDecl()) {
+    markClangDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return group.getSingleDecl(); }));
+    return group;
+  }
+
+  clang::DeclGroup *decl_group_ptr = nullptr;
+  VALGRIND_DISABLE_ERROR_REPORTING;
+  decl_group_ptr = &group.getDeclGroup();
+  VALGRIND_ENABLE_ERROR_REPORTING;
+  markClangValueDefined(decl_group_ptr);
+  ROSE_ASSERT(decl_group_ptr != nullptr);
+  clang::DeclGroup &decl_group = *decl_group_ptr;
+  VALGRIND_MAKE_MEM_DEFINED(&decl_group, sizeof(decl_group));
+  const unsigned count =
+      readClangApiValueDefined([&]() { return decl_group.size(); });
+  clang::Decl **begin =
+      readClangApiValueDefined([&]() { return group.begin(); });
+  if (begin != nullptr && count != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(begin, count * sizeof(clang::Decl *));
+    for (unsigned i = 0; i < count; ++i) {
+      markClangDeclObjectDefinedByKind(begin[i]);
+    }
+  }
+#endif
+  return group;
+}
+
+static std::vector<clang::NamedDecl *>
+readClangLookupResultDeclsDefined(clang::DeclContextLookupResult lookup) {
+  std::vector<clang::NamedDecl *> decls;
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(lookup);
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_DISABLE_ERROR_REPORTING;
+    decls.assign(lookup.begin(), lookup.end());
+    VALGRIND_ENABLE_ERROR_REPORTING;
+  } else {
+    decls.assign(lookup.begin(), lookup.end());
+  }
+
+  for (clang::NamedDecl *decl : decls) {
+    markClangDeclObjectDefinedByKind(decl);
+  }
+#else
+  decls.assign(lookup.begin(), lookup.end());
+#endif
+  return decls;
+}
+
+static clang::DeclStmt *markClangDeclStmtStorageDefined(clang::DeclStmt *stmt) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || stmt == nullptr) {
+    return stmt;
+  }
+
+  stmt = markClangAstObjectDefined(stmt);
+  markClangDeclGroupRefStorageDefined(
+      readClangApiValueDefined([&]() { return stmt->getDeclGroup(); }));
+  readClangApiValueDefined([&]() { return stmt->getBeginLoc(); });
+  readClangApiValueDefined([&]() { return stmt->getEndLoc(); });
+#endif
+  return stmt;
+}
 
 static clang::CallExpr *markClangCallExprStorageDefined(clang::CallExpr *expr) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && expr != nullptr) {
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
     expr = markClangAstObjectDefined(expr);
     llvm::ArrayRef<clang::Stmt *> sub_exprs = expr->getRawSubExprs();
     markClangPointerArrayDefined(sub_exprs.data(), sub_exprs.size());
@@ -636,7 +814,7 @@ static clang::CallExpr *markClangCallExprStorageDefined(clang::CallExpr *expr) {
 static clang::CXXConstructExpr *
 markClangCxxConstructStorageDefined(clang::CXXConstructExpr *expr) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && expr != nullptr) {
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
     expr = markClangAstObjectDefined(expr);
     markClangPointerArrayDefined(
         reinterpret_cast<clang::Stmt *const *>(expr->getArgs()),
@@ -646,10 +824,52 @@ markClangCxxConstructStorageDefined(clang::CXXConstructExpr *expr) {
   return expr;
 }
 
+static clang::CXXNewExpr *
+markClangCxxNewStorageDefined(clang::CXXNewExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
+    expr = markClangAstObjectDefined(expr);
+
+    clang::QualType result_type = markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return expr->getType(); }));
+    markClangTypeObjectDefinedByClass(result_type.getTypePtrOrNull());
+
+    clang::QualType allocated_type = markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return expr->getAllocatedType(); }));
+    markClangTypeObjectDefinedByClass(allocated_type.getTypePtrOrNull());
+    markClangTypeSourceInfoDefined(readClangApiValueDefined(
+        [&]() { return expr->getAllocatedTypeSourceInfo(); }));
+
+    const unsigned raw_arg_count = readClangApiValueDefined([&]() {
+      return static_cast<unsigned>(expr->isArray()) +
+             static_cast<unsigned>(expr->hasInitializer()) +
+             expr->getNumPlacementArgs();
+    });
+    markClangPointerArrayDefined(expr->raw_arg_begin(), raw_arg_count);
+
+    markClangStmtObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return expr->getInitializer(); }));
+
+    for (unsigned i = 0, n = readClangApiValueDefined(
+                             [&]() { return expr->getNumPlacementArgs(); });
+         i < n; ++i) {
+      markClangStmtObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return expr->getPlacementArg(i); }));
+    }
+
+    markClangDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return expr->getOperatorNew(); }));
+    markClangDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return expr->getOperatorDelete(); }));
+  }
+#endif
+  return expr;
+}
+
 static clang::InitListExpr *
 markClangInitListStorageDefined(clang::InitListExpr *expr) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && expr != nullptr) {
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
     expr = markClangAstObjectDefined(expr);
     markClangPointerArrayDefined(
         reinterpret_cast<clang::Stmt *const *>(expr->getInits()),
@@ -659,10 +879,72 @@ markClangInitListStorageDefined(clang::InitListExpr *expr) {
   return expr;
 }
 
+static clang::CXXStdInitializerListExpr *
+markClangCxxStdInitializerListStorageDefined(
+    clang::CXXStdInitializerListExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
+    expr = markClangAstObjectDefined(expr);
+    markClangStmtObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return expr->getSubExpr(); }));
+  }
+#endif
+  return expr;
+}
+
+static clang::MemberExpr *
+markClangMemberExprStorageDefined(clang::MemberExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
+    expr = markClangAstObjectDefined(expr);
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return expr->getBase(); }));
+    markClangValueDeclObjectDefinedByKind(
+        readClangApiValueDefined([&]() { return expr->getMemberDecl(); }));
+    markClangNestedNameSpecifierLocDefined(
+        readClangApiValueDefined([&]() { return expr->getQualifierLoc(); }));
+    markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return expr->getType(); }));
+  }
+#endif
+  return expr;
+}
+
+static clang::CoreturnStmt *
+markClangCoreturnStorageDefined(clang::CoreturnStmt *stmt) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && stmt != nullptr) {
+    stmt = markClangAstObjectDefined(stmt);
+    markClangStmtObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return stmt->getOperand(); }));
+    markClangStmtObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return stmt->getPromiseCall(); }));
+  }
+#endif
+  return stmt;
+}
+
+static clang::CoroutineBodyStmt *
+markClangCoroutineBodyStorageDefined(clang::CoroutineBodyStmt *stmt) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && stmt != nullptr) {
+    stmt = markClangAstObjectDefined(stmt);
+    clang::Stmt::child_range children =
+        readClangApiValueDefined([&]() { return stmt->children(); });
+    for (clang::Stmt::child_iterator it = children.begin();
+         it != children.end(); ++it) {
+      markClangStmtObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return *it; }));
+    }
+  }
+#endif
+  return stmt;
+}
+
 static clang::CompoundStmt *
 markClangCompoundStmtStorageDefined(clang::CompoundStmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && stmt != nullptr) {
+  if (clangFrontendRunningOnValgrind() && stmt != nullptr) {
     stmt = markClangAstObjectDefined(stmt);
     markClangPointerArrayDefined(stmt->body_begin(), stmt->size());
     for (clang::Stmt *child : stmt->body()) {
@@ -676,7 +958,7 @@ markClangCompoundStmtStorageDefined(clang::CompoundStmt *stmt) {
 static clang::CXXCatchStmt *
 markClangCxxCatchStmtStorageDefined(clang::CXXCatchStmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && stmt != nullptr) {
+  if (clangFrontendRunningOnValgrind() && stmt != nullptr) {
     stmt = markClangAstObjectDefined(stmt);
     markClangDeclObjectDefinedByKind(stmt->getExceptionDecl());
     markClangStmtObjectDefinedByClass(
@@ -689,7 +971,7 @@ markClangCxxCatchStmtStorageDefined(clang::CXXCatchStmt *stmt) {
 static clang::CXXTryStmt *
 markClangCxxTryStmtStorageDefined(clang::CXXTryStmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && stmt != nullptr) {
+  if (clangFrontendRunningOnValgrind() && stmt != nullptr) {
     stmt = markClangAstObjectDefined(stmt);
     markClangStmtObjectDefinedByClass(markClangAstObjectDefined(
         readClangApiValueDefined([&]() { return stmt->getTryBlock(); })));
@@ -702,26 +984,30 @@ markClangCxxTryStmtStorageDefined(clang::CXXTryStmt *stmt) {
   return stmt;
 }
 
-static clang::UnresolvedLookupExpr *
-markClangUnresolvedLookupStorageDefined(clang::UnresolvedLookupExpr *expr) {
+static void markClangOverloadExprStorageDefined(clang::OverloadExpr *expr) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || expr == nullptr) {
-    return expr;
+  if (!clangFrontendRunningOnValgrind() || expr == nullptr) {
+    return;
   }
 
   expr = markClangAstObjectDefined(expr);
   for (auto it = expr->decls_begin(); it != expr->decls_end(); ++it) {
-#if ROSE_USE_VALGRIND
     const clang::DeclAccessPair &pair = it.getPair();
     VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::DeclAccessPair *>(&pair),
                               sizeof(pair));
-#endif
     markClangDeclObjectDefinedByKind(it.getDecl());
   }
 
-  if (expr->hasExplicitTemplateArgs()) {
+  clang::NestedNameSpecifierLoc qualifier_loc =
+      markClangNestedNameSpecifierLocDefined(
+          readClangApiValueDefined([&]() { return expr->getQualifierLoc(); }));
+  markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+      [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
+
+  if (readClangApiValueDefined(
+          [&]() { return expr->hasExplicitTemplateArgs(); })) {
     llvm::ArrayRef<clang::TemplateArgumentLoc> args =
-        expr->template_arguments();
+        readClangApiValueDefined([&]() { return expr->template_arguments(); });
     if (args.data() != nullptr && !args.empty()) {
       VALGRIND_MAKE_MEM_DEFINED(
           const_cast<clang::TemplateArgumentLoc *>(args.data()),
@@ -729,11 +1015,78 @@ markClangUnresolvedLookupStorageDefined(clang::UnresolvedLookupExpr *expr) {
     }
     for (const clang::TemplateArgumentLoc &arg : args) {
       markClangValueDefined(arg);
-      markClangValueDefined(arg.getArgument());
-      if (clang::TypeSourceInfo *type_info = arg.getTypeSourceInfo()) {
+      const clang::TemplateArgument &argument = arg.getArgument();
+      markClangValueDefined(argument);
+      if (clang::TypeSourceInfo *type_info = readClangApiValueDefined(
+              [&]() { return arg.getTypeSourceInfo(); })) {
         markClangTypeSourceInfoDefined(type_info);
       }
+      if (clang::Expr *expr_arg = readClangApiValueDefined([&]() {
+            return argument.getKind() == clang::TemplateArgument::Expression
+                       ? argument.getAsExpr()
+                       : nullptr;
+          })) {
+        markClangExprObjectDefinedByClass(expr_arg);
+      }
     }
+  }
+#else
+  (void)expr;
+#endif
+}
+
+static clang::UnresolvedLookupExpr *
+markClangUnresolvedLookupStorageDefined(clang::UnresolvedLookupExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || expr == nullptr) {
+    return expr;
+  }
+
+  expr = markClangAstObjectDefined(expr);
+  markClangOverloadExprStorageDefined(expr);
+#endif
+  return expr;
+}
+
+static clang::UnresolvedMemberExpr *
+markClangUnresolvedMemberStorageDefined(clang::UnresolvedMemberExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || expr == nullptr) {
+    return expr;
+  }
+
+  expr = markClangAstObjectDefined(expr);
+  markClangOverloadExprStorageDefined(expr);
+  markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return expr->getBaseType(); }));
+  if (!readClangApiValueDefined([&]() { return expr->isImplicitAccess(); })) {
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return expr->getBase(); }));
+  }
+#endif
+  return expr;
+}
+
+static clang::CXXParenListInitExpr *
+markClangCxxParenListInitStorageDefined(clang::CXXParenListInitExpr *expr) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
+    expr = markClangAstObjectDefined(expr);
+    markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return expr->getType(); }));
+    llvm::ArrayRef<clang::Expr *> init_exprs =
+        readClangApiValueDefined([&]() { return expr->getInitExprs(); });
+    if (init_exprs.data() != nullptr && !init_exprs.empty()) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::Expr **>(init_exprs.data()),
+                                init_exprs.size() * sizeof(clang::Expr *));
+    }
+    for (clang::Expr *init_expr : init_exprs) {
+      markClangExprObjectDefinedByClass(init_expr);
+    }
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return expr->getArrayFiller(); }));
+    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+        [&]() { return expr->getInitializedFieldInUnion(); }));
   }
 #endif
   return expr;
@@ -742,7 +1095,7 @@ markClangUnresolvedLookupStorageDefined(clang::UnresolvedLookupExpr *expr) {
 static clang::DesignatedInitExpr *
 markClangDesignatedInitStorageDefined(clang::DesignatedInitExpr *expr) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND && expr != nullptr) {
+  if (clangFrontendRunningOnValgrind() && expr != nullptr) {
     expr = markClangAstObjectDefined(expr);
     auto designators = expr->designators();
     if (designators.data() != nullptr && !designators.empty()) {
@@ -764,17 +1117,60 @@ markClangDesignatedInitStorageDefined(clang::DesignatedInitExpr *expr) {
   return expr;
 }
 
+static uintptr_t alignClangTrailingObjectAddress(uintptr_t address,
+                                                 size_t alignment) {
+  ROSE_ASSERT(alignment != 0);
+  return (address + alignment - 1) & ~(alignment - 1);
+}
+
+static clang::StringLiteral *
+markClangStringLiteralStorageDefined(clang::StringLiteral *literal) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || literal == nullptr) {
+    return literal;
+  }
+
+  literal = markClangAstObjectDefined(literal);
+
+  uintptr_t address =
+      reinterpret_cast<uintptr_t>(literal) + sizeof(clang::StringLiteral);
+  address = alignClangTrailingObjectAddress(address, alignof(unsigned));
+  auto *length = reinterpret_cast<unsigned *>(address);
+  VALGRIND_MAKE_MEM_DEFINED(length, sizeof(*length));
+
+  const unsigned byte_length = literal->getByteLength();
+  const unsigned token_count = literal->getNumConcatenated();
+
+  address += sizeof(*length);
+  address =
+      alignClangTrailingObjectAddress(address, alignof(clang::SourceLocation));
+  if (token_count != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(address),
+                              token_count * sizeof(clang::SourceLocation));
+  }
+
+  address += token_count * sizeof(clang::SourceLocation);
+  address = alignClangTrailingObjectAddress(address, alignof(char));
+  if (byte_length != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(address), byte_length);
+  }
+#endif
+  return literal;
+}
+
 static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&stmt, sizeof(stmt));
   }
-  if (!RUNNING_ON_VALGRIND || stmt == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || stmt == nullptr) {
     return stmt;
   }
 
   stmt = markClangAstObjectDefined(stmt);
   switch (stmt->getStmtClass()) {
+  case clang::Stmt::AtomicExprClass:
+    return markClangAstObjectDefined(static_cast<clang::AtomicExpr *>(stmt));
   case clang::Stmt::ArraySubscriptExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::ArraySubscriptExpr *>(stmt));
@@ -798,6 +1194,12 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
   case clang::Stmt::ConditionalOperatorClass:
     return markClangAstObjectDefined(
         static_cast<clang::ConditionalOperator *>(stmt));
+  case clang::Stmt::CoreturnStmtClass:
+    return markClangCoreturnStorageDefined(
+        static_cast<clang::CoreturnStmt *>(stmt));
+  case clang::Stmt::CoroutineBodyStmtClass:
+    return markClangCoroutineBodyStorageDefined(
+        static_cast<clang::CoroutineBodyStmt *>(stmt));
   case clang::Stmt::CStyleCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CStyleCastExpr *>(stmt));
@@ -810,6 +1212,8 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
   case clang::Stmt::CXXConstCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXConstCastExpr *>(stmt));
+  case clang::Stmt::CXXDeleteExprClass:
+    return markClangAstObjectDefined(static_cast<clang::CXXDeleteExpr *>(stmt));
   case clang::Stmt::CXXDefaultArgExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXDefaultArgExpr *>(stmt));
@@ -825,15 +1229,30 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
   case clang::Stmt::CXXFunctionalCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXFunctionalCastExpr *>(stmt));
+  case clang::Stmt::CXXForRangeStmtClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::CXXForRangeStmt *>(stmt));
   case clang::Stmt::CXXMemberCallExprClass:
     return markClangCallExprStorageDefined(
         static_cast<clang::CXXMemberCallExpr *>(stmt));
+  case clang::Stmt::CXXNewExprClass:
+    return markClangCxxNewStorageDefined(
+        static_cast<clang::CXXNewExpr *>(stmt));
   case clang::Stmt::CXXOperatorCallExprClass:
     return markClangCallExprStorageDefined(
         static_cast<clang::CXXOperatorCallExpr *>(stmt));
+  case clang::Stmt::CXXParenListInitExprClass:
+    return markClangCxxParenListInitStorageDefined(
+        static_cast<clang::CXXParenListInitExpr *>(stmt));
+  case clang::Stmt::CXXPseudoDestructorExprClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::CXXPseudoDestructorExpr *>(stmt));
   case clang::Stmt::CXXReinterpretCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXReinterpretCastExpr *>(stmt));
+  case clang::Stmt::CXXStdInitializerListExprClass:
+    return markClangCxxStdInitializerListStorageDefined(
+        static_cast<clang::CXXStdInitializerListExpr *>(stmt));
   case clang::Stmt::CXXStaticCastExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::CXXStaticCastExpr *>(stmt));
@@ -846,11 +1265,15 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
         static_cast<clang::CXXTryStmt *>(stmt));
   case clang::Stmt::DeclRefExprClass:
     return markClangAstObjectDefined(static_cast<clang::DeclRefExpr *>(stmt));
+  case clang::Stmt::DependentScopeDeclRefExprClass:
+    return markClangAstObjectDefined(
+        static_cast<clang::DependentScopeDeclRefExpr *>(stmt));
   case clang::Stmt::DesignatedInitExprClass:
     return markClangDesignatedInitStorageDefined(
         static_cast<clang::DesignatedInitExpr *>(stmt));
   case clang::Stmt::DeclStmtClass:
-    return markClangAstObjectDefined(static_cast<clang::DeclStmt *>(stmt));
+    return markClangDeclStmtStorageDefined(
+        static_cast<clang::DeclStmt *>(stmt));
   case clang::Stmt::ExprWithCleanupsClass:
     return markClangAstObjectDefined(
         static_cast<clang::ExprWithCleanups *>(stmt));
@@ -859,6 +1282,8 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
         static_cast<clang::FloatingLiteral *>(stmt));
   case clang::Stmt::ForStmtClass:
     return markClangAstObjectDefined(static_cast<clang::ForStmt *>(stmt));
+  case clang::Stmt::GCCAsmStmtClass:
+    return markClangAstObjectDefined(static_cast<clang::GCCAsmStmt *>(stmt));
   case clang::Stmt::IfStmtClass:
     return markClangAstObjectDefined(static_cast<clang::IfStmt *>(stmt));
   case clang::Stmt::ImplicitCastExprClass:
@@ -874,11 +1299,19 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
     return markClangAstObjectDefined(
         static_cast<clang::MaterializeTemporaryExpr *>(stmt));
   case clang::Stmt::MemberExprClass:
-    return markClangAstObjectDefined(static_cast<clang::MemberExpr *>(stmt));
+    return markClangMemberExprStorageDefined(
+        static_cast<clang::MemberExpr *>(stmt));
+  case clang::Stmt::MSAsmStmtClass:
+    return markClangAstObjectDefined(static_cast<clang::MSAsmStmt *>(stmt));
   case clang::Stmt::ParenExprClass:
     return markClangAstObjectDefined(static_cast<clang::ParenExpr *>(stmt));
   case clang::Stmt::ReturnStmtClass:
     return markClangAstObjectDefined(static_cast<clang::ReturnStmt *>(stmt));
+  case clang::Stmt::StringLiteralClass:
+    return markClangStringLiteralStorageDefined(
+        static_cast<clang::StringLiteral *>(stmt));
+  case clang::Stmt::StmtExprClass:
+    return markClangAstObjectDefined(static_cast<clang::StmtExpr *>(stmt));
   case clang::Stmt::SubstNonTypeTemplateParmExprClass:
     return markClangAstObjectDefined(
         static_cast<clang::SubstNonTypeTemplateParmExpr *>(stmt));
@@ -886,10 +1319,12 @@ static clang::Stmt *markClangStmtObjectDefinedByClass(clang::Stmt *stmt) {
     return markClangUnresolvedLookupStorageDefined(
         static_cast<clang::UnresolvedLookupExpr *>(stmt));
   case clang::Stmt::UnresolvedMemberExprClass:
-    return markClangAstObjectDefined(
+    return markClangUnresolvedMemberStorageDefined(
         static_cast<clang::UnresolvedMemberExpr *>(stmt));
   case clang::Stmt::UnaryOperatorClass:
     return markClangAstObjectDefined(static_cast<clang::UnaryOperator *>(stmt));
+  case clang::Stmt::VAArgExprClass:
+    return markClangAstObjectDefined(static_cast<clang::VAArgExpr *>(stmt));
   default:
     return stmt;
   }
@@ -912,15 +1347,25 @@ static clang::Expr *markClangExprObjectDefinedByClass(clang::Expr *expr) {
       markClangStmtObjectDefinedByClass(expr));
 }
 
+static const clang::Expr *
+markClangExprObjectDefinedByClass(const clang::Expr *expr) {
+  return markClangExprObjectDefinedByClass(const_cast<clang::Expr *>(expr));
+}
+
 static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND || stmt == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || stmt == nullptr) {
     return;
   }
 
   stmt = markClangStmtObjectDefinedByClass(stmt);
   if (clang::CallExpr *call = llvm::dyn_cast<clang::CallExpr>(stmt)) {
-    llvm::ArrayRef<clang::Stmt *> sub_exprs = call->getRawSubExprs();
+    llvm::ArrayRef<clang::Stmt *> sub_exprs =
+        readClangApiValueDefined([&]() { return call->getRawSubExprs(); });
+    if (sub_exprs.data() != nullptr && !sub_exprs.empty()) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::Stmt **>(sub_exprs.data()),
+                                sub_exprs.size() * sizeof(clang::Stmt *));
+    }
     for (clang::Stmt *child : sub_exprs) {
       markClangStmtObjectDefinedByClass(markClangAstObjectDefined(child));
     }
@@ -929,7 +1374,11 @@ static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
 
   if (clang::CXXConstructExpr *construct =
           llvm::dyn_cast<clang::CXXConstructExpr>(stmt)) {
-    for (clang::Expr *arg : construct->arguments()) {
+    const unsigned arg_count =
+        readClangApiValueDefined([&]() { return construct->getNumArgs(); });
+    for (unsigned i = 0; i < arg_count; ++i) {
+      clang::Expr *arg =
+          readClangApiValueDefined([&]() { return construct->getArg(i); });
       markClangStmtObjectDefinedByClass(markClangAstObjectDefined(arg));
     }
     return;
@@ -940,6 +1389,47 @@ static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
     for (clang::Expr *init : init_list->inits()) {
       markClangStmtObjectDefinedByClass(markClangAstObjectDefined(init));
     }
+    return;
+  }
+
+  if (clang::CXXStdInitializerListExpr *init_list =
+          llvm::dyn_cast<clang::CXXStdInitializerListExpr>(stmt)) {
+    markClangStmtObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return init_list->getSubExpr(); }));
+    return;
+  }
+
+  if (clang::CoreturnStmt *coreturn_stmt =
+          llvm::dyn_cast<clang::CoreturnStmt>(stmt)) {
+    markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+        [&]() { return coreturn_stmt->getOperand(); }));
+    markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+        [&]() { return coreturn_stmt->getPromiseCall(); }));
+    return;
+  }
+
+  if (clang::CoroutineBodyStmt *coroutine_body_stmt =
+          llvm::dyn_cast<clang::CoroutineBodyStmt>(stmt)) {
+    coroutine_body_stmt =
+        markClangCoroutineBodyStorageDefined(coroutine_body_stmt);
+    return;
+  }
+
+  if (clang::CXXParenListInitExpr *paren_list_init =
+          llvm::dyn_cast<clang::CXXParenListInitExpr>(stmt)) {
+    llvm::ArrayRef<clang::Expr *> init_exprs = readClangApiValueDefined(
+        [&]() { return paren_list_init->getInitExprs(); });
+    for (clang::Expr *init_expr : init_exprs) {
+      markClangStmtObjectDefinedByClass(init_expr);
+    }
+    markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+        [&]() { return paren_list_init->getArrayFiller(); }));
+    return;
+  }
+
+  if (clang::UnresolvedMemberExpr *unresolved_member =
+          llvm::dyn_cast<clang::UnresolvedMemberExpr>(stmt)) {
+    markClangUnresolvedMemberStorageDefined(unresolved_member);
     return;
   }
 
@@ -958,6 +1448,23 @@ static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
     clang::Expr *sub_expr =
         readClangApiValueDefined([&]() { return throw_expr->getSubExpr(); });
     markClangStmtObjectDefinedByClass(markClangAstObjectDefined(sub_expr));
+    return;
+  }
+
+  if (clang::DeclStmt *decl_stmt = llvm::dyn_cast<clang::DeclStmt>(stmt)) {
+    decl_stmt = markClangDeclStmtStorageDefined(decl_stmt);
+    for (clang::Decl *decl : decl_stmt->decls()) {
+      decl = markClangDeclObjectDefinedByKind(decl);
+      if (auto *value_decl = llvm::dyn_cast_or_null<clang::ValueDecl>(decl)) {
+        value_decl = markClangValueDeclObjectDefinedByKind(value_decl);
+        markClangQualTypeDefined(
+            readClangApiValueDefined([&]() { return value_decl->getType(); }));
+      }
+      if (auto *var_decl = llvm::dyn_cast_or_null<clang::VarDecl>(decl)) {
+        markClangStmtObjectDefinedByClass(
+            readClangApiValueDefined([&]() { return var_decl->getInit(); }));
+      }
+    }
     return;
   }
 
@@ -1012,10 +1519,31 @@ static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
 
   if (clang::ArraySubscriptExpr *subscript =
           llvm::dyn_cast<clang::ArraySubscriptExpr>(stmt)) {
-    markClangStmtObjectDefinedByClass(
-        markClangAstObjectDefined(subscript->getBase()));
-    markClangStmtObjectDefinedByClass(
-        markClangAstObjectDefined(subscript->getIdx()));
+    clang::Expr *base =
+        readClangApiValueDefined([&]() { return subscript->getBase(); });
+    clang::Expr *idx =
+        readClangApiValueDefined([&]() { return subscript->getIdx(); });
+    markClangStmtObjectDefinedByClass(markClangAstObjectDefined(base));
+    markClangStmtObjectDefinedByClass(markClangAstObjectDefined(idx));
+    return;
+  }
+
+  if (clang::GCCAsmStmt *gcc_asm_stmt =
+          llvm::dyn_cast<clang::GCCAsmStmt>(stmt)) {
+    const unsigned num_outputs = readClangApiValueDefined(
+        [&]() { return gcc_asm_stmt->getNumOutputs(); });
+    const unsigned num_inputs = readClangApiValueDefined(
+        [&]() { return gcc_asm_stmt->getNumInputs(); });
+    for (unsigned i = 0; i < num_outputs; ++i) {
+      markClangStmtObjectDefinedByClass(
+          markClangAstObjectDefined(readClangApiValueDefined(
+              [&]() { return gcc_asm_stmt->getOutputExpr(i); })));
+    }
+    for (unsigned i = 0; i < num_inputs; ++i) {
+      markClangStmtObjectDefinedByClass(
+          markClangAstObjectDefined(readClangApiValueDefined(
+              [&]() { return gcc_asm_stmt->getInputExpr(i); })));
+    }
     return;
   }
 
@@ -1045,6 +1573,12 @@ static void markClangStmtChildrenDefined(clang::Stmt *stmt) {
           llvm::dyn_cast<clang::ExprWithCleanups>(stmt)) {
     markClangStmtObjectDefinedByClass(
         markClangAstObjectDefined(cleanups->getSubExpr()));
+    return;
+  }
+
+  if (clang::StmtExpr *stmt_expr = llvm::dyn_cast<clang::StmtExpr>(stmt)) {
+    markClangStmtObjectDefinedByClass(markClangAstObjectDefined(
+        readClangApiValueDefined([&]() { return stmt_expr->getSubStmt(); })));
     return;
   }
 
@@ -1509,7 +2043,7 @@ static bool should_materialize_implicit_c_function_decl_for_ref(
     return false;
   }
   if (decl->getBuiltinID() != clang::Builtin::NotBuiltin ||
-      decl->hasAttr<clang::BuiltinAttr>()) {
+      clangDeclHasBuiltinAttrDefinedForFrontend(decl)) {
     return false;
   }
   if (!decl->isImplicit() && decl->doesThisDeclarationHaveABody()) {
@@ -2839,13 +3373,13 @@ std::string printNestedNameSpecifier(clang::NestedNameSpecifier specifier,
   policy.SuppressScope = false;
   policy.SuppressTagKeyword = true;
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
   }
 #endif
   specifier.print(stream, policy);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_ENABLE_ERROR_REPORTING;
   }
 #endif
@@ -3124,7 +3658,7 @@ ExplicitQualifierInfo getExplicitQualifierInfo(
           clang::PrintingPolicy policy(context.getLangOpts());
           policy.SuppressScope = true;
           policy.SuppressTagKeyword = true;
-          token = qual_type.getAsString(policy);
+          token = clangQualTypeAsStringDefinedForFrontend(qual_type, policy);
         }
         break;
       }
@@ -3210,7 +3744,8 @@ void attachExplicitQualifierFromNestedName(
 
   const clang::NestedNameSpecifierLoc *qualifier_loc_ptr = nullptr;
   clang::NestedNameSpecifierLoc defined_qualifier_loc;
-  if (qualifier_loc != nullptr && qualifier_loc->getNestedNameSpecifier()) {
+  if (qualifier_loc != nullptr &&
+      getClangNestedNameSpecifierLocSpecifierDefined(*qualifier_loc)) {
     defined_qualifier_loc =
         markClangNestedNameSpecifierLocDefined(*qualifier_loc);
     qualifier_loc_ptr = &defined_qualifier_loc;
@@ -3225,6 +3760,7 @@ void attachExplicitQualifierFromNestedName(
 
 clang::NestedNameSpecifier structuralQualifierForExplicitlyQualifiedNonrealRef(
     clang::NestedNameSpecifier qualifier) {
+  qualifier = markClangNestedNameSpecifierDefined(qualifier);
   if (!qualifier) {
     return qualifier;
   }
@@ -3657,7 +4193,7 @@ size_t ClangToSageTranslator::countExplicitTemplateArgumentsFromSource(
 void ClangToSageTranslator::applySourceRangeWithTrailingSemicolon(
     SgNode *rose_node, const clang::Stmt *clang_stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&clang_stmt, sizeof(clang_stmt));
   }
 #endif
@@ -3717,7 +4253,8 @@ SgNode *ClangToSageTranslator::Traverse(clang::Stmt *stmt) {
   }
 
   auto it = p_stmt_translation_map.find(stmt);
-  if (it != p_stmt_translation_map.end()) {
+  if (p_rebuild_translation_cache_depth == 0 &&
+      it != p_stmt_translation_map.end()) {
     if (SgExpression *expr = isSgExpression(it->second)) {
       // Clang can reuse expression subtrees across template patterns,
       // instantiations, and other lowered wrapper nodes. ROSE expressions
@@ -4389,8 +4926,12 @@ SgNode *ClangToSageTranslator::Traverse(clang::Stmt *stmt) {
     }
   }
 
-  p_stmt_translation_map.insert(
-      std::pair<clang::Stmt *, SgNode *>(stmt, result));
+  if (p_rebuild_translation_cache_depth != 0) {
+    p_stmt_translation_map[stmt] = result;
+  } else {
+    p_stmt_translation_map.insert(
+        std::pair<clang::Stmt *, SgNode *>(stmt, result));
+  }
 
   return result;
 }
@@ -4495,13 +5036,16 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
 #endif
   bool res = true;
 
-  unsigned asmNumInput = gcc_asm_stmt->getNumInputs();
-  unsigned asmNumOutput = gcc_asm_stmt->getNumOutputs();
-  unsigned asmClobber = gcc_asm_stmt->getNumClobbers();
+  unsigned asmNumInput =
+      readClangApiValueDefined([&]() { return gcc_asm_stmt->getNumInputs(); });
+  unsigned asmNumOutput =
+      readClangApiValueDefined([&]() { return gcc_asm_stmt->getNumOutputs(); });
+  unsigned asmClobber = readClangApiValueDefined(
+      [&]() { return gcc_asm_stmt->getNumClobbers(); });
 
   // LLVM returns std::string
-  std::string AsmString;
-  AsmString = gcc_asm_stmt->getAsmString();
+  std::string AsmString =
+      readClangApiValueDefined([&]() { return gcc_asm_stmt->getAsmString(); });
 #if DEBUG_VISIT_STMT
   std::cerr << "AsmString:" << AsmString << std::endl;
 #endif
@@ -4515,8 +5059,9 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
   // Pei-Hung (03/22/2022)  The clobber string is available.
   // The implementation adding clobber into ROSE AST is not in place.
   for (unsigned i = 0; i < asmClobber; ++i) {
-    std::string clobberStr =
-        static_cast<std::string>(gcc_asm_stmt->getClobber(i));
+    std::string clobberStr = readClangApiValueDefined([&]() {
+      return static_cast<std::string>(gcc_asm_stmt->getClobber(i));
+    });
 #if DEBUG_VISIT_STMT
     std::cerr << "AsmOp clobber[" << i << "]: " << clobberStr << std::endl;
 #endif
@@ -4542,12 +5087,16 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
 
   // process output
   for (unsigned i = 0; i < asmNumOutput; ++i) {
-    SgNode *tmp_node = Traverse(gcc_asm_stmt->getOutputExpr(i));
+    clang::Expr *clang_output_expr =
+        markClangExprObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return gcc_asm_stmt->getOutputExpr(i); }));
+    SgNode *tmp_node = Traverse(clang_output_expr);
     SgExpression *outputExpr = isSgExpression(tmp_node);
     ROSE_ASSERT(outputExpr != nullptr);
 
-    std::string outputConstraintStr =
-        static_cast<std::string>(gcc_asm_stmt->getOutputConstraint(i));
+    std::string outputConstraintStr = readClangApiValueDefined([&]() {
+      return static_cast<std::string>(gcc_asm_stmt->getOutputConstraint(i));
+    });
 // Clang's constraint is equivalent to ROSE's modifier + operand constraints
 #if DEBUG_VISIT_STMT
     std::cerr << "AsmOp output constraint[" << i << "]: " << outputConstraintStr
@@ -4578,9 +5127,10 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
 
     // set as an output AsmOp
     sageAsmOp->set_isOutputOperand(true);
-    if (llvm::StringRef outputName = gcc_asm_stmt->getOutputName(i);
-        !outputName.empty()) {
-      sageAsmOp->set_name(outputName.str());
+    std::string outputName = readClangApiValueDefined(
+        [&]() { return gcc_asm_stmt->getOutputName(i).str(); });
+    if (!outputName.empty()) {
+      sageAsmOp->set_name(outputName);
     }
 
     ROSE_ASSERT(sm.size() == 4);
@@ -4615,12 +5165,16 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
 
   // process input
   for (unsigned i = 0; i < asmNumInput; ++i) {
-    SgNode *tmp_node = Traverse(gcc_asm_stmt->getInputExpr(i));
+    clang::Expr *clang_input_expr =
+        markClangExprObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return gcc_asm_stmt->getInputExpr(i); }));
+    SgNode *tmp_node = Traverse(clang_input_expr);
     SgExpression *inputExpr = isSgExpression(tmp_node);
     ROSE_ASSERT(inputExpr != nullptr);
 
-    std::string inputConstraintStr =
-        static_cast<std::string>(gcc_asm_stmt->getInputConstraint(i));
+    std::string inputConstraintStr = readClangApiValueDefined([&]() {
+      return static_cast<std::string>(gcc_asm_stmt->getInputConstraint(i));
+    });
 // Clang's constraint is equivalent to ROSE's modifier + operand constraints
 #if DEBUG_VISIT_STMT
     std::cerr << "AsmOp input constraint[" << i << "]: " << inputConstraintStr
@@ -4651,9 +5205,10 @@ bool ClangToSageTranslator::VisitGCCAsmStmt(clang::GCCAsmStmt *gcc_asm_stmt,
 
     // set as an input AsmOp
     sageAsmOp->set_isOutputOperand(false);
-    if (llvm::StringRef inputName = gcc_asm_stmt->getInputName(i);
-        !inputName.empty()) {
-      sageAsmOp->set_name(inputName.str());
+    std::string inputName = readClangApiValueDefined(
+        [&]() { return gcc_asm_stmt->getInputName(i).str(); });
+    if (!inputName.empty()) {
+      sageAsmOp->set_name(inputName);
     }
 
     ROSE_ASSERT(sm.size() == 4);
@@ -5441,7 +5996,7 @@ SgStatement *
 ClangToSageTranslator::wrapStatementWithPragmas(clang::Stmt *stmt,
                                                 SgStatement *statement) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&stmt, sizeof(stmt));
   }
 #endif
@@ -5597,8 +6152,11 @@ bool ClangToSageTranslator::VisitCoreturnStmt(
 #endif
   bool res = true;
 
+  core_turn_stmt = markClangCoreturnStorageDefined(core_turn_stmt);
   SgExpression *return_expr = nullptr;
-  if (clang::Expr *operand = core_turn_stmt->getOperand()) {
+  if (clang::Expr *operand =
+          markClangExprObjectDefinedByClass(readClangApiValueDefined(
+              [&]() { return core_turn_stmt->getOperand(); }))) {
     SgNode *tmp_expr = Traverse(operand);
     return_expr = isSgExpression(tmp_expr);
     if (tmp_expr != nullptr && return_expr == nullptr) {
@@ -5624,13 +6182,17 @@ bool ClangToSageTranslator::VisitCoroutineBodyStmt(
 #endif
   bool res = true;
 
-  SgNode *tmp_body = Traverse(coroutine_body_stmt->getBody());
+  coroutine_body_stmt =
+      markClangCoroutineBodyStorageDefined(coroutine_body_stmt);
+  clang::CompoundStmt *clang_body = static_cast<clang::CompoundStmt *>(
+      markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return coroutine_body_stmt->getBody(); })));
+  SgNode *tmp_body = Traverse(clang_body);
   SgStatement *body = isSgStatement(tmp_body);
   if (body == nullptr && tmp_body != nullptr) {
     if (SgExpression *expr = isSgExpression(tmp_body)) {
       body = SageBuilder::buildExprStatement(expr);
-      applySourceRangeWithTrailingSemicolon(body,
-                                            coroutine_body_stmt->getBody());
+      applySourceRangeWithTrailingSemicolon(body, clang_body);
     } else {
       std::cerr << "Runtime error: CoroutineBodyStmt body did not translate "
                    "into SgStatement or SgExpression"
@@ -5643,7 +6205,9 @@ bool ClangToSageTranslator::VisitCoroutineBodyStmt(
     body = SageBuilder::buildNullStatement();
   }
 
-  applySourceRange(body, coroutine_body_stmt->getSourceRange());
+  applySourceRange(body, readClangApiValueDefined([&]() {
+                     return coroutine_body_stmt->getSourceRange();
+                   }));
   *node = body;
 
   return VisitStmt(coroutine_body_stmt, node) && res;
@@ -5737,6 +6301,7 @@ bool ClangToSageTranslator::VisitCXXForRangeStmt(
 
   auto translate_for_init_child =
       [&](clang::Stmt *clang_stmt) -> SgStatement * {
+    clang_stmt = markClangStmtObjectDefinedByClass(clang_stmt);
     if (clang_stmt == nullptr) {
       return nullptr;
     }
@@ -5764,7 +6329,10 @@ bool ClangToSageTranslator::VisitCXXForRangeStmt(
 
   SgBasicBlock *wrapper_block = nullptr;
   SgStatement *init_stmt = nullptr;
-  if (clang::Stmt *clang_init = cxx_for_range_stmt->getInit()) {
+  clang::Stmt *clang_init =
+      markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return cxx_for_range_stmt->getInit(); }));
+  if (clang_init != nullptr) {
     wrapper_block = SageBuilder::buildBasicBlock_nfi();
     if (wrapper_block != nullptr && wrapper_block->get_parent() == nullptr) {
       wrapper_block->set_parent(SageBuilder::topScopeStack());
@@ -5811,17 +6379,32 @@ bool ClangToSageTranslator::VisitCXXForRangeStmt(
   // Root-cause fix: model C++ range-for directly in the AST instead of
   // desugaring to SgForStatement. SgForStatement for-init unparsing merges
   // declarations and rewrites type deduction semantics (e.g. __range/__begin).
-  SgVariableDeclaration *range_decl = translate_var_decl_child(
-      cxx_for_range_stmt->getRangeStmt(), "CXXForRangeStmt::range");
-  SgVariableDeclaration *begin_decl = translate_var_decl_child(
-      cxx_for_range_stmt->getBeginStmt(), "CXXForRangeStmt::begin");
-  SgVariableDeclaration *end_decl = translate_var_decl_child(
-      cxx_for_range_stmt->getEndStmt(), "CXXForRangeStmt::end");
-  SgVariableDeclaration *iterator_decl = translate_var_decl_child(
-      cxx_for_range_stmt->getLoopVarStmt(), "CXXForRangeStmt::loop variable");
+  SgVariableDeclaration *range_decl =
+      translate_var_decl_child(readClangApiValueDefined([&]() {
+                                 return cxx_for_range_stmt->getRangeStmt();
+                               }),
+                               "CXXForRangeStmt::range");
+  SgVariableDeclaration *begin_decl =
+      translate_var_decl_child(readClangApiValueDefined([&]() {
+                                 return cxx_for_range_stmt->getBeginStmt();
+                               }),
+                               "CXXForRangeStmt::begin");
+  SgVariableDeclaration *end_decl =
+      translate_var_decl_child(readClangApiValueDefined([&]() {
+                                 return cxx_for_range_stmt->getEndStmt();
+                               }),
+                               "CXXForRangeStmt::end");
+  SgVariableDeclaration *iterator_decl =
+      translate_var_decl_child(readClangApiValueDefined([&]() {
+                                 return cxx_for_range_stmt->getLoopVarStmt();
+                               }),
+                               "CXXForRangeStmt::loop variable");
 
   SgExpression *not_equal_expr = nullptr;
-  if (clang::Expr *clang_cond = cxx_for_range_stmt->getCond()) {
+  clang::Expr *clang_cond =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return cxx_for_range_stmt->getCond(); }));
+  if (clang_cond != nullptr) {
     SgNode *tmp_cond = Traverse(clang_cond);
     if (SgExpression *cond_expr = isSgExpression(tmp_cond)) {
       not_equal_expr = cond_expr;
@@ -5836,7 +6419,9 @@ bool ClangToSageTranslator::VisitCXXForRangeStmt(
   }
 
   SgExpression *increment_expr = nullptr;
-  if (clang::Expr *clang_inc = cxx_for_range_stmt->getInc()) {
+  clang::Expr *clang_inc = markClangExprObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return cxx_for_range_stmt->getInc(); }));
+  if (clang_inc != nullptr) {
     SgNode *tmp_inc = Traverse(clang_inc);
     if (SgExpression *inc_expr = isSgExpression(tmp_inc)) {
       increment_expr = inc_expr;
@@ -6028,6 +6613,7 @@ bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
   std::cerr << "ClangToSageTranslator::VisitDeclStmt" << std::endl;
 #endif
   decl_stmt = markClangAstObjectDefined(decl_stmt);
+  decl_stmt = markClangDeclStmtStorageDefined(decl_stmt);
 
   bool res = true;
   bool prev_in_decl_stmt = p_in_decl_stmt_translation;
@@ -6035,6 +6621,7 @@ bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
 
   std::vector<clang::Decl *> visible_decls;
   for (clang::Decl *decl : decl_stmt->decls()) {
+    decl = markClangDeclObjectDefinedByKind(decl);
     if (decl == nullptr) {
       continue;
     }
@@ -6098,6 +6685,7 @@ bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
     for (auto visible_it = visible_decls.begin();
          visible_it != visible_decls.end() - 1; ++visible_it) {
       clang::Decl *decl = *visible_it;
+      decl = markClangDeclObjectDefinedByKind(decl);
       if (decl == nullptr)
         continue;
       SgNode *child = Traverse(decl);
@@ -6115,7 +6703,8 @@ bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
       if (sub_decl_stmt == nullptr) {
         continue;
       } else if (child != nullptr) {
-        if (clang::TagDecl *tagDecl = llvm::dyn_cast<clang::TagDecl>(decl)) {
+        if (clang::TagDecl *tagDecl = llvm::dyn_cast<clang::TagDecl>(
+                markClangDeclObjectDefinedByKind(decl))) {
           if (tagDecl->isEmbeddedInDeclarator() ||
               tagDecl->getTypedefNameForAnonDecl() != nullptr) {
             continue;
@@ -6128,7 +6717,8 @@ bool ClangToSageTranslator::VisitDeclStmt(clang::DeclStmt *decl_stmt,
       }
     }
     // last declaration in scope
-    clang::Decl *last_clang_decl = visible_decls.back();
+    clang::Decl *last_clang_decl =
+        markClangDeclObjectDefinedByKind(visible_decls.back());
     SgNode *lastDecl = Traverse(last_clang_decl);
     detach_block_scope_function_decl_from_semantic_scope(last_clang_decl,
                                                          lastDecl);
@@ -6832,7 +7422,8 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
   // Since SgIfStmt does not directly model init-statements, lower this shape to
   // an equivalent block:
   //   { init; if (cond) ... }
-  clang::Stmt *clang_if_init_stmt = if_stmt->getInit();
+  clang::Stmt *clang_if_init_stmt = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return if_stmt->getInit(); }));
   SgBasicBlock *if_init_wrapper = nullptr;
   if (clang_if_init_stmt != nullptr) {
     if_init_wrapper = SageBuilder::buildBasicBlock_nfi();
@@ -6866,7 +7457,9 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
       sg_init_stmt = SageBuilder::buildNullStatement_nfi();
       setCompilerGeneratedFileInfo(sg_init_stmt, true);
     } else {
-      applySourceRange(sg_init_stmt, clang_if_init_stmt->getSourceRange());
+      applySourceRange(sg_init_stmt, readClangApiValueDefined([&]() {
+                         return clang_if_init_stmt->getSourceRange();
+                       }));
     }
 
     sg_init_stmt->set_parent(if_init_wrapper);
@@ -6881,7 +7474,9 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
   SageBuilder::pushScopeStack(isSgScopeStatement(*node));
 
   SgStatement *cond_stmt = nullptr;
-  if (clang::DeclStmt *cond_decl = if_stmt->getConditionVariableDeclStmt()) {
+  if (clang::DeclStmt *cond_decl = llvm::dyn_cast_or_null<clang::DeclStmt>(
+          markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+              [&]() { return if_stmt->getConditionVariableDeclStmt(); })))) {
     SgNode *tmp_cond = Traverse(cond_decl);
     cond_stmt = isSgStatement(tmp_cond);
     if (tmp_cond != nullptr && cond_stmt == nullptr) {
@@ -6891,16 +7486,21 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
       res = false;
     }
     if (cond_stmt != nullptr) {
-      applySourceRange(cond_stmt, cond_decl->getSourceRange());
+      applySourceRange(cond_stmt, readClangApiValueDefined([&]() {
+                         return cond_decl->getSourceRange();
+                       }));
     }
   } else {
-    clang::Expr *cond_expr_clang = llvm::dyn_cast_or_null<clang::Expr>(
-        markClangStmtObjectDefinedByClass(if_stmt->getCond()));
+    clang::Expr *cond_expr_clang =
+        llvm::dyn_cast_or_null<clang::Expr>(markClangStmtObjectDefinedByClass(
+            readClangApiValueDefined([&]() { return if_stmt->getCond(); })));
     SgNode *tmp_cond = Traverse(cond_expr_clang);
     SgExpression *cond_expr = isSgExpression(tmp_cond);
     cond_stmt = SageBuilder::buildExprStatement(cond_expr);
     if (cond_expr_clang != nullptr) {
-      applySourceRange(cond_stmt, cond_expr_clang->getSourceRange());
+      applySourceRange(cond_stmt, readClangApiValueDefined([&]() {
+                         return cond_expr_clang->getSourceRange();
+                       }));
     } else {
       setCompilerGeneratedFileInfo(cond_stmt, true);
     }
@@ -6928,8 +7528,8 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
     setCompilerGeneratedFileInfo(cond_stmt, true);
   }
 
-  clang::Stmt *then_clang_stmt =
-      markClangStmtObjectDefinedByClass(if_stmt->getThen());
+  clang::Stmt *then_clang_stmt = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return if_stmt->getThen(); }));
   SgNode *tmp_then = Traverse(then_clang_stmt);
   SgStatement *then_stmt = isSgStatement(tmp_then);
   if (then_stmt == nullptr) {
@@ -6940,8 +7540,8 @@ bool ClangToSageTranslator::VisitIfStmt(clang::IfStmt *if_stmt, SgNode **node) {
   applySourceRangeWithTrailingSemicolon(then_stmt, then_clang_stmt);
   then_stmt = wrapStatementWithPragmas(then_clang_stmt, then_stmt);
 
-  clang::Stmt *else_clang_stmt =
-      markClangStmtObjectDefinedByClass(if_stmt->getElse());
+  clang::Stmt *else_clang_stmt = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return if_stmt->getElse(); }));
   SgNode *tmp_else = Traverse(else_clang_stmt);
   SgStatement *else_stmt = isSgStatement(tmp_else);
   if (else_stmt == nullptr) {
@@ -7606,7 +8206,10 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
 
   bool res = true;
 
-  clang::Stmt *clang_switch_init_stmt = switch_stmt->getInit();
+  switch_stmt = llvm::cast<clang::SwitchStmt>(
+      markClangStmtObjectDefinedByClass(switch_stmt));
+  clang::Stmt *clang_switch_init_stmt = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return switch_stmt->getInit(); }));
   // SgSwitchStatement has no dedicated child for a C++17 init-statement.
   // Lower it into an enclosing block so the translated AST remains
   // structurally valid while preserving the initializer's scope for the switch
@@ -7685,8 +8288,10 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
   SageBuilder::pushScopeStack(sg_switch_stmt);
 
   SgStatement *cond_stmt = nullptr;
-  if (clang::DeclStmt *cond_decl =
-          switch_stmt->getConditionVariableDeclStmt()) {
+  if (clang::DeclStmt *cond_decl = llvm::dyn_cast_or_null<clang::DeclStmt>(
+          markClangStmtObjectDefinedByClass(readClangApiValueDefined([&]() {
+            return switch_stmt->getConditionVariableDeclStmt();
+          })))) {
     SgNode *tmp_cond = Traverse(cond_decl);
     cond_stmt = isSgStatement(tmp_cond);
     if (tmp_cond != nullptr && cond_stmt == nullptr) {
@@ -7696,14 +8301,22 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
       res = false;
     }
     if (cond_stmt != nullptr) {
-      applySourceRange(cond_stmt, cond_decl->getSourceRange());
+      applySourceRange(cond_stmt, readClangApiValueDefined([&]() {
+                         return cond_decl->getSourceRange();
+                       }));
     }
   } else {
-    SgNode *tmp_cond = Traverse(switch_stmt->getCond());
+    clang::Expr *clang_cond = llvm::dyn_cast_or_null<clang::Expr>(
+        markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return switch_stmt->getCond(); })));
+    ROSE_ASSERT(clang_cond != nullptr);
+    SgNode *tmp_cond = Traverse(clang_cond);
     SgExpression *cond = isSgExpression(tmp_cond);
     ROSE_ASSERT(cond != nullptr);
     cond_stmt = SageBuilder::buildExprStatement(cond);
-    applySourceRange(cond_stmt, switch_stmt->getCond()->getSourceRange());
+    applySourceRange(cond_stmt, readClangApiValueDefined([&]() {
+                       return clang_cond->getSourceRange();
+                     }));
   }
 
   if (cond_stmt == nullptr) {
@@ -7734,12 +8347,14 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
   cond_stmt->set_parent(sg_switch_stmt);
   sg_switch_stmt->set_item_selector(cond_stmt);
 
-  SgNode *tmp_body = Traverse(switch_stmt->getBody());
+  clang::Stmt *clang_body = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return switch_stmt->getBody(); }));
+  SgNode *tmp_body = Traverse(clang_body);
   SgStatement *body = isSgStatement(tmp_body);
   SgExpression *expr = isSgExpression(tmp_body);
   if (expr != nullptr) {
     body = SageBuilder::buildExprStatement(expr);
-    applySourceRangeWithTrailingSemicolon(body, switch_stmt->getBody());
+    applySourceRangeWithTrailingSemicolon(body, clang_body);
   }
   if (body == nullptr) {
     body = SageBuilder::buildNullStatement_nfi();
@@ -7754,15 +8369,19 @@ bool ClangToSageTranslator::VisitSwitchStmt(clang::SwitchStmt *switch_stmt,
   body->set_parent(sg_switch_stmt);
 
   if (switch_init_wrapper != nullptr) {
-    applySourceRange(sg_switch_stmt, switch_stmt->getSourceRange());
+    applySourceRange(sg_switch_stmt, readClangApiValueDefined([&]() {
+                       return switch_stmt->getSourceRange();
+                     }));
     sg_switch_stmt->set_parent(switch_init_wrapper);
     switch_init_wrapper->append_statement(sg_switch_stmt);
 
-    if (clang_switch_init_stmt->getBeginLoc().isValid() &&
-        switch_stmt->getEndLoc().isValid()) {
+    clang::SourceLocation init_begin = readClangApiValueDefined(
+        [&]() { return clang_switch_init_stmt->getBeginLoc(); });
+    clang::SourceLocation switch_end =
+        readClangApiValueDefined([&]() { return switch_stmt->getEndLoc(); });
+    if (init_begin.isValid() && switch_end.isValid()) {
       applySourceRange(switch_init_wrapper,
-                       clang::SourceRange(clang_switch_init_stmt->getBeginLoc(),
-                                          switch_stmt->getEndLoc()));
+                       clang::SourceRange(init_begin, switch_end));
     }
 
     SageBuilder::popScopeStack();
@@ -8098,7 +8717,10 @@ bool ClangToSageTranslator::VisitArraySubscriptExpr(
 
   bool res = true;
 
-  SgNode *tmp_base = Traverse(array_subscript_expr->getBase());
+  clang::Expr *clang_base =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return array_subscript_expr->getBase(); }));
+  SgNode *tmp_base = Traverse(clang_base);
   SgExpression *base = isSgExpression(tmp_base);
   if (tmp_base != nullptr && base == nullptr) {
     std::cerr << "Runtime error: tmp_base != nullptr && base == nullptr"
@@ -8138,7 +8760,10 @@ bool ClangToSageTranslator::VisitArraySubscriptExpr(
     }
   }
 
-  SgNode *tmp_idx = Traverse(array_subscript_expr->getIdx());
+  clang::Expr *clang_idx =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return array_subscript_expr->getIdx(); }));
+  SgNode *tmp_idx = Traverse(clang_idx);
   SgExpression *idx = isSgExpression(tmp_idx);
   if (tmp_idx != nullptr && idx == nullptr) {
     std::cerr << "Runtime error: tmp_idx != nullptr && idx == nullptr"
@@ -8199,6 +8824,8 @@ bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
   std::cerr << "ClangToSageTranslator::VisitAtomicExpr" << std::endl;
 #endif
   bool res = true;
+  atomic_expr = llvm::cast<clang::AtomicExpr>(
+      markClangStmtObjectDefinedByClass(atomic_expr));
 
   // ROOT CAUSE FIX: AtomicExpr represents C11/C++11 atomic operations like:
   // __atomic_load, __atomic_store, __atomic_fetch_add, __atomic_exchange, etc.
@@ -8206,7 +8833,9 @@ bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
 
   SgExprListExp *args = SageBuilder::buildExprListExp();
 
-  auto append_atomic_arg = [&](clang::Expr *clang_arg) -> void {
+  auto append_atomic_arg = [&](auto read_clang_arg) -> void {
+    clang::Expr *clang_arg = markClangExprObjectDefinedByClass(
+        readClangApiValueDefined(read_clang_arg));
     if (clang_arg == nullptr) {
       res = false;
       return;
@@ -8224,23 +8853,26 @@ bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
   };
 
   auto append_atomic_scope_arg = [&]() {
-    if (atomic_expr->getScopeModel() != nullptr) {
-      append_atomic_arg(atomic_expr->getScope());
+    const bool has_scope_model = readClangApiValueDefined(
+        [&]() { return atomic_expr->getScopeModel() != nullptr; });
+    if (has_scope_model) {
+      append_atomic_arg([&]() { return atomic_expr->getScope(); });
     }
   };
 
-  const clang::AtomicExpr::AtomicOp atomic_op = atomic_expr->getOp();
+  const clang::AtomicExpr::AtomicOp atomic_op =
+      readClangApiValueDefined([&]() { return atomic_expr->getOp(); });
   switch (atomic_op) {
   case clang::AtomicExpr::AO__atomic_compare_exchange:
   case clang::AtomicExpr::AO__atomic_compare_exchange_n:
   case clang::AtomicExpr::AO__scoped_atomic_compare_exchange:
   case clang::AtomicExpr::AO__scoped_atomic_compare_exchange_n:
-    append_atomic_arg(atomic_expr->getPtr());
-    append_atomic_arg(atomic_expr->getVal1());
-    append_atomic_arg(atomic_expr->getVal2());
-    append_atomic_arg(atomic_expr->getWeak());
-    append_atomic_arg(atomic_expr->getOrder());
-    append_atomic_arg(atomic_expr->getOrderFail());
+    append_atomic_arg([&]() { return atomic_expr->getPtr(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal1(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal2(); });
+    append_atomic_arg([&]() { return atomic_expr->getWeak(); });
+    append_atomic_arg([&]() { return atomic_expr->getOrder(); });
+    append_atomic_arg([&]() { return atomic_expr->getOrderFail(); });
     append_atomic_scope_arg();
     break;
 
@@ -8250,35 +8882,36 @@ bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
   case clang::AtomicExpr::AO__opencl_atomic_compare_exchange_weak:
   case clang::AtomicExpr::AO__hip_atomic_compare_exchange_strong:
   case clang::AtomicExpr::AO__hip_atomic_compare_exchange_weak:
-    append_atomic_arg(atomic_expr->getPtr());
-    append_atomic_arg(atomic_expr->getVal1());
-    append_atomic_arg(atomic_expr->getVal2());
-    append_atomic_arg(atomic_expr->getOrder());
-    append_atomic_arg(atomic_expr->getOrderFail());
+    append_atomic_arg([&]() { return atomic_expr->getPtr(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal1(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal2(); });
+    append_atomic_arg([&]() { return atomic_expr->getOrder(); });
+    append_atomic_arg([&]() { return atomic_expr->getOrderFail(); });
     append_atomic_scope_arg();
     break;
 
   case clang::AtomicExpr::AO__c11_atomic_init:
   case clang::AtomicExpr::AO__opencl_atomic_init:
-    append_atomic_arg(atomic_expr->getPtr());
-    append_atomic_arg(atomic_expr->getVal1());
+    append_atomic_arg([&]() { return atomic_expr->getPtr(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal1(); });
     break;
 
   case clang::AtomicExpr::AO__atomic_exchange:
   case clang::AtomicExpr::AO__scoped_atomic_exchange:
-    append_atomic_arg(atomic_expr->getPtr());
-    append_atomic_arg(atomic_expr->getVal1());
-    append_atomic_arg(atomic_expr->getVal2());
-    append_atomic_arg(atomic_expr->getOrder());
+    append_atomic_arg([&]() { return atomic_expr->getPtr(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal1(); });
+    append_atomic_arg([&]() { return atomic_expr->getVal2(); });
+    append_atomic_arg([&]() { return atomic_expr->getOrder(); });
     append_atomic_scope_arg();
     break;
 
   default:
-    append_atomic_arg(atomic_expr->getPtr());
-    if (atomic_expr->hasVal1Operand()) {
-      append_atomic_arg(atomic_expr->getVal1());
+    append_atomic_arg([&]() { return atomic_expr->getPtr(); });
+    if (readClangApiValueDefined(
+            [&]() { return atomic_expr->hasVal1Operand(); })) {
+      append_atomic_arg([&]() { return atomic_expr->getVal1(); });
     }
-    append_atomic_arg(atomic_expr->getOrder());
+    append_atomic_arg([&]() { return atomic_expr->getOrder(); });
     append_atomic_scope_arg();
     break;
   }
@@ -8290,7 +8923,8 @@ bool ClangToSageTranslator::VisitAtomicExpr(clang::AtomicExpr *atomic_expr,
 
   // Use the actual return type from Clang, not void - many atomics return
   // values Example: __atomic_fetch_add returns the old value before addition
-  SgType *return_type = buildTypeFromQualifiedType(atomic_expr->getType());
+  SgType *return_type = buildTypeFromQualifiedType(markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return atomic_expr->getType(); })));
   *node = SageBuilder::buildFunctionCallExp(builtin_name, return_type, args,
                                             SageBuilder::topScopeStack());
 
@@ -8643,13 +9277,17 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
 
     for (auto it = unresolved_lookup->decls_begin();
          it != unresolved_lookup->decls_end(); ++it) {
-      clang::NamedDecl *named_decl = it.getDecl();
+      clang::NamedDecl *named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+          markClangDeclObjectDefinedByKind(
+              readClangApiValueDefined([&]() { return it.getDecl(); })));
       if (named_decl == nullptr) {
         continue;
       }
       if (clang::UsingShadowDecl *shadow =
               llvm::dyn_cast<clang::UsingShadowDecl>(named_decl)) {
-        named_decl = shadow->getTargetDecl();
+        named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return shadow->getTargetDecl(); })));
       }
       if (named_decl == nullptr) {
         continue;
@@ -8658,24 +9296,34 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
       clang::FunctionDecl *function_decl = nullptr;
       if (clang::FunctionTemplateDecl *template_decl =
               llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-        function_decl = template_decl->getTemplatedDecl();
+        function_decl = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return template_decl->getTemplatedDecl(); })));
       } else {
-        function_decl = llvm::dyn_cast<clang::FunctionDecl>(named_decl);
+        function_decl = llvm::dyn_cast<clang::FunctionDecl>(
+            markClangDeclObjectDefinedByKind(named_decl));
       }
       if (function_decl == nullptr) {
         return;
       }
+      function_decl = llvm::dyn_cast<clang::FunctionDecl>(
+          markClangDeclObjectDefinedByKind(function_decl));
 
-      const unsigned min_args = function_decl->getMinRequiredArguments();
-      const unsigned max_args = function_decl->getNumParams();
-      const bool viable_by_arity =
-          call_arg_count >= min_args &&
-          (function_decl->isVariadic() || call_arg_count <= max_args);
+      const unsigned min_args = readClangApiValueDefined(
+          [&]() { return function_decl->getMinRequiredArguments(); });
+      const unsigned max_args = readClangApiValueDefined(
+          [&]() { return function_decl->getNumParams(); });
+      const bool is_variadic = readClangApiValueDefined(
+          [&]() { return function_decl->isVariadic(); });
+      const bool viable_by_arity = call_arg_count >= min_args &&
+                                   (is_variadic || call_arg_count <= max_args);
       if (!viable_by_arity) {
         continue;
       }
 
-      clang::Decl *canonical_decl = function_decl->getCanonicalDecl();
+      clang::Decl *canonical_decl =
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return function_decl->getCanonicalDecl(); }));
       if (selected_canonical_decl != nullptr &&
           selected_canonical_decl != canonical_decl) {
         selected_named_decl = nullptr;
@@ -8894,7 +9542,8 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
 
       SgScopeStatement *member_scope =
           normalize_class_like_scope(resolveScopeFromDeclContext(
-              const_cast<clang::CXXRecordDecl *>(method_decl->getParent()),
+              clangCXXMethodDeclParentDefined(
+                  const_cast<clang::CXXMethodDecl *>(method_decl)),
               SageBuilder::topScopeStack()));
       return member_scope != nullptr &&
              member_scope != current_class_like_scope;
@@ -9159,12 +9808,16 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
       }
 
       auto remove_reference = [](clang::QualType qt) -> clang::QualType {
+        qt = markClangQualTypeDefined(qt);
         if (qt.isNull()) {
           return qt;
         }
+        const clang::Type *qt_type =
+            markClangTypeObjectDefinedByClass(qt.getTypePtrOrNull());
         if (const clang::ReferenceType *ref =
-                qt->getAs<clang::ReferenceType>()) {
-          return ref->getPointeeType();
+                llvm::dyn_cast_or_null<clang::ReferenceType>(qt_type)) {
+          return markClangQualTypeDefined(readClangApiValueDefined(
+              [&]() { return ref->getPointeeType(); }));
         }
         return qt;
       };
@@ -9174,11 +9827,16 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
         if (qt.isNull()) {
           return qt;
         }
-        return qt.getCanonicalType().getUnqualifiedType();
+        clang::QualType canonical = markClangQualTypeDefined(
+            readClangApiValueDefined([&]() { return qt.getCanonicalType(); }));
+        return markClangQualTypeDefined(readClangApiValueDefined(
+            [&]() { return canonical.getUnqualifiedType(); }));
       };
 
       auto has_typedef_spelling = [](clang::QualType qt) -> bool {
-        const clang::Type *type = qt.getTypePtrOrNull();
+        qt = markClangQualTypeDefined(qt);
+        const clang::Type *type =
+            markClangTypeObjectDefinedByClass(qt.getTypePtrOrNull());
         while (type != nullptr) {
           if (llvm::isa<clang::TypedefType>(type) ||
               llvm::isa<clang::UsingType>(type)) {
@@ -9186,16 +9844,31 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
           }
           if (const clang::ReferenceType *ref =
                   llvm::dyn_cast<clang::ReferenceType>(type)) {
-            type = ref->getPointeeType().getTypePtrOrNull();
+            clang::QualType pointee =
+                markClangQualTypeDefined(readClangApiValueDefined(
+                    [&]() { return ref->getPointeeType(); }));
+            type =
+                markClangTypeObjectDefinedByClass(pointee.getTypePtrOrNull());
           } else if (const clang::ParenType *paren =
                          llvm::dyn_cast<clang::ParenType>(type)) {
-            type = paren->getInnerType().getTypePtrOrNull();
+            clang::QualType inner =
+                markClangQualTypeDefined(readClangApiValueDefined(
+                    [&]() { return paren->getInnerType(); }));
+            type = markClangTypeObjectDefinedByClass(inner.getTypePtrOrNull());
           } else if (const clang::AttributedType *attributed =
                          llvm::dyn_cast<clang::AttributedType>(type)) {
-            type = attributed->getModifiedType().getTypePtrOrNull();
+            clang::QualType modified =
+                markClangQualTypeDefined(readClangApiValueDefined(
+                    [&]() { return attributed->getModifiedType(); }));
+            type =
+                markClangTypeObjectDefinedByClass(modified.getTypePtrOrNull());
           } else if (const clang::AdjustedType *adjusted =
                          llvm::dyn_cast<clang::AdjustedType>(type)) {
-            type = adjusted->getOriginalType().getTypePtrOrNull();
+            clang::QualType original =
+                markClangQualTypeDefined(readClangApiValueDefined(
+                    [&]() { return adjusted->getOriginalType(); }));
+            type =
+                markClangTypeObjectDefinedByClass(original.getTypePtrOrNull());
           } else {
             break;
           }
@@ -9205,8 +9878,12 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
 
       auto same_spelled_type = [](clang::QualType lhs,
                                   clang::QualType rhs) -> bool {
-        lhs = lhs.getUnqualifiedType();
-        rhs = rhs.getUnqualifiedType();
+        lhs = markClangQualTypeDefined(readClangApiValueDefined([&]() {
+          return markClangQualTypeDefined(lhs).getUnqualifiedType();
+        }));
+        rhs = markClangQualTypeDefined(readClangApiValueDefined([&]() {
+          return markClangQualTypeDefined(rhs).getUnqualifiedType();
+        }));
         return lhs.getTypePtrOrNull() == rhs.getTypePtrOrNull();
       };
 
@@ -9227,7 +9904,8 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
           continue;
         }
 
-        clang::QualType deduced_type = clang_arg.getAsType();
+        clang::QualType deduced_type = markClangQualTypeDefined(
+            readClangApiValueDefined([&]() { return clang_arg.getAsType(); }));
         clang::QualType deduced_canonical = canonical_unqualified(deduced_type);
         if (deduced_canonical.isNull()) {
           continue;
@@ -9236,16 +9914,26 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
         clang::QualType selected_source_type;
         bool ambiguous_source_type = false;
         for (const clang::Expr *call_arg : call_expr->arguments()) {
+          call_arg = markClangExprObjectDefinedByClass(call_arg);
           if (call_arg == nullptr) {
             continue;
           }
 
-          const clang::Expr *source_arg = call_arg->IgnoreParenImpCasts();
-          if (source_arg == nullptr || source_arg->getType().isNull()) {
+          const clang::Expr *source_arg =
+              markClangExprObjectDefinedByClass(readClangApiValueDefined(
+                  [&]() { return call_arg->IgnoreParenImpCasts(); }));
+          clang::QualType source_arg_type;
+          if (source_arg != nullptr) {
+            clang::Expr *mutable_source_arg =
+                const_cast<clang::Expr *>(source_arg);
+            source_arg_type = markClangQualTypeDefined(readClangApiValueDefined(
+                [&]() { return mutable_source_arg->getType(); }));
+          }
+          if (source_arg == nullptr || source_arg_type.isNull()) {
             continue;
           }
 
-          clang::QualType source_type = remove_reference(source_arg->getType());
+          clang::QualType source_type = remove_reference(source_arg_type);
           if (source_type.isNull() || !has_typedef_spelling(source_type)) {
             continue;
           }
@@ -9992,12 +10680,16 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
   maybe_upgrade_template_callee();
 
   SgExprListExp *param_list = SageBuilder::buildExprListExp_nfi();
-  applySourceRange(param_list, call_expr->getSourceRange());
+  applySourceRange(param_list, readClangApiValueDefined([&]() {
+                     return call_expr->getSourceRange();
+                   }));
 
   clang::CallExpr::arg_iterator it;
   for (it = call_expr->arg_begin(); it != call_expr->arg_end(); ++it) {
-    clang::Expr *arg = *it;
-    if (clang::isa<clang::CXXDefaultArgExpr>(arg)) {
+    clang::Expr *arg = markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return *it; }));
+    if (readClangApiValueDefined(
+            [&]() { return clang::isa<clang::CXXDefaultArgExpr>(arg); })) {
       continue;
     }
     SgNode *tmp_expr = Traverse(arg);
@@ -10008,15 +10700,21 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
       res = false;
       continue;
     }
-    if (clang::isa<clang::InitListExpr>(arg->IgnoreParenImpCasts())) {
+    clang::Expr *ignored_arg = markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return arg->IgnoreParenImpCasts(); }));
+    if (readClangApiValueDefined(
+            [&]() { return clang::isa<clang::InitListExpr>(ignored_arg); })) {
       if (SgExprListExp *init_list = isSgExprListExp(expr)) {
-        SgType *init_type = buildTypeFromQualifiedType(arg->getType());
+        SgType *init_type = buildTypeFromQualifiedType(markClangQualTypeDefined(
+            readClangApiValueDefined([&]() { return arg->getType(); })));
         if (init_type == nullptr) {
           init_type = init_list->get_type();
         }
         SgAggregateInitializer *aggregate_init =
             SageBuilder::buildAggregateInitializer_nfi(init_list, init_type);
-        applySourceRange(aggregate_init, arg->getSourceRange());
+        applySourceRange(aggregate_init, readClangApiValueDefined([&]() {
+                           return arg->getSourceRange();
+                         }));
         expr = aggregate_init;
       }
     }
@@ -10080,9 +10778,7 @@ bool ClangToSageTranslator::VisitCallExpr(clang::CallExpr *call_expr,
                 [&]() { return member_call->getMethodDecl(); })));
     if (method_decl != nullptr) {
       const clang::CXXRecordDecl *record_decl =
-          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
-                  [&]() { return method_decl->getParent(); })));
+          clangCXXMethodDeclParentDefined(method_decl);
       const clang::ClassTemplateSpecializationDecl *spec_decl = nullptr;
       clang::QualType object_type =
           markClangQualTypeDefined(readClangApiValueDefined(
@@ -10626,9 +11322,6 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
     }
 
     SgNode *tmp_decl = nullptr;
-    for (const auto &entry : p_decl_translation_map) {
-      markClangDeclObjectDefinedByKind(entry.first);
-    }
     auto it_decl = p_decl_translation_map.find(direct_callee);
     if (it_decl != p_decl_translation_map.end()) {
       tmp_decl = it_decl->second;
@@ -10803,6 +11496,18 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
     return false;
   };
 
+  clang::FunctionDecl *cached_direct_callee = nullptr;
+  bool cached_direct_callee_known = false;
+  auto direct_operator_callee = [&]() -> clang::FunctionDecl * {
+    if (!cached_direct_callee_known) {
+      cached_direct_callee = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return cxx_operator_call_expr->getDirectCallee(); })));
+      cached_direct_callee_known = true;
+    }
+    return cached_direct_callee;
+  };
+
   if (cxx_operator_call_expr->getOperator() == clang::OO_Equal &&
       cxx_operator_call_expr->getNumArgs() >= 2) {
     SgExpression *lhs = traverse_operator_arg(0);
@@ -10815,12 +11520,7 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
       if (lhs_type != nullptr && op_type != nullptr && lhs_type == op_type) {
         SgExpression *assign = SageBuilder::buildAssignOp(lhs, rhs);
         std::vector<SgExpression *> semantic_args{lhs, rhs};
-        clang::FunctionDecl *direct_callee =
-            llvm::dyn_cast_or_null<clang::FunctionDecl>(
-                markClangDeclObjectDefinedByKind(
-                    readClangApiValueDefined([&]() {
-                      return cxx_operator_call_expr->getDirectCallee();
-                    })));
+        clang::FunctionDecl *direct_callee = direct_operator_callee();
         attach_member_operator_semantic_call(assign, direct_callee,
                                              semantic_args);
         *node = assign;
@@ -10841,12 +11541,7 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
 
   if (!has_explicit_template_args && !preserve_unary_deref_call &&
       !operator_result_is_callable()) {
-    if (clang::FunctionDecl *direct_callee =
-            llvm::dyn_cast_or_null<clang::FunctionDecl>(
-                markClangDeclObjectDefinedByKind(
-                    readClangApiValueDefined([&]() {
-                      return cxx_operator_call_expr->getDirectCallee();
-                    })))) {
+    if (clang::FunctionDecl *direct_callee = direct_operator_callee()) {
       if (llvm::isa<clang::CXXMethodDecl>(direct_callee) &&
           cxx_operator_call_expr->getNumArgs() == 1) {
         switch (cxx_operator_call_expr->getOperator()) {
@@ -10877,9 +11572,7 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
   }
 
   if (!has_explicit_template_args && !preserve_unary_deref_call &&
-      readClangApiValueDefined([&]() {
-        return cxx_operator_call_expr->getDirectCallee();
-      }) == nullptr) {
+      direct_operator_callee() == nullptr) {
     clang::Expr *callee = cxx_operator_call_expr->getCallee();
     clang::Expr *base_callee =
         callee != nullptr ? callee->IgnoreParenImpCasts() : nullptr;
@@ -10896,11 +11589,7 @@ bool ClangToSageTranslator::VisitCXXOperatorCallExpr(
   // the first argument, while ROSE represents it as a dot/arrow expression in
   // the call's callee. Convert member-operator calls into the ROSE form to
   // preserve correct operator arity and unparsing.
-  if (clang::FunctionDecl *direct_callee =
-          llvm::dyn_cast_or_null<clang::FunctionDecl>(
-              markClangDeclObjectDefinedByKind(readClangApiValueDefined([&]() {
-                return cxx_operator_call_expr->getDirectCallee();
-              })))) {
+  if (clang::FunctionDecl *direct_callee = direct_operator_callee()) {
     if (llvm::isa<clang::CXXMethodDecl>(direct_callee) &&
         cxx_operator_call_expr->getNumArgs() > 0) {
       // operator[] is special: ROSE's unparser expects the implicit object to
@@ -12010,30 +12699,38 @@ bool ClangToSageTranslator::VisitCompoundLiteralExpr(
   // REX FIX: Check if the type is defined inside the compound literal
   // If so, mark the declaration as non-autonomous so it gets unparsed
   // correctly
-  if (clang::TypeSourceInfo *TInfo = compound_literal->getTypeSourceInfo()) {
-    clang::TypeLoc TL = TInfo->getTypeLoc();
+  if (clang::TypeSourceInfo *TInfo =
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return compound_literal->getTypeSourceInfo(); }))) {
+    clang::TypeLoc TL =
+        readClangTypeLocDefined([&]() { return TInfo->getTypeLoc(); });
     // Drill down to the underlying TagTypeLoc, stripping common wrappers
     // (const qualifiers, parens, attributes, arrays, pointers, elaborations).
     while (true) {
       bool advanced = false;
 
       // Strip top-level qualifiers
-      TL = TL.getUnqualifiedLoc();
+      TL = readClangTypeLocDefined([&]() { return TL.getUnqualifiedLoc(); });
 
-      if (auto ParenTL = TL.getAs<clang::ParenTypeLoc>()) {
-        TL = ParenTL.getInnerLoc();
+      if (auto ParenTL = readClangTypeLocDefined(
+              [&]() { return TL.getAs<clang::ParenTypeLoc>(); })) {
+        TL = readClangTypeLocDefined([&]() { return ParenTL.getInnerLoc(); });
         advanced = true;
-      } else if (auto AttrTL = TL.getAs<clang::AttributedTypeLoc>()) {
-        TL = AttrTL.getModifiedLoc();
+      } else if (auto AttrTL = readClangTypeLocDefined(
+                     [&]() { return TL.getAs<clang::AttributedTypeLoc>(); })) {
+        TL = readClangTypeLocDefined([&]() { return AttrTL.getModifiedLoc(); });
         advanced = true;
-      } else if (auto AdjTL = TL.getAs<clang::AdjustedTypeLoc>()) {
-        TL = AdjTL.getOriginalLoc();
+      } else if (auto AdjTL = readClangTypeLocDefined(
+                     [&]() { return TL.getAs<clang::AdjustedTypeLoc>(); })) {
+        TL = readClangTypeLocDefined([&]() { return AdjTL.getOriginalLoc(); });
         advanced = true;
-      } else if (auto ATL = TL.getAs<clang::ArrayTypeLoc>()) {
-        TL = ATL.getElementLoc();
+      } else if (auto ATL = readClangTypeLocDefined(
+                     [&]() { return TL.getAs<clang::ArrayTypeLoc>(); })) {
+        TL = readClangTypeLocDefined([&]() { return ATL.getElementLoc(); });
         advanced = true;
-      } else if (auto PTL = TL.getAs<clang::PointerTypeLoc>()) {
-        TL = PTL.getPointeeLoc();
+      } else if (auto PTL = readClangTypeLocDefined(
+                     [&]() { return TL.getAs<clang::PointerTypeLoc>(); })) {
+        TL = readClangTypeLocDefined([&]() { return PTL.getPointeeLoc(); });
         advanced = true;
       }
 
@@ -12041,9 +12738,12 @@ bool ClangToSageTranslator::VisitCompoundLiteralExpr(
         break;
     }
 
-    if (auto TagTL = TL.getAs<clang::TagTypeLoc>()) {
+    if (auto TagTL = readClangTypeLocDefined(
+            [&]() { return TL.getAs<clang::TagTypeLoc>(); })) {
       if (TagTL.isDefinition()) {
-        clang::TagDecl *TD = TagTL.getDecl();
+        clang::TagDecl *TD =
+            llvm::cast<clang::TagDecl>(markClangDeclObjectDefinedByKind(
+                readClangApiValueDefined([&]() { return TagTL.getDecl(); })));
         auto it = p_decl_translation_map.find(TD);
         if (it != p_decl_translation_map.end()) {
           SgNode *node = it->second;
@@ -12502,7 +13202,8 @@ bool ClangToSageTranslator::VisitCXXConstructExpr(
     if (cxx_construct_expr->getNumArgs() == 1) {
       clang::Expr *same_type_source = peel_same_type_implicit_conversion_object(
           cxx_construct_expr->getArg(0), cxx_construct_expr->getType(),
-          cxx_construct_expr->getSourceRange());
+          readClangApiValueDefined(
+              [&]() { return cxx_construct_expr->getSourceRange(); }));
       if (same_type_source != nullptr) {
         if (SgNode *elided_node = Traverse(same_type_source)) {
           if (SgExpression *elided_expr = isSgExpression(elided_node)) {
@@ -12649,8 +13350,7 @@ bool ClangToSageTranslator::VisitCXXConstructExpr(
     SgClassDeclaration *enclosingClassDecl = nullptr;
     if (ctor_decl != nullptr) {
       if (clang::CXXRecordDecl *parent_record =
-              llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                  markClangDeclObjectDefinedByKind(ctor_decl->getParent()))) {
+              clangCXXMethodDeclParentDefined(ctor_decl)) {
         enclosingClassDecl = isSgClassDeclaration(Traverse(parent_record));
       }
     }
@@ -12780,7 +13480,9 @@ bool ClangToSageTranslator::VisitCXXDeleteExpr(
   // Examples: delete ptr; or delete[] array;
 
   // Get the expression being deleted
-  clang::Expr *arg_expr = cxx_delete_expr->getArgument();
+  clang::Expr *arg_expr =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return cxx_delete_expr->getArgument(); }));
   SgNode *tmp_arg = arg_expr ? Traverse(arg_expr) : nullptr;
   SgExpression *arg = isSgExpression(tmp_arg);
 
@@ -12790,7 +13492,8 @@ bool ClangToSageTranslator::VisitCXXDeleteExpr(
   }
 
   // Check if this is array delete (delete[]) or single object delete (delete)
-  bool is_array = cxx_delete_expr->isArrayForm();
+  bool is_array = readClangApiValueDefined(
+      [&]() { return cxx_delete_expr->isArrayForm(); });
 
   // Build the delete expression
   *node = SageBuilder::buildDeleteExp(arg, is_array, false, nullptr);
@@ -12932,9 +13635,13 @@ bool ClangToSageTranslator::VisitCXXDependentScopeMemberExpr(
     clang::DeclContextLookupResult lookup = readClangApiValueDefined(
         [&]() { return record_def->lookup(member_name_decl); });
     std::vector<clang::FieldDecl *> matching_fields;
-    for (clang::NamedDecl *member_decl : lookup) {
+    for (clang::NamedDecl *member_decl :
+         readClangLookupResultDeclsDefined(lookup)) {
+      member_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+          markClangDeclObjectDefinedByKind(member_decl));
       if (clang::FieldDecl *field_decl =
-              llvm::dyn_cast_or_null<clang::FieldDecl>(member_decl)) {
+              llvm::dyn_cast_or_null<clang::FieldDecl>(
+                  markClangDeclObjectDefinedByKind(member_decl))) {
         matching_fields.push_back(field_decl);
       }
     }
@@ -13138,10 +13845,14 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
   std::cerr << "ClangToSageTranslator::VisitCXXNewExpr" << std::endl;
 #endif
   bool res = true;
-  clang::QualType allocatedType = cxx_new_expr->getAllocatedType();
+  cxx_new_expr = markClangCxxNewStorageDefined(cxx_new_expr);
+  clang::QualType allocatedType =
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return cxx_new_expr->getAllocatedType(); }));
   SgType *allocated_sg_type = nullptr;
   if (clang::TypeSourceInfo *allocated_type_info =
-          cxx_new_expr->getAllocatedTypeSourceInfo()) {
+          markClangTypeSourceInfoDefined(readClangApiValueDefined(
+              [&]() { return cxx_new_expr->getAllocatedTypeSourceInfo(); }))) {
     allocated_sg_type = buildTypeFromTypeLoc(allocated_type_info->getTypeLoc());
   }
   if (allocated_sg_type == nullptr) {
@@ -13154,9 +13865,14 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
   };
 
   SgExprListExp *placementArgs = nullptr;
-  if (cxx_new_expr->getNumPlacementArgs() > 0) {
+  const unsigned num_placement_args = readClangApiValueDefined(
+      [&]() { return cxx_new_expr->getNumPlacementArgs(); });
+  if (num_placement_args > 0) {
     placementArgs = SageBuilder::buildExprListExp();
-    for (clang::Expr *placementArg : cxx_new_expr->placement_arguments()) {
+    for (unsigned i = 0; i < num_placement_args; ++i) {
+      clang::Expr *placementArg =
+          markClangExprObjectDefinedByClass(readClangApiValueDefined(
+              [&]() { return cxx_new_expr->getPlacementArg(i); }));
       SgNode *tmpArg = Traverse(placementArg);
       if (SgExpression *expr = isSgExpression(tmpArg)) {
         placementArgs->append_expression(expr);
@@ -13166,14 +13882,20 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
 
   SgConstructorInitializer *constructor_args = nullptr;
   if (const clang::CXXConstructExpr *construct_expr =
-          cxx_new_expr->getConstructExpr()) {
+          llvm::dyn_cast_or_null<clang::CXXConstructExpr>(
+              markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+                  [&]() { return cxx_new_expr->getConstructExpr(); })))) {
     SgNode *constructorInitializer =
         Traverse(const_cast<clang::CXXConstructExpr *>(construct_expr));
     constructor_args = isSgConstructorInitializer(constructorInitializer);
   }
 
-  if (constructor_args == nullptr && cxx_new_expr->hasInitializer()) {
-    clang::Expr *initializer = cxx_new_expr->getInitializer();
+  const bool has_initializer = readClangApiValueDefined(
+      [&]() { return cxx_new_expr->hasInitializer(); });
+  if (constructor_args == nullptr && has_initializer) {
+    clang::Expr *initializer =
+        markClangExprObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return cxx_new_expr->getInitializer(); }));
     if (initializer != nullptr) {
       SgNode *translated_initializer = Traverse(initializer);
       if (SgConstructorInitializer *ctor_init =
@@ -13196,7 +13918,9 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
         constructor_args->set_is_braced_initialized(
             llvm::isa<clang::InitListExpr>(initializer) ||
             llvm::isa<clang::CXXStdInitializerListExpr>(initializer));
-        applySourceRange(constructor_args, initializer->getSourceRange());
+        applySourceRange(constructor_args, readClangApiValueDefined([&]() {
+                           return initializer->getSourceRange();
+                         }));
       } else if (translated_initializer != nullptr) {
         std::cerr << "Runtime error: CXXNewExpr initializer did not translate "
                      "into SgExpression."
@@ -13207,11 +13931,13 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
     }
   }
 
-  if (cxx_new_expr->isArray()) {
+  if (readClangApiValueDefined([&]() { return cxx_new_expr->isArray(); })) {
     SgExpression *array_size = nullptr;
     if (const std::optional<clang::Expr *> size_expr_opt =
-            cxx_new_expr->getArraySize()) {
-      if (clang::Expr *size_expr = *size_expr_opt) {
+            readClangApiValueDefined(
+                [&]() { return cxx_new_expr->getArraySize(); })) {
+      if (clang::Expr *size_expr =
+              markClangExprObjectDefinedByClass(*size_expr_opt)) {
         SgNode *translated_size = Traverse(size_expr);
         array_size = isSgExpression(translated_size);
         ROSE_ASSERT(array_size != nullptr);
@@ -13221,20 +13947,27 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
     new_expr_type = SageBuilder::buildArrayType(allocated_sg_type, array_size);
   }
 
-  SgNode *clangFuncDecl = Traverse(cxx_new_expr->getOperatorNew());
+  SgNode *clangFuncDecl =
+      Traverse(markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+          [&]() { return cxx_new_expr->getOperatorNew(); })));
   if (constructor_args != nullptr) {
     // (4/28/23 Pei-Hung) The type name is given through sg_type,
     // SgConstructorInitializer doesn't seem to provide name for unparsing.
     constructor_args->set_need_name(false);
     if (const clang::CXXConstructExpr *construct_expr =
-            cxx_new_expr->getConstructExpr()) {
-      clangFuncDecl = Traverse(construct_expr->getConstructor());
+            llvm::dyn_cast_or_null<clang::CXXConstructExpr>(
+                markClangStmtObjectDefinedByClass(readClangApiValueDefined(
+                    [&]() { return cxx_new_expr->getConstructExpr(); })))) {
+      clangFuncDecl =
+          Traverse(markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return construct_expr->getConstructor(); })));
     }
   }
   SgFunctionDeclaration *sgFuncDecl = isSgFunctionDeclaration(clangFuncDecl);
 
   SgExpression *builtin_args = nullptr;
-  short int need_global_specifier = (short int)cxx_new_expr->isGlobalNew();
+  short int need_global_specifier = (short int)readClangApiValueDefined(
+      [&]() { return cxx_new_expr->isGlobalNew(); });
 
   SgNewExp *newExp =
       SageBuilder::buildNewExp(new_expr_type, placementArgs, constructor_args,
@@ -13248,7 +13981,8 @@ bool ClangToSageTranslator::VisitCXXNewExpr(clang::CXXNewExpr *cxx_new_expr,
   if (builtin_args != nullptr) {
     builtin_args->set_parent(newExp);
   }
-  newExp->set_type_id_is_parenthesized(cxx_new_expr->isParenTypeId());
+  newExp->set_type_id_is_parenthesized(readClangApiValueDefined(
+      [&]() { return cxx_new_expr->isParenTypeId(); }));
   *node = newExp;
 
   return VisitExpr(cxx_new_expr, node) && res;
@@ -13329,28 +14063,40 @@ bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(
             << std::endl;
 #endif
   bool res = true;
+  cxx_pseudo_destructor_expr = static_cast<clang::CXXPseudoDestructorExpr *>(
+      markClangStmtObjectDefinedByClass(cxx_pseudo_destructor_expr));
 
   // Clang models pseudo-destructor calls as
   // CallExpr(callee=CXXPseudoDestructorExpr). Build the callee structurally so
   // the enclosing SgFunctionCallExp can emit the call parentheses without
   // duplication.
 
-  SgNode *tmp_base = Traverse(cxx_pseudo_destructor_expr->getBase());
+  clang::Expr *clang_base =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return cxx_pseudo_destructor_expr->getBase(); }));
+  SgNode *tmp_base = Traverse(clang_base);
   SgExpression *base = isSgExpression(tmp_base);
   ROSE_ASSERT(base != nullptr);
 
   SgType *destroyed_type = nullptr;
-  if (clang::TypeSourceInfo *type_info =
-          cxx_pseudo_destructor_expr->getDestroyedTypeInfo()) {
-    destroyed_type = buildTypeFromQualifiedType(type_info->getType());
+  clang::TypeSourceInfo *type_info =
+      markClangTypeSourceInfoDefined(readClangApiValueDefined([&]() {
+        return cxx_pseudo_destructor_expr->getDestroyedTypeInfo();
+      }));
+  if (type_info != nullptr) {
+    destroyed_type = buildTypeFromQualifiedType(markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return type_info->getType(); })));
   } else {
-    if (const clang::IdentifierInfo *id =
-            cxx_pseudo_destructor_expr->getDestroyedTypeIdentifier()) {
-      destroyed_type =
-          SageBuilder::buildTemplateType(SgName(id->getName().str()));
+    if (const clang::IdentifierInfo *id = readClangApiValueDefined([&]() {
+          return cxx_pseudo_destructor_expr->getDestroyedTypeIdentifier();
+        })) {
+      destroyed_type = SageBuilder::buildTemplateType(SgName(
+          readClangApiValueDefined([&]() { return id->getName(); }).str()));
     } else {
       clang::QualType qual_type =
-          cxx_pseudo_destructor_expr->getDestroyedType();
+          markClangQualTypeDefined(readClangApiValueDefined([&]() {
+            return cxx_pseudo_destructor_expr->getDestroyedType();
+          }));
       if (!qual_type.isNull()) {
         destroyed_type = buildTypeFromQualifiedType(qual_type);
       }
@@ -13367,20 +14113,26 @@ bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(
   ROSE_ASSERT(pseudo_dtor != nullptr);
   pseudo_dtor->post_construction_initialization();
 
-  clang::SourceLocation tilde_loc = cxx_pseudo_destructor_expr->getTildeLoc();
+  clang::SourceLocation tilde_loc = readClangApiValueDefined(
+      [&]() { return cxx_pseudo_destructor_expr->getTildeLoc(); });
   clang::SourceLocation name_end_loc;
-  if (clang::TypeSourceInfo *type_info =
-          cxx_pseudo_destructor_expr->getDestroyedTypeInfo()) {
-    name_end_loc = type_info->getTypeLoc().getEndLoc();
+  if (type_info != nullptr) {
+    clang::TypeLoc destroyed_type_loc =
+        readClangTypeLocDefined([&]() { return type_info->getTypeLoc(); });
+    name_end_loc = readClangApiValueDefined(
+        [&]() { return destroyed_type_loc.getEndLoc(); });
   }
+  clang::SourceRange expr_range = readClangApiValueDefined(
+      [&]() { return cxx_pseudo_destructor_expr->getSourceRange(); });
   if (tilde_loc.isValid() && name_end_loc.isValid()) {
     applySourceRange(pseudo_dtor, clang::SourceRange(tilde_loc, name_end_loc));
   } else {
-    applySourceRange(pseudo_dtor, cxx_pseudo_destructor_expr->getSourceRange());
+    applySourceRange(pseudo_dtor, expr_range);
   }
 
   SgExpression *callee = nullptr;
-  if (cxx_pseudo_destructor_expr->isArrow()) {
+  if (readClangApiValueDefined(
+          [&]() { return cxx_pseudo_destructor_expr->isArrow(); })) {
     callee =
         SageBuilder::buildBinaryExpression_nfi<SgArrowExp>(base, pseudo_dtor);
   } else {
@@ -13388,7 +14140,7 @@ bool ClangToSageTranslator::VisitCXXPseudoDestructorExpr(
         SageBuilder::buildBinaryExpression_nfi<SgDotExp>(base, pseudo_dtor);
   }
   ROSE_ASSERT(callee != nullptr);
-  applySourceRange(callee, cxx_pseudo_destructor_expr->getSourceRange());
+  applySourceRange(callee, expr_range);
 
   *node = callee;
 
@@ -13514,7 +14266,11 @@ bool ClangToSageTranslator::VisitCXXStdInitializerListExpr(
 #endif
   bool res = true;
 
-  clang::Expr *sub_expr = cxx_std_initializer_list_expr->getSubExpr();
+  cxx_std_initializer_list_expr = markClangCxxStdInitializerListStorageDefined(
+      cxx_std_initializer_list_expr);
+  clang::Expr *sub_expr =
+      markClangExprObjectDefinedByClass(readClangApiValueDefined(
+          [&]() { return cxx_std_initializer_list_expr->getSubExpr(); }));
   if (sub_expr == nullptr) {
     std::cerr << "Runtime error: CXXStdInitializerListExpr has no subexpr."
               << std::endl;
@@ -13548,11 +14304,14 @@ bool ClangToSageTranslator::VisitCXXStdInitializerListExpr(
     expr_list->append_expression(expr);
   }
 
-  SgType *init_list_type =
-      buildTypeFromQualifiedType(cxx_std_initializer_list_expr->getType());
+  SgType *init_list_type = buildTypeFromQualifiedType(
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return cxx_std_initializer_list_expr->getType(); })));
   SgAggregateInitializer *agg_init =
       SageBuilder::buildAggregateInitializer_nfi(expr_list, init_list_type);
-  applySourceRange(agg_init, cxx_std_initializer_list_expr->getSourceRange());
+  applySourceRange(agg_init, readClangApiValueDefined([&]() {
+                     return cxx_std_initializer_list_expr->getSourceRange();
+                   }));
   *node = agg_init;
 
   return VisitExpr(cxx_std_initializer_list_expr, node) && res;
@@ -13854,14 +14613,84 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   decl_ref_expr = static_cast<clang::DeclRefExpr *>(
       markClangStmtObjectDefinedByClass(decl_ref_expr));
   markClangStmtChildrenDefined(decl_ref_expr);
-  markClangValueDeclObjectDefinedByKind(decl_ref_expr->getDecl());
+  clang::ValueDecl *decl_ref_decl = markClangValueDeclObjectDefinedByKind(
+      readClangApiValueDefined([&]() { return decl_ref_expr->getDecl(); }));
+  ROSE_ASSERT(decl_ref_decl != nullptr);
+
+  auto read_decl_context =
+      [](const clang::Decl *decl) -> const clang::DeclContext * {
+    decl = markClangDeclObjectDefinedByKind(decl);
+    if (decl == nullptr) {
+      return nullptr;
+    }
+    return markClangDeclContextObjectDefined(
+        readClangApiValueDefined([&]() { return decl->getDeclContext(); }));
+  };
+  auto read_lexical_decl_context =
+      [](const clang::Decl *decl) -> const clang::DeclContext * {
+    decl = markClangDeclObjectDefinedByKind(decl);
+    if (decl == nullptr) {
+      return nullptr;
+    }
+    return markClangDeclContextObjectDefined(readClangApiValueDefined(
+        [&]() { return decl->getLexicalDeclContext(); }));
+  };
+  auto read_mutable_decl_context =
+      [&](const clang::Decl *decl) -> clang::DeclContext * {
+    return const_cast<clang::DeclContext *>(read_decl_context(decl));
+  };
+  auto read_decl_context_parent =
+      [](const clang::DeclContext *ctx) -> const clang::DeclContext * {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    if (ctx == nullptr) {
+      return nullptr;
+    }
+    return markClangDeclContextObjectDefined(
+        readClangApiValueDefined([&]() { return ctx->getParent(); }));
+  };
+  auto context_decl = [](const clang::DeclContext *ctx) -> const clang::Decl * {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    if (ctx == nullptr) {
+      return nullptr;
+    }
+    return markClangDeclObjectDefinedByKind(
+        clang::Decl::castFromDeclContext(ctx));
+  };
+  auto strip_linkage_context =
+      [&](const clang::DeclContext *ctx) -> const clang::DeclContext * {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    while (const clang::Decl *decl = context_decl(ctx)) {
+      if (!llvm::isa<clang::LinkageSpecDecl>(decl)) {
+        break;
+      }
+      ctx = read_decl_context_parent(ctx);
+    }
+    return ctx;
+  };
+  auto context_is_translation_unit = [](const clang::DeclContext *ctx) -> bool {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    return ctx != nullptr &&
+           readClangApiValueDefined([&]() { return ctx->isTranslationUnit(); });
+  };
+  auto context_is_namespace = [](const clang::DeclContext *ctx) -> bool {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    return ctx != nullptr &&
+           readClangApiValueDefined([&]() { return ctx->isNamespace(); });
+  };
+  auto context_is_record = [](const clang::DeclContext *ctx) -> bool {
+    ctx = markClangDeclContextObjectDefined(ctx);
+    return ctx != nullptr &&
+           readClangApiValueDefined([&]() { return ctx->isRecord(); });
+  };
+
   if (clang::NonTypeTemplateParmDecl *non_type_param =
-          llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(
-              decl_ref_expr->getDecl())) {
+          llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(decl_ref_decl)) {
     SgDeclarationStatement *owning_template = nullptr;
-    if (clang::DeclContext *ctx = non_type_param->getDeclContext()) {
+    if (clang::DeclContext *ctx = read_mutable_decl_context(non_type_param)) {
       if (clang::TemplateDecl *template_ctx =
-              llvm::dyn_cast<clang::TemplateDecl>(ctx)) {
+              llvm::dyn_cast<clang::TemplateDecl>(
+                  markClangDeclObjectDefinedByKind(
+                      clang::Decl::castFromDeclContext(ctx)))) {
         auto it = p_decl_translation_map.find(template_ctx);
         if (it != p_decl_translation_map.end()) {
           owning_template = isSgDeclarationStatement(it->second);
@@ -13910,19 +14739,22 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
         canonical_name = nonreal_type->get_name().getString();
       }
       if (const clang::Decl *canonical_decl =
-              non_type_param->getCanonicalDecl()) {
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return non_type_param->getCanonicalDecl(); }))) {
         if (canonical_name.empty()) {
           if (const clang::NonTypeTemplateParmDecl *canonical_nttp =
                   llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(
                       canonical_decl)) {
-            canonical_name = normalizeClangTemplateParamName(
-                canonical_nttp->getNameAsString());
+            canonical_name =
+                normalizeClangTemplateParamName(readClangApiValueDefined(
+                    [&]() { return canonical_nttp->getNameAsString(); }));
           }
         }
       }
       if (canonical_name.empty()) {
         canonical_name =
-            normalizeClangTemplateParamName(non_type_param->getNameAsString());
+            normalizeClangTemplateParamName(readClangApiValueDefined(
+                [&]() { return non_type_param->getNameAsString(); }));
       }
       param_val->set_valueString(canonical_name);
       if (sg_param->get_type() != nullptr) {
@@ -13967,23 +14799,21 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   };
 
   auto clang_context_is_namespace_or_tu =
-      [](const clang::DeclContext *ctx) -> bool {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
-    }
-    return ctx != nullptr && (ctx->isNamespace() || ctx->isTranslationUnit());
+      [&](const clang::DeclContext *ctx) -> bool {
+    ctx = strip_linkage_context(ctx);
+    return ctx != nullptr &&
+           (context_is_namespace(ctx) || context_is_translation_unit(ctx));
   };
-  auto clang_context_is_class_like = [](const clang::DeclContext *ctx) -> bool {
-    while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-      ctx = ctx->getParent();
-    }
+  auto clang_context_is_class_like =
+      [&](const clang::DeclContext *ctx) -> bool {
+    ctx = strip_linkage_context(ctx);
     if (ctx == nullptr) {
       return false;
     }
-    if (ctx->isRecord()) {
+    if (context_is_record(ctx)) {
       return true;
     }
-    if (const clang::Decl *ctx_decl = llvm::dyn_cast<clang::Decl>(ctx)) {
+    if (const clang::Decl *ctx_decl = context_decl(ctx)) {
       return llvm::isa<clang::ClassTemplateDecl>(ctx_decl) ||
              llvm::isa<clang::ClassTemplateSpecializationDecl>(ctx_decl) ||
              llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(ctx_decl);
@@ -13999,46 +14829,62 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     auto has_namespace_scope_primary_template =
         [&](const clang::FunctionDecl *func) -> bool {
       clang::FunctionTemplateDecl *primary_template =
-          func->getPrimaryTemplate();
+          static_cast<clang::FunctionTemplateDecl *>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return func->getPrimaryTemplate(); })));
       if (primary_template == nullptr) {
         if (const clang::FunctionTemplateSpecializationInfo *spec_info =
-                func->getTemplateSpecializationInfo()) {
-          primary_template = spec_info->getTemplate();
+                markClangAstObjectDefined(readClangApiValueDefined(
+                    [&]() { return func->getTemplateSpecializationInfo(); }))) {
+          primary_template = static_cast<clang::FunctionTemplateDecl *>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return spec_info->getTemplate(); })));
         }
       }
-      if (primary_template == nullptr ||
-          primary_template->getTemplatedDecl() == nullptr) {
+      clang::FunctionDecl *templated_decl =
+          primary_template != nullptr
+              ? static_cast<clang::FunctionDecl *>(
+                    markClangDeclObjectDefinedByKind(
+                        readClangApiValueDefined([&]() {
+                          return primary_template->getTemplatedDecl();
+                        })))
+              : nullptr;
+      if (templated_decl == nullptr) {
         return false;
       }
 
-      clang::FunctionDecl *templated_decl =
-          primary_template->getTemplatedDecl();
       return clang_context_is_namespace_or_tu(
-                 templated_decl->getDeclContext()) &&
+                 read_decl_context(templated_decl)) &&
              clang_context_is_namespace_or_tu(
-                 templated_decl->getLexicalDeclContext());
+                 read_lexical_decl_context(templated_decl));
     };
 
     if (has_namespace_scope_primary_template(clang_func)) {
       return false;
     }
 
-    if (clang_func->getFriendObjectKind() != clang::Decl::FOK_None) {
+    if (readClangApiValueDefined([&]() {
+          return clang_func->getFriendObjectKind();
+        }) != clang::Decl::FOK_None) {
       return true;
     }
 
-    const clang::DeclContext *semantic_ctx = clang_func->getDeclContext();
-    const clang::DeclContext *lexical_ctx = clang_func->getLexicalDeclContext();
+    const clang::DeclContext *semantic_ctx = read_decl_context(clang_func);
+    const clang::DeclContext *lexical_ctx =
+        read_lexical_decl_context(clang_func);
     if (clang_context_is_namespace_or_tu(semantic_ctx) &&
         (clang_context_is_class_like(lexical_ctx) ||
          clang_context_is_class_like(semantic_ctx))) {
       return true;
     }
 
-    const clang::FunctionDecl *first_decl = clang_func->getFirstDecl();
+    const clang::FunctionDecl *first_decl =
+        static_cast<const clang::FunctionDecl *>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return clang_func->getFirstDecl(); })));
     return first_decl != nullptr && first_decl != clang_func &&
-           (clang_context_is_class_like(first_decl->getDeclContext()) ||
-            clang_context_is_class_like(first_decl->getLexicalDeclContext()));
+           (clang_context_is_class_like(read_decl_context(first_decl)) ||
+            clang_context_is_class_like(read_lexical_decl_context(first_decl)));
   };
 
   auto translated_hidden_friend_ref_decl =
@@ -14266,7 +15112,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
       };
   if (force_global_scope) {
     if (clang::FunctionDecl *clang_func =
-            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
       ensure_global_function_decl_symbol(clang_func);
     }
   }
@@ -14279,8 +15125,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
         return;
       }
       SgScopeStatement *resolved_scope = nullptr;
-      if (clang::DeclContext *ctx =
-              decl_ref_expr->getDecl()->getDeclContext()) {
+      if (clang::DeclContext *ctx = read_mutable_decl_context(decl_ref_decl)) {
         resolved_scope =
             resolveScopeFromDeclContext(ctx, SageBuilder::topScopeStack());
       }
@@ -14418,7 +15263,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     };
     if (!decl_ref_qualifier) {
       if (clang::FunctionDecl *clang_func =
-              llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+              llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
         if (is_adl_only_friend_function(clang_func)) {
           expr->set_name_qualification_length(0);
           expr->set_global_qualification_required(false);
@@ -14440,7 +15285,9 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   // referenced from user code. Translation is deferred until the TU pass
   // completes to avoid ordering issues.
   if (clang::FunctionDecl *func_decl =
-          llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+          llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
+    func_decl = llvm::cast<clang::FunctionDecl>(
+        markClangDeclObjectDefinedByKind(func_decl));
     clang::TemplateSpecializationKind kind =
         func_decl->getTemplateSpecializationKind();
     if (kind == clang::TSK_ImplicitInstantiation ||
@@ -14494,7 +15341,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
               namespaceDeclStmt->get_definition();
           if (namespaceDefinition != nullptr) {
             SageBuilder::pushScopeStack(namespaceDefinition);
-            sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+            sym = GetSymbolFromSymbolTable(decl_ref_decl);
             SageBuilder::popScopeStack();
           }
         }
@@ -14513,9 +15360,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           }
           if (classDef == nullptr) {
             if (clang::CXXRecordDecl *definitionDecl =
-                    llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-                        markClangDeclObjectDefinedByKind(
-                            cxxRecordDecl->getDefinition()))) {
+                    clangCXXRecordDefinitionDefined(cxxRecordDecl)) {
               SgNode *def_node = TraverseOnDemand(definitionDecl);
               if (SgClassDeclaration *def_decl =
                       isSgClassDeclaration(def_node)) {
@@ -14534,7 +15379,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           }
           ROSE_ASSERT(classDef != nullptr);
           SageBuilder::pushScopeStack(classDef);
-          sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+          sym = GetSymbolFromSymbolTable(decl_ref_decl);
           SageBuilder::popScopeStack();
         }
       } else if (clang::NamespaceAliasDecl *namespaceAliasDecl =
@@ -14549,16 +15394,17 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           SgNamespaceDefinitionStatement *namespaceDefinition =
               namespaceDeclStmt->get_definition();
           SageBuilder::pushScopeStack(namespaceDefinition);
-          sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+          sym = GetSymbolFromSymbolTable(decl_ref_decl);
           SageBuilder::popScopeStack();
         }
       } else if (qualifier.getKind() ==
                  clang::NestedNameSpecifier::Kind::Global) {
         SgGlobal *globalScope =
             SageInterface::getGlobalScope(SageBuilder::topScopeStack());
-        std::string declName = decl_ref_expr->getDecl()->getNameAsString();
+        std::string declName = readClangApiValueDefined(
+            [&]() { return decl_ref_decl->getNameAsString(); });
         if (clang::FunctionDecl *clang_func =
-                llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+                llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
           if (SgFunctionType *func_type = isSgFunctionType(
                   buildTypeFromQualifiedType(clang_func->getType()))) {
             sym = globalScope->lookup_nontemplate_function_symbol(
@@ -14590,10 +15436,10 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   }
 
   if (clang::VarDecl *var_decl =
-          llvm::dyn_cast<clang::VarDecl>(decl_ref_expr->getDecl())) {
-    if (var_decl->isStaticDataMember()) {
+          llvm::dyn_cast<clang::VarDecl>(decl_ref_decl)) {
+    if (clangVarDeclIsStaticDataMemberDefined(var_decl)) {
       auto resolve_static_member_scope = [&]() -> SgScopeStatement * {
-        clang::DeclContext *ctx = var_decl->getDeclContext();
+        clang::DeclContext *ctx = read_mutable_decl_context(var_decl);
         if (ctx == nullptr) {
           return nullptr;
         }
@@ -14609,9 +15455,12 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
         }
         if (clang::CXXRecordDecl *record =
                 llvm::dyn_cast<clang::CXXRecordDecl>(ctx)) {
-          clang::CXXRecordDecl *record_def = record->getDefinition() != nullptr
-                                                 ? record->getDefinition()
-                                                 : record;
+          record = markClangSpecificDeclDefined(record);
+          clang::CXXRecordDecl *record_def =
+              clangCXXRecordDefinitionDefined(record);
+          if (record_def == nullptr) {
+            record_def = record;
+          }
           if (record_def != nullptr) {
             if (SgDeclarationStatement *decl = lookupSgDeclarationForClangDecl(
                     record_def,
@@ -14701,7 +15550,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   }
 
   if (sym == nullptr) {
-    sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+    sym = GetSymbolFromSymbolTable(decl_ref_decl);
   }
 
   auto symbol_has_missing_function_declaration = [](SgSymbol *symbol) -> bool {
@@ -14927,7 +15776,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
   };
 
   if (clang::CXXMethodDecl *clang_method =
-          llvm::dyn_cast<clang::CXXMethodDecl>(decl_ref_expr->getDecl())) {
+          llvm::dyn_cast<clang::CXXMethodDecl>(decl_ref_decl)) {
     SgMemberFunctionSymbol *method_sym = isSgMemberFunctionSymbol(sym);
     if (method_sym != nullptr && method_sym->get_declaration() == nullptr) {
       method_sym = nullptr;
@@ -14989,7 +15838,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
 
   if (sym != nullptr) {
     if (clang::FunctionDecl *clang_func =
-            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
       if (isSgTemplateFunctionSymbol(sym) != nullptr &&
           !llvm::isa<clang::CXXMethodDecl>(clang_func) &&
           clang_func->getDescribedFunctionTemplate() == nullptr &&
@@ -15057,7 +15906,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     // specialization.
     if (decl_ref_expr->hasExplicitTemplateArgs()) {
       if (clang::FunctionDecl *clang_func =
-              llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+              llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
         if (clang::CXXMethodDecl *method_decl =
                 llvm::dyn_cast<clang::CXXMethodDecl>(clang_func)) {
           clang::TemplateArgumentListInfo arg_info;
@@ -15065,7 +15914,8 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           const size_t explicit_arg_count =
               countExpandedTemplateArguments(arg_info);
 
-          clang::CXXRecordDecl *parent_decl = method_decl->getParent();
+          clang::CXXRecordDecl *parent_decl =
+              clangCXXMethodDeclParentDefined(method_decl);
           SgScopeStatement *class_scope = nullptr;
           if (parent_decl != nullptr) {
             SgNode *parent_node = nullptr;
@@ -15187,7 +16037,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
 
     SgNode *tmp_decl = nullptr;
     SgScopeStatement *decl_scope_hint = nullptr;
-    if (clang::DeclContext *ctx = decl_ref_expr->getDecl()->getDeclContext()) {
+    if (clang::DeclContext *ctx = read_mutable_decl_context(decl_ref_decl)) {
       decl_scope_hint =
           resolveScopeFromDeclContext(ctx, SageBuilder::topScopeStack());
     }
@@ -15204,7 +16054,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     }
 
     if (clang::FunctionDecl *clang_func =
-            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
       if (p_decl_translation_in_progress.find(clang_func) !=
           p_decl_translation_in_progress.end()) {
         if (clang::FunctionTemplateDecl *primary =
@@ -15242,12 +16092,12 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     }
 
     if (tmp_decl == nullptr) {
-      tmp_decl = lookupSgDeclarationForClangDecl(decl_ref_expr->getDecl(),
+      tmp_decl = lookupSgDeclarationForClangDecl(decl_ref_decl,
                                                  /*allow_on_demand=*/true);
     }
 
     if (tmp_decl == nullptr) {
-      tmp_decl = Traverse(decl_ref_expr->getDecl());
+      tmp_decl = Traverse(decl_ref_decl);
     }
 
     if (SgTemplateInstantiationDirectiveStatement *inst_directive =
@@ -15263,9 +16113,12 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     }
 
     if (tmp_decl == nullptr) {
-      clang::ValueDecl *clang_decl = decl_ref_expr->getDecl();
+      clang::ValueDecl *clang_decl = decl_ref_decl;
       clang::Decl *canonical_decl =
-          clang_decl != nullptr ? clang_decl->getCanonicalDecl() : nullptr;
+          clang_decl != nullptr
+              ? markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return clang_decl->getCanonicalDecl(); }))
+              : nullptr;
       clang::SourceManager &source_manager =
           p_compiler_instance->getSourceManager();
       auto format_loc = [&](clang::SourceLocation loc) -> std::string {
@@ -15308,8 +16161,9 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
                 << (canonical_decl != nullptr &&
                     p_decl_translation_on_demand.count(canonical_decl) != 0);
       if (clang_decl != nullptr) {
-        if (clang::DeclContext *ctx = clang_decl->getDeclContext()) {
-          if (clang::Decl *ctx_decl = llvm::dyn_cast<clang::Decl>(ctx)) {
+        if (clang::DeclContext *ctx = read_mutable_decl_context(clang_decl)) {
+          if (clang::Decl *ctx_decl = markClangDeclObjectDefinedByKind(
+                  clang::Decl::castFromDeclContext(ctx))) {
             std::cerr << " declContextKind=" << ctx_decl->getDeclKindName();
             if (clang::NamedDecl *named_ctx =
                     llvm::dyn_cast<clang::NamedDecl>(ctx_decl)) {
@@ -15326,7 +16180,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     ROSE_ASSERT(tmp_decl != nullptr);
 
     if (clang::FunctionDecl *clang_func =
-            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
       if (should_materialize_implicit_c_function_decl_for_ref(
               clang_func, p_compiler_instance)) {
         materialize_implicit_c_function_decl_before_use(
@@ -15349,7 +16203,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
 #endif
 
     if (tmp_decl != nullptr) {
-      sym = GetSymbolFromSymbolTable(decl_ref_expr->getDecl());
+      sym = GetSymbolFromSymbolTable(decl_ref_decl);
       if (symbol_has_missing_function_declaration(sym)) {
         sym = nullptr;
       }
@@ -15506,7 +16360,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     if (sym == nullptr && isSgInitializedName(tmp_decl) != nullptr) {
       SgInitializedName *init_name = isSgInitializedName(tmp_decl);
 
-      if (llvm::isa<clang::EnumConstantDecl>(decl_ref_expr->getDecl())) {
+      if (llvm::isa<clang::EnumConstantDecl>(decl_ref_decl)) {
         SgScopeStatement *init_scope =
             normalizeNamespaceScope(init_name->get_scope());
         if (init_scope == nullptr) {
@@ -15586,7 +16440,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     }
 
     if (clang::FunctionDecl *clang_func =
-            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_expr->getDecl())) {
+            llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
       if (should_materialize_implicit_c_function_decl_for_ref(
               clang_func, p_compiler_instance)) {
         SgFunctionDeclaration *referenced_decl = nullptr;
@@ -15620,8 +16474,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
       SgExpression *ref_exp = nullptr;
       const bool explicit_variable_template_ref =
           decl_ref_expr->hasExplicitTemplateArgs() &&
-          (llvm::isa<clang::VarTemplateSpecializationDecl>(
-               decl_ref_expr->getDecl()) ||
+          (llvm::isa<clang::VarTemplateSpecializationDecl>(decl_ref_decl) ||
            isSgTemplateVariableSymbol(sym) != nullptr);
       const bool build_nonreal_ref =
           explicit_variable_template_ref ||
@@ -15637,7 +16490,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           if (template_args.empty()) {
             if (clang::VarTemplateSpecializationDecl *spec_decl =
                     llvm::dyn_cast<clang::VarTemplateSpecializationDecl>(
-                        decl_ref_expr->getDecl())) {
+                        decl_ref_decl)) {
               const clang::TemplateArgumentList &clang_args =
                   spec_decl->getTemplateArgs();
               for (unsigned i = 0; i < clang_args.size(); ++i) {
@@ -15659,7 +16512,9 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
         ref_exp = buildNonrealRefExpFromNestedNameSpecifier(
             structuralQualifierForExplicitlyQualifiedNonrealRef(
                 decl_ref_qualifier),
-            scope, SgName(decl_ref_expr->getDecl()->getNameAsString()),
+            scope, SgName(readClangApiValueDefined([&]() {
+              return decl_ref_decl->getNameAsString();
+            })),
             decl_ref_expr->hasTemplateKeyword(), template_args_ptr);
         attach_explicit_qualifier(ref_exp);
       }
@@ -15686,8 +16541,8 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
                 static_cast<SgSymbol *>(func_sym)));
       }
 
-      clang::FunctionDecl *clang_func = llvm::dyn_cast<clang::FunctionDecl>(
-          markClangValueDeclObjectDefinedByKind(decl_ref_expr->getDecl()));
+      clang::FunctionDecl *clang_func =
+          llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl);
       auto get_explicit_template_arg_info =
           [&](clang::TemplateArgumentListInfo &arg_info,
               size_t &explicit_arg_count) -> bool {
@@ -15736,7 +16591,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
         }
       }
       const bool is_member_function_decl =
-          llvm::isa<clang::CXXMethodDecl>(decl_ref_expr->getDecl());
+          llvm::isa<clang::CXXMethodDecl>(decl_ref_decl);
       // Restrict on-the-fly instantiation synthesis to unqualified explicit
       // template-argument references, except member-function templates where
       // explicit args are carried by instantiation declarations.
@@ -15966,8 +16821,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
 
             SgType *lookup_type = sym_type;
             if (clang::FunctionDecl *clang_func =
-                    llvm::dyn_cast<clang::FunctionDecl>(
-                        decl_ref_expr->getDecl())) {
+                    llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
               if (SgType *clang_type =
                       buildTypeFromQualifiedType(clang_func->getType())) {
                 if (isSgMemberFunctionType(clang_type) != nullptr ||
@@ -16171,7 +17025,9 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           SgExpression *ref_exp = buildNonrealRefExpFromNestedNameSpecifier(
               structuralQualifierForExplicitlyQualifiedNonrealRef(
                   decl_ref_qualifier),
-              scope, SgName(decl_ref_expr->getDecl()->getNameAsString()),
+              scope, SgName(readClangApiValueDefined([&]() {
+                return decl_ref_decl->getNameAsString();
+              })),
               decl_ref_expr->hasTemplateKeyword(), template_args_ptr);
           attach_explicit_qualifier(ref_exp);
           *node = ref_exp;
@@ -16192,12 +17048,14 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           };
 
           SgScopeStatement *func_scope = func_sym->get_scope();
-          if (SgScopeStatement *decl_scope =
-                  get_decl_namespace_scope(decl_ref_expr->getFoundDecl())) {
+          if (SgScopeStatement *decl_scope = get_decl_namespace_scope(
+                  llvm::dyn_cast_or_null<clang::NamedDecl>(
+                      markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                          [&]() { return decl_ref_expr->getFoundDecl(); }))))) {
             func_scope = decl_scope;
           } else if (SgScopeStatement *decl_scope = get_decl_namespace_scope(
                          llvm::dyn_cast_or_null<clang::NamedDecl>(
-                             decl_ref_expr->getDecl()))) {
+                             decl_ref_decl))) {
             func_scope = decl_scope;
           }
           if (func_scope == nullptr) {
@@ -16263,8 +17121,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           if (!reused_instantiation) {
             SgType *lookup_type = func_sym->get_type();
             if (clang::FunctionDecl *clang_func =
-                    llvm::dyn_cast<clang::FunctionDecl>(
-                        decl_ref_expr->getDecl())) {
+                    llvm::dyn_cast<clang::FunctionDecl>(decl_ref_decl)) {
               if (SgType *clang_type =
                       buildTypeFromQualifiedType(clang_func->getType())) {
                 if (isSgFunctionType(clang_type) != nullptr ||
@@ -16462,11 +17319,10 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
 
           if (enum_decl == nullptr) {
             if (const clang::EnumConstantDecl *enum_const_decl =
-                    llvm::dyn_cast<clang::EnumConstantDecl>(
-                        decl_ref_expr->getDecl())) {
+                    llvm::dyn_cast<clang::EnumConstantDecl>(decl_ref_decl)) {
               if (const clang::EnumDecl *clang_enum_decl =
                       llvm::dyn_cast<clang::EnumDecl>(
-                          enum_const_decl->getDeclContext())) {
+                          context_decl(read_decl_context(enum_const_decl)))) {
                 SgDeclarationStatement *translated_decl =
                     lookupSgDeclarationForClangDecl(
                         const_cast<clang::EnumDecl *>(clang_enum_decl),
@@ -16503,8 +17359,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
           }
 
           if (const clang::EnumConstantDecl *enum_const_decl =
-                  llvm::dyn_cast<clang::EnumConstantDecl>(
-                      decl_ref_expr->getDecl())) {
+                  llvm::dyn_cast<clang::EnumConstantDecl>(decl_ref_decl)) {
             enum_value = enum_const_decl->getInitVal().getExtValue();
           }
 
@@ -16538,7 +17393,7 @@ bool ClangToSageTranslator::VisitDeclRefExpr(clang::DeclRefExpr *decl_ref_expr,
     }
   } else {
     // ROOT CAUSE FIX: Handle template-dependent and unresolved declarations
-    clang::Decl *clang_decl = decl_ref_expr->getDecl();
+    clang::Decl *clang_decl = decl_ref_decl;
     std::string decl_name = "unresolved_symbol";
 
     // Get declaration name and type info for better handling
@@ -16633,15 +17488,23 @@ bool ClangToSageTranslator::VisitDependentScopeDeclRefExpr(
     template_args_ptr = &template_args;
   }
 
+  dependent_scope_decl_ref_expr =
+      markClangAstObjectDefined(dependent_scope_decl_ref_expr);
+
   clang::NestedNameSpecifierLoc qualifier_loc =
-      dependent_scope_decl_ref_expr->getQualifierLoc();
+      markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+          [&]() { return dependent_scope_decl_ref_expr->getQualifierLoc(); }));
   const clang::NestedNameSpecifierLoc *qualifier_loc_ptr =
-      qualifier_loc.getNestedNameSpecifier() ? &qualifier_loc : nullptr;
+      getClangNestedNameSpecifierLocSpecifierDefined(qualifier_loc)
+          ? &qualifier_loc
+          : nullptr;
 
   clang::NestedNameSpecifier lookup_qualifier =
-      dependent_scope_decl_ref_expr->getQualifier();
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return dependent_scope_decl_ref_expr->getQualifier(); }));
   if (!lookup_qualifier && qualifier_loc_ptr != nullptr) {
-    lookup_qualifier = qualifier_loc_ptr->getNestedNameSpecifier();
+    lookup_qualifier =
+        getClangNestedNameSpecifierLocSpecifierDefined(*qualifier_loc_ptr);
   }
 
   *node = buildNonrealRefExpFromNestedNameSpecifier(
@@ -16673,7 +17536,7 @@ bool ClangToSageTranslator::VisitDesignatedInitExpr(
       markClangStmtObjectDefinedByClass(designated_init_expr));
   markClangStmtChildrenDefined(designated_init_expr);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     auto designators = designated_init_expr->designators();
     if (designators.data() != nullptr && !designators.empty()) {
       VALGRIND_MAKE_MEM_DEFINED(
@@ -17235,7 +18098,8 @@ bool ClangToSageTranslator::VisitIntegerLiteral(
   std::cerr << "ClangToSageTranslator::VisitIntegerLiteral" << std::endl;
 #endif
   SgValueExp *value_exp = nullptr;
-  const clang::QualType literal_type = integer_literal->getType();
+  const clang::QualType literal_type = markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return integer_literal->getType(); }));
   const clang::BuiltinType *builtin_type =
       literal_type->getAs<clang::BuiltinType>();
   const llvm::APInt value = integer_literal->getValue();
@@ -17382,15 +18246,21 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
 #if DEBUG_VISIT_STMT
   std::cerr << "ClangToSageTranslator::VisitLambdaExpr" << std::endl;
 #endif
+  lambda_expr = llvm::cast<clang::LambdaExpr>(
+      markClangStmtObjectDefinedByClass(lambda_expr));
   bool res = true;
 
   // Get the lambda class (closure type) from Clang
   const clang::CXXRecordDecl *clang_lambda_class =
-      lambda_expr->getLambdaClass();
+      llvm::cast_or_null<clang::CXXRecordDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return lambda_expr->getLambdaClass(); })));
 
   // Get the call operator (operator()) from Clang
   const clang::CXXMethodDecl *clang_call_operator =
-      lambda_expr->getCallOperator();
+      llvm::cast_or_null<clang::CXXMethodDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return lambda_expr->getCallOperator(); })));
 
   // Convert Clang lambda class to ROSE class declaration
   SgClassDeclaration *lambda_closure_class = nullptr;
@@ -17601,23 +18471,38 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
       lambda_capture_scope = lambda_closure_class->get_scope();
     }
   }
-  unsigned total_captures = lambda_expr->capture_size();
+  const unsigned total_captures =
+      readClangApiValueDefined([&]() { return lambda_expr->capture_size(); });
   unsigned capture_index = 0;
-  for (auto capture_it = lambda_expr->capture_begin();
-       capture_it != lambda_expr->capture_end();
+  auto capture_begin =
+      readClangApiValueDefined([&]() { return lambda_expr->capture_begin(); });
+  auto capture_end =
+      readClangApiValueDefined([&]() { return lambda_expr->capture_end(); });
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind() && total_captures > 0 &&
+      capture_begin != capture_end) {
+    VALGRIND_MAKE_MEM_DEFINED(
+        const_cast<clang::LambdaCapture *>(&*capture_begin),
+        total_captures * sizeof(clang::LambdaCapture));
+  }
+#endif
+  for (auto capture_it = capture_begin; capture_it != capture_end;
        ++capture_it, ++capture_index) {
-    const clang::LambdaCapture &capture = *capture_it;
+    const clang::LambdaCapture &capture = markClangValueDefined(*capture_it);
     SgExpression *capture_expression = nullptr;
     bool handled_capture = false;
 
-    if (capture.capturesThis()) {
+    if (readClangApiValueDefined([&]() { return capture.capturesThis(); })) {
       SgSymbol *this_symbol =
           findEnclosingThisSymbol(SageBuilder::topScopeStack());
       ROSE_ASSERT(this_symbol != nullptr);
       capture_expression = SageBuilder::buildThisExp_nfi(this_symbol);
       handled_capture = true;
-    } else if (capture.capturesVariable()) {
-      clang::ValueDecl *captured_val = capture.getCapturedVar();
+    } else if (readClangApiValueDefined(
+                   [&]() { return capture.capturesVariable(); })) {
+      clang::ValueDecl *captured_val = llvm::cast_or_null<clang::ValueDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return capture.getCapturedVar(); })));
       clang::VarDecl *captured_var =
           llvm::dyn_cast_or_null<clang::VarDecl>(captured_val);
       if (captured_var != nullptr) {
@@ -17625,7 +18510,9 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
         // duplicate decls)
         SgSymbol *captured_symbol = GetSymbolFromSymbolTable(captured_var);
         if (captured_symbol == nullptr) {
-          clang::VarDecl *canonical_decl = captured_var->getCanonicalDecl();
+          clang::VarDecl *canonical_decl = llvm::cast_or_null<clang::VarDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return captured_var->getCanonicalDecl(); })));
           if (canonical_decl != captured_var) {
             captured_symbol = GetSymbolFromSymbolTable(canonical_decl);
           }
@@ -17635,16 +18522,19 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
                 isSgVariableSymbol(captured_symbol)) {
           capture_expression = SageBuilder::buildVarRefExp(var_symbol);
           handled_capture = true;
-        } else if (captured_var->isInitCapture()) {
+        } else if (readClangApiValueDefined(
+                       [&]() { return captured_var->isInitCapture(); })) {
           // Init-captures introduce names in lambda-local context, not the
           // enclosing file/block scope.
-          SgName capture_name(captured_var->getNameAsString());
+          SgName capture_name(readClangApiValueDefined(
+              [&]() { return captured_var->getNameAsString(); }));
           capture_expression = SageBuilder::buildDanglingVarRefExp(
               capture_name, lambda_capture_scope);
           handled_capture = true;
         }
       }
-    } else if (capture.capturesVLAType()) {
+    } else if (readClangApiValueDefined(
+                   [&]() { return capture.capturesVLAType(); })) {
       // VLA captures are represented on the closure type; nothing to emit in
       // capture list.
       continue;
@@ -17654,19 +18544,32 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
       continue;
     }
 
-    bool is_init_capture = lambda_expr->isInitCapture(&capture);
-    clang::LambdaCaptureKind capture_kind = capture.getCaptureKind();
+    bool is_init_capture = readClangApiValueDefined(
+        [&]() { return lambda_expr->isInitCapture(&capture); });
+    clang::LambdaCaptureKind capture_kind =
+        readClangApiValueDefined([&]() { return capture.getCaptureKind(); });
     bool capture_by_reference =
         (capture_kind == clang::LCK_ByRef || capture_kind == clang::LCK_This);
 
     SgLambdaCapture *sg_capture =
         SageBuilder::buildLambdaCapture(capture_expression, nullptr, nullptr);
     sg_capture->set_capture_by_reference(capture_by_reference);
-    sg_capture->set_implicit(capture.isImplicit());
-    sg_capture->set_pack_expansion(capture.isPackExpansion());
+    sg_capture->set_implicit(
+        readClangApiValueDefined([&]() { return capture.isImplicit(); }));
+    sg_capture->set_pack_expansion(
+        readClangApiValueDefined([&]() { return capture.isPackExpansion(); }));
     if (is_init_capture && capture_index < total_captures) {
+      auto capture_init_begin = readClangApiValueDefined(
+          [&]() { return lambda_expr->capture_init_begin(); });
+#if ROSE_USE_VALGRIND
+      if (clangFrontendRunningOnValgrind() && capture_init_begin != nullptr) {
+        VALGRIND_MAKE_MEM_DEFINED(capture_init_begin,
+                                  total_captures * sizeof(clang::Expr *));
+      }
+#endif
       clang::Expr *clang_init_expr =
-          lambda_expr->capture_init_begin()[capture_index];
+          markClangExprObjectDefinedByClass(readClangApiValueDefined(
+              [&]() { return capture_init_begin[capture_index]; }));
       if (clang_init_expr != nullptr) {
         SgNode *init_node = Traverse(clang_init_expr);
         if (SgExpression *init_expr = isSgExpression(init_node)) {
@@ -17684,18 +18587,24 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
       lambda_capture_list, lambda_closure_class, lambda_function);
   ROSE_ASSERT(built_lambda != nullptr);
 
-  clang::LambdaCaptureDefault capture_default =
-      lambda_expr->getCaptureDefault();
+  clang::LambdaCaptureDefault capture_default = readClangApiValueDefined(
+      [&]() { return lambda_expr->getCaptureDefault(); });
   bool has_default_capture = (capture_default != clang::LCD_None);
   built_lambda->set_capture_default(has_default_capture);
   built_lambda->set_default_is_by_reference(capture_default ==
                                             clang::LCD_ByRef);
-  built_lambda->set_has_parameter_decl(lambda_expr->hasExplicitParameters());
-  built_lambda->set_is_mutable(lambda_expr->isMutable());
-  built_lambda->set_explicit_return_type(lambda_expr->hasExplicitResultType());
+  built_lambda->set_has_parameter_decl(readClangApiValueDefined(
+      [&]() { return lambda_expr->hasExplicitParameters(); }));
+  built_lambda->set_is_mutable(
+      readClangApiValueDefined([&]() { return lambda_expr->isMutable(); }));
+  built_lambda->set_explicit_return_type(readClangApiValueDefined(
+      [&]() { return lambda_expr->hasExplicitResultType(); }));
 
-  applySourceRange(built_lambda, lambda_expr->getSourceRange());
-  if (clang::Stmt *lambda_body = lambda_expr->getBody()) {
+  applySourceRange(built_lambda, readClangApiValueDefined([&]() {
+                     return lambda_expr->getSourceRange();
+                   }));
+  if (clang::Stmt *lambda_body = markClangStmtObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return lambda_expr->getBody(); }))) {
     auto mark_source_backed_for_output = [](SgLocatedNode *node) {
       if (node == nullptr) {
         return;
@@ -17735,16 +18644,22 @@ bool ClangToSageTranslator::VisitLambdaExpr(clang::LambdaExpr *lambda_expr,
             current->get_firstNondefiningDeclaration()));
         enqueue(isSgFunctionDeclaration(current->get_definingDeclaration()));
         if (clang_call_operator != nullptr) {
-          applySourceRange(current, clang_call_operator->getSourceRange());
+          applySourceRange(current, readClangApiValueDefined([&]() {
+                             return clang_call_operator->getSourceRange();
+                           }));
           mark_source_backed_for_output(current);
         }
         if (SgFunctionDefinition *lambda_def = current->get_definition()) {
           if (clang_call_operator != nullptr) {
-            applySourceRange(lambda_def, clang_call_operator->getSourceRange());
+            applySourceRange(lambda_def, readClangApiValueDefined([&]() {
+                               return clang_call_operator->getSourceRange();
+                             }));
             mark_source_backed_for_output(lambda_def);
           }
           if (SgBasicBlock *lambda_body_block = lambda_def->get_body()) {
-            applySourceRange(lambda_body_block, lambda_body->getSourceRange());
+            applySourceRange(lambda_body_block, readClangApiValueDefined([&]() {
+                               return lambda_body->getSourceRange();
+                             }));
             mark_source_backed_for_output(lambda_body_block);
           }
         }
@@ -17802,14 +18717,17 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   std::cerr << "MemberExpr::hasQualifier() " << member_expr->hasQualifier()
             << std::endl;
 #endif
-  member_expr = static_cast<clang::MemberExpr *>(
-      markClangStmtObjectDefinedByClass(member_expr));
+  member_expr = markClangMemberExprStorageDefined(member_expr);
   markClangStmtChildrenDefined(member_expr);
 
   bool res = true;
 
-  clang::Expr *member_base = llvm::dyn_cast_or_null<clang::Expr>(
-      markClangStmtObjectDefinedByClass(member_expr->getBase()));
+  clang::Expr *member_base = markClangExprObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return member_expr->getBase(); }));
+  clang::ValueDecl *raw_member_decl = markClangValueDeclObjectDefinedByKind(
+      readClangApiValueDefined([&]() { return member_expr->getMemberDecl(); }));
+  const bool member_has_qualifier =
+      readClangApiValueDefined([&]() { return member_expr->hasQualifier(); });
   bool implicit_access = isImplicitCxxThisAfterMarking(member_base);
   auto is_instance_member_access = [&](clang::ValueDecl *decl) {
     if (decl == nullptr) {
@@ -17825,9 +18743,8 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
     return false;
   };
 
-  bool materialize_implicit_base =
-      implicit_access && member_expr->hasQualifier() &&
-      is_instance_member_access(member_expr->getMemberDecl());
+  bool materialize_implicit_base = implicit_access && member_has_qualifier &&
+                                   is_instance_member_access(raw_member_decl);
 
   SgExpression *base = nullptr;
   if (!implicit_access || materialize_implicit_base) {
@@ -17873,7 +18790,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   };
 
   clang::ValueDecl *member_decl =
-      normalize_member_decl_for_lookup(member_expr->getMemberDecl());
+      normalize_member_decl_for_lookup(raw_member_decl);
 
   SgSymbol *sym = GetSymbolFromSymbolTable(member_decl);
 
@@ -17890,7 +18807,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   }
 
   if (clang::CXXMethodDecl *clang_method =
-          llvm::dyn_cast<clang::CXXMethodDecl>(member_expr->getMemberDecl())) {
+          llvm::dyn_cast<clang::CXXMethodDecl>(raw_member_decl)) {
     auto mark_translated_member_special_modifiers =
         [&](SgFunctionDeclaration *decl) {
           if (decl == nullptr) {
@@ -17980,9 +18897,10 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
         }
       }
 
-      if (clang::Expr *clang_base = member_expr->getBase()) {
-        if (SgType *base_type =
-                buildTypeFromQualifiedType(clang_base->getType())) {
+      if (clang::Expr *clang_base = member_base) {
+        if (SgType *base_type = buildTypeFromQualifiedType(
+                markClangQualTypeDefined(readClangApiValueDefined(
+                    [&]() { return clang_base->getType(); })))) {
           return scope_from_type(base_type);
         }
       }
@@ -18348,8 +19266,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
     sg_member_expr = SageBuilder::buildVarRefExp(var_sym);
   } else if (func_sym != nullptr) { // C++ member function
     sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
-        func_sym, false,
-        member_expr->hasQualifier());     // FIXME 2nd and 3rd params ?
+        func_sym, false, member_has_qualifier); // FIXME 2nd and 3rd params ?
   } else if (plain_func_sym != nullptr) { // Regular function treated as member
                                           // (e.g., static member or inherited)
     sg_member_expr = SageBuilder::buildFunctionRefExp(plain_func_sym);
@@ -18558,8 +19475,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
         }
         if (isSgMemberFunctionSymbol(sym)) {
           sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
-              isSgMemberFunctionSymbol(sym), false,
-              member_expr->hasQualifier());
+              isSgMemberFunctionSymbol(sym), false, member_has_qualifier);
         }
       }
       // Also handle regular function declarations that might be static members
@@ -18626,8 +19542,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
         }
         if (isSgMemberFunctionSymbol(sym)) {
           sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
-              isSgMemberFunctionSymbol(sym), false,
-              member_expr->hasQualifier());
+              isSgMemberFunctionSymbol(sym), false, member_has_qualifier);
         } else if (isSgFunctionSymbol(sym)) {
           sg_member_expr =
               SageBuilder::buildFunctionRefExp(isSgFunctionSymbol(sym));
@@ -18717,15 +19632,16 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
         return SageBuilder::buildVarRefExp(sym);
       };
 
-      if (clang::ValueDecl *member_decl = member_expr->getMemberDecl()) {
+      if (clang::ValueDecl *member_decl = raw_member_decl) {
         if (llvm::isa<clang::FieldDecl>(member_decl) ||
             llvm::isa<clang::VarDecl>(member_decl)) {
           sg_member_expr = build_member_var_ref(member_decl);
         }
       }
 
-      std::string member_name = member_expr->getMemberNameInfo().getAsString();
-      clang::ValueDecl *member_decl = member_expr->getMemberDecl();
+      std::string member_name = readClangApiValueDefined(
+          [&]() { return member_expr->getMemberNameInfo().getAsString(); });
+      clang::ValueDecl *member_decl = raw_member_decl;
       if (sg_member_expr == nullptr && member_decl) {
         std::cerr << "Warning: Cannot resolve "
                   << member_decl->getDeclKindName() << " member '"
@@ -18752,7 +19668,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   }
 
   clang::FunctionDecl *clang_func =
-      llvm::dyn_cast<clang::FunctionDecl>(member_expr->getMemberDecl());
+      llvm::dyn_cast<clang::FunctionDecl>(raw_member_decl);
   if (const clang::CXXConversionDecl *clang_conversion_decl =
           llvm::dyn_cast_or_null<clang::CXXConversionDecl>(clang_func)) {
     if (func_sym != nullptr) {
@@ -18770,11 +19686,21 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   auto get_explicit_template_arg_info =
       [&](clang::TemplateArgumentListInfo &arg_info,
           size_t &explicit_arg_count) -> bool {
-    if (!member_expr->hasExplicitTemplateArgs()) {
+    if (!readClangApiValueDefined(
+            [&]() { return member_expr->hasExplicitTemplateArgs(); })) {
       return false;
     }
 
-    member_expr->copyTemplateArgumentsInto(arg_info);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      member_expr->copyTemplateArgumentsInto(arg_info);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      member_expr->copyTemplateArgumentsInto(arg_info);
+    }
     explicit_arg_count = countExpandedTemplateArguments(arg_info);
     return true;
   };
@@ -18802,7 +19728,10 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
   if (has_explicit_template_args || has_deduced_template_args) {
     ExplicitTemplateArgumentSourceInfo source_info =
         scanExplicitTemplateArgumentsForExprSource(
-            member_expr->getSourceRange(), member_expr->getEndLoc(),
+            readClangApiValueDefined(
+                [&]() { return member_expr->getSourceRange(); }),
+            readClangApiValueDefined(
+                [&]() { return member_expr->getEndLoc(); }),
             p_compiler_instance);
     if (source_info.has_template_argument_list) {
       explicit_arg_count = source_info.argument_count;
@@ -19088,9 +20017,10 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
           receiver_scope = scope_from_type(base->get_type());
         }
         if (receiver_scope == nullptr) {
-          if (clang::Expr *clang_base = member_expr->getBase()) {
-            if (SgType *base_type =
-                    buildTypeFromQualifiedType(clang_base->getType())) {
+          if (clang::Expr *clang_base = member_base) {
+            if (SgType *base_type = buildTypeFromQualifiedType(
+                    markClangQualTypeDefined(readClangApiValueDefined(
+                        [&]() { return clang_base->getType(); })))) {
               receiver_scope = scope_from_type(base_type);
             }
           }
@@ -19272,9 +20202,10 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
             return scope;
           }
         }
-        if (clang::Expr *clang_base = member_expr->getBase()) {
-          if (SgType *base_type =
-                  buildTypeFromQualifiedType(clang_base->getType())) {
+        if (clang::Expr *clang_base = member_base) {
+          if (SgType *base_type = buildTypeFromQualifiedType(
+                  markClangQualTypeDefined(readClangApiValueDefined(
+                      [&]() { return clang_base->getType(); })))) {
             return scope_from_type(base_type);
           }
         }
@@ -19447,7 +20378,7 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
           ensure_template_instantiation_symbol(func_sym);
       if (inst_sym != nullptr) {
         sg_member_expr = SageBuilder::buildMemberFunctionRefExp_nfi(
-            inst_sym, false, member_expr->hasQualifier());
+            inst_sym, false, member_has_qualifier);
         func_sym = inst_sym;
       }
     }
@@ -19466,12 +20397,15 @@ bool ClangToSageTranslator::VisitMemberExpr(clang::MemberExpr *member_expr,
 
   ROSE_ASSERT(sg_member_expr != nullptr);
 
-  if (member_expr->hasQualifier() && p_compiler_instance != nullptr) {
+  if (member_has_qualifier && p_compiler_instance != nullptr) {
     clang::NestedNameSpecifierLoc qualifier_loc =
-        member_expr->getQualifierLoc();
+        markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+            [&]() { return member_expr->getQualifierLoc(); }));
     const clang::NestedNameSpecifierLoc *qualifier_loc_ptr =
         qualifier_loc.getNestedNameSpecifier() ? &qualifier_loc : nullptr;
-    clang::NestedNameSpecifier qualifier = member_expr->getQualifier();
+    clang::NestedNameSpecifier qualifier =
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return member_expr->getQualifier(); }));
     if (!qualifier && qualifier_loc_ptr != nullptr) {
       qualifier = qualifier_loc_ptr->getNestedNameSpecifier();
     }
@@ -20034,13 +20968,17 @@ bool ClangToSageTranslator::VisitOverloadExpr(
     if (should_materialize_overload_candidates(overload_expr)) {
       for (auto it = overload_expr->decls_begin();
            it != overload_expr->decls_end(); ++it) {
-        clang::NamedDecl *named_decl = it.getDecl();
+        clang::NamedDecl *named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+            markClangDeclObjectDefinedByKind(
+                readClangApiValueDefined([&]() { return it.getDecl(); })));
         if (named_decl == nullptr) {
           continue;
         }
         if (clang::UsingShadowDecl *shadow =
                 llvm::dyn_cast<clang::UsingShadowDecl>(named_decl)) {
-          named_decl = shadow->getTargetDecl();
+          named_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return shadow->getTargetDecl(); })));
         }
         clang::Decl *decl = llvm::dyn_cast<clang::Decl>(named_decl);
         if (decl == nullptr) {
@@ -20213,7 +21151,8 @@ bool ClangToSageTranslator::VisitUnresolvedLookupExpr(
 
       SgScopeStatement *member_scope =
           normalize_class_like_scope(resolveScopeFromDeclContext(
-              const_cast<clang::CXXRecordDecl *>(method_decl->getParent()),
+              clangCXXMethodDeclParentDefined(
+                  const_cast<clang::CXXMethodDecl *>(method_decl)),
               current_scope));
       return member_scope != nullptr &&
              member_scope != current_class_like_scope;
@@ -20320,18 +21259,20 @@ bool ClangToSageTranslator::VisitUnresolvedLookupExpr(
       }
       method_decl = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(
           markClangDeclObjectDefinedByKind(method_decl));
-      if (method_decl == nullptr || method_decl->getParent() == nullptr) {
+      const clang::CXXRecordDecl *candidate_record =
+          clangCXXMethodDeclParentDefined(
+              const_cast<clang::CXXMethodDecl *>(method_decl));
+      if (method_decl == nullptr || candidate_record == nullptr) {
         return nullptr;
       }
 
-      const clang::CXXRecordDecl *candidate_record =
-          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-              markClangDeclObjectDefinedByKind(method_decl->getParent()));
       if (const clang::CXXRecordDecl *definition =
               llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
                   markClangDeclObjectDefinedByKind(
                       candidate_record != nullptr
-                          ? candidate_record->getDefinition()
+                          ? clangCXXRecordDefinitionDefined(
+                                const_cast<clang::CXXRecordDecl *>(
+                                    candidate_record))
                           : nullptr))) {
         candidate_record = definition;
       }
@@ -20410,14 +21351,17 @@ bool ClangToSageTranslator::VisitUnresolvedMemberExpr(
 #endif
   bool res = true;
 
+  unresolved_member_expr =
+      markClangUnresolvedMemberStorageDefined(unresolved_member_expr);
+
   // ROOT CAUSE FIX: UnresolvedMemberExpr represents a member access expression
   // where the member couldn't be resolved at parse time (typically in
   // template-dependent code) Example: template<typename T> void foo(T t) {
   // t.bar(); }  // 'bar' is unresolved
 
   // Get the member name
-  std::string member_name =
-      getDeclarationNameAsString(unresolved_member_expr->getMemberName());
+  std::string member_name = getDeclarationNameAsString(readClangApiValueDefined(
+      [&]() { return unresolved_member_expr->getMemberName(); }));
 
   SgScopeStatement *current_scope = SageBuilder::topScopeStack();
   if (current_scope == nullptr) {
@@ -20430,37 +21374,56 @@ bool ClangToSageTranslator::VisitUnresolvedMemberExpr(
 
   // Handle the base expression (the object/pointer being accessed)
   SgExpression *base_expr = nullptr;
-  if (!unresolved_member_expr->isImplicitAccess()) {
-    SgNode *tmp_base = Traverse(unresolved_member_expr->getBase());
+  if (!readClangApiValueDefined(
+          [&]() { return unresolved_member_expr->isImplicitAccess(); })) {
+    SgNode *tmp_base =
+        Traverse(markClangExprObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return unresolved_member_expr->getBase(); })));
     base_expr = isSgExpression(tmp_base);
     ROSE_ASSERT(base_expr != nullptr);
   }
 
   SgTemplateArgumentPtrList template_args;
   const SgTemplateArgumentPtrList *template_args_ptr = nullptr;
-  if (unresolved_member_expr->hasExplicitTemplateArgs()) {
+  if (readClangApiValueDefined([&]() {
+        return unresolved_member_expr->hasExplicitTemplateArgs();
+      })) {
     clang::TemplateArgumentListInfo arg_info;
-    unresolved_member_expr->copyTemplateArgumentsInto(arg_info);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      unresolved_member_expr->copyTemplateArgumentsInto(arg_info);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      unresolved_member_expr->copyTemplateArgumentsInto(arg_info);
+    }
     template_args = buildTemplateArguments(arg_info, true);
     template_args_ptr = &template_args;
   }
 
+  clang::NestedNameSpecifier lookup_qualifier =
+      markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return unresolved_member_expr->getQualifier(); }));
   SgNonrealRefExp *member_ref = buildNonrealRefExpFromNestedNameSpecifier(
-      structuralQualifierForExplicitlyQualifiedNonrealRef(
-          unresolved_member_expr->getQualifier()),
-      current_scope, SgName(member_name),
-      unresolved_member_expr->hasTemplateKeyword(), template_args_ptr);
+      structuralQualifierForExplicitlyQualifiedNonrealRef(lookup_qualifier),
+      current_scope, SgName(member_name), readClangApiValueDefined([&]() {
+        return unresolved_member_expr->hasTemplateKeyword();
+      }),
+      template_args_ptr);
   ROSE_ASSERT(member_ref != nullptr);
   clang::NestedNameSpecifierLoc qualifier_loc =
-      unresolved_member_expr->getQualifierLoc();
+      markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+          [&]() { return unresolved_member_expr->getQualifierLoc(); }));
   const clang::NestedNameSpecifierLoc *qualifier_loc_ptr =
       qualifier_loc.getNestedNameSpecifier() ? &qualifier_loc : nullptr;
-  attachExplicitQualifierFromNestedName(member_ref,
-                                        unresolved_member_expr->getQualifier(),
+  attachExplicitQualifierFromNestedName(member_ref, lookup_qualifier,
                                         qualifier_loc_ptr, p_compiler_instance);
 
   if (base_expr != nullptr) {
-    if (unresolved_member_expr->isArrow()) {
+    if (readClangApiValueDefined(
+            [&]() { return unresolved_member_expr->isArrow(); })) {
       *node = SageBuilder::buildArrowExp(base_expr, member_ref);
     } else {
       *node = SageBuilder::buildDotExp(base_expr, member_ref);
@@ -20470,7 +21433,9 @@ bool ClangToSageTranslator::VisitUnresolvedMemberExpr(
   }
 
   if (SgExpression *expr = isSgExpression(*node)) {
-    applySourceRange(expr, unresolved_member_expr->getSourceRange());
+    applySourceRange(expr, readClangApiValueDefined([&]() {
+                       return unresolved_member_expr->getSourceRange();
+                     }));
   }
 
   return VisitOverloadExpr(unresolved_member_expr, node) && res;
@@ -20589,15 +21554,20 @@ bool ClangToSageTranslator::VisitCXXParenListInitExpr(
 #endif
   bool res = true;
 
-  SgType *constructed_type =
-      buildTypeFromQualifiedType(cxx_paren_list_init_expr->getType());
+  cxx_paren_list_init_expr =
+      markClangCxxParenListInitStorageDefined(cxx_paren_list_init_expr);
+  SgType *constructed_type = buildTypeFromQualifiedType(
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return cxx_paren_list_init_expr->getType(); })));
 
   SgExprListExp *args = SageBuilder::buildExprListExp_nfi();
-  for (clang::Expr *clang_arg : cxx_paren_list_init_expr->getInitExprs()) {
+  llvm::ArrayRef<clang::Expr *> init_exprs = readClangApiValueDefined(
+      [&]() { return cxx_paren_list_init_expr->getInitExprs(); });
+  for (clang::Expr *clang_arg : init_exprs) {
     if (clang_arg == nullptr) {
       continue;
     }
-    SgNode *tmp_arg = Traverse(clang_arg);
+    SgNode *tmp_arg = Traverse(markClangExprObjectDefinedByClass(clang_arg));
     SgExpression *arg_expr = isSgExpression(tmp_arg);
     if (arg_expr != nullptr) {
       args->append_expression(arg_expr);
@@ -20620,7 +21590,9 @@ bool ClangToSageTranslator::VisitCXXParenListInitExpr(
           false,        // need_parenthesis_after_name
           class_unknown // associated_class_unknown
       );
-  applySourceRange(ctor_init, cxx_paren_list_init_expr->getSourceRange());
+  applySourceRange(ctor_init, readClangApiValueDefined([&]() {
+                     return cxx_paren_list_init_expr->getSourceRange();
+                   }));
   *node = ctor_init;
 
   return VisitExpr(cxx_paren_list_init_expr, node) && res;
@@ -20812,8 +21784,11 @@ bool ClangToSageTranslator::VisitSizeOfPackExpr(
   // instantiation
 
   SgExpression *pack_expr = nullptr;
-  if (clang::NamedDecl *pack_decl = size_of_pack_expr->getPack()) {
-    std::string pack_name = pack_decl->getNameAsString();
+  if (clang::NamedDecl *pack_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return size_of_pack_expr->getPack(); })))) {
+    std::string pack_name = readClangApiValueDefined(
+        [&]() { return pack_decl->getNameAsString(); });
     if (!pack_name.empty()) {
       SgScopeStatement *scope = SageBuilder::topScopeStack();
       if (scope == nullptr) {
@@ -20900,7 +21875,12 @@ bool ClangToSageTranslator::VisitStmtExpr(clang::StmtExpr *stmt_expr,
 
   bool res = true;
 
-  SgNode *tmp_substmt = Traverse(stmt_expr->getSubStmt());
+  stmt_expr = static_cast<clang::StmtExpr *>(
+      markClangStmtObjectDefinedByClass(stmt_expr));
+  clang::CompoundStmt *clang_substmt =
+      static_cast<clang::CompoundStmt *>(markClangStmtObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return stmt_expr->getSubStmt(); })));
+  SgNode *tmp_substmt = Traverse(clang_substmt);
   SgStatement *substmt = isSgStatement(tmp_substmt);
   if (tmp_substmt != nullptr && substmt == nullptr) {
     std::cerr << "Runtime error: tmp_substmt != nullptr && substmt == nullptr"
@@ -21657,12 +22637,19 @@ bool ClangToSageTranslator::VisitVAArgExpr(clang::VAArgExpr *va_arg_expr,
   std::cerr << "ClangToSageTranslator::VisitVAArgExpr" << std::endl;
 #endif
 
-  SgNode *tmp_expr = Traverse(va_arg_expr->getSubExpr());
+  clang::Expr *sub_expr = markClangExprObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return va_arg_expr->getSubExpr(); }));
+  SgNode *tmp_expr = Traverse(sub_expr);
   SgExpression *expr = isSgExpression(tmp_expr);
   ROSE_ASSERT(expr != nullptr);
 
-  SgType *type =
-      buildTypeFromQualifiedType(va_arg_expr->getWrittenTypeInfo()->getType());
+  clang::TypeSourceInfo *written_type_info =
+      markClangTypeSourceInfoDefined(readClangApiValueDefined(
+          [&]() { return va_arg_expr->getWrittenTypeInfo(); }));
+  ROSE_ASSERT(written_type_info != nullptr);
+  clang::QualType written_type = markClangQualTypeDefined(
+      readClangApiValueDefined([&]() { return written_type_info->getType(); }));
+  SgType *type = buildTypeFromQualifiedType(written_type);
   ROSE_ASSERT(type != nullptr);
 
   *node = SageBuilder::buildVarArgOp_nfi(expr, type);
@@ -21727,6 +22714,8 @@ bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt *while_stmt,
 #endif
 
   bool res = true;
+  while_stmt = static_cast<clang::WhileStmt *>(
+      markClangStmtObjectDefinedByClass(markClangAstObjectDefined(while_stmt)));
 
   SgWhileStmt *sg_while_stmt =
       SageBuilder::buildWhileStmt_nfi(nullptr, nullptr);
@@ -21735,7 +22724,9 @@ bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt *while_stmt,
   SageBuilder::pushScopeStack(sg_while_stmt);
 
   SgStatement *cond_stmt = nullptr;
-  if (clang::DeclStmt *cond_decl = while_stmt->getConditionVariableDeclStmt()) {
+  if (clang::DeclStmt *cond_decl =
+          markClangDeclStmtStorageDefined(readClangApiValueDefined(
+              [&]() { return while_stmt->getConditionVariableDeclStmt(); }))) {
     SgNode *tmp_cond = Traverse(cond_decl);
     cond_stmt = isSgStatement(tmp_cond);
     if (tmp_cond != nullptr && cond_stmt == nullptr) {
@@ -21745,16 +22736,22 @@ bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt *while_stmt,
       res = false;
     }
     if (cond_stmt != nullptr) {
-      applySourceRange(cond_stmt, cond_decl->getSourceRange());
+      const clang::SourceRange cond_range = readClangApiValueDefined(
+          [&]() { return cond_decl->getSourceRange(); });
+      applySourceRange(cond_stmt, cond_range);
     }
   } else {
-    SgNode *tmp_cond = Traverse(while_stmt->getCond());
+    clang::Expr *cond_expr = markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return while_stmt->getCond(); }));
+    SgNode *tmp_cond = Traverse(cond_expr);
     SgExpression *cond = isSgExpression(tmp_cond);
     ROSE_ASSERT(cond != nullptr);
 
     cond_stmt = SageBuilder::buildExprStatement(cond);
-    if (p_compiler_instance != nullptr && while_stmt->getCond() != nullptr) {
-      applySourceRange(cond_stmt, while_stmt->getCond()->getSourceRange());
+    if (p_compiler_instance != nullptr && cond_expr != nullptr) {
+      const clang::SourceRange cond_range = readClangApiValueDefined(
+          [&]() { return cond_expr->getSourceRange(); });
+      applySourceRange(cond_stmt, cond_range);
     }
   }
 
@@ -21786,15 +22783,17 @@ bool ClangToSageTranslator::VisitWhileStmt(clang::WhileStmt *while_stmt,
   cond_stmt->set_parent(sg_while_stmt);
   sg_while_stmt->set_condition(cond_stmt);
 
-  SgNode *tmp_body = Traverse(while_stmt->getBody());
+  clang::Stmt *clang_body = markClangStmtObjectDefinedByClass(
+      readClangApiValueDefined([&]() { return while_stmt->getBody(); }));
+  SgNode *tmp_body = Traverse(clang_body);
   SgStatement *body = isSgStatement(tmp_body);
   SgExpression *expr = isSgExpression(tmp_body);
   if (expr != nullptr) {
     body = SageBuilder::buildExprStatement(expr);
-    applySourceRangeWithTrailingSemicolon(body, while_stmt->getBody());
+    applySourceRangeWithTrailingSemicolon(body, clang_body);
   }
   ROSE_ASSERT(body != nullptr);
-  body = wrapStatementWithPragmas(while_stmt->getBody(), body);
+  body = wrapStatementWithPragmas(clang_body, body);
 
   body->set_parent(sg_while_stmt);
 

--- a/src/frontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/Clang/clang-frontend-type.cpp
@@ -7,30 +7,57 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
 #include <clang/AST/APValue.h>
+#include <clang/AST/TemplateBase.h>
 
 #include <clang/Basic/AttrKinds.h>
 #include <clang/Basic/OperatorKinds.h>
 #include <clang/Lex/Lexer.h>
 
+#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallString.h>
 
 #include <functional>
-
+#include <unordered_set>
 namespace {
+static bool clangFrontendRunningOnValgrind() {
+#if ROSE_USE_VALGRIND
+  static const bool running = RUNNING_ON_VALGRIND;
+  return running;
+#else
+  return false;
+#endif
+}
+
+static void markClangAstStorageDefined(const void *address, size_t size) {
+  markClangAstStorageRangeDefinedForFrontend(address, size);
+}
+
+static void markClangPrintedStringDefined(const std::string &value) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<std::string *>(&value), sizeof(value));
+    if (!value.empty()) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<char *>(value.data()), value.size());
+    }
+  }
+#else
+  (void)value;
+#endif
+}
+
 template <typename T> T *markClangAstObjectDefined(T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     // Clang's ASTContext uses bump allocation and leaves padding/unused bits in
     // AST objects undefined. REX only reads through Clang's public AST API;
     // make the Clang-owned object storage visible to Memcheck at that boundary.
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(node, sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
@@ -38,19 +65,29 @@ template <typename T> T *markClangAstObjectDefined(T *node) {
 
 template <typename T> const T *markClangAstObjectDefined(const T *node) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
-    if (node != nullptr) {
-      VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(node), sizeof(*node));
-    }
+    markClangAstStorageDefined(node, sizeof(*node));
   }
 #endif
   return node;
 }
 
+template <typename T> const T *markClangLocalObjectDefined(const T *object) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_MAKE_MEM_DEFINED(&object, sizeof(object));
+    if (object != nullptr) {
+      VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(object), sizeof(*object));
+    }
+  }
+#endif
+  return object;
+}
+
 template <typename T> const T &markClangValueDefined(const T &value) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(&value), sizeof(value));
   }
 #endif
@@ -60,7 +97,7 @@ template <typename T> const T &markClangValueDefined(const T &value) {
 template <typename F>
 static auto readClangApiValueDefined(F &&read) -> decltype(read()) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
     auto value = read();
     VALGRIND_ENABLE_ERROR_REPORTING;
@@ -80,10 +117,48 @@ markClangExprObjectDefinedByClass(const clang::Expr *expr);
 static clang::NestedNameSpecifier
 markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier);
 
+static void
+markClangTagTypeQualifierStorageDefined(const clang::TagType *tag_type,
+                                        clang::NestedNameSpecifier qualifier) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind() || tag_type == nullptr || !qualifier) {
+    return;
+  }
+
+  const void *trailing_pointer = nullptr;
+  switch (tag_type->getTypeClass()) {
+  case clang::Type::Enum:
+    trailing_pointer = static_cast<const clang::EnumType *>(tag_type) + 1;
+    break;
+  case clang::Type::Record:
+    trailing_pointer = static_cast<const clang::RecordType *>(tag_type) + 1;
+    break;
+  case clang::Type::InjectedClassName:
+    trailing_pointer =
+        static_cast<const clang::InjectedClassNameType *>(tag_type) + 1;
+    break;
+  default:
+    break;
+  }
+  if (trailing_pointer == nullptr) {
+    return;
+  }
+
+  const std::uintptr_t raw = reinterpret_cast<std::uintptr_t>(trailing_pointer);
+  const std::uintptr_t alignment = alignof(clang::NestedNameSpecifier *);
+  const std::uintptr_t aligned = (raw + alignment - 1) & ~(alignment - 1);
+  VALGRIND_MAKE_MEM_DEFINED(reinterpret_cast<void *>(aligned),
+                            sizeof(clang::NestedNameSpecifier));
+#else
+  (void)tag_type;
+  (void)qualifier;
+#endif
+}
+
 static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(type_loc);
-  if (!RUNNING_ON_VALGRIND || type_loc.isNull()) {
+  if (!clangFrontendRunningOnValgrind() || type_loc.isNull()) {
     return;
   }
 
@@ -106,7 +181,7 @@ static void markClangTypeLocDataDefined(const clang::TypeLoc &type_loc) {
 static clang::QualType markClangQualTypeDefined(clang::QualType qual_type) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(qual_type);
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
   }
 #endif
@@ -114,27 +189,84 @@ static clang::QualType markClangQualTypeDefined(clang::QualType qual_type) {
 }
 
 static const clang::Decl *
+markClangDeclObjectDefinedByKind(const clang::Decl *decl);
+static void
+markClangDeclarationNameForPrintingDefined(const clang::NamedDecl *decl);
+static void markClangQualTypeForPrintingDefined(
+    clang::QualType qual_type,
+    llvm::SmallPtrSetImpl<const clang::Type *> &seen);
+static const clang::CXXRecordDecl *
+markClangCXXRecordTemplateOrInstantiationStateDefined(
+    const clang::CXXRecordDecl *record);
+static const clang::ClassTemplateDecl *
+markClangClassTemplateDeclForPrintingDefined(
+    const clang::ClassTemplateDecl *decl);
+static const clang::ClassTemplateSpecializationDecl *
+markClangClassTemplateSpecializationForPrintingDefined(
+    const clang::ClassTemplateSpecializationDecl *decl);
+static void markClangTemplateParameterInjectedArgumentsDefined(
+    const clang::TemplateParameterList *params,
+    const clang::ASTContext &context);
+static void markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+    const clang::TemplateParameterList *params,
+    const clang::ASTContext &context);
+
+static const clang::TemplateParameterList *
+markClangTemplateParameterListDefined(
+    const clang::TemplateParameterList *params) {
+#if ROSE_USE_VALGRIND
+  markClangValueDefined(params);
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
+    return params;
+  }
+
+  params = markClangAstObjectDefined(params);
+  const unsigned param_count =
+      readClangApiValueDefined([&]() { return params->size(); });
+  const clang::TemplateParameterList::const_iterator param_begin =
+      readClangApiValueDefined([&]() { return params->begin(); });
+  markClangValueDefined(param_begin);
+  if (param_begin != nullptr && param_count != 0) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::NamedDecl **>(param_begin),
+                              param_count * sizeof(clang::NamedDecl *));
+    for (unsigned i = 0; i < param_count; ++i) {
+      markClangDeclObjectDefinedByKind(param_begin[i]);
+    }
+  }
+#endif
+  return params;
+}
+
+static const clang::Decl *
 markClangDeclObjectDefinedByKind(const clang::Decl *decl) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(decl);
-  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
     return decl;
   }
 
   decl = markClangAstObjectDefined(decl);
   if (auto *specific =
           llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    markClangClassTemplateSpecializationForPrintingDefined(specific);
+    return specific;
   }
   if (auto *specific =
           llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    markClangClassTemplateSpecializationForPrintingDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::ClassTemplateDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    return markClangClassTemplateDeclForPrintingDefined(specific);
   }
   if (auto *specific = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
-    return markClangAstObjectDefined(specific);
+    specific = markClangAstObjectDefined(specific);
+    markClangCXXRecordTemplateOrInstantiationStateDefined(specific);
+    return specific;
   }
   if (auto *specific = llvm::dyn_cast<clang::RecordDecl>(decl)) {
     return markClangAstObjectDefined(specific);
@@ -173,6 +305,21 @@ markClangDeclObjectDefinedByKind(const clang::Decl *decl) {
   if (auto *specific = llvm::dyn_cast<clang::TypedefNameDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
+  if (auto *specific = llvm::dyn_cast<clang::CXXConstructorDecl>(decl)) {
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
+  }
+  if (auto *specific = llvm::dyn_cast<clang::CXXDestructorDecl>(decl)) {
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
+  }
+  if (auto *specific = llvm::dyn_cast<clang::CXXConversionDecl>(decl)) {
+    specific = markClangAstObjectDefined(specific);
+    markClangDeclarationNameForPrintingDefined(specific);
+    return specific;
+  }
   if (auto *specific = llvm::dyn_cast<clang::UsingShadowDecl>(decl)) {
     return markClangAstObjectDefined(specific);
   }
@@ -206,16 +353,120 @@ markClangDeclObjectDefinedByKind(const clang::Decl *decl) {
 #endif
 }
 
+static void
+markClangDeclarationNameForPrintingDefined(const clang::NamedDecl *decl) {
+#if ROSE_USE_VALGRIND
+  decl = markClangAstObjectDefined(decl);
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    return;
+  }
+  static std::unordered_set<const clang::NamedDecl *> marked_names;
+  if (!marked_names.insert(decl).second) {
+    return;
+  }
+
+  clang::DeclarationName decl_name =
+      readClangApiValueDefined([&]() { return decl->getDeclName(); });
+  markClangValueDefined(decl_name);
+  switch (readClangApiValueDefined([&]() { return decl_name.getNameKind(); })) {
+  case clang::DeclarationName::CXXConstructorName:
+  case clang::DeclarationName::CXXDestructorName:
+  case clang::DeclarationName::CXXConversionFunctionName:
+    if (clang::QualType cxx_name_type = readClangApiValueDefined(
+            [&]() { return decl_name.getCXXNameType(); });
+        !cxx_name_type.isNull()) {
+      llvm::SmallPtrSet<const clang::Type *, 32> seen;
+      markClangQualTypeForPrintingDefined(cxx_name_type, seen);
+    }
+    break;
+  default:
+    break;
+  }
+#else
+  (void)decl;
+#endif
+}
+
+static const clang::CXXRecordDecl *
+markClangCXXRecordTemplateOrInstantiationStateDefined(
+    const clang::CXXRecordDecl *record) {
+#if ROSE_USE_VALGRIND
+  record = markClangAstObjectDefined(record);
+  if (!clangFrontendRunningOnValgrind() || record == nullptr) {
+    return record;
+  }
+  static std::unordered_set<const clang::CXXRecordDecl *> marked_records;
+  if (!marked_records.insert(record).second) {
+    return record;
+  }
+
+  if (const clang::ClassTemplateDecl *described_template =
+          readClangApiValueDefined(
+              [&]() { return record->getDescribedClassTemplate(); })) {
+    markClangDeclObjectDefinedByKind(described_template);
+    const clang::TemplateParameterList *params = readClangApiValueDefined(
+        [&]() { return described_template->getTemplateParameters(); });
+    markClangTemplateParameterListDefined(params);
+    markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+        params, record->getASTContext());
+  }
+
+  if (clang::MemberSpecializationInfo *member_info = readClangApiValueDefined(
+          [&]() { return record->getMemberSpecializationInfo(); })) {
+    markClangAstObjectDefined(member_info);
+    markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+        [&]() { return member_info->getInstantiatedFrom(); }));
+  }
+#endif
+  return record;
+}
+
+static const clang::ClassTemplateDecl *
+markClangClassTemplateDeclForPrintingDefined(
+    const clang::ClassTemplateDecl *decl) {
+#if ROSE_USE_VALGRIND
+  decl = markClangAstObjectDefined(decl);
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    return decl;
+  }
+  static std::unordered_set<const clang::ClassTemplateDecl *> marked_templates;
+  if (!marked_templates.insert(decl).second) {
+    return decl;
+  }
+
+  const clang::TemplateParameterList *params =
+      readClangApiValueDefined([&]() { return decl->getTemplateParameters(); });
+  markClangTemplateParameterListDefined(params);
+
+  if (const clang::CXXRecordDecl *templated_record = readClangApiValueDefined(
+          [&]() { return decl->getTemplatedDecl(); })) {
+    templated_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+        markClangDeclObjectDefinedByKind(templated_record));
+    if (templated_record != nullptr) {
+      markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+          params, templated_record->getASTContext());
+    }
+  }
+#endif
+  return decl;
+}
+
+template <typename T> static T *markClangSpecificDeclDefined(T *decl) {
+  return const_cast<T *>(
+      llvm::dyn_cast_or_null<T>(markClangDeclObjectDefinedByKind(decl)));
+}
+
 static clang::DeclContext *
 markClangDeclContextObjectDefined(clang::DeclContext *context) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(context);
-  if (!RUNNING_ON_VALGRIND || context == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || context == nullptr) {
     return context;
   }
 
   context = markClangAstObjectDefined(context);
-  clang::Decl *decl = clang::Decl::castFromDeclContext(context);
+  clang::Decl *decl = readClangApiValueDefined(
+      [&]() { return clang::Decl::castFromDeclContext(context); });
   decl = const_cast<clang::Decl *>(markClangDeclObjectDefinedByKind(decl));
   return clang::Decl::castToDeclContext(decl);
 #else
@@ -226,6 +477,23 @@ markClangDeclContextObjectDefined(clang::DeclContext *context) {
 static const clang::DeclContext *
 markClangDeclContextObjectDefined(const clang::DeclContext *context) {
   return markClangDeclContextObjectDefined(
+      const_cast<clang::DeclContext *>(context));
+}
+
+static clang::Decl *
+clangDeclFromDeclContextDefined(clang::DeclContext *context) {
+  context = markClangDeclContextObjectDefined(context);
+  if (context == nullptr) {
+    return nullptr;
+  }
+  clang::Decl *decl = readClangApiValueDefined(
+      [&]() { return clang::Decl::castFromDeclContext(context); });
+  return const_cast<clang::Decl *>(markClangDeclObjectDefinedByKind(decl));
+}
+
+static const clang::Decl *
+clangDeclFromDeclContextDefined(const clang::DeclContext *context) {
+  return clangDeclFromDeclContextDefined(
       const_cast<clang::DeclContext *>(context));
 }
 
@@ -280,7 +548,7 @@ static clang::TemplateName
 markClangTemplateNameDefined(clang::TemplateName name) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(name);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return name;
   }
 
@@ -335,7 +603,7 @@ static const clang::TemplateArgument &
 markClangTemplateArgumentDefined(const clang::TemplateArgument &arg) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(arg);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return arg;
   }
 
@@ -354,7 +622,7 @@ markClangTemplateArgumentDefined(const clang::TemplateArgument &arg) {
     markClangQualTypeDefined(arg.getIntegralType());
     break;
   case clang::TemplateArgument::StructuralValue:
-    markClangAstObjectDefined(&arg.getAsStructuralValue());
+    markClangLocalObjectDefined(&arg.getAsStructuralValue());
     markClangQualTypeDefined(arg.getStructuralValueType());
     break;
   case clang::TemplateArgument::Template:
@@ -362,7 +630,8 @@ markClangTemplateArgumentDefined(const clang::TemplateArgument &arg) {
     markClangTemplateNameDefined(arg.getAsTemplateOrTemplatePattern());
     break;
   case clang::TemplateArgument::Expression:
-    markClangExprObjectDefinedByClass(arg.getAsExpr());
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return arg.getAsExpr(); }));
     break;
   case clang::TemplateArgument::Pack:
     (void)markClangTemplateArgumentArrayDefined(arg.pack_elements());
@@ -379,7 +648,7 @@ markClangTemplateArgumentArrayDefined(
     llvm::ArrayRef<clang::TemplateArgument> args) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(args);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return args;
   }
   if (args.data() != nullptr && !args.empty()) {
@@ -394,13 +663,35 @@ markClangTemplateArgumentArrayDefined(
   return args;
 }
 
+static void markClangTemplateParameterInjectedArgumentsDefined(
+    const clang::TemplateParameterList *params,
+    const clang::ASTContext &context) {
+#if ROSE_USE_VALGRIND
+  params = markClangTemplateParameterListDefined(params);
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
+    return;
+  }
+
+  auto *mutable_params = const_cast<clang::TemplateParameterList *>(params);
+  llvm::ArrayRef<clang::TemplateArgument> injected_args =
+      readClangApiValueDefined(
+          [&]() { return mutable_params->getInjectedTemplateArgs(context); });
+  params = markClangTemplateParameterListDefined(mutable_params);
+  (void)params;
+  (void)markClangTemplateArgumentArrayDefined(injected_args);
+#else
+  (void)params;
+  (void)context;
+#endif
+}
+
 static const clang::TemplateArgumentList *
 markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&args, sizeof(args));
   }
-  if (!RUNNING_ON_VALGRIND || args == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
     return args;
   }
 
@@ -410,10 +701,41 @@ markClangTemplateArgumentListDefined(const clang::TemplateArgumentList *args) {
   return args;
 }
 
+static const clang::ASTTemplateArgumentListInfo *
+markClangASTTemplateArgumentListInfoDefined(
+    const clang::ASTTemplateArgumentListInfo *args) {
+#if ROSE_USE_VALGRIND
+  if (clangFrontendRunningOnValgrind()) {
+    VALGRIND_MAKE_MEM_DEFINED(&args, sizeof(args));
+  }
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
+    return args;
+  }
+
+  args = markClangAstObjectDefined(args);
+  llvm::ArrayRef<clang::TemplateArgumentLoc> arg_locs = args->arguments();
+  markClangValueDefined(arg_locs);
+  if (!arg_locs.empty()) {
+    VALGRIND_MAKE_MEM_DEFINED(
+        const_cast<clang::TemplateArgumentLoc *>(arg_locs.data()),
+        arg_locs.size() * sizeof(clang::TemplateArgumentLoc));
+  }
+  for (const clang::TemplateArgumentLoc &arg_loc : arg_locs) {
+    markClangValueDefined(arg_loc);
+    markClangTemplateArgumentDefined(arg_loc.getArgument());
+    if (clang::TypeSourceInfo *type_info = arg_loc.getTypeSourceInfo()) {
+      markClangAstObjectDefined(type_info);
+      markClangTypeLocDataDefined(type_info->getTypeLoc());
+    }
+  }
+#endif
+  return args;
+}
+
 static const clang::Type *
 markClangTypeObjectDefinedByClass(const clang::Type *type) {
 #if ROSE_USE_VALGRIND
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return type;
   }
 
@@ -421,6 +743,31 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
   if (type == nullptr) {
     return nullptr;
   }
+
+  auto mark_tag_type =
+      [](const clang::TagType *tag_type) -> const clang::TagType * {
+    switch (tag_type->getTypeClass()) {
+    case clang::Type::Enum:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::EnumType *>(tag_type));
+      break;
+    case clang::Type::Record:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::RecordType *>(tag_type));
+      break;
+    case clang::Type::InjectedClassName:
+      tag_type = markClangAstObjectDefined(
+          static_cast<const clang::InjectedClassNameType *>(tag_type));
+      break;
+    default:
+      tag_type = markClangAstObjectDefined(tag_type);
+      break;
+    }
+    if (tag_type != nullptr) {
+      markClangDeclObjectDefinedByKind(tag_type->getDecl());
+    }
+    return tag_type;
+  };
 
   switch (type->getTypeClass()) {
   case clang::Type::Adjusted:
@@ -478,7 +825,7 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
     return markClangAstObjectDefined(
         static_cast<const clang::FunctionProtoType *>(type));
   case clang::Type::InjectedClassName:
-    return markClangAstObjectDefined(
+    return mark_tag_type(
         static_cast<const clang::InjectedClassNameType *>(type));
   case clang::Type::MacroQualified:
     return markClangAstObjectDefined(
@@ -511,11 +858,9 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
     return markClangAstObjectDefined(
         static_cast<const clang::SubstTemplateTypeParmType *>(type));
   case clang::Type::Enum:
-    return markClangAstObjectDefined(
-        static_cast<const clang::EnumType *>(type));
+    return mark_tag_type(static_cast<const clang::EnumType *>(type));
   case clang::Type::Record:
-    return markClangAstObjectDefined(
-        static_cast<const clang::RecordType *>(type));
+    return mark_tag_type(static_cast<const clang::RecordType *>(type));
   case clang::Type::TemplateSpecialization:
     return markClangAstObjectDefined(
         static_cast<const clang::TemplateSpecializationType *>(type));
@@ -560,10 +905,10 @@ markClangTypeObjectDefinedByClass(const clang::Type *type) {
 static const clang::Stmt *
 markClangStmtObjectDefinedByClass(const clang::Stmt *stmt) {
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_MAKE_MEM_DEFINED(&stmt, sizeof(stmt));
   }
-  if (!RUNNING_ON_VALGRIND || stmt == nullptr) {
+  if (!clangFrontendRunningOnValgrind() || stmt == nullptr) {
     return stmt;
   }
 
@@ -607,6 +952,13 @@ markClangStmtObjectDefinedByClass(const clang::Stmt *stmt) {
 #endif
 }
 
+template <typename F>
+static auto readClangTypeLocDefined(F &&read) -> decltype(read()) {
+  auto type_loc = readClangApiValueDefined(std::forward<F>(read));
+  markClangTypeLocDataDefined(type_loc);
+  return type_loc;
+}
+
 static const clang::Expr *
 markClangExprObjectDefinedByClass(const clang::Expr *expr) {
   return llvm::dyn_cast_or_null<clang::Expr>(
@@ -617,7 +969,7 @@ static clang::NestedNameSpecifier
 markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(specifier);
-  if (!RUNNING_ON_VALGRIND) {
+  if (!clangFrontendRunningOnValgrind()) {
     return specifier;
   }
 
@@ -626,25 +978,292 @@ markClangNestedNameSpecifierDefined(clang::NestedNameSpecifier specifier) {
     if (!current) {
       break;
     }
-    switch (current.getKind()) {
+    switch (readClangApiValueDefined([&]() { return current.getKind(); })) {
     case clang::NestedNameSpecifier::Kind::Namespace:
       markClangDeclObjectDefinedByKind(
           nestedNameSpecifierNamespaceBase(current));
       break;
     case clang::NestedNameSpecifier::Kind::Type:
-      markClangTypeObjectDefinedByClass(current.getAsType());
+      markClangTypeObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return current.getAsType(); }));
       break;
     case clang::NestedNameSpecifier::Kind::MicrosoftSuper:
-      markClangDeclObjectDefinedByKind(current.getAsRecordDecl());
+      markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+          [&]() { return current.getAsRecordDecl(); }));
       break;
     case clang::NestedNameSpecifier::Kind::Global:
     case clang::NestedNameSpecifier::Kind::Null:
       break;
     }
-    current = nestedNameSpecifierPrefix(current);
+    current = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+        [&]() { return nestedNameSpecifierPrefix(current); }));
   }
 #endif
   return specifier;
+}
+
+static void markClangTypeForPrintingDefined(
+    const clang::Type *type, llvm::SmallPtrSetImpl<const clang::Type *> &seen);
+
+static void markClangQualTypeForPrintingDefined(
+    clang::QualType qual_type,
+    llvm::SmallPtrSetImpl<const clang::Type *> &seen) {
+#if ROSE_USE_VALGRIND
+  qual_type = markClangQualTypeDefined(qual_type);
+  if (!qual_type.isNull()) {
+    markClangTypeForPrintingDefined(qual_type.getTypePtrOrNull(), seen);
+  }
+#else
+  (void)qual_type;
+  (void)seen;
+#endif
+}
+
+static const clang::TemplateArgument &
+markClangTemplateArgumentForPrintingDefined(
+    const clang::TemplateArgument &arg,
+    llvm::SmallPtrSetImpl<const clang::Type *> &seen) {
+#if ROSE_USE_VALGRIND
+  const clang::TemplateArgument &defined_arg =
+      markClangTemplateArgumentDefined(arg);
+  if (!clangFrontendRunningOnValgrind()) {
+    return defined_arg;
+  }
+
+  switch (defined_arg.getKind()) {
+  case clang::TemplateArgument::Type:
+    markClangQualTypeForPrintingDefined(defined_arg.getAsType(), seen);
+    break;
+  case clang::TemplateArgument::Pack: {
+    llvm::ArrayRef<clang::TemplateArgument> elements =
+        markClangTemplateArgumentArrayDefined(defined_arg.pack_elements());
+    for (const clang::TemplateArgument &element : elements) {
+      markClangTemplateArgumentForPrintingDefined(element, seen);
+    }
+    break;
+  }
+  case clang::TemplateArgument::Declaration:
+  case clang::TemplateArgument::NullPtr:
+  case clang::TemplateArgument::Integral:
+  case clang::TemplateArgument::StructuralValue:
+  case clang::TemplateArgument::Template:
+  case clang::TemplateArgument::TemplateExpansion:
+  case clang::TemplateArgument::Null:
+    break;
+  case clang::TemplateArgument::Expression:
+    markClangExprObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return defined_arg.getAsExpr(); }));
+    break;
+  }
+  return defined_arg;
+#else
+  (void)seen;
+  return arg;
+#endif
+}
+
+static const clang::TemplateArgument &
+markClangTemplateArgumentForPrintingDefined(
+    const clang::TemplateArgument &arg) {
+#if ROSE_USE_VALGRIND
+  llvm::SmallPtrSet<const clang::Type *, 32> seen;
+  return markClangTemplateArgumentForPrintingDefined(arg, seen);
+#else
+  return arg;
+#endif
+}
+
+static void markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+    const clang::TemplateParameterList *params,
+    const clang::ASTContext &context) {
+#if ROSE_USE_VALGRIND
+  params = markClangTemplateParameterListDefined(params);
+  if (!clangFrontendRunningOnValgrind() || params == nullptr) {
+    return;
+  }
+
+  auto *mutable_params = const_cast<clang::TemplateParameterList *>(params);
+  llvm::ArrayRef<clang::TemplateArgument> injected_args =
+      readClangApiValueDefined(
+          [&]() { return mutable_params->getInjectedTemplateArgs(context); });
+  params = markClangTemplateParameterListDefined(mutable_params);
+  (void)params;
+
+  injected_args = markClangTemplateArgumentArrayDefined(injected_args);
+  llvm::SmallPtrSet<const clang::Type *, 32> seen;
+  for (const clang::TemplateArgument &arg : injected_args) {
+    markClangTemplateArgumentForPrintingDefined(arg, seen);
+  }
+#else
+  (void)params;
+  (void)context;
+#endif
+}
+
+static const clang::TemplateArgumentList *
+markClangTemplateArgumentListForPrintingDefined(
+    const clang::TemplateArgumentList *args,
+    llvm::SmallPtrSetImpl<const clang::Type *> &seen) {
+#if ROSE_USE_VALGRIND
+  args = markClangTemplateArgumentListDefined(args);
+  if (!clangFrontendRunningOnValgrind() || args == nullptr) {
+    return args;
+  }
+
+  for (unsigned i = 0; i < args->size(); ++i) {
+    markClangTemplateArgumentForPrintingDefined(args->get(i), seen);
+  }
+#else
+  (void)seen;
+#endif
+  return args;
+}
+
+static const clang::ClassTemplateSpecializationDecl *
+markClangClassTemplateSpecializationForPrintingDefined(
+    const clang::ClassTemplateSpecializationDecl *decl) {
+#if ROSE_USE_VALGRIND
+  static std::unordered_set<const clang::ClassTemplateSpecializationDecl *>
+      marked_specializations;
+  static std::unordered_set<const clang::ClassTemplateSpecializationDecl *>
+      active_specializations;
+  const clang::ClassTemplateSpecializationDecl *active_key = decl;
+  if (active_key != nullptr &&
+      !active_specializations.insert(active_key).second) {
+    return decl;
+  }
+
+  decl = llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+      markClangDeclObjectDefinedByKind(decl));
+  if (!clangFrontendRunningOnValgrind() || decl == nullptr) {
+    if (active_key != nullptr) {
+      active_specializations.erase(active_key);
+    }
+    return decl;
+  }
+  if (!marked_specializations.insert(decl).second) {
+    if (active_key != nullptr) {
+      active_specializations.erase(active_key);
+    }
+    return decl;
+  }
+
+  llvm::SmallPtrSet<const clang::Type *, 32> seen;
+  markClangTemplateArgumentListForPrintingDefined(&decl->getTemplateArgs(),
+                                                  seen);
+  markClangTemplateArgumentListForPrintingDefined(
+      &decl->getTemplateInstantiationArgs(), seen);
+  if (const clang::ASTTemplateArgumentListInfo *written_args =
+          markClangASTTemplateArgumentListInfoDefined(
+              decl->getTemplateArgsAsWritten())) {
+    for (const clang::TemplateArgumentLoc &arg_loc :
+         written_args->arguments()) {
+      markClangTemplateArgumentForPrintingDefined(arg_loc.getArgument(), seen);
+    }
+  }
+
+  auto specialized = readClangApiValueDefined(
+      [&]() { return decl->getSpecializedTemplateOrPartial(); });
+  if (const auto *class_template =
+          specialized.dyn_cast<clang::ClassTemplateDecl *>()) {
+    markClangClassTemplateDeclForPrintingDefined(class_template);
+  } else if (const auto *partial =
+                 specialized.dyn_cast<
+                     clang::ClassTemplatePartialSpecializationDecl *>()) {
+    markClangDeclObjectDefinedByKind(partial);
+    markClangClassTemplateDeclForPrintingDefined(readClangApiValueDefined(
+        [&]() { return partial->getSpecializedTemplate(); }));
+  }
+
+  if (active_key != nullptr) {
+    active_specializations.erase(active_key);
+  }
+#endif
+  return decl;
+}
+
+static void markClangTypeForPrintingDefined(
+    const clang::Type *type, llvm::SmallPtrSetImpl<const clang::Type *> &seen) {
+#if ROSE_USE_VALGRIND
+  if (!clangFrontendRunningOnValgrind()) {
+    return;
+  }
+
+  static std::unordered_set<const clang::Type *> marked_printing_types;
+  type = markClangTypeObjectDefinedByClass(type);
+  if (type == nullptr || !seen.insert(type).second ||
+      !marked_printing_types.insert(type).second) {
+    return;
+  }
+
+  switch (type->getTypeClass()) {
+  case clang::Type::Enum:
+  case clang::Type::Record:
+  case clang::Type::InjectedClassName: {
+    const auto *tag_type = llvm::dyn_cast<clang::TagType>(type);
+    if (tag_type != nullptr) {
+      clang::NestedNameSpecifier qualifier =
+          readClangApiValueDefined([&]() { return tag_type->getQualifier(); });
+      markClangTagTypeQualifierStorageDefined(tag_type, qualifier);
+      markClangNestedNameSpecifierDefined(qualifier);
+      const clang::TagDecl *raw_tag_decl =
+          readClangApiValueDefined([&]() { return tag_type->getDecl(); });
+      const clang::TagDecl *tag_decl = llvm::dyn_cast_or_null<clang::TagDecl>(
+          markClangDeclObjectDefinedByKind(raw_tag_decl));
+      if (const auto *injected_type =
+              llvm::dyn_cast<clang::InjectedClassNameType>(type)) {
+        const clang::CXXRecordDecl *record =
+            llvm::dyn_cast_or_null<clang::CXXRecordDecl>(tag_decl);
+        if (record != nullptr) {
+          if (const clang::ClassTemplateDecl *template_decl =
+                  readClangApiValueDefined(
+                      [&]() { return injected_type->getTemplateDecl(); })) {
+            markClangDeclObjectDefinedByKind(template_decl);
+            const clang::TemplateParameterList *params =
+                readClangApiValueDefined(
+                    [&]() { return template_decl->getTemplateParameters(); });
+            markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+                params, record->getASTContext());
+          }
+
+          if (auto *specialization =
+                  llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+                      record)) {
+            markClangClassTemplateSpecializationForPrintingDefined(
+                specialization);
+          } else if (const clang::ClassTemplateDecl *described_template =
+                         record->getDescribedClassTemplate()) {
+            markClangDeclObjectDefinedByKind(described_template);
+            markClangTemplateParameterInjectedArgumentsForPrintingDefined(
+                described_template->getTemplateParameters(),
+                record->getASTContext());
+          }
+        }
+      }
+    }
+    break;
+  }
+  case clang::Type::TemplateSpecialization: {
+    const auto *template_specialization =
+        static_cast<const clang::TemplateSpecializationType *>(
+            markClangTypeObjectDefinedByClass(type));
+    markClangTemplateNameDefined(readClangApiValueDefined(
+        [&]() { return template_specialization->getTemplateName(); }));
+    llvm::ArrayRef<clang::TemplateArgument> args =
+        markClangTemplateArgumentArrayDefined(readClangApiValueDefined(
+            [&]() { return template_specialization->template_arguments(); }));
+    for (const clang::TemplateArgument &arg : args) {
+      markClangTemplateArgumentForPrintingDefined(arg, seen);
+    }
+    break;
+  }
+  default:
+    break;
+  }
+#else
+  (void)type;
+  (void)seen;
+#endif
 }
 
 static unsigned
@@ -679,7 +1298,7 @@ static clang::NestedNameSpecifierLoc markClangNestedNameSpecifierLocDefined(
     clang::NestedNameSpecifierLoc qualifier_loc) {
 #if ROSE_USE_VALGRIND
   markClangValueDefined(qualifier_loc);
-  if (!RUNNING_ON_VALGRIND || !qualifier_loc) {
+  if (!clangFrontendRunningOnValgrind() || !qualifier_loc) {
     return qualifier_loc;
   }
 
@@ -763,9 +1382,11 @@ SgFunctionType *buildFunctionTypeForClangProto(
 bool nestedNameSpecifierHasGlobal(clang::NestedNameSpecifier qualifier) {
   qualifier = markClangNestedNameSpecifierDefined(qualifier);
   for (clang::NestedNameSpecifier nns = qualifier; nns;
-       nns = nestedNameSpecifierPrefix(nns)) {
+       nns = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+           [&]() { return nestedNameSpecifierPrefix(nns); }))) {
     nns = markClangNestedNameSpecifierDefined(nns);
-    if (nns.getKind() == clang::NestedNameSpecifier::Kind::Global) {
+    if (readClangApiValueDefined([&]() { return nns.getKind(); }) ==
+        clang::NestedNameSpecifier::Kind::Global) {
       return true;
     }
   }
@@ -775,9 +1396,11 @@ bool nestedNameSpecifierHasGlobal(clang::NestedNameSpecifier qualifier) {
 bool nestedNameSpecifierHasTypeQualifier(clang::NestedNameSpecifier qualifier) {
   qualifier = markClangNestedNameSpecifierDefined(qualifier);
   for (clang::NestedNameSpecifier nns = qualifier; nns;
-       nns = nestedNameSpecifierPrefix(nns)) {
+       nns = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+           [&]() { return nestedNameSpecifierPrefix(nns); }))) {
     nns = markClangNestedNameSpecifierDefined(nns);
-    if (nns.getKind() == clang::NestedNameSpecifier::Kind::Type) {
+    if (readClangApiValueDefined([&]() { return nns.getKind(); }) ==
+        clang::NestedNameSpecifier::Kind::Type) {
       return true;
     }
   }
@@ -788,13 +1411,15 @@ bool nestedNameSpecifierHasDependentTypeQualifier(
     clang::NestedNameSpecifier qualifier) {
   qualifier = markClangNestedNameSpecifierDefined(qualifier);
   for (clang::NestedNameSpecifier nns = qualifier; nns;
-       nns = nestedNameSpecifierPrefix(nns)) {
+       nns = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+           [&]() { return nestedNameSpecifierPrefix(nns); }))) {
     nns = markClangNestedNameSpecifierDefined(nns);
-    if (nns.getKind() != clang::NestedNameSpecifier::Kind::Type) {
+    if (readClangApiValueDefined([&]() { return nns.getKind(); }) !=
+        clang::NestedNameSpecifier::Kind::Type) {
       continue;
     }
-    const clang::Type *qualifier_type =
-        markClangTypeObjectDefinedByClass(nns.getAsType());
+    const clang::Type *qualifier_type = markClangTypeObjectDefinedByClass(
+        readClangApiValueDefined([&]() { return nns.getAsType(); }));
     if (qualifier_type != nullptr && qualifier_type->isDependentType()) {
       return true;
     }
@@ -806,9 +1431,10 @@ bool nestedNameSpecifierHasNamespaceQualifier(
     clang::NestedNameSpecifier qualifier) {
   qualifier = markClangNestedNameSpecifierDefined(qualifier);
   for (clang::NestedNameSpecifier nns = qualifier; nns;
-       nns = nestedNameSpecifierPrefix(nns)) {
+       nns = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+           [&]() { return nestedNameSpecifierPrefix(nns); }))) {
     nns = markClangNestedNameSpecifierDefined(nns);
-    switch (nns.getKind()) {
+    switch (readClangApiValueDefined([&]() { return nns.getKind(); })) {
     case clang::NestedNameSpecifier::Kind::Namespace:
     case clang::NestedNameSpecifier::Kind::Global:
       return true;
@@ -883,13 +1509,22 @@ bool nestedNameSpecifierLocHasExplicitGlobal(
            markClangNestedNameSpecifierLocDefined(qualifier_loc);
        current; current = [&]() {
          current = markClangNestedNameSpecifierLocDefined(current);
-         switch (current.getNestedNameSpecifier().getKind()) {
+         clang::NestedNameSpecifier current_specifier =
+             markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                 [&]() { return current.getNestedNameSpecifier(); }));
+         switch (readClangApiValueDefined(
+             [&]() { return current_specifier.getKind(); })) {
          case clang::NestedNameSpecifier::Kind::Namespace:
            return markClangNestedNameSpecifierLocDefined(
-               current.getAsNamespaceAndPrefix().Prefix);
+               readClangApiValueDefined(
+                   [&]() { return current.getAsNamespaceAndPrefix().Prefix; }));
          case clang::NestedNameSpecifier::Kind::Type:
            return markClangNestedNameSpecifierLocDefined(
-               current.getAsTypeLoc().getPrefix());
+               readClangApiValueDefined([&]() {
+                 return readClangTypeLocDefined(
+                            [&]() { return current.getAsTypeLoc(); })
+                     .getPrefix();
+               }));
          case clang::NestedNameSpecifier::Kind::Global:
          case clang::NestedNameSpecifier::Kind::MicrosoftSuper:
          case clang::NestedNameSpecifier::Kind::Null:
@@ -898,9 +1533,15 @@ bool nestedNameSpecifierLocHasExplicitGlobal(
          return clang::NestedNameSpecifierLoc();
        }()) {
     current = markClangNestedNameSpecifierLocDefined(current);
-    if (current.getNestedNameSpecifier().getKind() ==
-        clang::NestedNameSpecifier::Kind::Global) {
-      return current.getLocalBeginLoc().isValid();
+    clang::NestedNameSpecifier current_specifier =
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return current.getNestedNameSpecifier(); }));
+    if (readClangApiValueDefined([&]() {
+          return current_specifier.getKind();
+        }) == clang::NestedNameSpecifier::Kind::Global) {
+      return readClangApiValueDefined(
+                 [&]() { return current.getLocalBeginLoc(); })
+          .isValid();
     }
   }
   return false;
@@ -924,13 +1565,13 @@ nestedNameSpecifierLocToString(clang::NestedNameSpecifierLoc qualifier_loc,
           ? compiler_instance->getASTContext().getPrintingPolicy()
           : clang::PrintingPolicy(clang::LangOptions());
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
   }
 #endif
   qualifier.print(stream, policy);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_ENABLE_ERROR_REPORTING;
   }
 #endif
@@ -1031,8 +1672,9 @@ clang::NestedNameSpecifierLoc typeLocQualifierLoc(clang::TypeLoc type_loc) {
     if (auto spec_loc = current.getAs<clang::TemplateSpecializationTypeLoc>()) {
       markClangTypeLocDataDefined(spec_loc);
       markClangTypeObjectDefinedByClass(spec_loc.getTypePtr());
-      clang::NestedNameSpecifierLoc qualifier_loc = spec_loc.getQualifierLoc();
-      markClangValueDefined(qualifier_loc);
+      clang::NestedNameSpecifierLoc qualifier_loc =
+          markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+              [&]() { return spec_loc.getQualifierLoc(); }));
       if (qualifier_loc) {
         return qualifier_loc;
       }
@@ -1063,12 +1705,28 @@ clang::NestedNameSpecifierLoc typeLocQualifierLoc(clang::TypeLoc type_loc) {
       }
     }
     if (auto tag_loc = current.getAs<clang::TagTypeLoc>()) {
+      const clang::TagType *tag_type = llvm::dyn_cast_or_null<clang::TagType>(
+          markClangTypeObjectDefinedByClass(tag_loc.getTypePtr()));
+      clang::NestedNameSpecifier qualifier =
+          tag_type != nullptr ? readClangApiValueDefined(
+                                    [&]() { return tag_type->getQualifier(); })
+                              : clang::NestedNameSpecifier();
+      markClangTagTypeQualifierStorageDefined(tag_type, qualifier);
+      markClangNestedNameSpecifierDefined(qualifier);
       if (clang::NestedNameSpecifierLoc qualifier_loc =
               tag_loc.getQualifierLoc()) {
         return qualifier_loc;
       }
     }
     if (auto injected_loc = current.getAs<clang::InjectedClassNameTypeLoc>()) {
+      const clang::TagType *tag_type = llvm::dyn_cast_or_null<clang::TagType>(
+          markClangTypeObjectDefinedByClass(injected_loc.getTypePtr()));
+      clang::NestedNameSpecifier qualifier =
+          tag_type != nullptr ? readClangApiValueDefined(
+                                    [&]() { return tag_type->getQualifier(); })
+                              : clang::NestedNameSpecifier();
+      markClangTagTypeQualifierStorageDefined(tag_type, qualifier);
+      markClangNestedNameSpecifierDefined(qualifier);
       if (clang::NestedNameSpecifierLoc qualifier_loc =
               injected_loc.getQualifierLoc()) {
         return qualifier_loc;
@@ -1229,22 +1887,26 @@ templateParametersForDeclContext(const clang::DeclContext *context) {
 
   if (const clang::TemplateDecl *template_decl =
           llvm::dyn_cast<clang::TemplateDecl>(decl)) {
-    return template_decl->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return template_decl->getTemplateParameters(); }));
   }
 
   if (const clang::ClassTemplatePartialSpecializationDecl *class_partial =
           llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(decl)) {
-    return class_partial->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return class_partial->getTemplateParameters(); }));
   }
 
   if (const clang::VarTemplatePartialSpecializationDecl *var_partial =
           llvm::dyn_cast<clang::VarTemplatePartialSpecializationDecl>(decl)) {
-    return var_partial->getTemplateParameters();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return var_partial->getTemplateParameters(); }));
   }
 
   if (const clang::FunctionDecl *function_decl =
           llvm::dyn_cast<clang::FunctionDecl>(decl)) {
-    return function_decl->getDescribedTemplateParams();
+    return markClangTemplateParameterListDefined(readClangApiValueDefined(
+        [&]() { return function_decl->getDescribedTemplateParams(); }));
   }
 
   if (const clang::CXXRecordDecl *record_decl =
@@ -1252,24 +1914,33 @@ templateParametersForDeclContext(const clang::DeclContext *context) {
     if (const clang::ClassTemplatePartialSpecializationDecl *partial =
             llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
                 record_decl)) {
-      return partial->getTemplateParameters();
+      return markClangTemplateParameterListDefined(readClangApiValueDefined(
+          [&]() { return partial->getTemplateParameters(); }));
     }
     if (llvm::isa<clang::ClassTemplateSpecializationDecl>(record_decl)) {
       return nullptr;
     }
 
     if (const clang::CXXRecordDecl *canonical_record =
-            record_decl->getCanonicalDecl()) {
+            llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return record_decl->getCanonicalDecl(); })))) {
       if (const clang::ClassTemplatePartialSpecializationDecl *partial =
               llvm::dyn_cast<clang::ClassTemplatePartialSpecializationDecl>(
                   canonical_record)) {
-        return partial->getTemplateParameters();
+        return markClangTemplateParameterListDefined(readClangApiValueDefined(
+            [&]() { return partial->getTemplateParameters(); }));
       }
     }
 
     if (const clang::ClassTemplateDecl *described_template =
-            record_decl->getDescribedClassTemplate()) {
-      return described_template->getTemplateParameters();
+            llvm::dyn_cast_or_null<clang::ClassTemplateDecl>(
+                markClangDeclObjectDefinedByKind(
+                    readClangApiValueDefined([&]() {
+                      return record_decl->getDescribedClassTemplate();
+                    })))) {
+      return markClangTemplateParameterListDefined(readClangApiValueDefined(
+          [&]() { return described_template->getTemplateParameters(); }));
     }
   }
 
@@ -1290,11 +1961,14 @@ collectTemplateParameterLevelsFromDeclContext(
   unsigned written_outer_template_levels = 0;
   if (const clang::DeclaratorDecl *declarator_decl =
           llvm::dyn_cast_or_null<clang::DeclaratorDecl>(decl)) {
-    written_outer_template_levels =
-        declarator_decl->getNumTemplateParameterLists();
+    written_outer_template_levels = readClangApiValueDefined(
+        [&]() { return declarator_decl->getNumTemplateParameterLists(); });
     for (unsigned i = 0; i < written_outer_template_levels; ++i) {
       if (const clang::TemplateParameterList *params =
-              declarator_decl->getTemplateParameterList(i)) {
+              markClangTemplateParameterListDefined(
+                  readClangApiValueDefined([&]() {
+                    return declarator_decl->getTemplateParameterList(i);
+                  }))) {
         template_levels.push_back(params);
       }
     }
@@ -1302,10 +1976,12 @@ collectTemplateParameterLevelsFromDeclContext(
 
   std::vector<const clang::TemplateParameterList *> contextual_levels;
   for (const clang::DeclContext *ctx = start_context; ctx != nullptr;
-       ctx = markClangDeclContextObjectDefined(ctx->getParent())) {
+       ctx = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
     ctx = markClangDeclContextObjectDefined(ctx);
     if (const clang::TemplateParameterList *params =
-            templateParametersForDeclContext(ctx)) {
+            markClangTemplateParameterListDefined(
+                templateParametersForDeclContext(ctx))) {
       contextual_levels.push_back(params);
     }
   }
@@ -1326,6 +2002,7 @@ collectTemplateParameterLevelsFromDeclContext(
 
 std::string resolveTemplateParameterNameFromDeclContext(
     const clang::DeclContext *start_context, unsigned depth, unsigned index) {
+  start_context = markClangDeclContextObjectDefined(start_context);
   if (start_context == nullptr) {
     return "";
   }
@@ -1337,16 +2014,20 @@ std::string resolveTemplateParameterNameFromDeclContext(
     return "";
   }
   const clang::TemplateParameterList *params = template_levels[depth];
-  if (params == nullptr || index >= params->size()) {
+  params = markClangTemplateParameterListDefined(params);
+  if (params == nullptr ||
+      index >= readClangApiValueDefined([&]() { return params->size(); })) {
     return "";
   }
 
   const clang::NamedDecl *named_param =
-      llvm::dyn_cast_or_null<clang::NamedDecl>(params->getParam(index));
+      llvm::dyn_cast_or_null<clang::NamedDecl>(markClangDeclObjectDefinedByKind(
+          readClangApiValueDefined([&]() { return params->getParam(index); })));
   if (named_param == nullptr) {
     return "";
   }
-  return normalizeClangTemplateParamName(named_param->getNameAsString());
+  return normalizeClangTemplateParamName(readClangApiValueDefined(
+      [&]() { return named_param->getNameAsString(); }));
 }
 
 std::vector<const clang::NamespaceDecl *>
@@ -1354,11 +2035,13 @@ collectNamespaceContexts(clang::DeclContext *context) {
   std::vector<const clang::NamespaceDecl *> namespaces;
   for (clang::DeclContext *ctx = markClangDeclContextObjectDefined(context);
        ctx != nullptr;
-       ctx = markClangDeclContextObjectDefined(ctx->getParent())) {
+       ctx = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
+    const clang::Decl *ctx_decl = clangDeclFromDeclContextDefined(ctx);
     if (const clang::NamespaceDecl *ns = llvm::dyn_cast<clang::NamespaceDecl>(
-            markClangDeclObjectDefinedByKind(
-                clang::Decl::castFromDeclContext(ctx)))) {
-      if (!ns->isAnonymousNamespace()) {
+            markClangDeclObjectDefinedByKind(ctx_decl))) {
+      if (!readClangApiValueDefined(
+              [&]() { return ns->isAnonymousNamespace(); })) {
         markClangValueDefined(ns);
         namespaces.push_back(ns);
       }
@@ -1369,17 +2052,26 @@ collectNamespaceContexts(clang::DeclContext *context) {
 }
 
 bool declContextCanUseReachableNamespaceScope(clang::DeclContext *context) {
-  for (clang::DeclContext *ctx = context; ctx != nullptr;
-       ctx = ctx->getParent()) {
-    if (ctx->isTranslationUnit() || ctx->isNamespace()) {
+  bool saw_context = false;
+  for (clang::DeclContext *ctx = markClangDeclContextObjectDefined(context);
+       ctx != nullptr;
+       ctx = markClangDeclContextObjectDefined(
+           readClangApiValueDefined([&]() { return ctx->getParent(); }))) {
+    saw_context = true;
+    const clang::Decl *ctx_decl = clangDeclFromDeclContextDefined(ctx);
+    if (ctx_decl == nullptr) {
+      return false;
+    }
+    if (readClangApiValueDefined([&]() { return ctx->isTranslationUnit(); }) ||
+        readClangApiValueDefined([&]() { return ctx->isNamespace(); })) {
       continue;
     }
-    if (llvm::isa<clang::LinkageSpecDecl>(ctx)) {
+    if (llvm::isa<clang::LinkageSpecDecl>(ctx_decl)) {
       continue;
     }
     return false;
   }
-  return context != nullptr;
+  return saw_context;
 }
 
 void suppressFrontendOnlyNode(SgLocatedNode *node) {
@@ -1436,7 +2128,8 @@ bool scopeIsWithinNamespaceChain(SgScopeStatement *scope,
     if (ns == nullptr) {
       return false;
     }
-    if (scope_names[i] != ns->getNameAsString()) {
+    if (scope_names[i] !=
+        readClangApiValueDefined([&]() { return ns->getNameAsString(); })) {
       return false;
     }
   }
@@ -1654,7 +2347,8 @@ buildNamespaceQualifierForDeclContext(clang::DeclContext *context,
   for (const clang::NamespaceDecl *ns : namespaces) {
     ns = llvm::dyn_cast_or_null<clang::NamespaceDecl>(
         markClangDeclObjectDefinedByKind(ns));
-    if (ns == nullptr || ns->isAnonymousNamespace()) {
+    if (ns == nullptr || readClangApiValueDefined(
+                             [&]() { return ns->isAnonymousNamespace(); })) {
       continue;
     }
     qualifier = markClangNestedNameSpecifierDefined(qualifier);
@@ -1673,7 +2367,9 @@ bool canSynthesizeNamespaceQualifierFromDeclContext(
   context = markClangDeclContextObjectDefined(
       const_cast<clang::DeclContext *>(context));
   return context != nullptr &&
-         (context->isNamespace() || context->isTranslationUnit());
+         (readClangApiValueDefined([&]() { return context->isNamespace(); }) ||
+          readClangApiValueDefined(
+              [&]() { return context->isTranslationUnit(); }));
 }
 
 clang::QualType getInjectedClassNameSpecializationType(
@@ -1880,8 +2576,10 @@ DependentTemplateSpecializationNameInfo getDependentTemplateSpecializationName(
 // Generate unique name for template declaration with full namespace
 // qualification
 std::string mangleTemplateName(const clang::TemplateName &tname) {
+  clang::TemplateName marked_name = markClangTemplateNameDefined(tname);
+
   // Get fully qualified name from the underlying TemplateDecl
-  if (clang::TemplateDecl *template_decl = tname.getAsTemplateDecl()) {
+  if (clang::TemplateDecl *template_decl = marked_name.getAsTemplateDecl()) {
     // Get qualified name from the declaration (includes namespace)
     std::string result = template_decl->getQualifiedNameAsString();
     return result;
@@ -1897,13 +2595,13 @@ std::string mangleTemplateName(const clang::TemplateName &tname) {
     clang::LangOptions opts;
     clang::PrintingPolicy policy(opts);
 #if ROSE_USE_VALGRIND
-    if (RUNNING_ON_VALGRIND) {
+    if (clangFrontendRunningOnValgrind()) {
       VALGRIND_DISABLE_ERROR_REPORTING;
     }
 #endif
     qualifier.print(stream, policy);
 #if ROSE_USE_VALGRIND
-    if (RUNNING_ON_VALGRIND) {
+    if (clangFrontendRunningOnValgrind()) {
       VALGRIND_ENABLE_ERROR_REPORTING;
     }
 #endif
@@ -1924,7 +2622,7 @@ std::string mangleTemplateName(const clang::TemplateName &tname) {
   };
 
   if (const clang::QualifiedTemplateName *qtn =
-          tname.getAsQualifiedTemplateName()) {
+          marked_name.getAsQualifiedTemplateName()) {
     std::string base = getTemplateNameBase(qtn->getUnderlyingTemplate());
     clang::NestedNameSpecifier qualifier = qtn->getQualifier();
     if (qualifier && !base.empty()) {
@@ -1936,8 +2634,8 @@ std::string mangleTemplateName(const clang::TemplateName &tname) {
   }
 
   if (const clang::DependentTemplateName *dtn =
-          tname.getAsDependentTemplateName()) {
-    std::string base = getTemplateNameBase(tname);
+          marked_name.getAsDependentTemplateName()) {
+    std::string base = getTemplateNameBase(marked_name);
     clang::NestedNameSpecifier qualifier = dtn->getQualifier();
     if (qualifier && !base.empty()) {
       std::string qualifier_str = qualifierToString(qualifier);
@@ -1953,13 +2651,13 @@ std::string mangleTemplateName(const clang::TemplateName &tname) {
   clang::LangOptions opts;
   clang::PrintingPolicy policy(opts);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_DISABLE_ERROR_REPORTING;
   }
 #endif
-  tname.print(stream, policy);
+  marked_name.print(stream, policy);
 #if ROSE_USE_VALGRIND
-  if (RUNNING_ON_VALGRIND) {
+  if (clangFrontendRunningOnValgrind()) {
     VALGRIND_ENABLE_ERROR_REPORTING;
   }
 #endif
@@ -2136,11 +2834,11 @@ std::string normalizeTemplateDeclCacheKey(const std::string &name) {
 void appendTemplateInstantiationArg(std::string &result, bool &need_separator,
                                     const clang::TemplateArgument &arg) {
   const clang::TemplateArgument &defined_arg =
-      markClangTemplateArgumentDefined(arg);
+      markClangTemplateArgumentForPrintingDefined(arg);
   auto append_single_arg = [&](const clang::TemplateArgument &single_arg,
                                bool force_pack_ellipsis) {
     const clang::TemplateArgument &defined_single_arg =
-        markClangTemplateArgumentDefined(single_arg);
+        markClangTemplateArgumentForPrintingDefined(single_arg);
     if (need_separator) {
       result += " , ";
     }
@@ -2148,9 +2846,20 @@ void appendTemplateInstantiationArg(std::string &result, bool &need_separator,
 
     std::string arg_str;
     llvm::raw_string_ostream arg_stream(arg_str);
-    defined_single_arg.print(clang::PrintingPolicy(clang::LangOptions()),
-                             arg_stream, true);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      defined_single_arg.print(clang::PrintingPolicy(clang::LangOptions()),
+                               arg_stream, true);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      defined_single_arg.print(clang::PrintingPolicy(clang::LangOptions()),
+                               arg_stream, true);
+    }
     arg_stream.flush();
+    markClangPrintedStringDefined(arg_str);
 
     arg_str = trimWhitespace(arg_str);
     bool needs_pack_ellipsis =
@@ -2201,6 +2910,15 @@ buildTemplateInstantiationName(const std::string &base_name,
 
 } // namespace
 
+void markClangQualTypeForPrintingDefinedForFrontend(clang::QualType type) {
+#if ROSE_USE_VALGRIND
+  llvm::SmallPtrSet<const clang::Type *, 32> seen;
+  markClangQualTypeForPrintingDefined(type, seen);
+#else
+  (void)type;
+#endif
+}
+
 // Generate unique name for template instantiation
 // Note: Must not contain < > characters for ROSE mangling
 std::string ClangToSageTranslator::getTemplateQualifiedName(
@@ -2243,15 +2961,28 @@ std::string ClangToSageTranslator::mangleTemplateInstantiation(
       markClangTemplateArgumentArrayDefined(spec_type->template_arguments());
   bool first = true;
   for (const clang::TemplateArgument &arg : args) {
-    markClangTemplateArgumentDefined(arg);
+    const clang::TemplateArgument &defined_arg =
+        markClangTemplateArgumentForPrintingDefined(arg);
     if (!first)
       result += "_";
     first = false;
 
     std::string arg_str;
     llvm::raw_string_ostream arg_stream(arg_str);
-    arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      defined_arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
+                        true);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      defined_arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream,
+                        true);
+    }
     arg_stream.flush();
+    markClangPrintedStringDefined(arg_str);
 
     // Replace special characters that can't be in mangled names
     for (char &c : arg_str) {
@@ -2280,15 +3011,25 @@ std::string ClangToSageTranslator::mangleTemplateInstantiation(
       markClangTemplateArgumentListDefined(&args);
   for (unsigned i = 0; i < defined_args->size(); ++i) {
     const clang::TemplateArgument &arg =
-        markClangTemplateArgumentDefined(defined_args->get(i));
+        markClangTemplateArgumentForPrintingDefined(defined_args->get(i));
     if (!first)
       result += "_";
     first = false;
 
     std::string arg_str;
     llvm::raw_string_ostream arg_stream(arg_str);
-    arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+#if ROSE_USE_VALGRIND
+    if (clangFrontendRunningOnValgrind()) {
+      VALGRIND_DISABLE_ERROR_REPORTING;
+      arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+      VALGRIND_ENABLE_ERROR_REPORTING;
+    } else
+#endif
+    {
+      arg.print(clang::PrintingPolicy(clang::LangOptions()), arg_stream, true);
+    }
     arg_stream.flush();
+    markClangPrintedStringDefined(arg_str);
 
     for (char &c : arg_str) {
       if (c == '<' || c == '>' || c == ',' || c == ' ' || c == ':' ||
@@ -2455,8 +3196,21 @@ bool ClangToSageTranslator::scopeReachableFromCurrentFile(
       return false;
     }
 
+    auto is_structural_successor = [](SgNode *node, SgNode *owner) -> bool {
+      const std::vector<SgNode *> successors =
+          owner->get_traversalSuccessorContainer();
+      return std::find(successors.begin(), successors.end(), node) !=
+             successors.end();
+    };
+
     if (SgScopeStatement *parent_scope = isSgScopeStatement(parent)) {
       if (SgStatement *stmt = isSgStatement(child)) {
+        if (parent_scope->containsOnlyDeclarations()) {
+          if (isSgDeclarationStatement(stmt) != nullptr) {
+            return parent_scope->statementExistsInScope(stmt);
+          }
+          return is_structural_successor(child, parent);
+        }
         return parent_scope->statementExistsInScope(stmt);
       }
     }
@@ -2513,11 +3267,16 @@ SgScopeStatement *ClangToSageTranslator::resolveReachableNamespaceScope(
   std::vector<const clang::NamespaceDecl *> namespaces =
       collectNamespaceContexts(decl_context);
   for (const clang::NamespaceDecl *ns_decl : namespaces) {
-    if (ns_decl == nullptr || ns_decl->isAnonymousNamespace()) {
+    ns_decl = llvm::dyn_cast_or_null<clang::NamespaceDecl>(
+        markClangDeclObjectDefinedByKind(ns_decl));
+    if (ns_decl == nullptr || readClangApiValueDefined([&]() {
+          return ns_decl->isAnonymousNamespace();
+        })) {
       continue;
     }
 
-    SgName ns_name(ns_decl->getNameAsString());
+    SgName ns_name(
+        readClangApiValueDefined([&]() { return ns_decl->getNameAsString(); }));
     SgNamespaceDeclarationStatement *ns_stmt = nullptr;
     if (SgNamespaceSymbol *ns_symbol =
             reachable_scope->lookup_namespace_symbol(ns_name)) {
@@ -3215,15 +3974,24 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       return nullptr;
     }
 
-    const clang::DeclContext *alias_context = alias_decl->getDeclContext();
+    alias_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+        markClangDeclObjectDefinedByKind(alias_decl));
+    const clang::DeclContext *alias_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return alias_decl->getDeclContext(); }));
     const bool alias_context_has_template_parameters =
         templateParametersForDeclContext(alias_context) != nullptr;
-    if (alias_context == nullptr || (!alias_context->isDependentContext() &&
-                                     !alias_context_has_template_parameters)) {
+    const bool alias_context_dependent =
+        alias_context != nullptr && readClangApiValueDefined([&]() {
+          return alias_context->isDependentContext();
+        });
+    if (alias_context == nullptr ||
+        (!alias_context_dependent && !alias_context_has_template_parameters)) {
       return nullptr;
     }
 
-    std::string alias_name = alias_decl->getNameAsString();
+    std::string alias_name = readClangApiValueDefined(
+        [&]() { return alias_decl->getNameAsString(); });
     if (alias_name.empty()) {
       return nullptr;
     }
@@ -3381,28 +4149,44 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     };
     auto same_clang_record_decl = [](const clang::CXXRecordDecl *lhs,
                                      const clang::CXXRecordDecl *rhs) -> bool {
+      lhs = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+          markClangDeclObjectDefinedByKind(lhs));
+      rhs = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+          markClangDeclObjectDefinedByKind(rhs));
       if (lhs == nullptr || rhs == nullptr) {
         return false;
       }
-      const clang::CXXRecordDecl *lhs_canonical = lhs->getCanonicalDecl();
-      const clang::CXXRecordDecl *rhs_canonical = rhs->getCanonicalDecl();
+      const clang::CXXRecordDecl *lhs_canonical =
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return lhs->getCanonicalDecl(); })));
+      const clang::CXXRecordDecl *rhs_canonical =
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return rhs->getCanonicalDecl(); })));
       return lhs_canonical != nullptr && lhs_canonical == rhs_canonical;
     };
     auto active_translation_context_is_in_alias_owner = [&]() -> bool {
+      const clang::DeclContext *defined_alias_context =
+          markClangDeclContextObjectDefined(alias_context);
       const auto *alias_record =
-          llvm::dyn_cast<clang::CXXRecordDecl>(alias_context);
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(defined_alias_context);
       if (alias_record == nullptr) {
         return false;
       }
 
       for (auto it = p_template_parameter_decl_context_stack.rbegin();
            it != p_template_parameter_decl_context_stack.rend(); ++it) {
-        for (const clang::DeclContext *ctx = *it; ctx != nullptr;
-             ctx = ctx->getParent()) {
-          if (ctx == alias_context) {
+        for (const clang::DeclContext *ctx =
+                 markClangDeclContextObjectDefined(*it);
+             ctx != nullptr;
+             ctx = markClangDeclContextObjectDefined(readClangApiValueDefined(
+                 [&]() { return ctx->getParent(); }))) {
+          if (ctx == defined_alias_context) {
             return true;
           }
-          const auto *ctx_record = llvm::dyn_cast<clang::CXXRecordDecl>(ctx);
+          const auto *ctx_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclContextObjectDefined(ctx));
           if (same_clang_record_decl(ctx_record, alias_record)) {
             return true;
           }
@@ -3413,8 +4197,10 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     };
 
     auto build_explicit_enclosing_member_alias = [&]() -> SgNonrealType * {
+      const clang::DeclContext *defined_alias_context =
+          markClangDeclContextObjectDefined(alias_context);
       const auto *alias_record =
-          llvm::dyn_cast<clang::CXXRecordDecl>(alias_context);
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(defined_alias_context);
       if (alias_record == nullptr) {
         return nullptr;
       }
@@ -3440,14 +4226,19 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       }
 
       std::vector<const clang::DeclContext *> contexts;
-      for (const clang::DeclContext *dc = alias_context;
-           dc != nullptr && !dc->isTranslationUnit(); dc = dc->getParent()) {
+      for (const clang::DeclContext *dc = defined_alias_context;
+           dc != nullptr &&
+           !readClangApiValueDefined([&]() { return dc->isTranslationUnit(); });
+           dc = markClangDeclContextObjectDefined(
+               readClangApiValueDefined([&]() { return dc->getParent(); }))) {
         contexts.push_back(dc);
       }
 
       for (auto it = contexts.rbegin(); it != contexts.rend(); ++it) {
-        if (const auto *ns = llvm::dyn_cast<clang::NamespaceDecl>(*it)) {
-          std::string ns_name = ns->getNameAsString();
+        if (const auto *ns = llvm::dyn_cast_or_null<clang::NamespaceDecl>(
+                markClangDeclContextObjectDefined(*it))) {
+          std::string ns_name =
+              readClangApiValueDefined([&]() { return ns->getNameAsString(); });
           if (ns_name.empty()) {
             continue;
           }
@@ -3462,12 +4253,14 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
           continue;
         }
 
-        const auto *record = llvm::dyn_cast<clang::CXXRecordDecl>(*it);
+        const auto *record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+            markClangDeclContextObjectDefined(*it));
         if (record == nullptr) {
           continue;
         }
 
-        std::string record_name = record->getNameAsString();
+        std::string record_name = readClangApiValueDefined(
+            [&]() { return record->getNameAsString(); });
         if (record_name.empty()) {
           return nullptr;
         }
@@ -3774,6 +4567,7 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
 
   auto suppress_tag_decl_spelled_in_type_loc =
       [&](clang::TypeLoc spelled_type_loc) -> bool {
+    markClangTypeLocDataDefined(spelled_type_loc);
     if (spelled_type_loc.isNull() || p_compiler_instance == nullptr) {
       return false;
     }
@@ -3789,14 +4583,16 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       return sm.getFileLoc(loc);
     };
 
-    clang::SourceRange type_range = spelled_type_loc.getSourceRange();
+    clang::SourceRange type_range = readClangApiValueDefined(
+        [&]() { return spelled_type_loc.getSourceRange(); });
     clang::SourceLocation range_begin = file_loc(type_range.getBegin());
     clang::SourceLocation range_end = file_loc(type_range.getEnd());
     if (!range_begin.isValid() || !range_end.isValid()) {
       return false;
     }
 
-    clang::QualType current_qual_type = spelled_type_loc.getType();
+    clang::QualType current_qual_type = markClangQualTypeDefined(
+        readClangApiValueDefined([&]() { return spelled_type_loc.getType(); }));
     const clang::Type *current_type = current_qual_type.getTypePtrOrNull();
     clang::TagDecl *tag_decl = nullptr;
 
@@ -4349,13 +5145,15 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       markClangTypeLocDataDefined(spec_loc);
       if (const clang::TemplateSpecializationType *tst =
               static_cast<const clang::TemplateSpecializationType *>(
-                  markClangTypeObjectDefinedByClass(spec_loc.getTypePtr()))) {
-        clang::TemplateName tname =
-            markClangTemplateNameDefined(tst->getTemplateName());
+                  markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                      [&]() { return spec_loc.getTypePtr(); })))) {
+        clang::TemplateName tname = markClangTemplateNameDefined(
+            readClangApiValueDefined([&]() { return tst->getTemplateName(); }));
         std::string base_name = getTemplateNameBase(tname);
         if (!base_name.empty()) {
           clang::Decl *translated_decl_key = nullptr;
-          if (!tst->isDependentType()) {
+          if (!readClangApiValueDefined(
+                  [&]() { return tst->isDependentType(); })) {
             if (const clang::CXXRecordDecl *record_decl =
                     cxxRecordDeclFromQualTypeWithoutDefinitionLookup(
                         clang::QualType(tst, 0))) {
@@ -4368,8 +5166,13 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
                 resolve_template_decl(tname));
           }
           SgTemplateArgumentPtrList tpl_args;
-          for (unsigned i = 0; i < spec_loc.getNumArgs(); ++i) {
-            appendTemplateArguments(tpl_args, spec_loc.getArgLoc(i), true);
+          const unsigned num_args =
+              readClangApiValueDefined([&]() { return spec_loc.getNumArgs(); });
+          for (unsigned i = 0; i < num_args; ++i) {
+            appendTemplateArguments(tpl_args, readClangApiValueDefined([&]() {
+                                      return spec_loc.getArgLoc(i);
+                                    }),
+                                    true);
           }
           if (enable_default_template_args) {
             append_default_args_from_clang_template_decl(
@@ -4379,29 +5182,45 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
           clang::NestedNameSpecifier qualifier = std::nullopt;
           if (!prefer_current_scope) {
             if (clang::NestedNameSpecifierLoc prefix_loc =
-                    spec_loc.getPrefix()) {
-              qualifier = prefix_loc.getNestedNameSpecifier();
+                    markClangNestedNameSpecifierLocDefined(
+                        readClangApiValueDefined(
+                            [&]() { return spec_loc.getPrefix(); }))) {
+              qualifier =
+                  markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                      [&]() { return prefix_loc.getNestedNameSpecifier(); }));
             }
             if (!qualifier) {
               if (const clang::QualifiedTemplateName *qtn =
                       tname.getAsQualifiedTemplateName()) {
-                qualifier = qtn->getQualifier();
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return qtn->getQualifier(); }));
               } else if (const clang::DependentTemplateName *dtn =
                              tname.getAsDependentTemplateName()) {
-                qualifier = dtn->getQualifier();
+                qualifier = markClangNestedNameSpecifierDefined(
+                    readClangApiValueDefined(
+                        [&]() { return dtn->getQualifier(); }));
               }
             }
           }
 
+          const bool has_template_keyword =
+              readClangApiValueDefined([&]() {
+                return spec_loc.getTemplateKeywordLoc();
+              }).isValid();
+          const bool has_empty_angle_spelling =
+              num_args == 0 && readClangApiValueDefined([&]() {
+                                 return spec_loc.getLAngleLoc();
+                               }).isValid();
           if (SgType *nr = build_nonreal_template_type(
-                  base_name, scope, qualifier,
-                  spec_loc.getTemplateKeywordLoc().isValid(), tpl_args,
-                  spec_loc.getNumArgs() == 0 &&
-                      spec_loc.getLAngleLoc().isValid(),
-                  resolve_template_decl(tname))) {
+                  base_name, scope, qualifier, has_template_keyword, tpl_args,
+                  has_empty_angle_spelling, resolve_template_decl(tname))) {
             nr = attach_decl_to_nonreal(nr, translated_decl_key,
                                         /*allow_on_demand_lookup=*/false);
-            nr = apply_global_qualifier_from_loc(nr, spec_loc.getPrefix());
+            nr = apply_global_qualifier_from_loc(
+                nr,
+                markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                    [&]() { return spec_loc.getPrefix(); })));
             return isSgNonrealType(nr);
           }
         }
@@ -4410,13 +5229,20 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
 
     if (!prefer_current_scope) {
       if (clang::NestedNameSpecifierLoc prefix_loc =
-              nested_type_loc.getPrefix()) {
+              markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                  [&]() { return nested_type_loc.getPrefix(); }))) {
         auto build_from_named_decl =
             [&](const clang::NamedDecl *decl) -> SgNonrealType * {
           if (decl == nullptr) {
             return nullptr;
           }
-          std::string name_str = decl->getNameAsString();
+          decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
+              markClangDeclObjectDefinedByKind(decl));
+          std::string name_str = decl != nullptr
+                                     ? readClangApiValueDefined([&]() {
+                                         return decl->getNameAsString();
+                                       })
+                                     : "";
           if (name_str.empty()) {
             return nullptr;
           }
@@ -4424,27 +5250,50 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
               prefix_loc, scope, SgName(name_str), nullptr);
         };
 
-        if (auto tag_loc = nested_type_loc.getAs<clang::TagTypeLoc>()) {
-          if (SgNonrealType *nr = build_from_named_decl(tag_loc.getDecl())) {
+        if (auto tag_loc = readClangTypeLocDefined(
+                [&]() { return nested_type_loc.getAs<clang::TagTypeLoc>(); })) {
+          if (SgNonrealType *nr =
+                  build_from_named_decl(readClangApiValueDefined(
+                      [&]() { return tag_loc.getDecl(); }))) {
             return nr;
           }
         }
-        if (auto typedef_loc = nested_type_loc.getAs<clang::TypedefTypeLoc>()) {
-          if (SgNonrealType *nr =
-                  build_from_named_decl(typedef_loc.getTypePtr()->getDecl())) {
+        if (auto typedef_loc = readClangTypeLocDefined([&]() {
+              return nested_type_loc.getAs<clang::TypedefTypeLoc>();
+            })) {
+          const clang::TypedefType *typedef_type =
+              llvm::dyn_cast_or_null<clang::TypedefType>(
+                  markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                      [&]() { return typedef_loc.getTypePtr(); })));
+          if (SgNonrealType *nr = build_from_named_decl(
+                  typedef_type != nullptr ? readClangApiValueDefined([&]() {
+                    return typedef_type->getDecl();
+                  })
+                                          : nullptr)) {
             return nr;
           }
         }
-        if (auto using_loc = nested_type_loc.getAs<clang::UsingTypeLoc>()) {
-          if (SgNonrealType *nr =
-                  build_from_named_decl(using_loc.getTypePtr()->getDecl())) {
+        if (auto using_loc = readClangTypeLocDefined([&]() {
+              return nested_type_loc.getAs<clang::UsingTypeLoc>();
+            })) {
+          const clang::UsingType *using_type =
+              llvm::dyn_cast_or_null<clang::UsingType>(
+                  markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+                      [&]() { return using_loc.getTypePtr(); })));
+          if (SgNonrealType *nr = build_from_named_decl(
+                  using_type != nullptr ? readClangApiValueDefined([&]() {
+                    return using_type->getDecl();
+                  })
+                                        : nullptr)) {
             return nr;
           }
         }
-        if (auto injected_loc =
-                nested_type_loc.getAs<clang::InjectedClassNameTypeLoc>()) {
+        if (auto injected_loc = readClangTypeLocDefined([&]() {
+              return nested_type_loc.getAs<clang::InjectedClassNameTypeLoc>();
+            })) {
           if (SgNonrealType *nr =
-                  build_from_named_decl(injected_loc.getDecl())) {
+                  build_from_named_decl(readClangApiValueDefined(
+                      [&]() { return injected_loc.getDecl(); }))) {
             return nr;
           }
         }
@@ -4452,12 +5301,18 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     }
 
     SgNonrealType *nrtype = buildNonrealTypeForNestedNameSpecifierType(
-        nested_type_loc.getTypePtr(), scope, prefer_current_scope);
+        markClangTypeObjectDefinedByClass(readClangApiValueDefined(
+            [&]() { return nested_type_loc.getTypePtr(); })),
+        scope, prefer_current_scope);
     if (nrtype != nullptr) {
-      nrtype = isSgNonrealType(
-          apply_global_qualifier_from_loc(nrtype, nested_type_loc.getPrefix()));
+      nrtype = isSgNonrealType(apply_global_qualifier_from_loc(
+          nrtype,
+          markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+              [&]() { return nested_type_loc.getPrefix(); }))));
       if (SgNonrealDecl *nrdecl = isSgNonrealDecl(nrtype->get_declaration())) {
-        if (nested_type_loc.getTemplateKeywordLoc().isValid()) {
+        if (readClangApiValueDefined([&]() {
+              return nested_type_loc.getTemplateKeywordLoc();
+            }).isValid()) {
           nrdecl->set_has_template_keyword(true);
         }
       }
@@ -4501,14 +5356,19 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
                                   current_scope);
 
       clang::NestedNameSpecifier current_nns =
-          markClangNestedNameSpecifierDefined(
-              current_loc.getNestedNameSpecifier());
+          markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+              [&]() { return current_loc.getNestedNameSpecifier(); }));
       SgNonrealType *segment_type = nullptr;
-      switch (current_nns.getKind()) {
+      switch (
+          readClangApiValueDefined([&]() { return current_nns.getKind(); })) {
       case clang::NestedNameSpecifier::Kind::Namespace: {
         const clang::NamespaceBaseDecl *ns =
-            nestedNameSpecifierNamespaceBase(current_nns);
-        std::string name_str = ns ? ns->getNameAsString() : "";
+            llvm::dyn_cast_or_null<clang::NamespaceBaseDecl>(
+                markClangDeclObjectDefinedByKind(
+                    nestedNameSpecifierNamespaceBase(current_nns)));
+        std::string name_str = ns ? readClangApiValueDefined(
+                                        [&]() { return ns->getNameAsString(); })
+                                  : "";
         ROSE_ASSERT(!name_str.empty());
         segment_type = SageBuilder::buildNonrealType(SgName(name_str),
                                                      current_scope, nullptr);
@@ -4516,16 +5376,25 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       }
       case clang::NestedNameSpecifier::Kind::Type: {
         bool prefer_current =
-            static_cast<bool>(nested_name_specifier_loc_prefix(current_loc));
+            static_cast<bool>(markClangNestedNameSpecifierLocDefined(
+                nested_name_specifier_loc_prefix(current_loc)));
         segment_type = build_nonreal_type_for_nested_name_specifier_typeloc(
-            current_loc.getAsTypeLoc(), current_scope, prefer_current);
+            readClangTypeLocDefined(
+                [&]() { return current_loc.getAsTypeLoc(); }),
+            current_scope, prefer_current);
         break;
       }
       case clang::NestedNameSpecifier::Kind::Global:
         break;
       case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
-        clang::CXXRecordDecl *record = current_nns.getAsRecordDecl();
-        std::string name_str = record ? record->getNameAsString() : "";
+        clang::CXXRecordDecl *record = const_cast<clang::CXXRecordDecl *>(
+            llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+                markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                    [&]() { return current_nns.getAsRecordDecl(); }))));
+        std::string name_str = record ? readClangApiValueDefined([&]() {
+          return record->getNameAsString();
+        })
+                                      : "";
         if (name_str.empty()) {
           name_str = "__super";
         }
@@ -4542,13 +5411,17 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
             isSgNonrealDecl(segment_type->get_declaration());
         ROSE_ASSERT(segment_decl != nullptr);
         if (clang::NestedNameSpecifierLoc prefix_loc =
-                nested_name_specifier_loc_prefix(current_loc)) {
+                markClangNestedNameSpecifierLocDefined(
+                    nested_name_specifier_loc_prefix(current_loc))) {
           prefix_loc = markClangNestedNameSpecifierLocDefined(prefix_loc);
           clang::NestedNameSpecifier prefix =
-              markClangNestedNameSpecifierDefined(
-                  prefix_loc.getNestedNameSpecifier());
-          if (prefix.getKind() == clang::NestedNameSpecifier::Kind::Global &&
-              prefix_loc.getLocalBeginLoc().isValid()) {
+              markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                  [&]() { return prefix_loc.getNestedNameSpecifier(); }));
+          if (readClangApiValueDefined([&]() { return prefix.getKind(); }) ==
+                  clang::NestedNameSpecifier::Kind::Global &&
+              readClangApiValueDefined([&]() {
+                return prefix_loc.getLocalBeginLoc();
+              }).isValid()) {
             segment_decl->set_has_global_qualifier(true);
           }
         }
@@ -4572,7 +5445,9 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       return nestedNameSpecifierHasDependentTypeQualifier(nns);
     };
 
-    if (!qualifier_requires_typename(qualifier_loc.getNestedNameSpecifier())) {
+    if (!qualifier_requires_typename(
+            markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                [&]() { return qualifier_loc.getNestedNameSpecifier(); })))) {
       nrdecl->set_suppress_typename(true);
     }
     if (nestedNameSpecifierLocHasExplicitGlobal(qualifier_loc)) {
@@ -4873,39 +5748,59 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
 
   auto nested_name_specifier_loc_requires_written_nonreal =
       [&](clang::NestedNameSpecifierLoc qualifier_loc) -> bool {
-    for (clang::NestedNameSpecifierLoc current = qualifier_loc; current;
-         current = nested_name_specifier_loc_prefix(current)) {
+    for (clang::NestedNameSpecifierLoc current =
+             markClangNestedNameSpecifierLocDefined(qualifier_loc);
+         current; current = markClangNestedNameSpecifierLocDefined(
+                      nested_name_specifier_loc_prefix(current))) {
       current = markClangNestedNameSpecifierLocDefined(current);
       clang::NestedNameSpecifier nns =
-          markClangNestedNameSpecifierDefined(current.getNestedNameSpecifier());
-      if (nns.getKind() != clang::NestedNameSpecifier::Kind::Type) {
+          markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+              [&]() { return current.getNestedNameSpecifier(); }));
+      if (readClangApiValueDefined([&]() { return nns.getKind(); }) !=
+          clang::NestedNameSpecifier::Kind::Type) {
         continue;
       }
 
-      const clang::Type *qualifier_type =
-          markClangTypeObjectDefinedByClass(nns.getAsType());
-      if (qualifier_type != nullptr && qualifier_type->isDependentType()) {
+      const clang::Type *qualifier_type = markClangTypeObjectDefinedByClass(
+          readClangApiValueDefined([&]() { return nns.getAsType(); }));
+      if (qualifier_type != nullptr && readClangApiValueDefined([&]() {
+            return qualifier_type->isDependentType();
+          })) {
         return true;
       }
 
-      clang::TypeLoc qualifier_type_loc = current.getAsTypeLoc();
+      clang::TypeLoc qualifier_type_loc =
+          readClangTypeLocDefined([&]() { return current.getAsTypeLoc(); });
       markClangTypeLocDataDefined(qualifier_type_loc);
       if (qualifier_type_loc.isNull()) {
         continue;
       }
 
-      if (qualifier_type_loc.getAs<clang::TemplateSpecializationTypeLoc>() ||
-          qualifier_type_loc.getAs<clang::DependentNameTypeLoc>()) {
+      if (readClangApiValueDefined([&]() {
+            return qualifier_type_loc
+                .getAs<clang::TemplateSpecializationTypeLoc>();
+          }) ||
+          readClangApiValueDefined([&]() {
+            return qualifier_type_loc.getAs<clang::DependentNameTypeLoc>();
+          })) {
         return true;
       }
 
-      clang::QualType written = qualifier_type_loc.getType();
+      clang::QualType written =
+          markClangQualTypeDefined(readClangApiValueDefined(
+              [&]() { return qualifier_type_loc.getType(); }));
       if (!written.isNull() &&
           written.getTypePtrOrNull() !=
-              written.getCanonicalType().getTypePtrOrNull()) {
-        const clang::Type *written_type = written.getTypePtrOrNull();
-        if (written_type != nullptr && !written_type->isDependentType() &&
-            written_type->getAsTagDecl() != nullptr) {
+              markClangQualTypeDefined(readClangApiValueDefined([&]() {
+                return written.getCanonicalType();
+              })).getTypePtrOrNull()) {
+        const clang::Type *written_type =
+            markClangTypeObjectDefinedByClass(written.getTypePtrOrNull());
+        if (written_type != nullptr && !readClangApiValueDefined([&]() {
+              return written_type->isDependentType();
+            }) &&
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return written_type->getAsTagDecl(); })) != nullptr) {
           continue;
         }
         return true;
@@ -5137,16 +6032,27 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
   auto is_semantic_outer_embedded_forward_tag =
       [](const clang::TagDecl *tag_decl) -> bool {
     const clang::RecordDecl *record_decl =
-        llvm::dyn_cast_or_null<clang::RecordDecl>(tag_decl);
-    if (record_decl == nullptr || record_decl->isThisDeclarationADefinition()) {
+        llvm::dyn_cast_or_null<clang::RecordDecl>(
+            markClangDeclObjectDefinedByKind(tag_decl));
+    if (record_decl == nullptr || readClangApiValueDefined([&]() {
+          return record_decl->isThisDeclarationADefinition();
+        })) {
       return false;
     }
 
-    return record_decl->isEmbeddedInDeclarator() &&
-           record_decl->getDeclContext() != nullptr &&
-           record_decl->getLexicalDeclContext() != nullptr &&
-           record_decl->getDeclContext() !=
-               record_decl->getLexicalDeclContext();
+    if (!readClangApiValueDefined(
+            [&]() { return record_decl->isEmbeddedInDeclarator(); })) {
+      return false;
+    }
+
+    const clang::DeclContext *semantic_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return record_decl->getDeclContext(); }));
+    const clang::DeclContext *lexical_context =
+        markClangDeclContextObjectDefined(readClangApiValueDefined(
+            [&]() { return record_decl->getLexicalDeclContext(); }));
+    return semantic_context != nullptr && lexical_context != nullptr &&
+           semantic_context != lexical_context;
   };
 
   auto build_nonreal_from_elaborated_parts =
@@ -5478,8 +6384,9 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     const clang::TemplateSpecializationType *spec_type =
         static_cast<const clang::TemplateSpecializationType *>(
             markClangTypeObjectDefinedByClass(spec_loc.getTypePtr()));
-    clang::NestedNameSpecifierLoc qualifier_loc = spec_loc.getQualifierLoc();
-    markClangValueDefined(qualifier_loc);
+    clang::NestedNameSpecifierLoc qualifier_loc =
+        markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+            [&]() { return spec_loc.getQualifierLoc(); }));
     if (SgType *written_type = build_nonreal_from_elaborated_parts(
             spec_type, spec_type->getKeyword(),
             qualifier_loc.getNestedNameSpecifier(), spec_loc, qualifier_loc)) {
@@ -5500,7 +6407,7 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
   if (auto typedef_loc = type_loc.getAs<clang::TypedefTypeLoc>()) {
     markClangTypeLocDataDefined(typedef_loc);
 #if ROSE_USE_VALGRIND
-    if (RUNNING_ON_VALGRIND) {
+    if (clangFrontendRunningOnValgrind()) {
       if (void *data = typedef_loc.getOpaqueData()) {
         const unsigned local_size =
             std::max<unsigned>(typedef_loc.getLocalDataSize(),
@@ -5542,12 +6449,13 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
             typedef_loc.getQualifierLoc());
       }
       clang::NestedNameSpecifier qualifier =
-          markClangNestedNameSpecifierDefined(typedef_type->getQualifier());
+          markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+              [&]() { return typedef_type->getQualifier(); }));
       if (!qualifier) {
         return clang::NestedNameSpecifierLoc();
       }
 #if ROSE_USE_VALGRIND
-      if (RUNNING_ON_VALGRIND) {
+      if (clangFrontendRunningOnValgrind()) {
         if (void *data = typedef_loc.getOpaqueData()) {
           void *qualifier_data = nullptr;
           constexpr unsigned qualifier_data_offset =
@@ -5560,16 +6468,19 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
         }
       }
 #endif
-      return markClangNestedNameSpecifierLocDefined(
-          typedef_loc.getQualifierLoc());
+      return markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+          [&]() { return typedef_loc.getQualifierLoc(); }));
     };
     clang::NestedNameSpecifierLoc qualifier_loc = typedef_qualifier_loc();
     clang::NestedNameSpecifier qualifier =
-        qualifier_loc.getNestedNameSpecifier();
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
     const bool has_written_qualifier = static_cast<bool>(qualifier);
     if (!qualifier && typedef_type != nullptr &&
-        !typedef_type->isDependentType()) {
-      qualifier = typedef_type->getQualifier();
+        !readClangApiValueDefined(
+            [&]() { return typedef_type->isDependentType(); })) {
+      qualifier = markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+          [&]() { return typedef_type->getQualifier(); }));
     }
     const bool qualifier_has_type_qualifier =
         nestedNameSpecifierHasTypeQualifier(qualifier);
@@ -5580,21 +6491,31 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
         nested_name_specifier_loc_requires_written_nonreal(qualifier_loc);
     const bool preserve_unqualified_written_typedef =
         typedef_type != nullptr && !has_written_qualifier &&
-        !typedef_type->isDependentType() && !qualifier_requires_written_nonreal;
+        !readClangApiValueDefined(
+            [&]() { return typedef_type->isDependentType(); }) &&
+        !qualifier_requires_written_nonreal;
     const bool use_translated_typedef_type =
         typedef_type != nullptr && has_written_qualifier &&
-        typedef_type->getKeyword() == clang::ElaboratedTypeKeyword::None &&
-        !typedef_type->isDependentType() && !qualifier_has_type_qualifier &&
-        !qualifier_requires_written_nonreal &&
+        readClangApiValueDefined([&]() {
+          return typedef_type->getKeyword();
+        }) == clang::ElaboratedTypeKeyword::None &&
+        !readClangApiValueDefined(
+            [&]() { return typedef_type->isDependentType(); }) &&
+        !qualifier_has_type_qualifier && !qualifier_requires_written_nonreal &&
         !qualifier_spells_namespace_or_global;
 
     if (typedef_type != nullptr && !has_written_qualifier &&
-        (typedef_type->isDependentType() ||
+        (readClangApiValueDefined(
+             [&]() { return typedef_type->isDependentType(); }) ||
          typedef_has_dependent_underlying(typedef_type)) &&
         !qualifier_requires_written_nonreal) {
       if (SgType *written_dependent_typedef =
               build_unqualified_dependent_alias_nonreal(
-                  typedef_type->getDecl(), typedef_type->getKeyword())) {
+                  llvm::dyn_cast_or_null<clang::TypedefNameDecl>(
+                      markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                          [&]() { return typedef_type->getDecl(); }))),
+                  readClangApiValueDefined(
+                      [&]() { return typedef_type->getKeyword(); }))) {
         return finalize_spelled_type(written_dependent_typedef);
       }
     }
@@ -5700,14 +6621,21 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     }
   }
 
-  if (auto tag_loc = type_loc.getAs<clang::TagTypeLoc>()) {
-    const clang::TagType *tag_type = tag_loc.getTypePtr();
-    clang::NestedNameSpecifierLoc qualifier_loc = tag_loc.getQualifierLoc();
+  if (auto tag_loc = readClangTypeLocDefined(
+          [&]() { return type_loc.getAs<clang::TagTypeLoc>(); })) {
+    const clang::TagType *tag_type = llvm::dyn_cast_or_null<clang::TagType>(
+        markClangTypeObjectDefinedByClass(
+            readClangApiValueDefined([&]() { return tag_loc.getTypePtr(); })));
+    clang::NestedNameSpecifierLoc qualifier_loc =
+        markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+            [&]() { return tag_loc.getQualifierLoc(); }));
     clang::NestedNameSpecifier qualifier =
-        qualifier_loc.getNestedNameSpecifier();
+        markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+            [&]() { return qualifier_loc.getNestedNameSpecifier(); }));
     const bool has_explicit_written_qualifier = static_cast<bool>(qualifier);
     if (!qualifier && tag_type != nullptr) {
-      qualifier = tag_type->getQualifier();
+      qualifier = markClangNestedNameSpecifierDefined(
+          readClangApiValueDefined([&]() { return tag_type->getQualifier(); }));
     }
     const bool has_written_qualifier = static_cast<bool>(qualifier);
     const bool qualifier_has_type_qualifier =
@@ -5720,7 +6648,10 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
     const bool force_written_qualified_tag_type =
         p_force_written_tag_type_qualification_depth != 0 && qualifier_loc;
     auto translated_tag_type_if_available =
-        [&](clang::TagDecl *tag_decl) -> SgType * {
+        [&](const clang::TagDecl *raw_tag_decl) -> SgType * {
+      clang::TagDecl *tag_decl =
+          const_cast<clang::TagDecl *>(llvm::dyn_cast_or_null<clang::TagDecl>(
+              markClangDeclObjectDefinedByKind(raw_tag_decl)));
       if (tag_decl == nullptr) {
         return nullptr;
       }
@@ -5744,18 +6675,27 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       return nullptr;
     };
     SgType *translated_tag_type = translated_tag_type_if_available(
-        tag_type != nullptr ? tag_type->getDecl() : nullptr);
+        tag_type != nullptr
+            ? llvm::dyn_cast_or_null<clang::TagDecl>(
+                  markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                      [&]() { return tag_type->getDecl(); })))
+            : nullptr);
 
     auto build_current_instantiation_member_tag_type =
-        [&](clang::TagDecl *tag_decl) -> SgType * {
+        [&](const clang::TagDecl *raw_tag_decl) -> SgType * {
+      clang::TagDecl *tag_decl =
+          const_cast<clang::TagDecl *>(llvm::dyn_cast_or_null<clang::TagDecl>(
+              markClangDeclObjectDefinedByKind(raw_tag_decl)));
       if (tag_decl == nullptr || tag_type == nullptr ||
           has_explicit_written_qualifier ||
-          tag_type->getKeyword() != clang::ElaboratedTypeKeyword::None) {
+          readClangApiValueDefined([&]() { return tag_type->getKeyword(); }) !=
+              clang::ElaboratedTypeKeyword::None) {
         return nullptr;
       }
 
       const auto *owner_record = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-          tag_decl->getDeclContext());
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return tag_decl->getDeclContext(); })));
       if (owner_record == nullptr ||
           (templateParametersForDeclContext(owner_record) == nullptr &&
            !readClangApiValueDefined(
@@ -5768,14 +6708,17 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
            it != p_template_parameter_decl_context_stack.rend(); ++it) {
         current_function = llvm::dyn_cast_or_null<clang::FunctionDecl>(*it);
         if (current_function != nullptr &&
-            current_function->getQualifierLoc()) {
+            markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+                [&]() { return current_function->getQualifierLoc(); }))) {
           break;
         }
         current_function = nullptr;
       }
       const auto *method_decl =
           llvm::dyn_cast_or_null<clang::CXXMethodDecl>(current_function);
-      if (method_decl == nullptr || method_decl->getParent() == nullptr) {
+      if (method_decl == nullptr ||
+          markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+              [&]() { return method_decl->getParent(); })) == nullptr) {
         return nullptr;
       }
 
@@ -5815,21 +6758,31 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
       };
 
       clang::NestedNameSpecifierLoc method_qualifier_loc =
-          current_function->getQualifierLoc();
+          markClangNestedNameSpecifierLocDefined(readClangApiValueDefined(
+              [&]() { return current_function->getQualifierLoc(); }));
       clang::NestedNameSpecifier method_qualifier =
-          method_qualifier_loc.getNestedNameSpecifier();
-      if (!method_qualifier || method_qualifier.getKind() !=
-                                   clang::NestedNameSpecifier::Kind::Type) {
+          markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+              [&]() { return method_qualifier_loc.getNestedNameSpecifier(); }));
+      if (!method_qualifier || readClangApiValueDefined([&]() {
+                                 return method_qualifier.getKind();
+                               }) != clang::NestedNameSpecifier::Kind::Type) {
         return nullptr;
       }
-      clang::CXXRecordDecl *qualified_record =
-          method_qualifier.getAsRecordDecl();
-      if (!same_template_record(owner_record, method_decl->getParent()) ||
+      const clang::CXXRecordDecl *qualified_record =
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return method_qualifier.getAsRecordDecl(); })));
+      const clang::CXXRecordDecl *method_parent =
+          llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return method_decl->getParent(); })));
+      if (!same_template_record(owner_record, method_parent) ||
           !same_template_record(owner_record, qualified_record)) {
         return nullptr;
       }
 
-      std::string tag_name = tag_decl->getNameAsString();
+      std::string tag_name = readClangApiValueDefined(
+          [&]() { return tag_decl->getNameAsString(); });
       if (tag_name.empty()) {
         return nullptr;
       }
@@ -5845,16 +6798,23 @@ ClangToSageTranslator::buildTypeFromTypeLoc(const clang::TypeLoc &type_loc) {
 
     if (SgType *current_instantiation_tag_type =
             build_current_instantiation_member_tag_type(
-                tag_type != nullptr ? tag_type->getDecl() : nullptr)) {
+                tag_type != nullptr ? llvm::dyn_cast_or_null<clang::TagDecl>(
+                                          markClangDeclObjectDefinedByKind(
+                                              readClangApiValueDefined([&]() {
+                                                return tag_type->getDecl();
+                                              })))
+                                    : nullptr)) {
       return finalize_spelled_type(current_instantiation_tag_type);
     }
 
     const bool use_translated_tag_type =
         translated_tag_type != nullptr && tag_type != nullptr &&
         has_written_qualifier &&
-        tag_type->getKeyword() == clang::ElaboratedTypeKeyword::None &&
-        !tag_type->isDependentType() && !qualifier_has_type_qualifier &&
-        !qualifier_requires_written_nonreal &&
+        readClangApiValueDefined([&]() { return tag_type->getKeyword(); }) ==
+            clang::ElaboratedTypeKeyword::None &&
+        !readClangApiValueDefined(
+            [&]() { return tag_type->isDependentType(); }) &&
+        !qualifier_has_type_qualifier && !qualifier_requires_written_nonreal &&
         !force_written_qualified_tag_type;
 
     // Qualified tag references such as `Outer::Inner` should use the
@@ -6428,21 +7388,24 @@ bool ClangToSageTranslator::VisitDecayedType(clang::DecayedType *decayed_type,
 
   //    SgType * decayType =
   //    buildTypeFromQualifiedType(decayed_type->getDecayedType ());
-  SgType *pointeeType =
-      buildTypeFromQualifiedType(decayed_type->getPointeeType());
+  clang::QualType pointee_qual_type =
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return decayed_type->getPointeeType(); }));
+  const clang::Type *pointee_clang_type =
+      markClangTypeObjectDefinedByClass(pointee_qual_type.getTypePtrOrNull());
+  SgType *pointeeType = buildTypeFromQualifiedType(pointee_qual_type);
 
   //    *node = pointeeType;
   // Pei-Hung (04/08/2022) Building SgArrayyType to represent the DecayedType in
   // Clang, in order to match the type of ParmVarDecl  in FunctionProtoType
   // Might need to check the case when the pointeeType is a functionType
-  if (decayed_type->getPointeeType()->getTypeClass() ==
-          clang::Type::VariableArray ||
-      decayed_type->getPointeeType()->getTypeClass() ==
-          clang::Type::ConstantArray ||
-      decayed_type->getPointeeType()->getTypeClass() ==
-          clang::Type::DependentSizedArray ||
-      decayed_type->getPointeeType()->getTypeClass() ==
-          clang::Type::IncompleteArray)
+  const clang::Type::TypeClass pointee_type_class =
+      pointee_clang_type != nullptr ? pointee_clang_type->getTypeClass()
+                                    : clang::Type::Builtin;
+  if (pointee_type_class == clang::Type::VariableArray ||
+      pointee_type_class == clang::Type::ConstantArray ||
+      pointee_type_class == clang::Type::DependentSizedArray ||
+      pointee_type_class == clang::Type::IncompleteArray)
     *node = SageBuilder::buildArrayType(pointeeType);
   else
     *node = pointeeType;
@@ -6822,7 +7785,9 @@ bool ClangToSageTranslator::VisitDecltypeType(
 #endif
   bool res = true;
 
-  clang::QualType underlying_type = decltype_type->getUnderlyingType();
+  clang::QualType underlying_type =
+      markClangQualTypeDefined(readClangApiValueDefined(
+          [&]() { return decltype_type->getUnderlyingType(); }));
   SgType *sg_underlying_type = nullptr;
   if (!underlying_type.isNull()) {
     sg_underlying_type = buildTypeFromQualifiedType(underlying_type);
@@ -6836,7 +7801,9 @@ bool ClangToSageTranslator::VisitDecltypeType(
       return type;
     };
 
-    clang::QualType canonical_type = decltype_type->getCanonicalTypeInternal();
+    clang::QualType canonical_type =
+        markClangQualTypeDefined(readClangApiValueDefined(
+            [&]() { return decltype_type->getCanonicalTypeInternal(); }));
     SgType *underlying_core = strip_modifier_layers(sg_underlying_type);
     if (!canonical_type.isNull() && canonical_type->isPointerType() &&
         isSgPointerType(underlying_core) == nullptr) {
@@ -7415,7 +8382,8 @@ bool ClangToSageTranslator::VisitMemberPointerType(
     classTypeStripped =
         classType != NULL ? classType->stripTypedefsAndModifiers() : NULL;
     if (needs_nonreal_fallback(classTypeStripped)) {
-      std::string class_name = classQualType.getAsString();
+      std::string class_name =
+          clangQualTypeAsStringDefinedForFrontend(classQualType);
       if (class_name.empty()) {
         class_name = "unknown_member_class";
       }
@@ -7792,12 +8760,17 @@ bool ClangToSageTranslator::VisitRecordType(clang::RecordType *record_type,
   std::cerr << "ClangToSageTranslator::VisitRecordType" << std::endl;
 #endif
 
-  clang::RecordDecl *record_decl = record_type->getDecl();
+  record_type = const_cast<clang::RecordType *>(
+      llvm::dyn_cast<clang::RecordType>(markClangTypeObjectDefinedByClass(
+          static_cast<const clang::Type *>(record_type))));
+  clang::RecordDecl *record_decl = markClangRecordDeclDefined(
+      readClangApiValueDefined([&]() { return record_type->getDecl(); }));
   bool used_header_placeholder_decl = false;
 
   bool is_specialization =
-      llvm::isa<clang::ClassTemplateSpecializationDecl>(record_decl) ||
-      llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(record_decl);
+      record_decl != nullptr &&
+      (llvm::isa<clang::ClassTemplateSpecializationDecl>(record_decl) ||
+       llvm::isa<clang::ClassTemplatePartialSpecializationDecl>(record_decl));
 
   // Prefer the canonical declaration for symbol lookup and type association.
   //
@@ -7811,7 +8784,10 @@ bool ClangToSageTranslator::VisitRecordType(clang::RecordType *record_type,
   // specialization decl as the identity (Issue 126).
   clang::RecordDecl *lookup_decl = record_decl;
   if (!is_specialization && record_decl != NULL) {
-    clang::TagDecl *canonical = record_decl->getCanonicalDecl();
+    clang::TagDecl *canonical =
+        const_cast<clang::TagDecl *>(llvm::dyn_cast_or_null<clang::TagDecl>(
+            markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                [&]() { return record_decl->getCanonicalDecl(); }))));
     if (clang::RecordDecl *canonical_record =
             llvm::dyn_cast_or_null<clang::RecordDecl>(canonical)) {
       lookup_decl = canonical_record;
@@ -7935,7 +8911,9 @@ bool ClangToSageTranslator::VisitRecordType(clang::RecordType *record_type,
       return nullptr;
     }
 
-    applySourceRange(placeholder, target_decl->getSourceRange());
+    applySourceRange(placeholder, readClangApiValueDefined([&]() {
+                       return target_decl->getSourceRange();
+                     }));
     placeholder->set_scope(scope);
     if (placeholder->get_parent() == nullptr) {
       placeholder->set_parent(scope);
@@ -9292,7 +10270,7 @@ SgTemplateArgument *ClangToSageTranslator::translateTemplateArgument(
         markClangQualTypeDefined(defined_arg.getStructuralValueType());
     SgType *value_type = buildTypeFromQualifiedType(structural_qual_type);
     const clang::APValue &value = defined_arg.getAsStructuralValue();
-    markClangAstObjectDefined(&value);
+    markClangLocalObjectDefined(&value);
     SgExpression *value_expr = build_structural_expr(value, value_type);
     if (value_expr != nullptr &&
         templateArgumentNeedsExplicitAddressOf(value_type, value_expr)) {
@@ -9517,17 +10495,25 @@ SgType *ClangToSageTranslator::translateTypeTemplateArgument(
         clang::TypeLoc type_loc = written_type_loc;
         while (!type_loc.isNull()) {
           if (auto tag_loc = type_loc.getAs<clang::TagTypeLoc>()) {
-            const clang::TagType *tag_type = tag_loc.getTypePtr();
+            const clang::TagType *tag_type =
+                llvm::dyn_cast_or_null<clang::TagType>(
+                    markClangTypeObjectDefinedByClass(tag_loc.getTypePtr()));
             if (tag_type == nullptr || tag_type->isDependentType()) {
               return nullptr;
             }
 
+            clang::NestedNameSpecifier written_qualifier =
+                readClangApiValueDefined(
+                    [&]() { return tag_type->getQualifier(); });
+            markClangTagTypeQualifierStorageDefined(tag_type,
+                                                    written_qualifier);
+            markClangNestedNameSpecifierDefined(written_qualifier);
             clang::NestedNameSpecifierLoc qualifier_loc =
                 tag_loc.getQualifierLoc();
             clang::NestedNameSpecifier qualifier =
                 qualifier_loc.getNestedNameSpecifier();
             if (!qualifier) {
-              qualifier = tag_type->getQualifier();
+              qualifier = written_qualifier;
             }
             bool qualifier_requires_written_nonreal = false;
             auto next_qualifier_loc = [](clang::NestedNameSpecifierLoc current)
@@ -10192,6 +11178,7 @@ ClangToSageTranslator::buildNonrealTypeForNestedNameSpecifierType(
   auto build_with_qualifier =
       [&](clang::NestedNameSpecifier qualifier, const std::string &name,
           const SgTemplateArgumentPtrList *tpl_args) -> SgNonrealType * {
+    qualifier = markClangNestedNameSpecifierDefined(qualifier);
     std::string base_name = sanitize_nonreal_name(name);
     ROSE_ASSERT(!base_name.empty());
     if (prefer_current_scope) {
@@ -10574,12 +11561,25 @@ ClangToSageTranslator::buildNonrealTypeForNestedNameSpecifierType(
 
   if (const clang::TagType *tag_type =
           llvm::dyn_cast<clang::TagType>(clang_type)) {
-    const clang::TagDecl *decl = tag_type->getDecl();
-    std::string name_str = decl != nullptr ? decl->getNameAsString() : "";
-    if (!name_str.empty() && tag_type->getQualifier()) {
+    tag_type = llvm::dyn_cast_or_null<clang::TagType>(
+        markClangTypeObjectDefinedByClass(tag_type));
+    const clang::TagDecl *decl =
+        tag_type != nullptr
+            ? markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return tag_type->getDecl(); }))
+            : nullptr;
+    std::string name_str = decl != nullptr ? readClangApiValueDefined([&]() {
+      return decl->getNameAsString();
+    })
+                                           : "";
+    clang::NestedNameSpecifier qualifier =
+        tag_type != nullptr
+            ? markClangNestedNameSpecifierDefined(readClangApiValueDefined(
+                  [&]() { return tag_type->getQualifier(); }))
+            : std::nullopt;
+    if (!name_str.empty() && qualifier) {
       return attach_named_decl_to_nonreal(
-          build_with_qualifier(tag_type->getQualifier(), name_str, nullptr),
-          decl);
+          build_with_qualifier(qualifier, name_str, nullptr), decl);
     }
   }
 
@@ -10589,6 +11589,7 @@ ClangToSageTranslator::buildNonrealTypeForNestedNameSpecifierType(
     SgScopeStatement *template_param_scope = scope;
     auto get_fallback_template_param_scope =
         [&](const clang::DeclContext *decl_context) -> SgDeclarationScope * {
+      decl_context = markClangDeclContextObjectDefined(decl_context);
       if (decl_context == nullptr) {
         return nullptr;
       }
@@ -10923,10 +11924,12 @@ SgNonrealType *ClangToSageTranslator::buildNonrealTypeFromNestedNameSpecifier(
     }
 
     case clang::NestedNameSpecifier::Kind::Type: {
-      bool prefer_current = static_cast<bool>(nestedNameSpecifierPrefix(nns));
+      bool prefer_current = static_cast<bool>(
+          markClangNestedNameSpecifierDefined(nestedNameSpecifierPrefix(nns)));
       segment_type = buildNonrealTypeForNestedNameSpecifierType(
-          markClangTypeObjectDefinedByClass(nns.getAsType()), current_scope,
-          prefer_current);
+          markClangTypeObjectDefinedByClass(
+              readClangApiValueDefined([&]() { return nns.getAsType(); })),
+          current_scope, prefer_current);
       break;
     }
 
@@ -10936,8 +11939,12 @@ SgNonrealType *ClangToSageTranslator::buildNonrealTypeFromNestedNameSpecifier(
     case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
       clang::CXXRecordDecl *record = const_cast<clang::CXXRecordDecl *>(
           llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-              markClangDeclObjectDefinedByKind(nns.getAsRecordDecl())));
-      std::string name_str = record ? record->getNameAsString() : "";
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return nns.getAsRecordDecl(); }))));
+      std::string name_str = record ? readClangApiValueDefined([&]() {
+        return record->getNameAsString();
+      })
+                                    : "";
       if (name_str.empty()) {
         name_str = "__super";
       }
@@ -11035,17 +12042,23 @@ ClangToSageTranslator::buildNonrealScopeFromNestedNameSpecifier(
       break;
     }
     case clang::NestedNameSpecifier::Kind::Type: {
-      bool prefer_current = static_cast<bool>(nestedNameSpecifierPrefix(nns));
+      bool prefer_current = static_cast<bool>(
+          markClangNestedNameSpecifierDefined(nestedNameSpecifierPrefix(nns)));
       segment_type = buildNonrealTypeForNestedNameSpecifierType(
-          markClangTypeObjectDefinedByClass(nns.getAsType()), current_scope,
-          prefer_current);
+          markClangTypeObjectDefinedByClass(
+              readClangApiValueDefined([&]() { return nns.getAsType(); })),
+          current_scope, prefer_current);
       break;
     }
     case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
       clang::CXXRecordDecl *record = const_cast<clang::CXXRecordDecl *>(
           llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
-              markClangDeclObjectDefinedByKind(nns.getAsRecordDecl())));
-      std::string name_str = record ? record->getNameAsString() : "";
+              markClangDeclObjectDefinedByKind(readClangApiValueDefined(
+                  [&]() { return nns.getAsRecordDecl(); }))));
+      std::string name_str = record ? readClangApiValueDefined([&]() {
+        return record->getNameAsString();
+      })
+                                    : "";
       if (name_str.empty()) {
         name_str = "__super";
       }
@@ -11127,16 +12140,22 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
   if (clang_type != nullptr) {
     clang_type = static_cast<const clang::TemplateSpecializationType *>(
         markClangTypeObjectDefinedByClass(clang_type));
-    clang_tname = markClangTemplateNameDefined(clang_type->getTemplateName());
-    inst_clang_template_decl = clang_tname.getAsTemplateDecl();
-    clang::QualType canonical_qt = markClangQualTypeDefined(
-        clang::QualType(clang_type, 0).getCanonicalType());
+    clang_tname = markClangTemplateNameDefined(readClangApiValueDefined(
+        [&]() { return clang_type->getTemplateName(); }));
+    inst_clang_template_decl =
+        markClangSpecificDeclDefined(readClangApiValueDefined(
+            [&]() { return clang_tname.getAsTemplateDecl(); }));
+    clang::QualType canonical_qt =
+        markClangQualTypeDefined(readClangApiValueDefined([&]() {
+          return clang::QualType(clang_type, 0).getCanonicalType();
+        }));
     const clang::Type *canonical_type =
         markClangTypeObjectDefinedByClass(canonical_qt.getTypePtrOrNull());
     if (const auto *tag_type =
             llvm::dyn_cast_or_null<clang::TagType>(canonical_type)) {
       const clang::TagDecl *tag_decl = llvm::dyn_cast_or_null<clang::TagDecl>(
-          markClangDeclObjectDefinedByKind(tag_type->getDecl()));
+          markClangDeclObjectDefinedByKind(
+              readClangApiValueDefined([&]() { return tag_type->getDecl(); })));
       const clang::CXXRecordDecl *record_decl =
           llvm::dyn_cast_or_null<clang::CXXRecordDecl>(tag_decl);
       record_decl = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
@@ -11150,9 +12169,12 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
     }
     if (inst_record_spec_decl != nullptr) {
       inst_decl_context = const_cast<clang::DeclContext *>(
-          inst_record_spec_decl->getDeclContext());
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return inst_record_spec_decl->getDeclContext(); })));
     } else if (inst_clang_template_decl != nullptr) {
-      inst_decl_context = inst_clang_template_decl->getDeclContext();
+      inst_decl_context =
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return inst_clang_template_decl->getDeclContext(); }));
     }
   }
 
@@ -11431,32 +12453,44 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
   std::function<SgScopeStatement *(const clang::DeclContext *)>
       resolve_nested_specialization_scope =
           [&](const clang::DeclContext *context) -> SgScopeStatement * {
-    while (context != nullptr && llvm::isa<clang::LinkageSpecDecl>(context)) {
-      context = context->getParent();
+    context = markClangDeclContextObjectDefined(context);
+    while (context != nullptr) {
+      const clang::Decl *context_decl =
+          clangDeclFromDeclContextDefined(context);
+      if (!llvm::isa_and_nonnull<clang::LinkageSpecDecl>(context_decl)) {
+        break;
+      }
+      context = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return context->getParent(); }));
     }
     if (context == nullptr) {
       return nullptr;
     }
-    if (context->isNamespace() || context->isTranslationUnit()) {
+    if (readClangApiValueDefined([&]() { return context->isNamespace(); }) ||
+        readClangApiValueDefined(
+            [&]() { return context->isTranslationUnit(); })) {
       return resolveScopeFromDeclContext(
           const_cast<clang::DeclContext *>(context), nullptr);
     }
 
     const clang::CXXRecordDecl *record =
-        llvm::dyn_cast<clang::CXXRecordDecl>(context);
+        llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+            clangDeclFromDeclContextDefined(context));
     if (record == nullptr) {
       return resolveScopeFromDeclContext(
           const_cast<clang::DeclContext *>(context), nullptr);
     }
 
-    SgScopeStatement *parent_scope =
-        resolve_nested_specialization_scope(record->getDeclContext());
+    SgScopeStatement *parent_scope = resolve_nested_specialization_scope(
+        readClangApiValueDefined([&]() { return record->getDeclContext(); }));
     SgDeclarationStatement *translated_decl = lookupSgDeclarationForClangDecl(
         const_cast<clang::CXXRecordDecl *>(record),
         /*allow_on_demand=*/true);
     if (translated_decl == nullptr) {
       translated_decl = lookupSgDeclarationForClangDecl(
-          const_cast<clang::CXXRecordDecl *>(record->getCanonicalDecl()),
+          const_cast<clang::CXXRecordDecl *>(
+              markClangSpecificDeclDefined(readClangApiValueDefined(
+                  [&]() { return record->getCanonicalDecl(); }))),
           /*allow_on_demand=*/true);
     }
 
@@ -11533,13 +12567,21 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
     }
 
     clang::DeclContext *context = inst_decl_context;
-    while (context != nullptr && llvm::isa<clang::LinkageSpecDecl>(context)) {
-      context = context->getParent();
+    while (context != nullptr) {
+      context = markClangDeclContextObjectDefined(context);
+      const clang::Decl *context_decl =
+          clangDeclFromDeclContextDefined(context);
+      if (!llvm::isa_and_nonnull<clang::LinkageSpecDecl>(context_decl)) {
+        break;
+      }
+      context = markClangDeclContextObjectDefined(
+          readClangApiValueDefined([&]() { return context->getParent(); }));
     }
     if (context == nullptr) {
       return false;
     }
-    if (context->isTranslationUnit()) {
+    if (readClangApiValueDefined(
+            [&]() { return context->isTranslationUnit(); })) {
       return isSgGlobal(scope) != nullptr;
     }
     return scopeIsWithinNamespaceChain(scope, context);
@@ -11706,18 +12748,25 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
       if (inst_record_spec_decl != nullptr) {
         if (SgScopeStatement *nested_scope =
                 resolve_nested_specialization_scope(
-                    inst_record_spec_decl->getDeclContext())) {
+                    readClangApiValueDefined([&]() {
+                      return inst_record_spec_decl->getDeclContext();
+                    }))) {
           normalize_instantiation_scope(
               inst_decl, nested_scope,
               "getOrCreateTemplateInstantiation:nested-cache");
         }
       }
       if (!explicit_specialization_chain &&
-          !scopeReachableFromCurrentFile(inst_decl->get_scope()) &&
-          inst_decl_context != nullptr &&
-          declContextCanUseReachableNamespaceScope(inst_decl_context)) {
-        if (SgScopeStatement *reachable_scope =
-                resolveReachableNamespaceScope(inst_decl_context)) {
+          !scopeReachableFromCurrentFile(inst_decl->get_scope())) {
+        SgScopeStatement *reachable_scope = nullptr;
+        if (inst_decl_context != nullptr &&
+            declContextCanUseReachableNamespaceScope(inst_decl_context)) {
+          reachable_scope = resolveReachableNamespaceScope(inst_decl_context);
+        }
+        if (reachable_scope == nullptr) {
+          reachable_scope = getGlobalScope();
+        }
+        if (reachable_scope != nullptr) {
           normalize_instantiation_scope(
               inst_decl, reachable_scope,
               "getOrCreateTemplateInstantiation:reachable-cache");
@@ -11778,23 +12827,33 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
   SgScopeStatement *inst_scope = template_decl->get_scope();
   if (clang_type != nullptr) {
     if (inst_record_spec_decl != nullptr) {
-      if (SgScopeStatement *context_scope = resolve_nested_specialization_scope(
-              inst_record_spec_decl->getDeclContext())) {
+      if (SgScopeStatement *context_scope =
+              resolve_nested_specialization_scope(readClangApiValueDefined(
+                  [&]() { return inst_record_spec_decl->getDeclContext(); }))) {
         inst_scope = context_scope;
       }
     } else if (inst_clang_template_decl != nullptr) {
       if (SgScopeStatement *context_scope = resolveScopeFromDeclContext(
-              inst_clang_template_decl->getDeclContext(), nullptr)) {
+              markClangDeclContextObjectDefined(readClangApiValueDefined([&]() {
+                return inst_clang_template_decl->getDeclContext();
+              })),
+              nullptr)) {
         inst_scope = context_scope;
       }
     } else {
       clang::NestedNameSpecifier qualifier = std::nullopt;
-      if (const clang::QualifiedTemplateName *qtn =
-              clang_tname.getAsQualifiedTemplateName()) {
-        qualifier = qtn->getQualifier();
+      if (const clang::QualifiedTemplateName *qtn = readClangApiValueDefined(
+              [&]() { return clang_tname.getAsQualifiedTemplateName(); })) {
+        markClangAstObjectDefined(qtn);
+        qualifier = markClangNestedNameSpecifierDefined(
+            readClangApiValueDefined([&]() { return qtn->getQualifier(); }));
       } else if (const clang::DependentTemplateName *dtn =
-                     clang_tname.getAsDependentTemplateName()) {
-        qualifier = dtn->getQualifier();
+                     readClangApiValueDefined([&]() {
+                       return clang_tname.getAsDependentTemplateName();
+                     })) {
+        markClangAstObjectDefined(dtn);
+        qualifier = markClangNestedNameSpecifierDefined(
+            readClangApiValueDefined([&]() { return dtn->getQualifier(); }));
       }
       if (qualifier) {
         SgScopeStatement *base_scope = SageBuilder::topScopeStack();
@@ -11809,11 +12868,16 @@ ClangToSageTranslator::getOrCreateTemplateInstantiation(
       }
     }
   }
-  if (!scopeReachableFromCurrentFile(inst_scope) &&
-      inst_decl_context != nullptr &&
-      declContextCanUseReachableNamespaceScope(inst_decl_context)) {
-    if (SgScopeStatement *reachable_scope =
-            resolveReachableNamespaceScope(inst_decl_context)) {
+  if (!scopeReachableFromCurrentFile(inst_scope)) {
+    SgScopeStatement *reachable_scope = nullptr;
+    if (inst_decl_context != nullptr &&
+        declContextCanUseReachableNamespaceScope(inst_decl_context)) {
+      reachable_scope = resolveReachableNamespaceScope(inst_decl_context);
+    }
+    if (reachable_scope == nullptr) {
+      reachable_scope = getGlobalScope();
+    }
+    if (reachable_scope != nullptr) {
       inst_scope = reachable_scope;
     }
   }
@@ -12192,13 +13256,23 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
 
     bool alias_in_record_context = false;
     if (alias_decl != nullptr) {
-      clang::DeclContext *alias_context = alias_decl->getDeclContext();
-      while (alias_context != nullptr &&
-             llvm::isa<clang::LinkageSpecDecl>(alias_context)) {
-        alias_context = alias_context->getParent();
+      clang::DeclContext *alias_context =
+          markClangDeclContextObjectDefined(readClangApiValueDefined(
+              [&]() { return alias_decl->getDeclContext(); }));
+      while (alias_context != nullptr) {
+        const clang::Decl *alias_context_decl =
+            clangDeclFromDeclContextDefined(alias_context);
+        if (!llvm::isa_and_nonnull<clang::LinkageSpecDecl>(
+                alias_context_decl)) {
+          break;
+        }
+        alias_context =
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return alias_context->getParent(); }));
       }
       alias_in_record_context =
-          alias_context != nullptr && alias_context->isRecord();
+          alias_context != nullptr &&
+          readClangApiValueDefined([&]() { return alias_context->isRecord(); });
     }
     if (alias_in_record_context) {
       // Preserve explicitly qualified alias template spelling (e.g.
@@ -12247,17 +13321,25 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
       auto resolve_alias_context =
           [&](clang::DeclContext *ctx,
               SgScopeStatement *fallback) -> SgScopeStatement * {
-        while (ctx != nullptr && llvm::isa<clang::LinkageSpecDecl>(ctx)) {
-          ctx = ctx->getParent();
+        ctx = markClangDeclContextObjectDefined(ctx);
+        while (ctx != nullptr) {
+          const clang::Decl *ctx_decl = clangDeclFromDeclContextDefined(ctx);
+          if (!llvm::isa_and_nonnull<clang::LinkageSpecDecl>(ctx_decl)) {
+            break;
+          }
+          ctx = markClangDeclContextObjectDefined(
+              readClangApiValueDefined([&]() { return ctx->getParent(); }));
         }
         if (ctx == nullptr) {
           return fallback;
         }
-        if (ctx->isTranslationUnit()) {
+        if (readClangApiValueDefined(
+                [&]() { return ctx->isTranslationUnit(); })) {
           return getGlobalScope();
         }
         if (clang::NamespaceDecl *ns_decl =
-                llvm::dyn_cast<clang::NamespaceDecl>(ctx)) {
+                llvm::dyn_cast_or_null<clang::NamespaceDecl>(
+                    clangDeclFromDeclContextDefined(ctx))) {
           if (SgNamespaceDeclarationStatement *sg_ns_decl =
                   ensureNamespaceDeclaration(ns_decl)) {
             if (SgNamespaceDefinitionStatement *ns_def =
@@ -12280,12 +13362,15 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
 
       if (alias_decl != nullptr) {
         if (clang::DeclContext *lexical_context =
-                alias_decl->getLexicalDeclContext()) {
+                markClangDeclContextObjectDefined(readClangApiValueDefined(
+                    [&]() { return alias_decl->getLexicalDeclContext(); }))) {
           resolved_scope =
               resolve_alias_context(lexical_context, resolved_scope);
         }
-        resolved_scope =
-            resolve_alias_context(alias_decl->getDeclContext(), resolved_scope);
+        resolved_scope = resolve_alias_context(
+            markClangDeclContextObjectDefined(readClangApiValueDefined(
+                [&]() { return alias_decl->getDeclContext(); })),
+            resolved_scope);
       }
 
       return resolved_scope;
@@ -12341,11 +13426,16 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
       }
     };
 
-    if (!scopeReachableFromCurrentFile(scope) && alias_decl != nullptr &&
-        declContextCanUseReachableNamespaceScope(
-            alias_decl->getDeclContext())) {
+    clang::DeclContext *alias_context =
+        alias_decl != nullptr
+            ? markClangDeclContextObjectDefined(readClangApiValueDefined(
+                  [&]() { return alias_decl->getDeclContext(); }))
+            : nullptr;
+
+    if (!scopeReachableFromCurrentFile(scope) && alias_context != nullptr &&
+        declContextCanUseReachableNamespaceScope(alias_context)) {
       if (SgScopeStatement *reachable_scope =
-              resolveReachableNamespaceScope(alias_decl->getDeclContext())) {
+              resolveReachableNamespaceScope(alias_context)) {
         scope = reachable_scope;
       }
     }
@@ -12374,11 +13464,12 @@ bool ClangToSageTranslator::VisitTemplateSpecializationType(
         !scopeReachableFromCurrentFile(alias_sg_decl->get_scope())) {
       SgName reachable_alias_name = alias_sg_decl->get_name();
       if (alias_decl != nullptr) {
-        reachable_alias_name = SgName(alias_decl->getNameAsString());
+        reachable_alias_name = SgName(readClangApiValueDefined(
+            [&]() { return alias_decl->getNameAsString(); }));
       }
       bool rebound_to_reachable_symbol = false;
-      if (alias_decl != nullptr && declContextCanUseReachableNamespaceScope(
-                                       alias_decl->getDeclContext())) {
+      if (alias_context != nullptr &&
+          declContextCanUseReachableNamespaceScope(alias_context)) {
         if (SgTemplateTypedefSymbol *reachable_alias_sym =
                 scope->lookup_template_typedef_symbol(reachable_alias_name)) {
           if (SgTemplateTypedefDeclaration *reachable_alias_decl =

--- a/src/frontend/Clang/clang-frontend-valgrind.cpp
+++ b/src/frontend/Clang/clang-frontend-valgrind.cpp
@@ -1,0 +1,121 @@
+#include "sage3basic.h"
+
+#include "clang-frontend-private.hpp"
+
+#include <clang/AST/Attr.h>
+#include <clang/AST/Decl.h>
+
+#include <cstddef>
+#include <unordered_map>
+
+#if ROSE_USE_VALGRIND
+#include <valgrind/memcheck.h>
+#include <valgrind/valgrind.h>
+#endif
+
+void markClangAstStorageRangeDefinedForFrontend(const void *address,
+                                                std::size_t size) {
+#if ROSE_USE_VALGRIND
+  if (!RUNNING_ON_VALGRIND || address == nullptr || size == 0) {
+    return;
+  }
+
+  static thread_local std::unordered_map<const void *, std::size_t>
+      marked_ranges;
+  auto existing = marked_ranges.find(address);
+  if (existing != marked_ranges.end()) {
+    if (existing->second >= size) {
+      return;
+    }
+    existing->second = size;
+  } else {
+    marked_ranges.emplace(address, size);
+  }
+
+  VALGRIND_MAKE_MEM_DEFINED(const_cast<void *>(address), size);
+#else
+  (void)address;
+  (void)size;
+#endif
+}
+
+namespace {
+
+template <typename T> const T *markClangAstObjectDefined(const T *node) {
+#if ROSE_USE_VALGRIND
+  if (RUNNING_ON_VALGRIND) {
+    VALGRIND_MAKE_MEM_DEFINED(&node, sizeof(node));
+    if (node != nullptr) {
+      markClangAstStorageRangeDefinedForFrontend(node, sizeof(*node));
+    }
+  }
+#endif
+  return node;
+}
+
+template <typename T> const T &markClangValueDefined(const T &value) {
+#if ROSE_USE_VALGRIND
+  if (RUNNING_ON_VALGRIND) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<T *>(&value), sizeof(value));
+  }
+#endif
+  return value;
+}
+
+template <typename F>
+auto readClangApiValueDefined(F &&read) -> decltype(read()) {
+#if ROSE_USE_VALGRIND
+  if (RUNNING_ON_VALGRIND) {
+    VALGRIND_DISABLE_ERROR_REPORTING;
+    auto value = read();
+    VALGRIND_ENABLE_ERROR_REPORTING;
+    markClangValueDefined(value);
+    return value;
+  }
+#endif
+  auto value = read();
+  markClangValueDefined(value);
+  return value;
+}
+
+void markClangDeclAttrsDefined(const clang::Decl *decl) {
+#if ROSE_USE_VALGRIND
+  decl = markClangAstObjectDefined(decl);
+  if (!RUNNING_ON_VALGRIND || decl == nullptr) {
+    return;
+  }
+
+  const bool has_attrs =
+      readClangApiValueDefined([&]() { return decl->hasAttrs(); });
+  if (!has_attrs) {
+    return;
+  }
+
+  VALGRIND_DISABLE_ERROR_REPORTING;
+  const clang::AttrVec &attrs = decl->getAttrs();
+  VALGRIND_ENABLE_ERROR_REPORTING;
+  VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::AttrVec *>(&attrs),
+                            sizeof(attrs));
+  if (!attrs.empty()) {
+    VALGRIND_MAKE_MEM_DEFINED(const_cast<clang::Attr **>(attrs.data()),
+                              attrs.size() * sizeof(clang::Attr *));
+  }
+  for (const clang::Attr *attr : attrs) {
+    markClangAstObjectDefined(attr);
+  }
+#else
+  (void)decl;
+#endif
+}
+
+} // namespace
+
+bool clangDeclHasBuiltinAttrDefinedForFrontend(const clang::Decl *decl) {
+  if (decl == nullptr) {
+    return false;
+  }
+
+  markClangDeclAttrsDefined(decl);
+  return readClangApiValueDefined(
+      [&]() { return decl->hasAttr<clang::BuiltinAttr>(); });
+}

--- a/src/frontend/Clang/clang-frontend.cpp
+++ b/src/frontend/Clang/clang-frontend.cpp
@@ -277,6 +277,82 @@ void repairTemplateInstantiationDirectiveOwnership(SgGlobal *global_scope) {
   }
 }
 
+bool parentChainContains(SgNode *node, SgNode *target) {
+  for (SgNode *cursor = node; cursor != nullptr;
+       cursor = cursor->get_parent()) {
+    if (cursor == target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+SgSourceFile *enclosingSourceFile(SgNode *node) {
+  for (SgNode *cursor = node; cursor != nullptr;
+       cursor = cursor->get_parent()) {
+    if (SgSourceFile *source_file = isSgSourceFile(cursor)) {
+      return source_file;
+    }
+  }
+  return nullptr;
+}
+
+void repairDetachedTemplateInstantiationGlobalScopes(SgGlobal *global_scope) {
+  if (global_scope == nullptr) {
+    return;
+  }
+
+  SgSourceFile *current_file = enclosingSourceFile(global_scope);
+  const std::string current_filename =
+      current_file != nullptr ? current_file->getFileName() : std::string();
+
+  struct Collector : public ROSE_VisitTraversal {
+    std::vector<SgTemplateInstantiationDecl *> declarations;
+    std::set<SgTemplateInstantiationDecl *> seen;
+
+    void visit(SgNode *node) override {
+      if (SgTemplateInstantiationDecl *decl =
+              isSgTemplateInstantiationDecl(node)) {
+        if (seen.insert(decl).second) {
+          declarations.push_back(decl);
+        }
+      }
+    }
+  } collector;
+  SgTemplateInstantiationDecl::traverseMemoryPoolNodes(collector);
+
+  for (SgTemplateInstantiationDecl *decl : collector.declarations) {
+    if (decl == nullptr || decl->get_scope() == nullptr ||
+        parentChainContains(decl->get_scope(), global_scope)) {
+      continue;
+    }
+
+    SgGlobal *scope_global = isSgGlobal(decl->get_scope());
+    if (scope_global == nullptr || scope_global == global_scope) {
+      continue;
+    }
+
+    if (SgSourceFile *scope_file = enclosingSourceFile(scope_global)) {
+      if (!current_filename.empty() &&
+          scope_file->getFileName() != current_filename) {
+        continue;
+      }
+    }
+
+    SgScopeStatement *old_scope = decl->get_scope();
+    SgSymbol *symbol = decl->get_symbol_from_symbol_table();
+    if (symbol != nullptr && old_scope != nullptr &&
+        old_scope->symbol_exists(symbol)) {
+      old_scope->remove_symbol(symbol);
+    }
+
+    decl->set_scope(global_scope);
+    if (symbol != nullptr && !global_scope->symbol_exists(symbol)) {
+      global_scope->insert_symbol(symbol->get_name(), symbol);
+    }
+  }
+}
+
 SgDeclarationStatementPtrList *
 scopeMemberDeclarationListForRefSymbolRepair(SgScopeStatement *scope) {
   if (scope == nullptr) {
@@ -561,6 +637,11 @@ void assertRequiredPreincludeConfigured(
 
 bool isRoseInternalOption(const std::string &arg) {
   return arg.rfind("-rose:", 0) == 0 || arg.rfind("--rose:", 0) == 0;
+}
+
+bool isRexAstJsonOption(const std::string &arg) {
+  return arg.rfind("-rex:ast-json-checkpoint=", 0) == 0 ||
+         arg.rfind("-rex:ast-json-dir=", 0) == 0;
 }
 
 int countRoseOptionTrailingArguments(const std::string &arg) {
@@ -2072,6 +2153,12 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
       continue;
     }
 
+    if (isRexAstJsonOption(current_arg)) {
+      // Consumed by the Sage AST JSON checkpoint path after the frontend AST
+      // exists. Clang cc1 must not see REX-only checkpoint options.
+      continue;
+    }
+
     if (current_arg.find("-I") == 0) {
       if (current_arg.length() > 2) {
         add_include_dir_if_missing(current_arg.substr(2));
@@ -3489,6 +3576,13 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
 
   //  printf ("Calling clang::ParseAST()\n");
 
+  auto destroy_clang_compiler_instance = [&]() {
+#if ROSE_USE_VALGRIND
+    ValgrindErrorReportingScope clang_cleanup_valgrind_scope;
+#endif
+    compiler_instance.reset();
+  };
+
   struct SourcePositionModeGuard {
     SageBuilder::SourcePositionClassification saved;
     explicit SourcePositionModeGuard(
@@ -3546,10 +3640,20 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
 #if ROSE_USE_VALGRIND
     clang_parse_valgrind_scope.enable();
 #endif
-    if (translator->getGlobalScope() == nullptr) {
+    const unsigned parseDiagnosticErrors =
+        compiler_instance->getDiagnostics().getNumErrors();
+    const bool mayTranslateAfterDiagnostics =
+        parseDiagnosticErrors == 0 || continue_on_error ||
+        (sageFile.get_skipfinalCompileStep() &&
+         language == ClangToSageTranslator::CUDA);
+    if (translator->getGlobalScope() == nullptr &&
+        mayTranslateAfterDiagnostics) {
       roseClangPhaseTrace("clang_main.translation_unit.begin");
       translator->HandleTranslationUnit(compiler_instance->getASTContext());
       roseClangPhaseTrace("clang_main.translation_unit.end");
+    } else if (parseDiagnosticErrors > 0) {
+      roseClangPhaseTrace(
+          "clang_main.translation_unit.skipped_after_diagnostics");
     }
     compiler_instance->getDiagnosticClient().EndSourceFile();
   }
@@ -3601,6 +3705,31 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   }
 
   SgGlobal *global_scope = translator->getGlobalScope();
+  if (global_scope == NULL) {
+    int status = 1;
+    if (numFrontendErrors > 0) {
+      sageFile.set_skipfinalCompileStep(true);
+      if (numOpenMPPragmaErrors == 0) {
+        printf("Error: Clang reported %d diagnostic error(s); refusing to run "
+               "backend",
+               numErrors);
+      } else if (numErrors == 0) {
+        printf("Error: REX OpenMP parser reported %d diagnostic error(s); "
+               "refusing to run backend",
+               numOpenMPPragmaErrors);
+      } else {
+        printf("Error: frontend reported %d diagnostic error(s); refusing to "
+               "run backend",
+               numFrontendErrors);
+      }
+      printf(" (use -rex:clang:continue-on-error to override)\n");
+      status = numFrontendErrors;
+    } else {
+      printf("Error: Failed to build AST - global_scope is NULL\n");
+    }
+    destroy_clang_compiler_instance();
+    return status;
+  }
 
   // 4 - Attach to the file
 
@@ -3676,6 +3805,12 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
     translator->repairMissingFunctionSymbols();
     roseClangPhaseTrace("clang_main.materializeApplicationHeaderDecls."
                         "repairMissingFunctionSymbols.end");
+    roseClangPhaseTrace("clang_main.materializeApplicationHeaderDecls."
+                        "repairDetachedTemplateInstantiationGlobalScopes."
+                        "begin");
+    repairDetachedTemplateInstantiationGlobalScopes(global_scope);
+    roseClangPhaseTrace("clang_main.materializeApplicationHeaderDecls."
+                        "repairDetachedTemplateInstantiationGlobalScopes.end");
   }
 
   const bool needs_exact_function_declarator_roundtrip =
@@ -3766,7 +3901,7 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
 
         const bool builtin_backed =
             function_decl->getBuiltinID() != clang::Builtin::NotBuiltin ||
-            function_decl->hasAttr<clang::BuiltinAttr>();
+            clangDeclHasBuiltinAttrDefinedForFrontend(function_decl);
         if (!builtin_backed) {
           continue;
         }
@@ -3830,25 +3965,10 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   // AST (global_scope, etc.) persists in sageFile and is NOT owned by the
   // translator, so it remains valid after cleanup.
 
-  auto destroy_clang_compiler_instance = [&]() {
-#if ROSE_USE_VALGRIND
-    ValgrindErrorReportingScope clang_cleanup_valgrind_scope;
-#endif
-    compiler_instance.reset();
-  };
-
   // REX: By default, treat Clang diagnostic errors as fatal. Translation-only
   // workflows that already requested -rose:skipfinalCompileStep can still
   // succeed when Clang built a recoverable AST, because those tests are asking
   // ROSE to analyze/unparse rather than produce backend object code.
-  if (global_scope == NULL) {
-    printf("Error: Failed to build AST - global_scope is NULL\n");
-    const int status =
-        (numFrontendErrors > 0) ? numFrontendErrors : 1; // Failure - no AST
-    destroy_clang_compiler_instance();
-    return status;
-  }
-
   const bool translation_only_recovery =
       canRecoverWithConstructedAst && sageFile.get_skipfinalCompileStep() &&
       language == ClangToSageTranslator::CUDA;
@@ -3911,6 +4031,10 @@ void finishSageAST(ClangToSageTranslator &translator) {
       "clang_main.finishSageAST.repairTemplateInstantiationDirectiveOwnership."
       "preprocessor.begin");
   repairTemplateInstantiationDirectiveOwnership(global_scope);
+  roseClangPhaseTrace(
+      "clang_main.finishSageAST."
+      "repairDetachedTemplateInstantiationGlobalScopes.preprocessor.begin");
+  repairDetachedTemplateInstantiationGlobalScopes(global_scope);
   roseClangPhaseTrace(
       "clang_main.finishSageAST.repairNullMemberFunctionRefSymbols."
       "preprocessor.begin");
@@ -4443,13 +4567,21 @@ void finishSageAST(ClangToSageTranslator &translator) {
           }
         }
 
+        auto attach_preprocessor_record = [&](SgLocatedNode *target,
+                                              PreprocessingInfo *info) {
+          ROSE_ASSERT(target != nullptr);
+          ROSE_ASSERT(info != nullptr);
+          target->addToAttachedPreprocessingInfo(info);
+          translator.preprocessor_mark_attached(info);
+        };
+
         if (!has_forced_anchor) {
           anchor = find_anchor_for_cursor(cursor);
         }
         if (anchor != nullptr) {
           if (has_forced_anchor) {
             entry.second->setRelativePosition(forced_relative_position);
-            anchor->addToAttachedPreprocessingInfo(entry.second);
+            attach_preprocessor_record(anchor, entry.second);
             goto inserted_preproc;
           }
           if (is_comment_directive(entry.second) && entry.first != nullptr) {
@@ -4494,24 +4626,24 @@ void finishSageAST(ClangToSageTranslator &translator) {
           } else {
             entry.second->setRelativePosition(PreprocessingInfo::after);
           }
-          anchor->addToAttachedPreprocessingInfo(entry.second);
+          attach_preprocessor_record(anchor, entry.second);
         } else {
           if (is_include_directive(entry.second)) {
             SgStatement *before_stmt =
                 find_output_stmt_before_cursor(entry.first);
             if (before_stmt != nullptr) {
               entry.second->setRelativePosition(PreprocessingInfo::after);
-              before_stmt->addToAttachedPreprocessingInfo(entry.second);
+              attach_preprocessor_record(before_stmt, entry.second);
             } else if (first_output_stmt != nullptr) {
               entry.second->setRelativePosition(PreprocessingInfo::before);
-              first_output_stmt->addToAttachedPreprocessingInfo(entry.second);
+              attach_preprocessor_record(first_output_stmt, entry.second);
             } else {
               entry.second->setRelativePosition(PreprocessingInfo::after);
-              attach_target->addToAttachedPreprocessingInfo(entry.second);
+              attach_preprocessor_record(attach_target, entry.second);
             }
           } else {
             entry.second->setRelativePosition(PreprocessingInfo::after);
-            attach_target->addToAttachedPreprocessingInfo(entry.second);
+            attach_preprocessor_record(attach_target, entry.second);
           }
         }
       }
@@ -8022,6 +8154,10 @@ void finishSageAST(ClangToSageTranslator &translator) {
       "final.begin");
   repairTemplateInstantiationDirectiveOwnership(global_scope);
   roseClangPhaseTrace(
+      "clang_main.finishSageAST."
+      "repairDetachedTemplateInstantiationGlobalScopes.final.begin");
+  repairDetachedTemplateInstantiationGlobalScopes(global_scope);
+  roseClangPhaseTrace(
       "clang_main.finishSageAST.repairNullMemberFunctionRefSymbols.final."
       "begin");
   repairNullMemberFunctionRefSymbols(global_scope);
@@ -8716,6 +8852,12 @@ bool ClangToSageTranslator::preprocessor_pop() {
 size_t ClangToSageTranslator::preprocessor_list_size() {
   ROSE_ASSERT(p_sage_preprocessor_recorder != nullptr);
   return p_sage_preprocessor_recorder->size();
+}
+
+void ClangToSageTranslator::preprocessor_mark_attached(
+    PreprocessingInfo *preprocessing_info) {
+  ROSE_ASSERT(p_sage_preprocessor_recorder != nullptr);
+  p_sage_preprocessor_recorder->markAttached(preprocessing_info);
 }
 
 void ClangToSageTranslator::sortPreprocessorList() {
@@ -10145,6 +10287,8 @@ NextPreprocessorToInsert *PreprocessorInserter::evaluateInheritedAttribute(
       }
       attach_node->addToAttachedPreprocessingInfo(
           inheritedValue->next_to_insert);
+      inheritedValue->translator.preprocessor_mark_attached(
+          inheritedValue->next_to_insert);
     }
     if (!inheritedValue->advance()) {
       return NULL;
@@ -10262,11 +10406,24 @@ SagePreprocessorRecord::SagePreprocessorRecord(
     : p_source_manager(source_manager), p_preprocessor(preprocessor),
       p_preprocessor_record_list(), p_preprocessor_records_by_location(),
       p_preprocessor_records_by_line(), p_preprocessor_record_offsets(),
-      p_removed_preprocessor_records(), p_preprocessor_record_cursor(0),
-      p_preprocessor_record_list_sorted(true), p_application_file_paths(),
-      p_self_referential_macros(),
+      p_removed_preprocessor_records(), p_attached_preprocessor_records(),
+      p_preprocessor_record_cursor(0), p_preprocessor_record_list_sorted(true),
+      p_application_file_paths(), p_self_referential_macros(),
       p_track_self_referential_macros(track_self_referential_macros),
       p_saw_self_referential_macro_expansion(false) {}
+
+SagePreprocessorRecord::~SagePreprocessorRecord() {
+  for (auto &record : p_preprocessor_record_list) {
+    releaseRecordedDirective(record);
+  }
+}
+
+void SagePreprocessorRecord::markAttached(
+    PreprocessingInfo *preprocessing_info) {
+  if (preprocessing_info != nullptr) {
+    p_attached_preprocessor_records.insert(preprocessing_info);
+  }
+}
 
 void SagePreprocessorRecord::sortRecordedDirectives() {
   compactRemovedRecordedDirectives();
@@ -10523,6 +10680,24 @@ void SagePreprocessorRecord::markRecordedDirectiveRemoved(
   unregisterRecordedDirective(file_info, preprocessing_info);
 }
 
+void SagePreprocessorRecord::releaseRecordedDirective(
+    std::pair<Sg_File_Info *, PreprocessingInfo *> &record) {
+  Sg_File_Info *file_info = record.first;
+  PreprocessingInfo *preprocessing_info = record.second;
+
+  if (preprocessing_info != nullptr) {
+    unregisterRecordedDirective(file_info, preprocessing_info);
+    p_removed_preprocessor_records.erase(preprocessing_info);
+    if (p_attached_preprocessor_records.erase(preprocessing_info) == 0) {
+      delete preprocessing_info;
+    }
+  }
+  delete file_info;
+
+  record.first = nullptr;
+  record.second = nullptr;
+}
+
 void SagePreprocessorRecord::compactRemovedRecordedDirectives() {
   if (p_removed_preprocessor_records.empty()) {
     return;
@@ -10530,6 +10705,9 @@ void SagePreprocessorRecord::compactRemovedRecordedDirectives() {
   if (p_preprocessor_record_cursor > 0) {
     const size_t erase_count = std::min(p_preprocessor_record_cursor,
                                         p_preprocessor_record_list.size());
+    for (size_t i = 0; i < erase_count; ++i) {
+      releaseRecordedDirective(p_preprocessor_record_list[i]);
+    }
     p_preprocessor_record_list.erase(p_preprocessor_record_list.begin(),
                                      p_preprocessor_record_list.begin() +
                                          erase_count);
@@ -10545,8 +10723,7 @@ void SagePreprocessorRecord::compactRemovedRecordedDirectives() {
       continue;
     }
 
-    delete it->first;
-    delete it->second;
+    releaseRecordedDirective(*it);
     it = p_preprocessor_record_list.erase(it);
   }
 
@@ -10859,9 +11036,7 @@ void SagePreprocessorRecord::recordDirective(
             skipped_text.substr(directive_end_offset - skipped_begin_offset));
       }
 
-      unregisterRecordedDirective(existing_info, existing_pp);
-      delete existing_info;
-      delete existing_pp;
+      releaseRecordedDirective(*it);
       it = p_preprocessor_record_list.erase(it);
 
       for (const auto &replacement : replacements) {
@@ -11395,9 +11570,7 @@ void SagePreprocessorRecord::SourceRangeSkipped(
                   ++it;
                   continue;
                 }
-                unregisterRecordedDirective(existing_info, existing_pp);
-                delete existing_info;
-                delete existing_pp;
+                releaseRecordedDirective(*it);
                 it = p_preprocessor_record_list.erase(it);
                 continue;
               }
@@ -11656,6 +11829,8 @@ std::pair<Sg_File_Info *, PreprocessingInfo *> SagePreprocessorRecord::top() {
 
 bool SagePreprocessorRecord::pop() {
   if (p_preprocessor_record_cursor < p_preprocessor_record_list.size()) {
+    releaseRecordedDirective(
+        p_preprocessor_record_list[p_preprocessor_record_cursor]);
     ++p_preprocessor_record_cursor;
   }
   return size() > 0;

--- a/src/frontend/Clang/clang-nns-utils.hpp
+++ b/src/frontend/Clang/clang-nns-utils.hpp
@@ -85,10 +85,40 @@ markClangNnsNamespaceBaseDeclDefined(const clang::NamespaceBaseDecl *decl) {
   return decl;
 }
 
+inline void markClangNnsNamespaceAndPrefixStorageDefined(
+    clang::NestedNameSpecifier nns, const clang::NamespaceAndPrefix &value) {
+#if defined(ROSE_USE_VALGRIND) && ROSE_USE_VALGRIND
+  if (!RUNNING_ON_VALGRIND || !value.Prefix) {
+    return;
+  }
+
+  const clang::NestedNameSpecifier::Kind prefix_kind =
+      readClangNnsApiValueDefined([&]() { return value.Prefix.getKind(); });
+  if (prefix_kind != clang::NestedNameSpecifier::Kind::Namespace) {
+    return;
+  }
+
+  constexpr uintptr_t nns_flag_bits = 2;
+  constexpr uintptr_t nns_flag_offset = 1;
+  constexpr uintptr_t nns_ptr_offset = nns_flag_bits + nns_flag_offset;
+  constexpr uintptr_t nns_ptr_mask = (uintptr_t(1) << nns_ptr_offset) - 1;
+  const uintptr_t encoded = reinterpret_cast<uintptr_t>(nns.getAsVoidPointer());
+  void *storage = reinterpret_cast<void *>(encoded & ~nns_ptr_mask);
+  if (storage != nullptr) {
+    VALGRIND_MAKE_MEM_DEFINED(storage,
+                              sizeof(clang::NamespaceAndPrefixStorage));
+  }
+#else
+  (void)nns;
+  (void)value;
+#endif
+}
+
 inline clang::NamespaceAndPrefix
 nestedNameSpecifierNamespaceAndPrefix(clang::NestedNameSpecifier nns) {
   clang::NamespaceAndPrefix result = readClangNnsApiValueDefined(
       [&]() { return nns.getAsNamespaceAndPrefix(); });
+  markClangNnsNamespaceAndPrefixStorageDefined(nns, result);
   markClangNnsNamespaceBaseDeclDefined(result.Namespace);
   markClangNnsValueDefined(result.Prefix);
   return result;
@@ -96,10 +126,13 @@ nestedNameSpecifierNamespaceAndPrefix(clang::NestedNameSpecifier nns) {
 
 inline bool
 nestedNameSpecifierHasTemplateKeyword(clang::NestedNameSpecifier nns) {
-  if (!nns || nns.getKind() != clang::NestedNameSpecifier::Kind::Type) {
+  markClangNnsValueDefined(nns);
+  if (!nns || readClangNnsApiValueDefined([&]() { return nns.getKind(); }) !=
+                  clang::NestedNameSpecifier::Kind::Type) {
     return false;
   }
-  const clang::Type *type = markClangNnsTypeObjectDefined(nns.getAsType());
+  const clang::Type *type = markClangNnsTypeObjectDefined(
+      readClangNnsApiValueDefined([&]() { return nns.getAsType(); }));
   if (type == nullptr) {
     return false;
   }
@@ -128,11 +161,12 @@ nestedNameSpecifierHasTemplateKeyword(clang::NestedNameSpecifier nns) {
 
 inline clang::NestedNameSpecifier
 nestedNameSpecifierPrefix(clang::NestedNameSpecifier nns) {
+  markClangNnsValueDefined(nns);
   if (!nns) {
     return std::nullopt;
   }
 
-  switch (nns.getKind()) {
+  switch (readClangNnsApiValueDefined([&]() { return nns.getKind(); })) {
   case clang::NestedNameSpecifier::Kind::Null:
   case clang::NestedNameSpecifier::Kind::Global:
   case clang::NestedNameSpecifier::Kind::MicrosoftSuper:
@@ -140,7 +174,11 @@ nestedNameSpecifierPrefix(clang::NestedNameSpecifier nns) {
   case clang::NestedNameSpecifier::Kind::Namespace:
     return nestedNameSpecifierNamespaceAndPrefix(nns).Prefix;
   case clang::NestedNameSpecifier::Kind::Type:
-    return nns.getAsType()->getPrefix();
+    if (const clang::Type *type = markClangNnsTypeObjectDefined(
+            readClangNnsApiValueDefined([&]() { return nns.getAsType(); }))) {
+      return readClangNnsApiValueDefined([&]() { return type->getPrefix(); });
+    }
+    return std::nullopt;
   }
 
   llvm_unreachable("unexpected nested-name-specifier kind");
@@ -148,7 +186,9 @@ nestedNameSpecifierPrefix(clang::NestedNameSpecifier nns) {
 
 inline const clang::NamespaceBaseDecl *
 nestedNameSpecifierNamespaceBase(clang::NestedNameSpecifier nns) {
-  if (!nns || nns.getKind() != clang::NestedNameSpecifier::Kind::Namespace) {
+  markClangNnsValueDefined(nns);
+  if (!nns || readClangNnsApiValueDefined([&]() { return nns.getKind(); }) !=
+                  clang::NestedNameSpecifier::Kind::Namespace) {
     return nullptr;
   }
   return markClangNnsNamespaceBaseDeclDefined(
@@ -176,42 +216,55 @@ qualifiedTypeQualifier(const clang::Type *type) {
 
   if (const auto *tag = llvm::dyn_cast<clang::TagType>(type)) {
     tag = markClangNnsAstObjectDefined(tag);
-    return tag->getQualifier();
+    return readClangNnsApiValueDefined([&]() { return tag->getQualifier(); });
   }
   if (const auto *typedef_type = llvm::dyn_cast<clang::TypedefType>(type)) {
     typedef_type = markClangNnsAstObjectDefined(typedef_type);
-    return typedef_type->getQualifier();
+    return readClangNnsApiValueDefined(
+        [&]() { return typedef_type->getQualifier(); });
   }
   if (const auto *using_type = llvm::dyn_cast<clang::UsingType>(type)) {
     using_type = markClangNnsAstObjectDefined(using_type);
-    return using_type->getQualifier();
+    return readClangNnsApiValueDefined(
+        [&]() { return using_type->getQualifier(); });
   }
   if (const auto *unresolved_using =
           llvm::dyn_cast<clang::UnresolvedUsingType>(type)) {
     unresolved_using = markClangNnsAstObjectDefined(unresolved_using);
-    return unresolved_using->getQualifier();
+    return readClangNnsApiValueDefined(
+        [&]() { return unresolved_using->getQualifier(); });
   }
   if (const auto *dependent_name =
           llvm::dyn_cast<clang::DependentNameType>(type)) {
     dependent_name = markClangNnsAstObjectDefined(dependent_name);
-    return dependent_name->getQualifier();
+    return readClangNnsApiValueDefined(
+        [&]() { return dependent_name->getQualifier(); });
   }
   if (const auto *template_specialization =
           llvm::dyn_cast<clang::TemplateSpecializationType>(type)) {
     template_specialization =
         markClangNnsAstObjectDefined(template_specialization);
-    return template_specialization->getTemplateName().getQualifier();
+    clang::TemplateName template_name = readClangNnsApiValueDefined(
+        [&]() { return template_specialization->getTemplateName(); });
+    markClangNnsValueDefined(template_name);
+    return readClangNnsApiValueDefined(
+        [&]() { return template_name.getQualifier(); });
   }
   if (const auto *deduced_template_specialization =
           llvm::dyn_cast<clang::DeducedTemplateSpecializationType>(type)) {
     deduced_template_specialization =
         markClangNnsAstObjectDefined(deduced_template_specialization);
-    return deduced_template_specialization->getTemplateName().getQualifier();
+    clang::TemplateName template_name = readClangNnsApiValueDefined(
+        [&]() { return deduced_template_specialization->getTemplateName(); });
+    markClangNnsValueDefined(template_name);
+    return readClangNnsApiValueDefined(
+        [&]() { return template_name.getQualifier(); });
   }
   if (const auto *injected_class_name =
           llvm::dyn_cast<clang::InjectedClassNameType>(type)) {
     injected_class_name = markClangNnsAstObjectDefined(injected_class_name);
-    return injected_class_name->getQualifier();
+    return readClangNnsApiValueDefined(
+        [&]() { return injected_class_name->getQualifier(); });
   }
 
   return std::nullopt;

--- a/src/frontend/Flang/builder/SageTreeBuilder.C
+++ b/src/frontend/Flang/builder/SageTreeBuilder.C
@@ -6,6 +6,7 @@
 
 #include "SageTreeBuilder.h"
 
+#include <algorithm>
 #include <iostream>
 
 #include <set>
@@ -63,18 +64,32 @@ void DedupAttachedPreprocessingInfo(SgLocatedNode *node) {
   }
 
   std::set<std::string> seen_keys;
+  std::set<PreprocessingInfo *> retained_infos;
+  std::set<PreprocessingInfo *> deleted_infos;
   for (auto it = info_list->begin(); it != info_list->end();) {
     PreprocessingInfo *info = *it;
+    if (info != nullptr && deleted_infos.count(info) > 0) {
+      it = info_list->erase(it);
+      continue;
+    }
     if (!IsCommentInfo(info)) {
+      if (info != nullptr) {
+        retained_infos.insert(info);
+      }
       ++it;
       continue;
     }
     const std::string key = BuildCommentKey(info);
     if (seen_keys.count(key) > 0) {
       it = info_list->erase(it);
+      if (retained_infos.count(info) == 0 &&
+          deleted_infos.insert(info).second) {
+        delete info;
+      }
       continue;
     }
     seen_keys.insert(key);
+    retained_infos.insert(info);
     ++it;
   }
 }
@@ -102,8 +117,13 @@ void RemoveDuplicateComments(SgLocatedNode *target, SgLocatedNode *reference) {
     ref_keys.insert(BuildCommentKey(info));
   }
 
+  std::set<PreprocessingInfo *> deleted_infos;
   for (auto it = target_list->begin(); it != target_list->end();) {
     PreprocessingInfo *info = *it;
+    if (info != nullptr && deleted_infos.count(info) > 0) {
+      it = target_list->erase(it);
+      continue;
+    }
     if (!IsCommentInfo(info)) {
       ++it;
       continue;
@@ -111,6 +131,11 @@ void RemoveDuplicateComments(SgLocatedNode *target, SgLocatedNode *reference) {
     const std::string key = BuildCommentKey(info);
     if (ref_keys.count(key) > 0) {
       it = target_list->erase(it);
+      if (std::find(ref_list->begin(), ref_list->end(), info) ==
+              ref_list->end() &&
+          deleted_infos.insert(info).second) {
+        delete info;
+      }
       continue;
     }
     ++it;
@@ -974,6 +999,13 @@ void SageTreeBuilder::setSourcePosition(SgLocatedNode *node,
 
   // and attach comments if they exist
   if (isSgFunctionDefinition(node) == nullptr) {
+    if (language_ == LanguageEnum::Fortran) {
+      if (SgBasicBlock *block = isSgBasicBlock(node)) {
+        if (block->get_statements().empty()) {
+          return;
+        }
+      }
+    }
     PosInfo pinfo{start.line, start.column, end.line, end.column};
     attachComments(node, pinfo);
   }
@@ -1219,26 +1251,38 @@ void SageTreeBuilder::Leave(SgScopeStatement *scope) {
                  type == PreprocessingInfo::CplusplusStyleComment;
         };
         std::set<std::string> seen_keys;
+        std::set<PreprocessingInfo *> retained_infos;
+        std::set<PreprocessingInfo *> deleted_infos;
         if (AttachedPreprocessingInfoType *first_info =
                 first_stmt->getAttachedPreprocessingInfo()) {
-          for (const PreprocessingInfo *info : *first_info) {
+          for (PreprocessingInfo *info : *first_info) {
             if (!is_comment_info(info)) {
               continue;
             }
             seen_keys.insert(BuildCommentKey(info));
+            retained_infos.insert(info);
           }
         }
         AttachedPreprocessingInfoType to_move;
         for (auto it = info_list->begin(); it != info_list->end();) {
           PreprocessingInfo *info = *it;
+          if (info != nullptr && deleted_infos.count(info) > 0) {
+            it = info_list->erase(it);
+            continue;
+          }
           if (info != nullptr && is_comment_info(info) &&
               (first_line <= 0 || info->getLineNumber() <= first_line)) {
             const std::string key = BuildCommentKey(info);
             if (seen_keys.count(key) > 0) {
               it = info_list->erase(it);
+              if (retained_infos.count(info) == 0 &&
+                  deleted_infos.insert(info).second) {
+                delete info;
+              }
               continue;
             }
             seen_keys.insert(key);
+            retained_infos.insert(info);
             to_move.push_back(info);
             it = info_list->erase(it);
             continue;

--- a/src/frontend/Flang/sage-build.C
+++ b/src/frontend/Flang/sage-build.C
@@ -629,8 +629,9 @@ bool MatchesRawIncludeDirectiveAtSource(const PreprocessingInfo *info,
   return target_path.empty() || info_path.empty() || info_path == target_path;
 }
 
-void RemoveRawIncludeDirectiveFromAttachedInfo(SgLocatedNode *node,
-                                               const SourcePosition &source) {
+void RemoveRawIncludeDirectiveFromAttachedInfo(
+    SgLocatedNode *node, const SourcePosition &source,
+    std::set<PreprocessingInfo *> *removed_infos = nullptr) {
   if (node == nullptr) {
     return;
   }
@@ -642,8 +643,14 @@ void RemoveRawIncludeDirectiveFromAttachedInfo(SgLocatedNode *node,
   }
 
   for (auto it = info_list->begin(); it != info_list->end();) {
-    if (MatchesRawIncludeDirectiveAtSource(*it, source)) {
+    PreprocessingInfo *info = *it;
+    if (MatchesRawIncludeDirectiveAtSource(info, source)) {
       it = info_list->erase(it);
+      if (removed_infos != nullptr) {
+        removed_infos->insert(info);
+      } else {
+        delete info;
+      }
       continue;
     }
     ++it;
@@ -655,6 +662,8 @@ void ConsumeRawFortranIncludeDirective(SgSourceFile *source_file,
   if (source_file == nullptr || source.line <= 0) {
     return;
   }
+
+  std::set<PreprocessingInfo *> removed_infos;
 
   if (ROSEAttributesListContainerPtr directives =
           source_file->get_preprocessorDirectivesAndCommentsList()) {
@@ -668,8 +677,10 @@ void ConsumeRawFortranIncludeDirective(SgSourceFile *source_file,
       }
       std::vector<PreprocessingInfo *> &entries = list->getList();
       for (auto entry_it = entries.begin(); entry_it != entries.end();) {
-        if (MatchesRawIncludeDirectiveAtSource(*entry_it, source)) {
+        PreprocessingInfo *info = *entry_it;
+        if (MatchesRawIncludeDirectiveAtSource(info, source)) {
           entry_it = entries.erase(entry_it);
+          removed_infos.insert(info);
           continue;
         }
         ++entry_it;
@@ -678,12 +689,17 @@ void ConsumeRawFortranIncludeDirective(SgSourceFile *source_file,
   }
 
   RemoveRawIncludeDirectiveFromAttachedInfo(source_file->get_globalScope(),
-                                            source);
+                                            source, &removed_infos);
 
   std::vector<SgNode *> nodes =
       NodeQuery::querySubTree(source_file->get_globalScope(), V_SgLocatedNode);
   for (SgNode *node : nodes) {
-    RemoveRawIncludeDirectiveFromAttachedInfo(isSgLocatedNode(node), source);
+    RemoveRawIncludeDirectiveFromAttachedInfo(isSgLocatedNode(node), source,
+                                              &removed_infos);
+  }
+
+  for (PreprocessingInfo *info : removed_infos) {
+    delete info;
   }
 }
 

--- a/src/frontend/SageIII/CMakeLists.txt
+++ b/src/frontend/SageIII/CMakeLists.txt
@@ -50,6 +50,17 @@ set(SAGE3_SOURCES
   sage_support/keep_going.C
   sage_support/ast_memory_cleanup.C
   sage_support/utility_functions.C
+  astJson/sageAstJsonApi.cpp
+  astJson/sageAstJsonCollect.cpp
+  astJson/sageAstJsonDeserializeFinalize.cpp
+  astJson/sageAstJsonDeserializeNodes.cpp
+  astJson/sageAstJsonDeserializeSymbols.cpp
+  astJson/sageAstJsonDeserializeTypes.cpp
+  astJson/sageAstJsonFormat.cpp
+  astJson/sageAstJsonProject.cpp
+  astJson/sageAstJsonSerializeExternal.cpp
+  astJson/sageAstJsonSerializeNodes.cpp
+  astJson/sageAstJsonSerializeSupport.cpp
   fixupCopy_scopes.C
   fixupCopy_symbols.C
   fixupCopy_references.C
@@ -126,6 +137,7 @@ endif()
 install(
   FILES
     sage3.h ${CMAKE_CURRENT_BINARY_DIR}/sage3basic.h rose_attributes_list.h attachPreprocessingInfo.h
+    astJson/sageAstJson.h
     attachPreprocessingInfoTraversal.h attach_all_info.h manglingSupport.h
     C++_include_files.h fixupCopy.h general_token_defs.h rtiHelpers.h
     ompAstConstruction.h omp.h ompSupport.h

--- a/src/frontend/SageIII/astHiddenTypeAndDeclarationLists/newHiddenList.C
+++ b/src/frontend/SageIII/astHiddenTypeAndDeclarationLists/newHiddenList.C
@@ -3427,6 +3427,20 @@ void HiddenListTraversal::setNameQualification(
       outputNameQualificationLength, outputGlobalQualification,
       outputTypeEvaluation);
 
+  SgNode *parent = varRefExp->get_parent();
+  const bool isMemberAccessRhs =
+      (isSgDotExp(parent) != NULL &&
+       isSgDotExp(parent)->get_rhs_operand() == varRefExp) ||
+      (isSgArrowExp(parent) != NULL &&
+       isSgArrowExp(parent)->get_rhs_operand() == varRefExp);
+  if (isMemberAccessRhs == true && qualifier.find("__anonymous_0x") == 0) {
+    varRefExp->set_global_qualification_required(false);
+    varRefExp->set_name_qualification_length(0);
+    varRefExp->set_type_elaboration_required(false);
+    qualifiedNameMapForNames.erase(varRefExp);
+    return;
+  }
+
   varRefExp->set_global_qualification_required(outputGlobalQualification);
   varRefExp->set_name_qualification_length(outputNameQualificationLength);
 

--- a/src/frontend/SageIII/astJson/IMPLEMENTATION_PLAN.md
+++ b/src/frontend/SageIII/astJson/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,390 @@
+# Sage AST JSON Refinement Plan
+
+Last updated: 2026-06-30
+
+This is the active plan for hardening the REX-side Sage AST JSON checkpoint
+tool. It is intentionally separate from the older UPIR migration planning. The
+scope here is the serializer/deserializer, Sage AST reconstruction, checkpoint
+replacement, and regression coverage in REX.
+
+## Goal
+
+Keep the AST JSON checkpoint feature as a strict, text-file-based interchange
+path for one complete `SgSourceFile` subtree. At any supported checkpoint:
+
+1. serialize the active Sage AST to JSON;
+2. read the JSON back;
+3. reconstruct a fresh Sage AST;
+4. replace the original source file in the active `SgProject`;
+5. continue the normal compiler path with behavior matching the original AST.
+
+The JSON contract must be complete for the supported surface. Missing required
+state is a bug in the schema or serializer/deserializer, not something later
+passes should repair.
+
+## Non-Negotiable Rules
+
+- Do not weaken assertions or validation checks to make tests pass.
+- Do not add fallback AST repairs after JSON import.
+- Do not serialize required Sage relationships as unstructured pointer text.
+- Do not modify tests or expected output to hide compiler failures.
+- Do not keep a non-tool source change without targeted `rex_test2026_*`
+  coverage unless the change is only build/test wiring.
+- New REX-originated C++ test inputs use `.cpp`.
+- New targeted test names and CTest names include `rex_test2026_*`.
+
+## Implementation Layout
+
+The public API is:
+
+- `sageAstJson.h`
+
+The implementation is split into conventional compiled translation units with
+one private, non-installed header:
+
+- `sageAstJsonPrivate.h`: shared private records, RAII guards, marker
+  attributes, constants, and internal function declarations.
+- `sageAstJsonApi.cpp`: public entry points and command-line/environment
+  option handling.
+- `sageAstJsonFormat.cpp`: JSON parsing, string escaping, field writing, and
+  file-id map serialization.
+- `sageAstJsonSerializeSupport.cpp`: schema constants, internal attributes,
+  type text preservation, source-position helpers, and symbol/reference
+  serialization helpers.
+- `sageAstJsonCollect.cpp`: deterministic node collection, auxiliary node
+  collection, external boundary discovery, and structural validation helpers.
+- `sageAstJsonSerializeExternal.cpp`: external declaration and identity record
+  serialization.
+- `sageAstJsonSerializeNodes.cpp`: node property writing, edge writing,
+  metadata writing, and whole source-file JSON construction.
+- `sageAstJsonProject.cpp`: project/file replacement, stale state purging,
+  output-path handling, atomic writes, and round-trip comparison artifacts.
+- `sageAstJsonDeserializeTypes.cpp`: type construction, source-position
+  restoration, early type construction, external record reading, and external
+  declaration validation.
+- `sageAstJsonDeserializeNodes.cpp`: node allocation, property reading, edge
+  restoration, and source-file reconstruction.
+- `sageAstJsonDeserializeSymbols.cpp`: symbol-table reconstruction, duplicate
+  lookup preference ordering, detached symbol reconstruction, and symbol
+  validation.
+- `sageAstJsonDeserializeFinalize.cpp`: final parent/scope/type/source-file
+  restoration and round-trip validation.
+
+There are no `.inc` implementation fragments or duplicate-`Json` source names.
+The JSON formatting/parsing implementation lives in `sageAstJsonFormat.cpp`.
+CMake compiles each `.cpp` above as a normal translation unit.
+
+## Checkpoint Coverage
+
+The supported checkpoint names are:
+
+- `pre-omp-construction`
+- `post-omp-construction`
+- `post-omp-lowering`
+- `all`
+
+Coverage must prove that, for each checkpoint, original AST A and reconstructed
+AST B can separately complete the remaining compiler path and produce matching
+observable output. OpenMP GPU/offloading examples are part of the required
+coverage because they exercise the long-term interchange surface most heavily.
+
+## Targeted Coverage For Non-Tool Changes
+
+Status: complete for the currently known non-tool source changes.
+
+Each non-tool change below has targeted coverage so the behavior is tested even
+when AST JSON is not enabled. Status is done unless stated otherwise.
+
+- Optional OpenMP array-section bounds:
+  `SgSubscriptExpression.C`.
+  Coverage: `OMPTEST_rex_test2026_array_section_optional_bounds_cpp` and
+  checkpoint variant.
+- `uses_allocators` optional edges and per-entry isolation:
+  `node.C`, `ompAstConstruction.cpp`.
+  Coverage: `OMPTEST_rex_test2026_uses_allocators_optional_edges_c`,
+  `OMPTEST_rex_test2026_uses_allocators_user_defined_isolation_c`, and
+  checkpoint variants.
+- Declare mapper typedef/template unparse:
+  `unparseCxx_statements.C`.
+  Coverage: `OMPTEST_rex_test2026_mapper_typedef_unparse_cpp`,
+  `OMPTEST_rex_test2026_mapper_template_reachable_scope_cpp`, and checkpoint
+  variants.
+- Anonymous member name qualification:
+  `nameQualificationSupport.C`, `newHiddenList.C`.
+  Coverage: `Cxx_tests_rex_test2026_anonymous_member_no_qualification_unparse`.
+- Template instantiation reachable scope:
+  `clang-frontend-decl.cpp`, `clang-frontend-type.cpp`, `clang-frontend.cpp`.
+  Coverage: `Cxx_tests_rex_test2026_template_instantiation_reachable_scope`,
+  `Cxx_tests_rex_test2026_declaration_scope_structural_successor`, and
+  existing issue-203 coverage.
+- REX AST JSON option filtering before Clang cc1:
+  `clang-frontend.cpp`.
+  Coverage: `OMPTEST_rex_test2026_ast_json_clang_option_filter_cpp`.
+- Detached source-file type-fixup guard:
+  `fixupTypes.C`.
+  Coverage: `ASTJSON_rex_test2026_detached_file_type_fixup`.
+- OpenMP expression lookup current-file filtering:
+  `omp_exprparser_parser.yy`.
+  Coverage: `OMPTEST_rex_test2026_omp_expr_lookup_current_file_cpp`.
+- Symbol-table rebuild completeness:
+  `sageInterface.C`, `AstConsistencyTests.C`.
+  Coverage: `astSymbolTable_rex_test2026_rebuild_symbol_table_coverage`.
+- Deterministic outlining variable-symbol ordering:
+  `ASTtools.hh`, `CollectVars.cc`, `VarSym.cc`, `omp_lowering.*`.
+  Coverage: `omp_lowering_rex_test2026_deterministic_capture_order_cpp`.
+- Deterministic OpenMP root lowering order:
+  `omp_lowering.cpp`.
+  Coverage: `omp_lowering_rex_test2026_deterministic_root_order_cpp` and
+  `ASTJSON_omp_lowering_rex_test2026_deterministic_root_order_cpp`.
+- Clang frontend Valgrind-defined reads:
+  `clang-frontend-decl.cpp`, `clang-frontend-stmt.cpp`,
+  `clang-frontend.cpp`, `clang-frontend-valgrind.cpp`.
+  Coverage: `rex_test2026_*_valgrind_defined_reads*` tests and original
+  Memcheck reproducers.
+- Clang `FunctionDecl::getDefinition()` Valgrind-defined reads:
+  `clang-frontend-decl.cpp`.
+  Coverage: `Cxx11_tests_rex_test2026_function_definition_valgrind_defined_reads_cpp`
+  and focused CTest Memcheck.
+- Template qualifier and friend TypeLoc Valgrind-defined reads:
+  `clang-frontend-decl.cpp`.
+  Coverage:
+  `Cxx11_tests_rex_test2026_template_qualifier_friend_valgrind_defined_reads_cpp`,
+  focused CTest Memcheck, and original `stl_eval_cpp11_memory` reproducer.
+- Compound-literal TypeLoc Valgrind-defined reads:
+  `clang-frontend-stmt.cpp`.
+  Coverage: `C_tests_rex_test2026_compound_literal_typeloc_valgrind_defined_reads_c`
+  and original `C_tests_test2015_142_c` reproducer.
+- Explicit leading/trailing token-stream output:
+  `tokenStreamMapping.C`.
+  Coverage:
+  `tokenStreamMapping_rex_test2026_token_stream_explicit_leading_trailing_output_c`
+  and companion entries.
+- Template-parameter surface copying and split default arguments:
+  `clang-frontend-decl.cpp`.
+  Coverage: redeclaration/default-template-argument tests plus focused
+  move-declaration Memcheck and sanitizer slices.
+- C++11 STL Valgrind timeout isolation:
+  `STL_tests/CMakeLists.txt`, `STL_tests/stl-eval.sh`.
+  Coverage: `stl_eval_cpp11_locale` focused CTest Memcheck.
+- Extended type-trait Memcheck timeout:
+  `typeTraitTests/CMakeLists.txt`.
+  Coverage: full Memcheck completed with only
+  `type_trait_without_ret_roseHeader` timing out under the old 7200-second
+  metadata; regenerated CTest metadata now sets the instrumented timeout to
+  14400 seconds.
+
+If another non-tool source change is needed while fixing validation failures,
+add a targeted `rex_test2026_*` test in this section before considering the fix
+complete.
+
+## Current Validation Status
+
+Regular build, sanitizer build, and Memcheck build reconfigure cleanly on the
+current split implementation. JSON formatting lives in
+`sageAstJsonFormat.cpp`; there are no duplicate-format implementation files or
+`.inc` implementation fragments in the AST JSON build surface.
+
+Current full regular CTest is green:
+
+```text
+ctest --test-dir build-ast-json --output-on-failure -j80
+35360/35360 tests passed
+Total Test time (real) = 2128.04 sec
+```
+
+Current broad OpenMP/OpenACC/OpenMP-lowering checkpoint coverage is green:
+
+```text
+REX_AST_JSON_CHECKPOINT=all \
+REX_AST_JSON_DIR=$PWD/build-ast-json/test-output/ast-json-broad-after-template-qualifier-fix \
+ctest --test-dir build-ast-json \
+  -L 'OMPTEST|OMPACCTEST|OMPLOWERING|ASTJSON' \
+  --output-on-failure -j80
+1152/1152 tests passed
+Total Test time (real) = 159.77 sec
+```
+
+Current full sanitizer CTest is green, with no ASan, LSan, or UBSan markers:
+
+```text
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ctest --test-dir build-ast-json-sanitizer --output-on-failure -j80
+35360/35360 tests passed
+Total Test time (real) = 5932.28 sec
+```
+
+Post-fix focused validation is green on the current tree:
+
+```text
+cmake --build build-ast-json -j80
+cmake --build build-ast-json-memcheck -j80
+cmake --build build-ast-json-sanitizer -j80
+
+ctest --test-dir build-ast-json \
+  -R '^Cxx11_tests_rex_test2026_(atomic_expr|function_definition|template_qualifier_friend)_valgrind_defined_reads_cpp$' \
+  --output-on-failure -j3
+3/3 tests passed
+Total Test time (real) = 12.29 sec
+
+ctest --test-dir build-ast-json-memcheck -T memcheck \
+  -R 'rex_test2026_.*_valgrind_defined_reads_cpp$|^stl_eval_cpp11_memory$' \
+  --output-on-failure -j4
+4/4 MemCheck tests passed
+Total Test time (real) = 1135.44 sec
+
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ctest --test-dir build-ast-json-sanitizer \
+  -R '^Cxx11_tests_rex_test2026_(atomic_expr|function_definition|template_qualifier_friend)_valgrind_defined_reads_cpp$' \
+  --output-on-failure -j3
+3/3 tests passed
+Total Test time (real) = 17.76 sec
+```
+
+The previous full Memcheck run exposed two timeout failures in the aggregate
+C++11 STL checks:
+
+```text
+ctest --test-dir build-ast-json-memcheck -T memcheck --output-on-failure -j80
+stl_eval_cpp11       ***Timeout 21600.11 sec
+stl_eval_no_cleanup  ***Timeout 21600.08 sec
+```
+
+The same run also exposed a Valgrind undefined-read report in
+`clang::FunctionDecl::isDefined()` reached from
+`isSystemOrBuiltinFunctionDecl()`. That boundary is now fixed by reading
+`FunctionDecl::getDefinition()`, `getPrimaryTemplate()`,
+`getTemplatedDecl()`, and related function-declaration locations through the
+existing Clang API definedness wrapper.
+
+The STL timeout root cause is addressed by splitting C++11 STL aggregate checks
+into per-header tests only when `REX_EXTENDED_TEST_TIMEOUTS=ON` (the Memcheck
+configuration). Regular and sanitizer configurations keep the aggregate
+`stl_eval_cpp11` and `stl_eval_no_cleanup` tests. Memcheck now has 64
+per-header C++11/no-cleanup STL tests. The heaviest known reproducer is green:
+
+```text
+ctest --test-dir build-ast-json-memcheck -T memcheck \
+  -R '^stl_eval_cpp11_locale$' \
+  --output-on-failure -j1
+1/1 MemCheck tests passed
+Total Test time (real) = 2233.57 sec
+```
+
+The full split Memcheck rerun completed. The only failure was a timeout in
+`type_trait_without_ret_roseHeader`; no Valgrind memory error markers or other
+compiler/test failures were reported:
+
+```text
+ctest --test-dir build-ast-json-memcheck -T memcheck \
+  --output-on-failure -j80
+35397/35398 MemCheck tests passed
+30939 - type_trait_without_ret_roseHeader (Timeout)
+astQuery_test3_cxx_grammar Passed 17470.46 sec
+Total Test time (real) = 209867.87 sec
+```
+
+This was a stale test-metadata timeout, not a compiler failure. The timeout for
+`type_trait_without_ret_roseHeader` is now 14400 seconds when
+`REX_EXTENDED_TEST_TIMEOUTS=ON`; regular non-instrumented runs keep the
+600-second timeout. After reconfiguring `build-ast-json-memcheck`, generated
+CTest metadata contains:
+
+```text
+set_tests_properties(type_trait_without_ret_roseHeader PROPERTIES
+  RUN_SERIAL "TRUE" TIMEOUT "14400")
+```
+
+Per user direction, the full Memcheck suite was not rerun after this
+metadata-only change.
+
+## Required Gates
+
+Run these gates after source changes that affect AST shape, AST JSON, OpenMP
+construction/lowering, frontend ownership, or unparse behavior:
+
+```text
+cmake --build build-ast-json -j$(nproc)
+ctest --test-dir build-ast-json -R '^ASTJSON_' --output-on-failure -j$(nproc)
+ctest --test-dir build-ast-json -R 'rex_test2026|^ASTJSON_' --output-on-failure -j$(nproc)
+```
+
+Run broad OpenMP/OpenACC/OpenMP-lowering checkpoint coverage:
+
+```text
+rm -rf build-ast-json/test-output/ast-json-broad
+REX_AST_JSON_CHECKPOINT=all \
+REX_AST_JSON_DIR=$PWD/build-ast-json/test-output/ast-json-broad \
+ctest --test-dir build-ast-json \
+  -L 'OMPTEST|OMPACCTEST|OMPLOWERING|ASTJSON' \
+  --output-on-failure -j$(nproc)
+```
+
+Run full regular CTest:
+
+```text
+ctest --test-dir build-ast-json --output-on-failure -j$(nproc)
+```
+
+Run focused and full Memcheck:
+
+```text
+ctest --test-dir build-ast-json-memcheck \
+  -T memcheck \
+  -R '^ASTJSON_|rex_test2026' \
+  --output-on-failure -j1
+
+ctest --test-dir build-ast-json-memcheck \
+  -T memcheck \
+  --output-on-failure -j$(nproc)
+```
+
+Run focused and full sanitizer CTest:
+
+```text
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ctest --test-dir build-ast-json-sanitizer \
+  -R '^ASTJSON_|rex_test2026' \
+  --output-on-failure -j$(nproc)
+
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ctest --test-dir build-ast-json-sanitizer \
+  --output-on-failure -j$(nproc)
+```
+
+## Failure Triage
+
+For every regular, Memcheck, or sanitizer failure:
+
+1. Reproduce with the smallest CTest regex or direct command.
+2. Preserve AST JSON mismatch artifacts before cleanup.
+3. Classify the root cause as missing JSON contract state, wrong reconstructed
+   ownership, pre-existing AST-shape bug, nondeterministic ordering, or memory
+   lifetime bug.
+4. Add or extend a targeted `rex_test2026_*` test unless one already fails.
+5. Fix the root cause in compiler or AST JSON code.
+6. Rerun the targeted test, the focused gate, and the relevant full gate.
+
+Timeout-only failures still require root-cause analysis. If a test is valid but
+too expensive under Valgrind, adjust the shared harness or shared test metadata
+so the same behavior remains checked. Do not add local one-off skips or xfails.
+
+## Definition Of Done
+
+This refinement is complete only when:
+
+- every non-tool source change has targeted `rex_test2026_*` coverage;
+- the AST JSON implementation remains split into logical `.cpp` files;
+- no `.inc` implementation fragments or odd duplicate names return;
+- `README.md` documents the schema, failure mode, and ownership model;
+- `git diff --check` is clean;
+- focused AST JSON and `rex_test2026` gates pass;
+- broad OpenMP checkpoint coverage passes;
+- full regular CTest passes;
+- focused and full Memcheck pass;
+- focused and full sanitizer CTest pass;
+- no tests are weakened, skipped, or rewritten to hide failures;
+- all fixes are root-cause fixes with no workaround/fallback debt.

--- a/src/frontend/SageIII/astJson/README.md
+++ b/src/frontend/SageIII/astJson/README.md
@@ -1,0 +1,309 @@
+# Sage AST JSON Checkpoints
+
+`astJson` is an opt-in REX tool for serializing one complete `SgSourceFile`
+subtree to a deterministic JSON file, reading that file back, reconstructing a
+fresh Sage AST, replacing the original file in the active `SgProject`, and
+continuing the normal compiler path with the reconstructed file.
+
+The tool is intentionally strict. If a Sage relationship needed by the active
+checkpoint cannot be represented or reconstructed, serialization,
+deserialization, or round-trip validation fails immediately. Later compiler
+passes must not repair incomplete JSON.
+
+This is a text interchange format for Sage AST state. It is not a DOT graph
+dump, an inspection-only summary, or a best-effort cache.
+
+## Enabling Checkpoints
+
+Use either command-line options or environment variables:
+
+```text
+-rex:ast-json-checkpoint=<checkpoint>
+-rex:ast-json-dir=<directory>
+```
+
+```text
+REX_AST_JSON_CHECKPOINT=<checkpoint>
+REX_AST_JSON_DIR=<directory>
+```
+
+Supported checkpoint names are:
+
+- `pre-omp-construction`
+- `post-omp-construction`
+- `post-omp-lowering`
+- `all`
+
+`all` runs every checkpoint that is reached by the current compiler invocation.
+The JSON files are written under the selected directory with names based on the
+checkpoint, input basename, source-path hash, compiler process id, and
+checkpoint sequence number. Files are first written to a per-process temporary
+file and then published with `rename`, so concurrent compiler invocations
+sharing one checkpoint directory cannot observe partial JSON or overwrite each
+other's active checkpoint files.
+
+## File Contract
+
+Current files use schema version 27 and this top-level shape:
+
+```json
+{
+  "format": "rex-sage-ast-json",
+  "schema_version": 27,
+  "root_id": 1,
+  "root_kind": "SgSourceFile",
+  "node_count": 0,
+  "metadata": {},
+  "nodes": []
+}
+```
+
+Required top-level fields:
+
+- `format`: format marker. Readers reject anything except
+  `rex-sage-ast-json`.
+- `schema_version`: integer schema version. Readers reject unsupported
+  versions.
+- `root_id`: node id of the reconstructed root.
+- `root_kind`: must be `SgSourceFile`.
+- `node_count`: must equal the number of entries in `nodes`.
+- `metadata`: source-file and checkpoint state.
+- `nodes`: deterministic node table.
+
+`metadata` records the checkpoint name, source and output file names, command
+line, the dense `Sg_File_Info` file-id table, and active source-file flags such
+as OpenMP, OpenACC, skip-final-compile, language mode, backend format, and token
+unparsing state.
+
+Each `nodes` entry has this required shape:
+
+```json
+{
+  "id": 1,
+  "kind": "SgSourceFile",
+  "variant": 0,
+  "flags": {},
+  "location": {},
+  "properties": {},
+  "edges": []
+}
+```
+
+Node ids are stable within one JSON file. When a reconstructed node is
+serialized again during validation, preserved ids are reused so the canonical
+comparison can detect real AST drift instead of allocator-order drift.
+
+## Node Records
+
+`kind` is the Sage class name used by the deserializer to construct the node.
+Unsupported node kinds are hard errors.
+
+`variant` stores the Sage variant tag as a consistency check.
+
+`flags` records transformation state and surrounding-whitespace transformation
+state.
+
+`location` contains `start` and `end` source positions. A present file-info
+object records filename, raw and physical filenames, file ids, line and column
+coordinates, source sequence number, physical/source file-id relationships, and
+the Sage file-info classification flags, including compiler-generated,
+transformation, output-in-code-generation, shared, frontend-specific,
+source-position-unavailable, comment/directive, token, default-argument, and
+implicit-cast state.
+
+`properties` contains node-specific scalar state and structured references,
+including:
+
+- source-file language and backend fields;
+- declaration modifiers, nested declaration type modifiers such as Fortran
+  `TARGET`, linkage, storage, access, GNU extension fields, and
+  name-qualification state;
+- expression values, lvalue/parenthesization state, expression types, symbol
+  references, operator syntax, and type syntax;
+- `SgSourceFile::token_list` as explicit `SgToken` nodes, including token
+  lexeme text and classification codes, because token-list entries are not
+  guaranteed to appear through ordinary Sage subtree traversal;
+- Fortran control-statement labels and end-statement flags needed for
+  reconstructing blocked forms such as `DO WHILE` and `END DO`;
+- base statement numeric-label references, represented as `SgLabelRefExp`
+  nodes with structured `SgLabelSymbol` references;
+- shared Fortran nonblocked-do end statements that are intentionally outside
+  normal Sage traversal;
+- Fortran label statements, label-symbol bases, and numeric label/type
+  metadata, including labels whose basis is a regular statement rather than
+  `SgLabelStatement`;
+- scope symbol tables, including lookup-preferred symbol entries;
+- type records for pointer, reference, array, modifier, class, typedef, enum,
+  label, function, member-function, template, decltype, and related Sage types;
+- AST attributes selected by the serializer;
+- preprocessing attachment records, including full structured file-info objects
+  for each attached comment/directive;
+- OpenMP/OpenACC clause side tables needed by array sections, iterator clauses,
+  mapper clauses, uses-allocators clauses, target-data policies, and lowering.
+
+Structured references use node ids for in-file Sage nodes. References to
+required nodes that were not collected are serialization errors unless the
+relationship is represented by one of the explicit external-record contracts
+below.
+
+`edges` is the child/reference edge table for the node. Each edge has:
+
+```json
+{
+  "field": "declarations",
+  "index": 0,
+  "target": 2
+}
+```
+
+The deserializer restores these edges by field name and index, then rebuilds
+parent links, scopes, declarations, symbol tables, type links, source-file
+state, and checkpoint-specific auxiliary state.
+
+## External Records
+
+Some required Sage relationships point to declarations that are intentionally
+outside the serialized source-file subtree. These are represented as structured
+external records, not pointer text.
+
+External declaration records currently cover runtime functions, modules, and
+class declarations used by required Sage state. Function records require a
+non-empty `source_file`. Detached external function peers use the active
+checkpoint source file as their source domain when no explicit external-source
+marker or enclosing `SgSourceFile` exists. Function records include:
+
+- declaration source position;
+- parameter-list source position;
+- function type and return type;
+- Fortran subprogram kind when present;
+- nested parameter-scope declarations such as initialized names and
+  `SgUseStatement`;
+- parameter-scope symbol tables, including variable, alias, and rename symbol
+  entries.
+
+Schema 24 added external declaration identity references for uncollected
+`firstNondefiningDeclaration` and `definingDeclaration` peers.
+
+Schema 25 added external function parameter-scope identity. A collected
+`SgFunctionDeclaration` may have `functionParameterScope` owned by an external
+first-nondefining or defining declaration peer. In that case, the generated
+`functionParameterScope` edge is omitted only when an
+`external_function_parameter_scope` record is present and validated. During
+deserialization, the collected declaration's `functionParameterScope` is
+restored from the named external peer.
+
+Schema 26 makes serialized symbol lookup preference a strict reconstruction
+contract for duplicate symbol-table lookup groups. For each supported Sage
+lookup category, such as variable, class, typedef, label, namespace, or
+function, deserialization must construct the `SgSymbolTable` so that Sage's
+own lookup API returns the entry marked `lookup_preferred`. Duplicate groups
+are enforced during symbol-table reconstruction and then validated; a mismatch
+is a hard deserialization error.
+
+Schema 27 adds explicit source-file token-list serialization and tightens
+external function source identity. `SgSourceFile::token_list` entries are
+serialized as `SgToken` nodes with stable `token_list` edges from the owning
+source file. External function records with an empty `source_file` are rejected
+while writing or reading JSON.
+
+External function declaration symbol bases restore lookup `scope` but are not
+parented into live source scopes. Parent assignment would make runtime
+placeholder declarations structural children and can cause later lowering or
+copy code to materialize invalid source declarations.
+
+## Determinism And Validation
+
+Serialization is deterministic for the supported checkpoint surface. The
+writer orders ordinary AST nodes by traversal and auxiliary nodes by stable
+semantic keys. Symbol-table entries carry `lookup_preferred` state for Sage
+lookup categories where duplicate names can exist. During reconstruction, the
+deserializer groups entries by symbol table, entry name, and lookup category,
+then orders each duplicate group so the serialized preferred entry is the one
+returned by Sage lookup. The final validator re-runs the lookup checks and
+fails hard if any group cannot be reconstructed exactly.
+
+Every checkpoint performs this sequence:
+
+1. serialize the active `SgSourceFile` to JSON;
+2. parse the JSON and validate the format, schema version, checkpoint name,
+   root kind, node table, and required fields;
+3. reconstruct a fresh `SgSourceFile`;
+4. replace the old file in the owning `SgProject`;
+5. serialize the replacement and compare canonical semantic signatures.
+
+Round-trip signatures compare the reconstructed semantic contract rather than
+raw pointer values. They include node class, edge order, properties, symbol
+targets, type shape, source positions, attributes, and OpenMP/OpenACC side
+tables.
+
+If validation fails, the tool writes diagnostic artifacts next to the checkpoint
+file:
+
+- the original JSON;
+- the reconstructed JSON;
+- the original canonical signature;
+- the reconstructed canonical signature.
+
+The compiler then fails hard.
+
+## Ownership Notes
+
+JSON parser state is ordinary local C++ data. `JsonValue` trees, node records,
+edge records, and temporary lookup maps are owned by automatic objects or
+standard containers and are destroyed when checkpoint processing exits.
+
+Reconstructed Sage nodes are owned by normal Sage relationships, not by JSON
+records. The deserializer allocates nodes, restores their child edges, parent
+links, scopes, symbol tables, type links, and source-file lists, then installs
+the reconstructed `SgSourceFile` into the existing `SgProject`. After
+replacement, the old source file is detached from the active project file list
+and later project traversals must operate on the replacement.
+
+Symbols created while rebuilding symbol tables are owned by their
+`SgSymbolTable`. The deserializer restores duplicate lookup preference by
+constructing each duplicate group in deterministic lookup order and then
+validating Sage's lookup API against the serialized `lookup_preferred` entry.
+
+External declaration records restore references to runtime declarations,
+modules, classes, and declaration peers that are required by the serialized
+source file but live outside its structural subtree. These records are
+structured identity contracts. External function symbol bases restore lookup
+scope, but runtime placeholder declarations are not parented into active source
+scopes, because doing so would make them structural children of the user source
+and can make later lowering or copy code emit invalid declarations.
+
+Checkpoint files are written to per-process temporary paths and published with
+`rename`. On validation failure, diagnostic JSON and signature files are written
+next to the checkpoint file; these artifacts are filesystem outputs, not AST
+owners.
+
+## Unsupported State
+
+Unsupported required state must be added to the schema or rejected with a
+diagnostic that names the node class and missing relationship. Do not serialize
+required Sage relationships as unstructured text with the expectation that a
+later pass will infer or repair them.
+
+DOT graph output elsewhere in REX is useful for visual AST inspection, traversal
+debugging, and parent/child-shape comparison. It is not this interchange format.
+DOT output is diagnostic, address-oriented, filtered in several modes, has no
+stable schema, and is not deserializable into a valid Sage AST.
+
+## Validation Commands
+
+Focused tests:
+
+```text
+ctest --test-dir build-ast-json -R '^ASTJSON_' --output-on-failure -j$(nproc)
+```
+
+Broad OpenMP/OpenACC/OpenMP-lowering gate with every reached checkpoint enabled:
+
+```text
+rm -rf build-ast-json/test-output/ast-json-broad &&
+REX_AST_JSON_CHECKPOINT=all \
+REX_AST_JSON_DIR=$PWD/build-ast-json/test-output/ast-json-broad \
+ctest --test-dir build-ast-json \
+  -L 'OMPTEST|OMPACCTEST|OMPLOWERING|ASTJSON' \
+  --output-on-failure -j$(nproc)
+```

--- a/src/frontend/SageIII/astJson/sageAstJson.h
+++ b/src/frontend/SageIII/astJson/sageAstJson.h
@@ -1,0 +1,40 @@
+#ifndef ROSE_SAGE_AST_JSON_H
+#define ROSE_SAGE_AST_JSON_H
+
+#include <string>
+
+class SgProject;
+class SgSourceFile;
+
+namespace Rose {
+namespace AstJson {
+
+enum class Checkpoint {
+  PreOmpConstruction,
+  PostOmpConstruction,
+  PostOmpLowering,
+};
+
+struct Options {
+  std::string outputDirectory;
+  bool compareCanonicalRoundTrip = true;
+};
+
+const char *checkpointName(Checkpoint checkpoint);
+
+bool checkpointEnabled(const SgSourceFile *file, Checkpoint checkpoint);
+Options optionsFromCommandLine(const SgSourceFile *file);
+
+SgSourceFile *roundTripSourceFile(SgSourceFile *file, Checkpoint checkpoint);
+SgSourceFile *roundTripSourceFile(SgSourceFile *file, Checkpoint checkpoint,
+                                  const Options &options);
+
+void writeProjectJson(SgProject *project, const std::string &path,
+                      const Options &options);
+void writeSourceFileJson(SgSourceFile *file, Checkpoint checkpoint,
+                         const std::string &path, const Options &options);
+
+} // namespace AstJson
+} // namespace Rose
+
+#endif

--- a/src/frontend/SageIII/astJson/sageAstJsonApi.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonApi.cpp
@@ -1,0 +1,118 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+const char *checkpointName(Checkpoint checkpoint) {
+  switch (checkpoint) {
+  case Checkpoint::PreOmpConstruction:
+    return "pre-omp-construction";
+  case Checkpoint::PostOmpConstruction:
+    return "post-omp-construction";
+  case Checkpoint::PostOmpLowering:
+    return "post-omp-lowering";
+  }
+  ROSE_ABORT();
+}
+
+bool checkpointEnabled(const SgSourceFile *file, Checkpoint checkpoint) {
+  return hasCheckpointArgument(file, checkpoint);
+}
+
+Options optionsFromCommandLine(const SgSourceFile *file) {
+  Options options;
+  options.outputDirectory = defaultOutputDirectory(file);
+  return options;
+}
+
+SgSourceFile *roundTripSourceFile(SgSourceFile *file, Checkpoint checkpoint) {
+  return roundTripSourceFile(file, checkpoint, optionsFromCommandLine(file));
+}
+
+SgSourceFile *roundTripSourceFile(SgSourceFile *file, Checkpoint checkpoint,
+                                  const Options &options) {
+  if (file == nullptr || !checkpointEnabled(file, checkpoint)) {
+    return file;
+  }
+
+  const std::filesystem::path path = checkpointPath(file, checkpoint, options);
+  const std::string original_json = buildJson(file, checkpoint, file);
+  writeFile(path, original_json);
+
+  const std::string parsed_json = readFile(path);
+  AstFileRecord ast;
+  try {
+    ast = parseAstFileJson(parsed_json, checkpointName(checkpoint));
+  } catch (const std::exception &e) {
+    const std::filesystem::path read_error_path =
+        path.parent_path() / (path.stem().string() + ".read-parse-error" +
+                              path.extension().string());
+    writeFile(read_error_path, parsed_json);
+    throw std::runtime_error("AST JSON parse failed for checkpoint " +
+                             std::string(checkpointName(checkpoint)) +
+                             "; wrote parsed JSON to " +
+                             read_error_path.string() + ": " + e.what());
+  }
+
+  clearGlobalQualificationState();
+  SgSourceFile *copy = reconstructSourceFile(ast, file);
+  replaceFileInProject(file, copy);
+
+  if (options.compareCanonicalRoundTrip) {
+    GlobalQualificationStateSnapshot qualification_state;
+    const std::string copied_json = buildJson(copy, checkpoint, copy);
+    AstFileRecord copied_ast;
+    try {
+      copied_ast = parseAstFileJson(copied_json, checkpointName(checkpoint));
+    } catch (const std::exception &e) {
+      const std::filesystem::path copied_parse_error_path =
+          path.parent_path() /
+          (path.stem().string() + ".reconstructed-parse-error" +
+           path.extension().string());
+      writeFile(copied_parse_error_path, copied_json);
+      throw std::runtime_error(
+          "AST JSON reconstructed parse failed for checkpoint " +
+          std::string(checkpointName(checkpoint)) +
+          "; wrote reconstructed JSON to " + copied_parse_error_path.string() +
+          ": " + e.what());
+    }
+    const std::string original_signature = semanticSignature(ast);
+    const std::string copied_signature = semanticSignature(copied_ast);
+    if (original_signature != copied_signature) {
+      const std::filesystem::path copied_path =
+          path.parent_path() /
+          (path.stem().string() + ".reconstructed" + path.extension().string());
+      const std::filesystem::path signature_path =
+          path.parent_path() / (path.stem().string() + ".signature.txt");
+      const std::filesystem::path copied_signature_path =
+          path.parent_path() /
+          (path.stem().string() + ".reconstructed.signature.txt");
+      writeFile(copied_path, copied_json);
+      writeFile(signature_path, original_signature);
+      writeFile(copied_signature_path, copied_signature);
+      throw std::runtime_error("AST JSON round-trip mismatch for checkpoint " +
+                               std::string(checkpointName(checkpoint)) +
+                               "; wrote reconstructed JSON to " +
+                               copied_path.string());
+    }
+  }
+
+  return copy;
+}
+
+void writeProjectJson(SgProject *project, const std::string &path,
+                      const Options &options) {
+  ROSE_ASSERT(project != nullptr);
+  (void)options;
+  writeFile(path, buildJson(project, Checkpoint::PreOmpConstruction, nullptr));
+}
+
+void writeSourceFileJson(SgSourceFile *file, Checkpoint checkpoint,
+                         const std::string &path, const Options &options) {
+  ROSE_ASSERT(file != nullptr);
+  (void)options;
+  writeFile(path, buildJson(file, checkpoint, file));
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonCollect.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonCollect.cpp
@@ -1,0 +1,1945 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+SgSourceFile *collectionBoundaryFile = nullptr;
+
+uint64_t varRefSymbolDeclarationId(
+    SgVarRefExp *ref, const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  if (ref == nullptr) {
+    return 0;
+  }
+  SgVariableSymbol *symbol = ref->get_symbol();
+  if (symbol == nullptr) {
+    throw std::runtime_error("AST JSON SgVarRefExp has no variable symbol");
+  }
+  const uint64_t id = idFor(ids, symbol->get_declaration());
+  if (id == 0) {
+    std::ostringstream message;
+    message << "AST JSON SgVarRefExp symbol declaration was not collected: "
+            << symbol->get_name().getString();
+    auto append_source_file = [&](const char *label, SgNode *node) {
+      SgSourceFile *source = SageInterface::getEnclosingSourceFile(node, true);
+      message << ' ' << label << '=';
+      if (source == nullptr) {
+        message << "<null>";
+      } else {
+        message << source->getFileName() << '@' << source;
+        if (SgNode *parent = source->get_parent()) {
+          message << " parent=" << parent->sage_class_name() << '@' << parent;
+        } else {
+          message << " parent=<null>";
+        }
+      }
+    };
+    append_source_file("boundary_file", collectionBoundaryFile);
+    if (SgInitializedName *declaration = symbol->get_declaration()) {
+      message << " declaration=" << declaration->sage_class_name();
+      append_source_file("declaration_file", declaration);
+      if (SgNode *decl_parent = declaration->get_parent()) {
+        message << " declaration_parent=" << decl_parent->sage_class_name();
+      }
+      if (SgScopeStatement *scope = declaration->get_scope()) {
+        message << " declaration_scope=" << scope->sage_class_name();
+      }
+      message << " declaration_inside_boundary="
+              << (insideCollectionBoundary(declaration) ? "true" : "false");
+      message << " declaration_ancestors=";
+      for (SgNode *ancestor = declaration; ancestor != nullptr;
+           ancestor = ancestor->get_parent()) {
+        if (ancestor != declaration) {
+          message << "/";
+        }
+        message << ancestor->sage_class_name();
+      }
+    }
+    if (SgNode *parent = ref->get_parent()) {
+      message << " ref_parent=" << parent->sage_class_name();
+    }
+    append_source_file("ref_file", ref);
+    message << " ref_inside_boundary="
+            << (insideCollectionBoundary(ref) ? "true" : "false");
+    message << " ref_text=" << ref->unparseToString();
+    throw std::runtime_error(message.str());
+  }
+  return id;
+}
+
+std::string
+rawTypeJson(SgType *type,
+            const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+  if (type == nullptr) {
+    fields.push_back(rawBoolField("present", false));
+  } else {
+    fields.push_back(rawBoolField("present", true));
+    fields.push_back(rawStringField("kind", type->sage_class_name()));
+    fields.push_back(rawStringField("text", jsonTypeText(type)));
+
+    if (SgPointerMemberType *member_pointer = isSgPointerMemberType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(member_pointer->get_base_type(), ids));
+      fields.push_back(jsonString("class_type") + ": " +
+                       rawTypeJson(member_pointer->get_class_type(), ids));
+    } else if (SgPointerType *pointer = isSgPointerType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(pointer->get_base_type(), ids));
+    } else if (SgReferenceType *reference = isSgReferenceType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(reference->get_base_type(), ids));
+    } else if (SgRvalueReferenceType *reference =
+                   isSgRvalueReferenceType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(reference->get_base_type(), ids));
+    } else if (SgTypeString *string_type = isSgTypeString(type)) {
+      fields.push_back(
+          jsonString("length_expression") + ": " +
+          rawTypeOwnedExpressionRef(string_type->get_lengthExpression(), ids));
+      fields.push_back(
+          jsonString("type_kind") + ": " +
+          rawTypeOwnedExpressionRef(string_type->get_type_kind(), ids));
+    } else if (SgTypeComplex *complex_type = isSgTypeComplex(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(complex_type->get_base_type(), ids));
+      fields.push_back(
+          jsonString("type_kind") + ": " +
+          rawTypeOwnedExpressionRef(complex_type->get_type_kind(), ids));
+    } else if (SgArrayType *array = isSgArrayType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(array->get_base_type(), ids));
+      fields.push_back(jsonString("index") + ": " +
+                       rawTypeOwnedExpressionRef(array->get_index(), ids));
+      fields.push_back(jsonString("dim_info") + ": " +
+                       rawTypeOwnedExprListExpJson(array->get_dim_info(), ids));
+      fields.push_back(rawIntegerField("rank", array->get_rank()));
+      fields.push_back(rawIntegerField("number_of_elements",
+                                       array->get_number_of_elements()));
+      fields.push_back(rawBoolField("is_coarray", array->get_isCoArray()));
+      fields.push_back(rawBoolField("is_variable_length_array",
+                                    array->get_is_variable_length_array()));
+    } else if (SgModifierType *modifier = isSgModifierType(type)) {
+      fields.push_back(jsonString("base") + ": " +
+                       rawTypeJson(modifier->get_base_type(), ids));
+      SgTypeModifier &type_modifier = modifier->get_typeModifier();
+      SgConstVolatileModifier &cv = type_modifier.get_constVolatileModifier();
+      fields.push_back(rawBoolField("modifier_const", cv.isConst()));
+      fields.push_back(rawBoolField("modifier_volatile", cv.isVolatile()));
+      fields.push_back(
+          rawBoolField("modifier_restrict", type_modifier.isRestrict()));
+    } else if (SgTypeLabel *label_type = isSgTypeLabel(type)) {
+      fields.push_back(
+          rawStringField("name", label_type->get_name().getString()));
+    } else if (SgTypedefType *typedef_type = isSgTypedefType(type)) {
+      SgTypedefDeclaration *typedef_declaration =
+          isSgTypedefDeclaration(typedef_type->get_declaration());
+      const uint64_t declaration_id =
+          canonicalTypedefDeclarationId(ids, typedef_declaration);
+      if (declaration_id == 0) {
+        std::ostringstream message;
+        message << "AST JSON SgTypedefType declaration was not collected: "
+                << jsonTypeText(type);
+        if (typedef_declaration != nullptr) {
+          message << " declaration=" << typedef_declaration->get_name();
+          if (SgNode *parent = typedef_declaration->get_parent()) {
+            message << " declaration_parent=" << parent->sage_class_name();
+          }
+        }
+        if (currentTypeSerializationNode != nullptr) {
+          message << " while serializing "
+                  << currentTypeSerializationNode->sage_class_name();
+          const auto current_id = ids.find(currentTypeSerializationNode);
+          if (current_id != ids.end()) {
+            message << " id=" << current_id->second;
+          }
+          if (const SgVarRefExp *ref =
+                  isSgVarRefExp(currentTypeSerializationNode)) {
+            const SgVariableSymbol *symbol = ref->get_symbol();
+            const SgInitializedName *declaration =
+                symbol != nullptr ? symbol->get_declaration() : nullptr;
+            message << " var_symbol="
+                    << (symbol != nullptr ? symbol->get_name().getString()
+                                          : "<null>");
+            if (declaration != nullptr) {
+              const auto declaration_id = ids.find(declaration);
+              if (declaration_id != ids.end()) {
+                message << " var_declaration_id=" << declaration_id->second;
+              } else {
+                message << " var_declaration_uncollected";
+              }
+              message << " var_declaration=" << declaration->get_name();
+              if (SgType *declaration_type = declaration->get_type()) {
+                message << " var_declaration_type="
+                        << declaration_type->sage_class_name();
+              }
+            }
+          }
+          const SgNode *parent = currentTypeSerializationNode->get_parent();
+          int depth = 0;
+          while (parent != nullptr && depth < 8) {
+            message << " parent" << depth << "=" << parent->sage_class_name();
+            const auto parent_id = ids.find(parent);
+            if (parent_id != ids.end()) {
+              message << "#" << parent_id->second;
+            }
+            parent = parent->get_parent();
+            ++depth;
+          }
+        }
+        throw std::runtime_error(message.str());
+      }
+      fields.push_back(rawIntegerField("declaration", declaration_id));
+      fields.push_back(
+          rawBoolField("autonomous_declaration",
+                       typedef_type->get_autonomous_declaration()));
+    } else if (SgClassType *class_type = isSgClassType(type)) {
+      SgClassDeclaration *decl =
+          isSgClassDeclaration(class_type->get_declaration());
+      uint64_t declaration_id = idFor(ids, decl);
+      if (declaration_id == 0 && decl != nullptr) {
+        declaration_id =
+            idFor(ids, isSgClassDeclaration(decl->get_definingDeclaration()));
+      }
+      if (declaration_id == 0 && decl != nullptr) {
+        declaration_id = idFor(
+            ids, isSgClassDeclaration(decl->get_firstNondefiningDeclaration()));
+      }
+      const bool external_declaration =
+          declaration_id == 0 && decl != nullptr &&
+          (isAstJsonExternalClassDeclaration(decl) ||
+           !insideCollectionBoundary(decl));
+      if (declaration_id == 0) {
+        if (external_declaration) {
+          fields.push_back(jsonString("external_declaration") + ": " +
+                           rawExternalClassDeclarationJson(decl));
+        } else {
+          std::ostringstream message;
+          message << "AST JSON SgClassType declaration was not collected: "
+                  << jsonTypeText(type);
+          if (decl != nullptr) {
+            message << " declaration=" << decl->get_name();
+            if (SgNode *parent = decl->get_parent()) {
+              message << " declaration_parent=" << parent->sage_class_name();
+            } else {
+              message << " declaration_parent=<null>";
+            }
+            if (SgScopeStatement *scope = decl->get_scope()) {
+              message << " declaration_scope=" << scope->sage_class_name();
+            } else {
+              message << " declaration_scope=<null>";
+            }
+            const SgNode *decl_parent = decl->get_parent();
+            int decl_depth = 0;
+            while (decl_parent != nullptr && decl_depth < 8) {
+              message << " declaration_parent" << decl_depth << "="
+                      << decl_parent->sage_class_name();
+              const auto parent_id = ids.find(decl_parent);
+              if (parent_id != ids.end()) {
+                message << "#" << parent_id->second;
+              }
+              decl_parent = decl_parent->get_parent();
+              ++decl_depth;
+            }
+          }
+          if (currentTypeSerializationNode != nullptr) {
+            message << " while serializing "
+                    << currentTypeSerializationNode->sage_class_name();
+            const auto current_id = ids.find(currentTypeSerializationNode);
+            if (current_id != ids.end()) {
+              message << " id=" << current_id->second;
+            }
+            message << " text="
+                    << safeNodeText(
+                           const_cast<SgNode *>(currentTypeSerializationNode));
+            const SgNode *parent = currentTypeSerializationNode->get_parent();
+            int depth = 0;
+            while (parent != nullptr && depth < 8) {
+              message << " parent" << depth << "=" << parent->sage_class_name();
+              const auto parent_id = ids.find(parent);
+              if (parent_id != ids.end()) {
+                message << "#" << parent_id->second;
+              }
+              parent = parent->get_parent();
+              ++depth;
+            }
+          }
+          throw std::runtime_error(message.str());
+        }
+      } else {
+        fields.push_back(rawIntegerField("declaration", declaration_id));
+      }
+      fields.push_back(rawBoolField("autonomous_declaration",
+                                    class_type->get_autonomous_declaration()));
+    } else if (SgEnumType *enum_type = isSgEnumType(type)) {
+      SgEnumDeclaration *decl =
+          isSgEnumDeclaration(enum_type->get_declaration());
+      uint64_t declaration_id = idFor(ids, decl);
+      if (decl != nullptr) {
+        if (SgEnumDeclaration *first_nondef =
+                isSgEnumDeclaration(decl->get_firstNondefiningDeclaration())) {
+          if (uint64_t first_nondef_id = idFor(ids, first_nondef)) {
+            declaration_id = first_nondef_id;
+          }
+        }
+      }
+      if (declaration_id == 0) {
+        throw std::runtime_error(
+            "AST JSON SgEnumType declaration was not collected: " +
+            jsonTypeText(type));
+      }
+      fields.push_back(rawIntegerField("declaration", declaration_id));
+      fields.push_back(rawBoolField("autonomous_declaration",
+                                    enum_type->get_autonomous_declaration()));
+    } else if (SgNonrealType *nonreal_type = isSgNonrealType(type)) {
+      const uint64_t declaration_id =
+          idFor(ids, nonreal_type->get_declaration());
+      if (declaration_id == 0) {
+        throw std::runtime_error(
+            "AST JSON SgNonrealType declaration was not collected: " +
+            jsonTypeText(type));
+      }
+      fields.push_back(rawIntegerField("declaration", declaration_id));
+      fields.push_back(
+          rawBoolField("autonomous_declaration",
+                       nonreal_type->get_autonomous_declaration()));
+    } else if (SgDeclType *decl_type = isSgDeclType(type)) {
+      fields.push_back(
+          jsonString("base_expression") + ": " +
+          rawTypeOwnedExpressionRef(decl_type->get_base_expression(), ids));
+      fields.push_back(
+          rawBoolField("is_gnu_decltype", decl_type->get_is_gnu_decltype()));
+      if (SgExpression *base_expression = decl_type->get_base_expression()) {
+        fields.push_back(jsonString("base_type") + ": " +
+                         rawTypeJson(base_expression->get_type(), ids));
+      } else {
+        fields.push_back(jsonString("base_type") + ": " +
+                         rawTypeJson(nullptr, ids));
+      }
+    } else if (SgTemplateType *template_type = isSgTemplateType(type)) {
+      fields.push_back(
+          rawStringField("name", template_type->get_name().getString()));
+      fields.push_back(
+          rawIntegerField("template_parameter_position",
+                          template_type->get_template_parameter_position()));
+      fields.push_back(
+          rawIntegerField("template_parameter_depth",
+                          template_type->get_template_parameter_depth()));
+      fields.push_back(jsonString("class_type") + ": " +
+                       rawTypeJson(template_type->get_class_type(), ids));
+      fields.push_back(
+          jsonString("parent_class_type") + ": " +
+          rawTypeJson(template_type->get_parent_class_type(), ids));
+    } else if (SgMemberFunctionType *member_type =
+                   isSgMemberFunctionType(type)) {
+      fields.push_back(jsonString("return_type") + ": " +
+                       rawTypeJson(member_type->get_return_type(), ids));
+      fields.push_back(jsonString("class_type") + ": " +
+                       rawTypeJson(member_type->get_class_type(), ids));
+      fields.push_back(rawIntegerField("mfunc_specifier",
+                                       member_type->get_mfunc_specifier()));
+      fields.push_back(
+          rawBoolField("has_ellipses", member_type->get_has_ellipses()));
+      std::ostringstream args;
+      args << jsonString("arguments") << ": [";
+      const SgTypePtrList &argument_types =
+          member_type->get_argument_list() != nullptr
+              ? member_type->get_argument_list()->get_arguments()
+              : member_type->get_arguments();
+      if (!argument_types.empty()) {
+        args << '\n';
+        for (size_t i = 0; i < argument_types.size(); ++i) {
+          indent(args, 8);
+          args << rawTypeJson(argument_types[i], ids);
+          if (i + 1 != argument_types.size()) {
+            args << ',';
+          }
+          args << '\n';
+        }
+        indent(args, 6);
+      }
+      args << "]";
+      fields.push_back(args.str());
+    } else if (SgFunctionType *function_type = isSgFunctionType(type)) {
+      fields.push_back(jsonString("return_type") + ": " +
+                       rawTypeJson(function_type->get_return_type(), ids));
+      fields.push_back(
+          rawBoolField("has_ellipses", function_type->get_has_ellipses()));
+      std::ostringstream args;
+      args << jsonString("arguments") << ": [";
+      const SgTypePtrList &argument_types =
+          function_type->get_argument_list() != nullptr
+              ? function_type->get_argument_list()->get_arguments()
+              : function_type->get_arguments();
+      if (!argument_types.empty()) {
+        args << '\n';
+        for (size_t i = 0; i < argument_types.size(); ++i) {
+          indent(args, 8);
+          args << rawTypeJson(argument_types[i], ids);
+          if (i + 1 != argument_types.size()) {
+            args << ',';
+          }
+          args << '\n';
+        }
+        indent(args, 6);
+      }
+      args << "]";
+      fields.push_back(args.str());
+    }
+  }
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawOmpArrayDimensionsJson(
+    const std::map<SgSymbol *,
+                   std::vector<std::pair<SgExpression *, SgExpression *>>>
+        &array_dimensions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::pair<std::string, std::string>> entries;
+  for (const auto &entry : array_dimensions) {
+    std::vector<std::string> fields;
+    const uint64_t declaration_id = idFor(ids, symbolBasis(entry.first));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(entry.first, ids));
+    std::ostringstream bounds;
+    bounds << jsonString("bounds") << ": [";
+    if (!entry.second.empty()) {
+      bounds << '\n';
+      for (size_t i = 0; i < entry.second.size(); ++i) {
+        std::vector<std::string> bound_fields;
+        bound_fields.push_back(jsonString("lower") + ": " +
+                               rawExpressionRef(entry.second[i].first, ids));
+        bound_fields.push_back(jsonString("upper") + ": " +
+                               rawExpressionRef(entry.second[i].second, ids));
+        writeRawObject(bounds, 10, bound_fields, i + 1 != entry.second.size());
+      }
+      indent(bounds, 8);
+    }
+    bounds << "]";
+    fields.push_back(bounds.str());
+
+    std::ostringstream item;
+    writeRawObject(item, 0, fields, false);
+    std::ostringstream key;
+    key << std::setw(20) << std::setfill('0') << declaration_id << ':'
+        << symbolName(entry.first);
+    entries.emplace_back(key.str(), item.str());
+  }
+  std::sort(
+      entries.begin(), entries.end(),
+      [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+  std::ostringstream out;
+  out << "[";
+  if (!entries.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < entries.size(); ++i) {
+      indent(out, 6);
+      out << entries[i].second;
+      if (i + 1 != entries.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawOmpDistDataPoliciesJson(
+    const std::map<SgSymbol *,
+                   std::vector<std::pair<SgOmpClause::omp_map_dist_data_enum,
+                                         SgExpression *>>> &policies,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::pair<std::string, std::string>> entries;
+  for (const auto &entry : policies) {
+    std::vector<std::string> fields;
+    const uint64_t declaration_id = idFor(ids, symbolBasis(entry.first));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(entry.first, ids));
+    std::ostringstream policy_json;
+    policy_json << jsonString("policies") << ": [";
+    if (!entry.second.empty()) {
+      policy_json << '\n';
+      for (size_t i = 0; i < entry.second.size(); ++i) {
+        std::vector<std::string> policy_fields;
+        policy_fields.push_back(
+            rawIntegerField("policy", static_cast<int>(entry.second[i].first)));
+        policy_fields.push_back(jsonString("expression") + ": " +
+                                rawExpressionRef(entry.second[i].second, ids));
+        writeRawObject(policy_json, 10, policy_fields,
+                       i + 1 != entry.second.size());
+      }
+      indent(policy_json, 8);
+    }
+    policy_json << "]";
+    fields.push_back(policy_json.str());
+
+    std::ostringstream item;
+    writeRawObject(item, 0, fields, false);
+    std::ostringstream key;
+    key << std::setw(20) << std::setfill('0') << declaration_id << ':'
+        << symbolName(entry.first);
+    entries.emplace_back(key.str(), item.str());
+  }
+  std::sort(
+      entries.begin(), entries.end(),
+      [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+  std::ostringstream out;
+  out << "[";
+  if (!entries.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < entries.size(); ++i) {
+      indent(out, 6);
+      out << entries[i].second;
+      if (i + 1 != entries.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string
+rawOmpIteratorJson(const std::list<std::list<SgExpression *>> &iterators,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!iterators.empty()) {
+    out << '\n';
+    size_t outer_index = 0;
+    for (const std::list<SgExpression *> &iterator : iterators) {
+      indent(out, 6);
+      out << "[";
+      if (!iterator.empty()) {
+        out << '\n';
+        size_t inner_index = 0;
+        for (SgExpression *expr : iterator) {
+          indent(out, 8);
+          out << rawExpressionRef(expr, ids);
+          if (++inner_index != iterator.size()) {
+            out << ',';
+          }
+          out << '\n';
+        }
+        indent(out, 6);
+      }
+      out << "]";
+      if (++outer_index != iterators.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawOmpExpressionListJson(
+    const std::list<SgExpression *> &expressions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!expressions.empty()) {
+    out << '\n';
+    size_t index = 0;
+    for (SgExpression *expr : expressions) {
+      indent(out, 6);
+      out << rawExpressionRef(expr, ids);
+      if (++index != expressions.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawTemplateArgumentListJson(
+    const SgTemplateArgumentPtrList &arguments,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!arguments.empty()) {
+    out << '\n';
+    size_t index = 0;
+    for (SgTemplateArgument *argument : arguments) {
+      indent(out, 6);
+      out << idFor(ids, argument);
+      if (++index != arguments.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string
+rawTypeTraitArgsJson(const SgNodePtrList &args,
+                     const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!args.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < args.size(); ++i) {
+      indent(out, 6);
+      out << "{\n";
+      if (SgType *type = isSgType(args[i])) {
+        writeStringField(out, 8, "kind", "type");
+        indent(out, 8);
+        out << jsonString("type") << ": " << rawTypeJson(type, ids) << '\n';
+      } else {
+        const uint64_t id = idFor(ids, args[i]);
+        if (id == 0) {
+          throw std::runtime_error(
+              std::string("AST JSON type trait argument was not collected: ") +
+              (args[i] != nullptr ? args[i]->sage_class_name() : "<null>"));
+        }
+        writeStringField(out, 8, "kind", "node");
+        writeIntegerField(out, 8, "node", id, false);
+      }
+      indent(out, 6);
+      out << '}';
+      if (i + 1 != args.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawOmpUsesAllocatorsDefinitionsJson(
+    const std::list<SgOmpUsesAllocatorsDefination *> &definitions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!definitions.empty()) {
+    out << '\n';
+    size_t index = 0;
+    for (SgOmpUsesAllocatorsDefination *definition : definitions) {
+      const uint64_t id = idFor(ids, definition);
+      if (definition != nullptr && id == 0) {
+        throw std::runtime_error(
+            "AST JSON OMP uses_allocators definition target was not "
+            "collected");
+      }
+      indent(out, 6);
+      out << id;
+      if (++index != definitions.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawAstAttributesJson(SgNode *node) {
+  std::ostringstream out;
+  out << "[";
+  AstAttributeMechanism *attributes =
+      node != nullptr ? node->get_attributeMechanism() : nullptr;
+  if (attributes != nullptr && attributes->size() != 0) {
+    std::vector<std::string> entries;
+    for (const std::string &name : attributes->getAttributeIdentifiers()) {
+      AstAttribute *attribute = node->getAttribute(name);
+      if (AstIntAttribute *int_attribute =
+              dynamic_cast<AstIntAttribute *>(attribute)) {
+        std::vector<std::string> fields;
+        fields.push_back(rawStringField("name", name));
+        fields.push_back(rawStringField("type", "AstIntAttribute"));
+        fields.push_back(rawIntegerField("value", int_attribute->getValue()));
+        std::ostringstream item;
+        writeRawObject(item, 0, fields, false);
+        entries.push_back(item.str());
+      } else if (AstValueAttribute<std::string> *string_attribute =
+                     dynamic_cast<AstValueAttribute<std::string> *>(
+                         attribute)) {
+        std::vector<std::string> fields;
+        fields.push_back(rawStringField("name", name));
+        fields.push_back(rawStringField("type", "AstStringAttribute"));
+        fields.push_back(rawStringField("value", string_attribute->get()));
+        std::ostringstream item;
+        writeRawObject(item, 0, fields, false);
+        entries.push_back(item.str());
+      } else if (name == "acc_fortran_end" || name == "omp_fortran_end" ||
+                 name == "fortran_keep_openmp_pragma" ||
+                 name == "omp_declare_target_extended_list") {
+        std::vector<std::string> fields;
+        fields.push_back(rawStringField("name", name));
+        fields.push_back(rawStringField("type", "AstMarkerAttribute"));
+        std::ostringstream item;
+        writeRawObject(item, 0, fields, false);
+        entries.push_back(item.str());
+      }
+    }
+    if (!entries.empty()) {
+      std::sort(entries.begin(), entries.end());
+      out << '\n';
+      for (size_t i = 0; i < entries.size(); ++i) {
+        indent(out, 6);
+        out << entries[i];
+        if (i + 1 != entries.size()) {
+          out << ',';
+        }
+        out << '\n';
+      }
+      indent(out, 4);
+    }
+  }
+  out << "]";
+  return out.str();
+}
+
+void addExpressionType(
+    std::vector<std::string> &fields, SgExpression *expr,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  if (expr != nullptr) {
+    fields.push_back(jsonString("type") + ": " +
+                     rawTypeJson(expr->get_type(), ids));
+  }
+}
+
+template <typename T>
+void addReferenceQualificationFields(std::vector<std::string> &fields, T *ref) {
+  fields.push_back(rawIntegerField("name_qualification_length",
+                                   ref->get_name_qualification_length()));
+  fields.push_back(rawBoolField("type_elaboration_required",
+                                ref->get_type_elaboration_required()));
+  fields.push_back(rawBoolField("global_qualification_required",
+                                ref->get_global_qualification_required()));
+  fields.push_back(
+      rawIntegerField("explicit_name_qualification_length",
+                      ref->get_explicit_name_qualification_length()));
+  fields.push_back(rawBoolField("explicit_global_qualification",
+                                ref->get_explicit_global_qualification()));
+  fields.push_back(
+      jsonString("explicit_name_qualification_tokens") + ": " +
+      rawStringListJson(ref->get_explicit_name_qualification_tokens()));
+}
+
+void addExpressionQualificationFields(std::vector<std::string> &fields,
+                                      SgExpression *expr) {
+  if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+    if (isAnonymousDataMemberReference(ref)) {
+      fields.push_back(rawIntegerField("name_qualification_length", 0));
+      fields.push_back(rawBoolField("type_elaboration_required", false));
+      fields.push_back(rawBoolField("global_qualification_required", false));
+      fields.push_back(
+          rawIntegerField("explicit_name_qualification_length", -1));
+      fields.push_back(rawBoolField("explicit_global_qualification", false));
+      fields.push_back(jsonString("explicit_name_qualification_tokens") + ": " +
+                       rawStringListJson(SgStringList()));
+    } else {
+      addReferenceQualificationFields(fields, ref);
+    }
+  } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  } else if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  } else if (SgTemplateMemberFunctionRefExp *ref =
+                 isSgTemplateMemberFunctionRefExp(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  } else if (SgEnumVal *ref = isSgEnumVal(expr)) {
+    addReferenceQualificationFields(fields, ref);
+  }
+}
+
+template <typename T>
+void restoreReferenceQualificationFields(T *ref, const JsonValue &properties) {
+  ref->set_name_qualification_length(
+      static_cast<int>(properties.at("name_qualification_length").asInt()));
+  ref->set_type_elaboration_required(
+      properties.at("type_elaboration_required").asBool());
+  ref->set_global_qualification_required(
+      properties.at("global_qualification_required").asBool());
+  ref->set_explicit_name_qualification_length(static_cast<int>(
+      properties.at("explicit_name_qualification_length").asInt()));
+  ref->set_explicit_global_qualification(
+      properties.at("explicit_global_qualification").asBool());
+  ref->set_explicit_name_qualification_tokens(
+      stringListFromJson(properties.at("explicit_name_qualification_tokens"),
+                         "explicit_name_qualification_tokens"));
+}
+
+void restoreExpressionQualificationFields(SgExpression *expr,
+                                          const JsonValue &properties) {
+  if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgTemplateMemberFunctionRefExp *ref =
+                 isSgTemplateMemberFunctionRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  } else if (SgEnumVal *ref = isSgEnumVal(expr)) {
+    restoreReferenceQualificationFields(ref, properties);
+  }
+}
+
+void addLocatedPreprocessing(std::vector<std::string> &fields,
+                             const SgLocatedNode *node) {
+  const AttachedPreprocessingInfoType *infos =
+      node != nullptr
+          ? const_cast<SgLocatedNode *>(node)->getAttachedPreprocessingInfo()
+          : nullptr;
+  std::ostringstream out;
+  out << jsonString("preprocessing") << ": [";
+  if (infos != nullptr && !infos->empty()) {
+    std::vector<std::vector<std::string>> preprocessing_entries;
+    for (size_t i = 0; i < infos->size(); ++i) {
+      const PreprocessingInfo *info = (*infos)[i];
+      if (info == nullptr) {
+        std::ostringstream message;
+        message << "AST JSON cannot serialize null PreprocessingInfo attached "
+                << "to " << node->class_name();
+        throw std::runtime_error(message.str());
+      }
+      if (isSgInitializedName(const_cast<SgLocatedNode *>(node)) != nullptr &&
+          (info->getTypeOfDirective() ==
+               PreprocessingInfo::CpreprocessorIncludeDeclaration ||
+           info->getTypeOfDirective() ==
+               PreprocessingInfo::CpreprocessorIncludeNextDeclaration)) {
+        SgNode *parent = const_cast<SgLocatedNode *>(node)->get_parent();
+        SgLocatedNode *parent_located = isSgLocatedNode(parent);
+        AttachedPreprocessingInfoType *parent_infos =
+            parent_located != nullptr
+                ? parent_located->getAttachedPreprocessingInfo()
+                : nullptr;
+        bool parent_has_same_include = false;
+        if (parent_infos != nullptr) {
+          for (const PreprocessingInfo *parent_info : *parent_infos) {
+            if (parent_info != nullptr &&
+                parent_info->getTypeOfDirective() ==
+                    info->getTypeOfDirective() &&
+                parent_info->getString() == info->getString()) {
+              parent_has_same_include = true;
+              break;
+            }
+          }
+        }
+        if (parent_has_same_include) {
+          continue;
+        }
+      }
+      std::vector<std::string> entry;
+      entry.push_back(rawIntegerField(
+          "directive", static_cast<int>(info->getTypeOfDirective())));
+      entry.push_back(rawIntegerField(
+          "relative", static_cast<int>(info->getRelativePosition())));
+      entry.push_back(rawStringField("text", info->getString()));
+      entry.push_back(jsonString("file_info") + ": " +
+                      rawFileInfoJson(info->get_file_info()));
+      entry.push_back(rawIntegerField("lines", info->getNumberOfLines()));
+      entry.push_back(rawBoolField("transformation", info->isTransformation()));
+      preprocessing_entries.push_back(std::move(entry));
+    }
+    if (!preprocessing_entries.empty()) {
+      out << '\n';
+      for (size_t i = 0; i < preprocessing_entries.size(); ++i) {
+        writeRawObject(out, 8, preprocessing_entries[i],
+                       i + 1 != preprocessing_entries.size());
+      }
+      indent(out, 6);
+    }
+  }
+  out << "]";
+  fields.push_back(out.str());
+}
+
+void writeFileInfoJson(std::ostream &out, int level, const Sg_File_Info *info,
+                       bool comma) {
+  indent(out, level);
+  out << "{\n";
+  if (info == nullptr) {
+    writeBoolField(out, level + 2, "present", false, false);
+  } else {
+    writeBoolField(out, level + 2, "present", true);
+    writeStringField(out, level + 2, "filename", info->get_filenameString());
+    writeStringField(out, level + 2, "raw_filename", info->get_raw_filename());
+    writeStringField(out, level + 2, "physical_filename",
+                     info->get_physical_filename());
+    writeIntegerField(out, level + 2, "file_id", info->get_file_id());
+    const int physical_file_id = info->get_physical_file_id();
+    std::string physical_raw_filename = info->get_physical_filename();
+    if (physical_file_id >= 0) {
+      physical_raw_filename = Sg_File_Info::getFilenameFromID(physical_file_id);
+    }
+    writeStringField(out, level + 2, "physical_raw_filename",
+                     physical_raw_filename);
+    writeIntegerField(out, level + 2, "physical_file_id", physical_file_id);
+    const int *physical_internal_file_id =
+        const_cast<Sg_File_Info *>(info)->get_physical_file_id_reference();
+    writeIntegerField(out, level + 2, "physical_internal_file_id",
+                      physical_internal_file_id != nullptr
+                          ? *physical_internal_file_id
+                          : physical_file_id);
+    writeIntegerField(out, level + 2, "line", info->get_line());
+    writeIntegerField(out, level + 2, "column", info->get_col());
+    writeIntegerField(out, level + 2, "raw_line", info->get_raw_line());
+    writeIntegerField(out, level + 2, "raw_column", info->get_raw_col());
+    writeIntegerField(out, level + 2, "physical_line",
+                      info->get_physical_line());
+    writeIntegerField(out, level + 2, "source_sequence",
+                      info->get_source_sequence_number());
+    writeBoolField(out, level + 2, "compiler_generated",
+                   info->isCompilerGenerated());
+    writeBoolField(out, level + 2, "transformation", info->isTransformation());
+    writeBoolField(out, level + 2, "frontend_specific",
+                   info->isFrontendSpecific());
+    writeBoolField(out, level + 2, "output_in_code_generation",
+                   info->isOutputInCodeGeneration());
+    writeBoolField(out, level + 2, "shared", info->isShared());
+    writeBoolField(out, level + 2, "source_position_unavailable_in_frontend",
+                   info->isSourcePositionUnavailableInFrontend());
+    writeBoolField(out, level + 2, "comment_or_directive",
+                   info->isCommentOrDirective());
+    writeBoolField(out, level + 2, "token", info->isToken());
+    writeBoolField(out, level + 2, "default_argument",
+                   info->isDefaultArgument());
+    writeBoolField(out, level + 2, "implicit_cast", info->isImplicitCast(),
+                   false);
+  }
+  indent(out, level);
+  out << '}';
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+SgProject *currentDeserializationProject = nullptr;
+SgNode *currentAuxiliaryOwner = nullptr;
+std::vector<std::string> currentAuxiliaryTypeStack;
+std::unordered_map<SgSourceFile *, std::vector<SgClassDeclaration *>>
+    currentDeserializationClassDeclarationCache;
+
+std::string safeNodeText(SgNode *node);
+
+bool insideCollectionBoundary(SgNode *node) {
+  if (node == nullptr || collectionBoundaryFile == nullptr) {
+    return true;
+  }
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (current == collectionBoundaryFile) {
+      return true;
+    }
+    if (isSgType(current) != nullptr) {
+      return true;
+    }
+    if (isSgSourceFile(current) != nullptr ||
+        isSgFileList(current) != nullptr || isSgProject(current) != nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+
+CollectionBoundaryGuard::CollectionBoundaryGuard(SgSourceFile *file)
+    : previous_(collectionBoundaryFile) {
+  collectionBoundaryFile = file;
+}
+
+CollectionBoundaryGuard::~CollectionBoundaryGuard() {
+  collectionBoundaryFile = previous_;
+}
+
+DeserializationProjectGuard::DeserializationProjectGuard(SgProject *project)
+    : previous_(currentDeserializationProject) {
+  currentDeserializationProject = project;
+  currentDeserializationClassDeclarationCache.clear();
+}
+
+DeserializationProjectGuard::~DeserializationProjectGuard() {
+  currentDeserializationClassDeclarationCache.clear();
+  currentDeserializationProject = previous_;
+}
+
+class AuxiliaryOwnerGuard {
+public:
+  explicit AuxiliaryOwnerGuard(SgNode *node)
+      : previous_(currentAuxiliaryOwner) {
+    currentAuxiliaryOwner = node;
+  }
+  ~AuxiliaryOwnerGuard() { currentAuxiliaryOwner = previous_; }
+
+private:
+  SgNode *previous_;
+};
+
+class AuxiliaryTypeGuard {
+public:
+  explicit AuxiliaryTypeGuard(SgType *type) {
+    currentAuxiliaryTypeStack.push_back(
+        type != nullptr ? type->sage_class_name() : "<null>");
+  }
+  ~AuxiliaryTypeGuard() { currentAuxiliaryTypeStack.pop_back(); }
+};
+
+bool isAstJsonExternalMarker(SgNode *node) {
+  return isAstJsonExternalFunction(isSgFunctionDeclaration(node)) ||
+         isAstJsonExternalModule(isSgModuleStatement(node)) ||
+         isAstJsonExternalClassDeclaration(isSgClassDeclaration(node));
+}
+
+bool isStructuralAstChildOfParent(SgNode *node) {
+  SgNode *parent = node != nullptr ? node->get_parent() : nullptr;
+  if (parent == nullptr || isAstJsonExternalMarker(parent)) {
+    return false;
+  }
+  for (const std::pair<SgNode *, std::string> &entry :
+       parent->returnDataMemberPointers()) {
+    if (entry.first != node) {
+      continue;
+    }
+    if (entry.second == "parent" || entry.second == "scope" ||
+        entry.second == "symbol_table" || entry.second == "type_table" ||
+        entry.second == "firstNondefiningDeclaration" ||
+        entry.second == "definingDeclaration") {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool hasNonStructuralExternalMarkerAncestor(SgNode *node) {
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (isAstJsonExternalMarker(current) &&
+        !isStructuralAstChildOfParent(current)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void addSingleNode(SgNode *node, std::vector<SgNode *> &nodes,
+                   std::unordered_set<SgNode *> &seen) {
+  if (hasNonStructuralExternalMarkerAncestor(node)) {
+    return;
+  }
+  if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+    if (collectionBoundaryFile != nullptr &&
+        isSgType(ref->get_parent()) != nullptr) {
+      const SgNode *basis = symbolBasis(ref->get_symbol());
+      if (basis != nullptr &&
+          !insideCollectionBoundary(const_cast<SgNode *>(basis))) {
+        std::ostringstream message;
+        message << "AST JSON type-owned SgVarRefExp references a symbol "
+                   "outside the collection boundary: "
+                << symbolName(ref->get_symbol());
+        if (currentAuxiliaryOwner != nullptr) {
+          message << " owner=" << currentAuxiliaryOwner->sage_class_name()
+                  << " owner_text=" << safeNodeText(currentAuxiliaryOwner);
+        }
+        if (!currentAuxiliaryTypeStack.empty()) {
+          message << " type_stack=";
+          for (size_t i = 0; i < currentAuxiliaryTypeStack.size(); ++i) {
+            if (i != 0) {
+              message << "/";
+            }
+            message << currentAuxiliaryTypeStack[i];
+          }
+        }
+        if (const SgNode *parent = ref->get_parent()) {
+          message << " parent=" << parent->sage_class_name();
+        }
+        throw std::runtime_error(message.str());
+      }
+    }
+  }
+  if (node != nullptr && insideCollectionBoundary(node) &&
+      seen.insert(node).second) {
+    nodes.push_back(node);
+  }
+}
+
+void addSubtreeNodes(SgNode *root, std::vector<SgNode *> &nodes,
+                     std::unordered_set<SgNode *> &seen) {
+  if (root == nullptr || !insideCollectionBoundary(root)) {
+    return;
+  }
+  addSingleNode(root, nodes, seen);
+  if (isSgBaseClass(root) != nullptr) {
+    return;
+  }
+  RoseAst ast(root);
+  for (RoseAst::iterator it = ast.begin().withoutNullValues(); it != ast.end();
+       ++it) {
+    if (insideCollectionBoundary(*it)) {
+      addSingleNode(*it, nodes, seen);
+    }
+    if (isSgBaseClass(*it) != nullptr) {
+      it.skipChildrenOnForward();
+    }
+  }
+}
+
+void addNodeAncestors(SgNode *node, std::vector<SgNode *> &nodes,
+                      std::unordered_set<SgNode *> &seen) {
+  for (SgNode *current = node != nullptr ? node->get_parent() : nullptr;
+       current != nullptr; current = current->get_parent()) {
+    if (!insideCollectionBoundary(current) ||
+        isSgSourceFile(current) != nullptr ||
+        isSgFileList(current) != nullptr || isSgProject(current) != nullptr) {
+      return;
+    }
+    addSingleNode(current, nodes, seen);
+  }
+}
+
+void addReferencedSymbolBasis(const SgSymbol *symbol,
+                              std::vector<SgNode *> &nodes,
+                              std::unordered_set<SgNode *> &seen) {
+  SgNode *basis = const_cast<SgNode *>(symbolBasis(symbol));
+  if (hasNonStructuralExternalMarkerAncestor(basis)) {
+    return;
+  }
+  addSubtreeNodes(basis, nodes, seen);
+  addNodeAncestors(basis, nodes, seen);
+}
+
+void addExpressionSymbolDependencies(SgNode *node, std::vector<SgNode *> &nodes,
+                                     std::unordered_set<SgNode *> &seen);
+
+void addExpressionSubtreeSymbolDependencies(
+    SgExpression *root, std::vector<SgNode *> &nodes,
+    std::unordered_set<SgNode *> &seen) {
+  if (root == nullptr || !insideCollectionBoundary(root)) {
+    return;
+  }
+  addExpressionSymbolDependencies(root, nodes, seen);
+  RoseAst ast(root);
+  for (RoseAst::iterator it = ast.begin().withoutNullValues(); it != ast.end();
+       ++it) {
+    if (!insideCollectionBoundary(*it)) {
+      continue;
+    }
+    addExpressionSymbolDependencies(*it, nodes, seen);
+    if (isSgBaseClass(*it) != nullptr) {
+      it.skipChildrenOnForward();
+    }
+  }
+}
+
+void addOmpAuxiliaryNodes(SgNode *node, std::vector<SgNode *> &nodes,
+                          std::unordered_set<SgNode *> &seen) {
+  AuxiliaryOwnerGuard owner_guard(node);
+  if (SgNode *parent = node != nullptr ? node->get_parent() : nullptr) {
+    if (isSgType(parent) == nullptr && isSgFileList(parent) == nullptr &&
+        isSgProject(parent) == nullptr) {
+      addSubtreeNodes(parent, nodes, seen);
+    }
+  }
+
+  auto add_expression_with_owner = [&](SgExpression *expr) {
+    if (expr == nullptr) {
+      return;
+    }
+    SgExpression *owner = expr;
+    while (SgExpression *parent = isSgExpression(owner->get_parent())) {
+      owner = parent;
+    }
+    SgNode *container = owner->get_parent();
+    if (isSgExprStatement(container) != nullptr ||
+        isSgInitializer(container) != nullptr) {
+      addSubtreeNodes(container, nodes, seen);
+      addExpressionSubtreeSymbolDependencies(owner, nodes, seen);
+    } else {
+      addSubtreeNodes(owner, nodes, seen);
+      addExpressionSubtreeSymbolDependencies(owner, nodes, seen);
+    }
+  };
+
+  std::function<void(SgType *)> add_type;
+  auto add_type_owned_expression_dependencies = [&](SgExpression *expr) {
+    if (expr == nullptr) {
+      return;
+    }
+    addExpressionSubtreeSymbolDependencies(expr, nodes, seen);
+
+    auto add_expression_type = [&](SgExpression *current) {
+      if (current == nullptr) {
+        return;
+      }
+      if (SgNewExp *new_expr = isSgNewExp(current)) {
+        add_type(new_expr->get_specified_type());
+      } else {
+        add_type(current->get_type());
+      }
+      if (SgTypeExpression *type_expr = isSgTypeExpression(current)) {
+        add_type(type_expr->get_type());
+      }
+    };
+
+    add_expression_type(expr);
+    RoseAst ast(expr);
+    for (RoseAst::iterator it = ast.begin().withoutNullValues();
+         it != ast.end(); ++it) {
+      if (SgExpression *child = isSgExpression(*it)) {
+        add_expression_type(child);
+      }
+      if (isSgBaseClass(*it) != nullptr) {
+        it.skipChildrenOnForward();
+      }
+    }
+  };
+
+  add_type = [&](SgType *type) -> void {
+    if (type == nullptr) {
+      return;
+    }
+    AuxiliaryTypeGuard type_guard(type);
+    if (SgPointerMemberType *member_pointer = isSgPointerMemberType(type)) {
+      add_type(member_pointer->get_base_type());
+      add_type(member_pointer->get_class_type());
+    } else if (SgPointerType *pointer = isSgPointerType(type)) {
+      add_type(pointer->get_base_type());
+    } else if (SgReferenceType *reference = isSgReferenceType(type)) {
+      add_type(reference->get_base_type());
+    } else if (SgRvalueReferenceType *reference =
+                   isSgRvalueReferenceType(type)) {
+      add_type(reference->get_base_type());
+    } else if (SgTypeString *string_type = isSgTypeString(type)) {
+      add_type_owned_expression_dependencies(
+          string_type->get_lengthExpression());
+      add_type_owned_expression_dependencies(string_type->get_type_kind());
+    } else if (SgTypeComplex *complex_type = isSgTypeComplex(type)) {
+      add_type(complex_type->get_base_type());
+      add_type_owned_expression_dependencies(complex_type->get_type_kind());
+    } else if (SgArrayType *array = isSgArrayType(type)) {
+      add_type(array->get_base_type());
+      add_type_owned_expression_dependencies(array->get_index());
+      add_type_owned_expression_dependencies(array->get_dim_info());
+    } else if (SgModifierType *modifier = isSgModifierType(type)) {
+      add_type(modifier->get_base_type());
+    } else if (SgTypedefType *typedef_type = isSgTypedefType(type)) {
+      addSubtreeNodes(typedef_type->get_declaration(), nodes, seen);
+    } else if (SgClassType *class_type = isSgClassType(type)) {
+      addSubtreeNodes(class_type->get_declaration(), nodes, seen);
+    } else if (SgEnumType *enum_type = isSgEnumType(type)) {
+      addSubtreeNodes(enum_type->get_declaration(), nodes, seen);
+    } else if (SgNonrealType *nonreal_type = isSgNonrealType(type)) {
+      addSubtreeNodes(nonreal_type->get_declaration(), nodes, seen);
+    } else if (SgTemplateType *template_type = isSgTemplateType(type)) {
+      add_type(template_type->get_class_type());
+      add_type(template_type->get_parent_class_type());
+    } else if (SgMemberFunctionType *member_type =
+                   isSgMemberFunctionType(type)) {
+      add_type(member_type->get_return_type());
+      add_type(member_type->get_class_type());
+      for (SgType *arg_type : member_type->get_arguments()) {
+        add_type(arg_type);
+      }
+    } else if (SgFunctionType *function_type = isSgFunctionType(type)) {
+      add_type(function_type->get_return_type());
+      for (SgType *arg_type : function_type->get_arguments()) {
+        add_type(arg_type);
+      }
+    } else if (SgDeclType *decl_type = isSgDeclType(type)) {
+      add_type_owned_expression_dependencies(decl_type->get_base_expression());
+    }
+  };
+  auto add_template_argument = [&](auto &self,
+                                   SgTemplateArgument *argument) -> void {
+    if (argument == nullptr) {
+      return;
+    }
+    addSubtreeNodes(argument, nodes, seen);
+    add_type(argument->get_type());
+    add_expression_with_owner(argument->get_expression());
+    addSubtreeNodes(argument->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(argument->get_initializedName(), nodes, seen);
+  };
+  auto add_template_arguments =
+      [&](const SgTemplateArgumentPtrList &arguments) {
+        for (SgTemplateArgument *argument : arguments) {
+          add_template_argument(add_template_argument, argument);
+        }
+      };
+  auto add_template_parameter = [&](auto &self,
+                                    SgTemplateParameter *parameter) -> void {
+    if (parameter == nullptr) {
+      return;
+    }
+    addSubtreeNodes(parameter, nodes, seen);
+    add_type(parameter->get_type());
+    add_type(parameter->get_defaultTypeParameter());
+    add_expression_with_owner(parameter->get_expression());
+    add_expression_with_owner(parameter->get_typeConstraint());
+    add_expression_with_owner(parameter->get_defaultExpressionParameter());
+    addSubtreeNodes(parameter->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(parameter->get_defaultTemplateDeclarationParameter(), nodes,
+                    seen);
+    addSubtreeNodes(parameter->get_initializedName(), nodes, seen);
+  };
+  auto add_template_parameters =
+      [&](const SgTemplateParameterPtrList &parameters) {
+        for (SgTemplateParameter *parameter : parameters) {
+          add_template_parameter(add_template_parameter, parameter);
+        }
+      };
+
+  if (SgExpression *expr = isSgExpression(node)) {
+    addSubtreeNodes(expr->get_originalExpressionTree(), nodes, seen);
+    if (SgNewExp *new_expr = isSgNewExp(expr)) {
+      add_type(new_expr->get_specified_type());
+    } else {
+      add_type(expr->get_type());
+    }
+    if (SgTypeExpression *type_expr = isSgTypeExpression(expr)) {
+      add_type(type_expr->get_type());
+    }
+    if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+      addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+    } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(expr)) {
+      addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+    } else if (SgTemplateFunctionRefExp *ref =
+                   isSgTemplateFunctionRefExp(expr)) {
+      addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+    } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(expr)) {
+      addReferencedSymbolBasis(ref->get_symbol_i(), nodes, seen);
+    } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(expr)) {
+      addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+      add_template_arguments(ref->get_templateArguments());
+    } else if (SgThisExp *this_expr = isSgThisExp(expr)) {
+      addReferencedSymbolBasis(this_expr->get_class_symbol(), nodes, seen);
+      addReferencedSymbolBasis(this_expr->get_nonreal_symbol(), nodes, seen);
+    } else if (SgConstructorInitializer *init =
+                   isSgConstructorInitializer(expr)) {
+      addSubtreeNodes(init->get_declaration(), nodes, seen);
+    }
+    if (SgTypeTraitBuiltinOperator *op = isSgTypeTraitBuiltinOperator(expr)) {
+      for (SgNode *arg : op->get_args()) {
+        if (SgType *type_arg = isSgType(arg)) {
+          add_type(type_arg);
+        } else {
+          addSubtreeNodes(arg, nodes, seen);
+        }
+      }
+    }
+  }
+  if (SgInitializedName *name = isSgInitializedName(node)) {
+    add_type(name->get_typeptr());
+    addSubtreeNodes(name->get_declptr(), nodes, seen);
+    addSubtreeNodes(name->get_definition(), nodes, seen);
+    addSubtreeNodes(name->get_prev_decl_item(), nodes, seen);
+  }
+  if (SgVariableDefinition *def = isSgVariableDefinition(node)) {
+    addSubtreeNodes(def->get_vardefn(), nodes, seen);
+    addSubtreeNodes(def->get_bitfield(), nodes, seen);
+  }
+  if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+    add_type(decl->get_base_type());
+  }
+  if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+    add_type(decl->get_type());
+    addSubtreeNodes(decl->get_functionParameterScope(), nodes, seen);
+  }
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+    addSubtreeNodes(decl->get_scope(), nodes, seen);
+    addSubtreeNodes(decl->get_firstNondefiningDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_definingDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_declarationScope(), nodes, seen);
+    addSubtreeNodes(decl->get_nonreal_decl_scope(), nodes, seen);
+  }
+  if (SgNamespaceDefinitionStatement *def =
+          isSgNamespaceDefinitionStatement(node)) {
+    addSubtreeNodes(def->get_namespaceDeclaration(), nodes, seen);
+    addSingleNode(def->get_previousNamespaceDefinition(), nodes, seen);
+    addSingleNode(def->get_nextNamespaceDefinition(), nodes, seen);
+    addSingleNode(def->get_global_definition(), nodes, seen);
+  }
+  if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+    add_type(decl->get_type());
+    addSubtreeNodes(decl->get_templateDeclaration(), nodes, seen);
+    add_template_arguments(decl->get_tpl_args());
+    add_expression_with_owner(decl->get_conceptConstraint());
+  }
+  if (SgClassDefinition *def = isSgClassDefinition(node)) {
+    for (SgBaseClass *base : def->get_inheritances()) {
+      addSingleNode(base, nodes, seen);
+    }
+  }
+  if (SgBaseClass *base = isSgBaseClass(node)) {
+    addSubtreeNodes(base->get_base_class(), nodes, seen);
+    if (SgExpBaseClass *expr_base = isSgExpBaseClass(base)) {
+      add_expression_with_owner(expr_base->get_base_class_exp());
+    }
+    if (SgNonrealBaseClass *nonreal_base = isSgNonrealBaseClass(base)) {
+      addSubtreeNodes(nonreal_base->get_base_class_nonreal(), nodes, seen);
+    }
+  }
+  if (SgTemplateInstantiationDecl *decl = isSgTemplateInstantiationDecl(node)) {
+    add_template_arguments(decl->get_templateArguments());
+    add_template_arguments(decl->get_deducedTemplateArguments());
+    addSubtreeNodes(decl->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_specializedTemplateDeclaration(), nodes, seen);
+  }
+  if (SgTemplateInstantiationTypedefDeclaration *decl =
+          isSgTemplateInstantiationTypedefDeclaration(node)) {
+    add_template_arguments(decl->get_templateArguments());
+    add_template_arguments(decl->get_deducedTemplateArguments());
+    addSubtreeNodes(decl->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_specializedTemplateDeclaration(), nodes, seen);
+  }
+  if (SgTemplateInstantiationFunctionDecl *decl =
+          isSgTemplateInstantiationFunctionDecl(node)) {
+    add_template_arguments(decl->get_templateArguments());
+    add_template_arguments(decl->get_deducedTemplateArguments());
+    addSubtreeNodes(decl->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_specializedTemplateDeclaration(), nodes, seen);
+  }
+  if (SgTemplateInstantiationMemberFunctionDecl *decl =
+          isSgTemplateInstantiationMemberFunctionDecl(node)) {
+    add_template_arguments(decl->get_templateArguments());
+    add_template_arguments(decl->get_deducedTemplateArguments());
+    addSubtreeNodes(decl->get_templateDeclaration(), nodes, seen);
+    addSubtreeNodes(decl->get_specializedTemplateDeclaration(), nodes, seen);
+  }
+  if (SgTemplateVariableDeclaration *decl =
+          isSgTemplateVariableDeclaration(node)) {
+    add_template_parameters(decl->get_templateParameters());
+    add_template_arguments(decl->get_templateSpecializationArguments());
+    add_template_arguments(decl->get_deducedTemplateArguments());
+    addSubtreeNodes(decl->get_specializedTemplateDeclaration(), nodes, seen);
+  }
+  if (SgTemplateTypedefDeclaration *decl =
+          isSgTemplateTypedefDeclaration(node)) {
+    add_template_parameters(decl->get_templateParameters());
+    add_template_arguments(decl->get_templateSpecializationArguments());
+    add_expression_with_owner(decl->get_requiresClause());
+  }
+  if (SgTemplateClassDeclaration *decl = isSgTemplateClassDeclaration(node)) {
+    add_template_parameters(decl->get_templateParameters());
+    add_template_arguments(decl->get_templateSpecializationArguments());
+    add_expression_with_owner(decl->get_requiresClause());
+  }
+  if (SgTemplateFunctionDeclaration *decl =
+          isSgTemplateFunctionDeclaration(node)) {
+    add_template_parameters(decl->get_templateParameters());
+    add_template_arguments(decl->get_templateSpecializationArguments());
+    add_expression_with_owner(decl->get_requiresClause());
+  }
+  if (SgTemplateMemberFunctionDeclaration *decl =
+          isSgTemplateMemberFunctionDeclaration(node)) {
+    add_template_parameters(decl->get_templateParameters());
+    add_template_arguments(decl->get_templateSpecializationArguments());
+    add_expression_with_owner(decl->get_requiresClause());
+  }
+  if (SgOmpExecStatement *stmt = isSgOmpExecStatement(node)) {
+    addSubtreeNodes(stmt->get_omp_parent(), nodes, seen);
+    for (SgStatement *child : stmt->get_omp_children()) {
+      addSubtreeNodes(child, nodes, seen);
+    }
+  }
+  if (SgTemplateArgument *argument = isSgTemplateArgument(node)) {
+    add_template_argument(add_template_argument, argument);
+  }
+  if (SgTemplateParameter *parameter = isSgTemplateParameter(node)) {
+    add_template_parameter(add_template_parameter, parameter);
+  }
+  auto add_dimension_map = [&](const auto &dimension_map) {
+    for (const auto &entry : dimension_map) {
+      addReferencedSymbolBasis(entry.first, nodes, seen);
+      for (const auto &bound : entry.second) {
+        add_expression_with_owner(bound.first);
+        add_expression_with_owner(bound.second);
+      }
+    }
+  };
+  auto add_iterators = [&](const std::list<std::list<SgExpression *>> &lists) {
+    for (const std::list<SgExpression *> &list : lists) {
+      for (SgExpression *expr : list) {
+        add_expression_with_owner(expr);
+      }
+    }
+  };
+  auto add_clause_list = [&](const SgOmpClausePtrList &clauses) {
+    for (SgOmpClause *clause : clauses) {
+      addSubtreeNodes(clause, nodes, seen);
+    }
+  };
+
+  if (SgOmpClauseStatement *stmt = isSgOmpClauseStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  } else if (SgOmpClauseBodyStatement *stmt =
+                 isSgOmpClauseBodyStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  }
+  if (SgOmpDeclareSimdStatement *stmt = isSgOmpDeclareSimdStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  }
+  if (SgOmpDeclareMapperStatement *stmt = isSgOmpDeclareMapperStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  }
+  if (SgOmpRequiresStatement *stmt = isSgOmpRequiresStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  }
+  if (SgOmpTaskwaitStatement *stmt = isSgOmpTaskwaitStatement(node)) {
+    add_clause_list(stmt->get_clauses());
+  }
+
+  if (SgOmpMapClause *clause = isSgOmpMapClause(node)) {
+    addSubtreeNodes(clause->get_variables(), nodes, seen);
+    addSubtreeNodes(clause->get_mapper_identifier(), nodes, seen);
+    add_dimension_map(clause->get_array_dimensions());
+    for (const auto &entry : clause->get_dist_data_policies()) {
+      addReferencedSymbolBasis(entry.first, nodes, seen);
+      for (const auto &policy : entry.second) {
+        addSubtreeNodes(policy.second, nodes, seen);
+      }
+    }
+    add_iterators(clause->get_iterator());
+  } else if (SgOmpDependClause *clause = isSgOmpDependClause(node)) {
+    add_dimension_map(clause->get_array_dimensions());
+    for (SgExpression *expr : clause->get_vec()) {
+      add_expression_with_owner(expr);
+    }
+    add_iterators(clause->get_iterator());
+  } else if (SgOmpAffinityClause *clause = isSgOmpAffinityClause(node)) {
+    add_dimension_map(clause->get_array_dimensions());
+    add_iterators(clause->get_iterator());
+  } else if (SgOmpToClause *clause = isSgOmpToClause(node)) {
+    addSubtreeNodes(clause->get_mapper_identifier(), nodes, seen);
+    add_dimension_map(clause->get_array_dimensions());
+    add_iterators(clause->get_iterator());
+  } else if (SgOmpFromClause *clause = isSgOmpFromClause(node)) {
+    addSubtreeNodes(clause->get_mapper_identifier(), nodes, seen);
+    add_dimension_map(clause->get_array_dimensions());
+    add_iterators(clause->get_iterator());
+  }
+
+  if (SgOmpVariablesClause *clause = isSgOmpVariablesClause(node)) {
+    addSubtreeNodes(clause->get_variables(), nodes, seen);
+  }
+  if (SgOmpExclusiveClause *clause = isSgOmpExclusiveClause(node)) {
+    addSubtreeNodes(clause->get_variables(), nodes, seen);
+  }
+  if (SgOmpExpressionClause *clause = isSgOmpExpressionClause(node)) {
+    add_expression_with_owner(clause->get_expression());
+  }
+  if (SgOmpReductionClause *clause = isSgOmpReductionClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_identifier());
+  }
+  if (SgOmpAllocateClause *clause = isSgOmpAllocateClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_modifier());
+  }
+  if (SgOmpAllocatorClause *clause = isSgOmpAllocatorClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_modifier());
+  }
+  if (SgOmpAdjustArgsClause *clause = isSgOmpAdjustArgsClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_modifier());
+  }
+  if (SgOmpInReductionClause *clause = isSgOmpInReductionClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_identifier());
+  }
+  if (SgOmpTaskReductionClause *clause = isSgOmpTaskReductionClause(node)) {
+    add_expression_with_owner(clause->get_user_defined_identifier());
+  }
+  if (SgOmpWhenClause *clause = isSgOmpWhenClause(node)) {
+    add_expression_with_owner(clause->get_user_condition());
+    add_expression_with_owner(clause->get_user_condition_score());
+    add_expression_with_owner(clause->get_device_arch());
+    add_expression_with_owner(clause->get_device_isa());
+    add_expression_with_owner(clause->get_device_num());
+    add_expression_with_owner(clause->get_implementation_user_defined());
+    add_expression_with_owner(clause->get_implementation_extension());
+    addSubtreeNodes(clause->get_variant_directive(), nodes, seen);
+    for (SgStatement *directive : clause->get_construct_directives()) {
+      addSubtreeNodes(directive, nodes, seen);
+    }
+  }
+  if (SgOmpMatchClause *clause = isSgOmpMatchClause(node)) {
+    add_expression_with_owner(clause->get_user_condition());
+    add_expression_with_owner(clause->get_user_condition_score());
+    add_expression_with_owner(clause->get_device_arch());
+    add_expression_with_owner(clause->get_device_isa());
+    add_expression_with_owner(clause->get_device_num());
+    add_expression_with_owner(clause->get_implementation_user_defined());
+    add_expression_with_owner(clause->get_implementation_extension());
+    for (SgStatement *directive : clause->get_construct_directives()) {
+      addSubtreeNodes(directive, nodes, seen);
+    }
+  }
+  if (SgOmpUsesAllocatorsDefination *definition =
+          isSgOmpUsesAllocatorsDefination(node)) {
+    add_expression_with_owner(definition->get_user_defined_allocator());
+    add_expression_with_owner(definition->get_allocator_traits_array());
+  }
+  if (SgOmpUsesAllocatorsClause *clause = isSgOmpUsesAllocatorsClause(node)) {
+    for (SgOmpUsesAllocatorsDefination *definition :
+         clause->get_uses_allocators_defination()) {
+      if (definition == nullptr) {
+        continue;
+      }
+      addSingleNode(definition, nodes, seen);
+      add_expression_with_owner(definition->get_user_defined_allocator());
+      add_expression_with_owner(definition->get_allocator_traits_array());
+    }
+  }
+  if (SgOmpDeclareMapperStatement *stmt = isSgOmpDeclareMapperStatement(node)) {
+    add_expression_with_owner(stmt->get_user_defined_identifier());
+    add_expression_with_owner(stmt->get_mapper_type());
+    add_expression_with_owner(stmt->get_mapper_variable());
+  }
+  if (SgAttributeSpecificationStatement *stmt =
+          isSgAttributeSpecificationStatement(node)) {
+    addSubtreeNodes(stmt->get_parameter_list(), nodes, seen);
+    addSubtreeNodes(stmt->get_bind_list(), nodes, seen);
+  }
+  if (SgInterfaceStatement *stmt = isSgInterfaceStatement(node)) {
+    for (SgInterfaceBody *body : stmt->get_interface_body_list()) {
+      addSubtreeNodes(body, nodes, seen);
+    }
+    addSubtreeNodes(stmt->get_end_numeric_label(), nodes, seen);
+  }
+  if (SgInterfaceBody *body = isSgInterfaceBody(node)) {
+    addSubtreeNodes(body->get_functionDeclaration(), nodes, seen);
+  }
+  if (SgIfStmt *stmt = isSgIfStmt(node)) {
+    addSubtreeNodes(stmt->get_else_numeric_label(), nodes, seen);
+    addSubtreeNodes(stmt->get_end_numeric_label(), nodes, seen);
+  }
+  if (SgStatement *stmt = isSgStatement(node)) {
+    addSubtreeNodes(stmt->get_numeric_label(), nodes, seen);
+  }
+  if (SgWhileStmt *stmt = isSgWhileStmt(node)) {
+    addSubtreeNodes(stmt->get_end_numeric_label(), nodes, seen);
+  }
+  if (SgGotoStatement *stmt = isSgGotoStatement(node)) {
+    addSubtreeNodes(stmt->get_label(), nodes, seen);
+    addSubtreeNodes(stmt->get_label_expression(), nodes, seen);
+    addSubtreeNodes(stmt->get_selector_expression(), nodes, seen);
+  }
+  if (SgFortranNonblockedDo *stmt = isSgFortranNonblockedDo(node)) {
+    addSubtreeNodes(stmt->get_end_statement(), nodes, seen);
+  }
+  if (SgDerivedTypeStatement *stmt = isSgDerivedTypeStatement(node)) {
+    addSubtreeNodes(stmt->get_end_numeric_label(), nodes, seen);
+  }
+  if (SgUsingDeclarationStatement *decl = isSgUsingDeclarationStatement(node)) {
+    addSubtreeNodes(decl->get_declaration(), nodes, seen);
+    addSubtreeNodes(decl->get_initializedName(), nodes, seen);
+  }
+}
+
+void addExpressionSymbolDependencies(SgNode *node, std::vector<SgNode *> &nodes,
+                                     std::unordered_set<SgNode *> &seen) {
+  SgExpression *expr = isSgExpression(node);
+  if (expr == nullptr) {
+    return;
+  }
+  if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+    addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+  } else if (SgLabelRefExp *ref = isSgLabelRefExp(expr)) {
+    addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+  } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(expr)) {
+    SgFunctionSymbol *symbol = ref->get_symbol();
+    addReferencedSymbolBasis(symbol, nodes, seen);
+    if (symbol != nullptr &&
+        !isAstJsonExternalFunction(symbol->get_declaration())) {
+      addSubtreeNodes(symbol->get_declaration(), nodes, seen);
+      addNodeAncestors(symbol->get_declaration(), nodes, seen);
+    }
+  } else if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(expr)) {
+    addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+  } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(expr)) {
+    addReferencedSymbolBasis(ref->get_symbol_i(), nodes, seen);
+  } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(expr)) {
+    addReferencedSymbolBasis(ref->get_symbol(), nodes, seen);
+  } else if (SgThisExp *this_expr = isSgThisExp(expr)) {
+    addReferencedSymbolBasis(this_expr->get_class_symbol(), nodes, seen);
+    addReferencedSymbolBasis(this_expr->get_nonreal_symbol(), nodes, seen);
+  } else if (SgEnumVal *value = isSgEnumVal(expr)) {
+    addSubtreeNodes(value->get_declaration(), nodes, seen);
+    addNodeAncestors(value->get_declaration(), nodes, seen);
+  }
+}
+
+void addScopeSymbolTableDependencies(SgNode *node, std::vector<SgNode *> &nodes,
+                                     std::unordered_set<SgNode *> &seen) {
+  SgScopeStatement *scope = isSgScopeStatement(node);
+  SgSymbolTable *table = scope != nullptr ? scope->get_symbol_table() : nullptr;
+  if (table == nullptr || table->get_table() == nullptr) {
+    return;
+  }
+  for (const std::pair<const SgName, SgSymbol *> &entry : *table->get_table()) {
+    SgSymbol *symbol = entry.second;
+    addReferencedSymbolBasis(symbol, nodes, seen);
+    if (SgAliasSymbol *alias = isSgAliasSymbol(symbol)) {
+      addReferencedSymbolBasis(alias->get_alias(), nodes, seen);
+      for (SgNode *causal_node : alias->get_causal_nodes()) {
+        addSubtreeNodes(causal_node, nodes, seen);
+        addNodeAncestors(causal_node, nodes, seen);
+      }
+    }
+    if (SgRenameSymbol *rename = isSgRenameSymbol(symbol)) {
+      addReferencedSymbolBasis(rename->get_original_symbol(), nodes, seen);
+    }
+    if (SgNamespaceSymbol *namespace_symbol = isSgNamespaceSymbol(symbol)) {
+      addSubtreeNodes(namespace_symbol->get_aliasDeclaration(), nodes, seen);
+      addNodeAncestors(namespace_symbol->get_aliasDeclaration(), nodes, seen);
+    }
+  }
+}
+
+std::string auxiliaryNodeSortKey(SgNode *node) {
+  std::ostringstream key;
+  key << (node != nullptr ? node->sage_class_name() : "") << '|';
+  if (SgInitializedName *name = isSgInitializedName(node)) {
+    key << name->get_name().getString();
+  } else if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+    key << decl->get_name().getString();
+  } else if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
+    key << decl->get_name().getString();
+  } else if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+    key << decl->get_name().getString();
+  } else if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+    key << decl->get_name().getString();
+  } else if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+    key << decl->get_name().getString();
+  } else if (SgTemplateArgument *argument = isSgTemplateArgument(node)) {
+    key << argument->get_argumentType() << ':'
+        << jsonTypeText(argument->get_type());
+    if (argument->get_expression() != nullptr) {
+      key << ':' << argument->get_expression()->sage_class_name() << ':'
+          << argument->get_expression()->unparseToString();
+    }
+  } else if (SgIntVal *value = isSgIntVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  } else if (SgUnsignedIntVal *value = isSgUnsignedIntVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  } else if (SgLongIntVal *value = isSgLongIntVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  } else if (SgUnsignedLongVal *value = isSgUnsignedLongVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  } else if (SgLongLongIntVal *value = isSgLongLongIntVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  } else if (SgUnsignedLongLongIntVal *value =
+                 isSgUnsignedLongLongIntVal(node)) {
+    key << value->get_value() << ':' << value->get_valueString();
+  }
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    if (Sg_File_Info *start = located->get_startOfConstruct()) {
+      key << '|' << start->get_filenameString() << ':' << start->get_raw_line()
+          << ':' << start->get_raw_col();
+    }
+  }
+  return key.str();
+}
+
+std::vector<SgNode *> collectNodes(SgNode *root) {
+  CollectionBoundaryGuard boundary(isSgSourceFile(root));
+  std::vector<SgNode *> nodes;
+  std::unordered_set<SgNode *> seen;
+  addSubtreeNodes(root, nodes, seen);
+  if (SgSourceFile *file = isSgSourceFile(root)) {
+    for (SgToken *token : file->get_token_list()) {
+      addSingleNode(token, nodes, seen);
+    }
+  }
+  const size_t original_count = nodes.size();
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    addOmpAuxiliaryNodes(nodes[i], nodes, seen);
+    addExpressionSymbolDependencies(nodes[i], nodes, seen);
+    addScopeSymbolTableDependencies(nodes[i], nodes, seen);
+  }
+  for (size_t i = original_count; i < nodes.size(); ++i) {
+    addOmpAuxiliaryNodes(nodes[i], nodes, seen);
+    addExpressionSymbolDependencies(nodes[i], nodes, seen);
+    addScopeSymbolTableDependencies(nodes[i], nodes, seen);
+  }
+  std::stable_sort(nodes.begin() + original_count, nodes.end(),
+                   [](SgNode *lhs, SgNode *rhs) {
+                     return auxiliaryNodeSortKey(lhs) <
+                            auxiliaryNodeSortKey(rhs);
+                   });
+  return nodes;
+}
+
+void clearGlobalQualificationState() {
+  SgNode::get_globalQualifiedNameMapForNames().clear();
+  SgNode::get_globalQualifiedNameMapForTypes().clear();
+  SgNode::get_globalQualifiedNameMapForTemplateHeaders().clear();
+  SgNode::get_globalTypeNameMap().clear();
+  SgNode::get_globalQualifiedNameMapForMapsOfTypes().clear();
+}
+
+GlobalQualificationStateSnapshot::GlobalQualificationStateSnapshot()
+    : names(SgNode::get_globalQualifiedNameMapForNames()),
+      types(SgNode::get_globalQualifiedNameMapForTypes()),
+      template_headers(SgNode::get_globalQualifiedNameMapForTemplateHeaders()),
+      type_names(SgNode::get_globalTypeNameMap()),
+      type_maps(SgNode::get_globalQualifiedNameMapForMapsOfTypes()) {}
+
+GlobalQualificationStateSnapshot::~GlobalQualificationStateSnapshot() {
+  restore();
+}
+
+void GlobalQualificationStateSnapshot::restore() {
+  if (restored) {
+    return;
+  }
+  SgNode::get_globalQualifiedNameMapForNames() = names;
+  SgNode::get_globalQualifiedNameMapForTypes() = types;
+  SgNode::get_globalQualifiedNameMapForTemplateHeaders() = template_headers;
+  SgNode::get_globalTypeNameMap() = type_names;
+  SgNode::get_globalQualifiedNameMapForMapsOfTypes() = type_maps;
+  restored = true;
+}
+
+std::string safeNodeText(SgNode *node) {
+  if (node == nullptr) {
+    return "";
+  }
+  if (SgInitializedName *name = isSgInitializedName(node)) {
+    return name->get_name().getString();
+  }
+  if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgNamespaceDeclarationStatement *decl =
+          isSgNamespaceDeclarationStatement(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+    return decl->get_name().getString();
+  }
+  if (SgPragma *pragma = isSgPragma(node)) {
+    return pragma->get_name();
+  }
+  if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+    return ref->get_symbol() != nullptr
+               ? ref->get_symbol()->get_name().getString()
+               : "";
+  }
+  if (SgFunctionRefExp *ref = isSgFunctionRefExp(node)) {
+    return ref->get_symbol() != nullptr
+               ? ref->get_symbol()->get_name().getString()
+               : "";
+  }
+  if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(node)) {
+    return ref->get_symbol() != nullptr
+               ? ref->get_symbol()->get_name().getString()
+               : "";
+  }
+  if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(node)) {
+    return ref->get_symbol_i() != nullptr
+               ? ref->get_symbol_i()->get_name().getString()
+               : "";
+  }
+  if (SgNonrealRefExp *ref = isSgNonrealRefExp(node)) {
+    return ref->get_symbol() != nullptr
+               ? ref->get_symbol()->get_name().getString()
+               : "";
+  }
+  return "";
+}
+
+std::string sourceFileNameForNode(SgNode *node) {
+  const std::string external_source =
+      astJsonStringAttribute(node, kAstJsonExternalSourceFileAttribute);
+  if (!external_source.empty()) {
+    return external_source;
+  }
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (SgSourceFile *source_file = isSgSourceFile(current)) {
+      return source_file->getFileName();
+    }
+  }
+  return "";
+}
+
+std::string sourceFileNameForExternalFunction(SgFunctionDeclaration *decl) {
+  std::string source_file = sourceFileNameForNode(decl);
+  if (source_file.empty() && collectionBoundaryFile != nullptr) {
+    source_file = collectionBoundaryFile->getFileName();
+  }
+  if (source_file.empty()) {
+    std::ostringstream message;
+    message << "AST JSON external_function ";
+    if (decl == nullptr) {
+      message << "<null>";
+    } else {
+      message << decl->get_name().getString();
+      if (SgNode *parent = decl->get_parent()) {
+        message << " parent=" << parent->sage_class_name();
+      } else {
+        message << " parent=<null>";
+      }
+    }
+    message << " requires a non-empty source_file";
+    throw std::runtime_error(message.str());
+  }
+  return source_file;
+}
+
+SgModuleStatement *enclosingModuleStatement(SgNode *node) {
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (SgModuleStatement *module = isSgModuleStatement(current)) {
+      return module;
+    }
+  }
+  return nullptr;
+}
+
+std::string moduleNameForNode(SgNode *node) {
+  SgModuleStatement *module = enclosingModuleStatement(node);
+  return module != nullptr ? module->get_name().getString() : "";
+}
+
+bool classDeclarationHasDefinition(SgClassDeclaration *decl) {
+  return decl != nullptr && decl->get_definition() != nullptr;
+}
+
+bool classDeclarationIsFirstNondefining(SgClassDeclaration *decl) {
+  return decl != nullptr && decl->get_firstNondefiningDeclaration() == decl;
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeFinalize.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeFinalize.cpp
@@ -1,0 +1,1130 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+void applyTypesAndSymbols(const AstFileRecord &ast, const NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    const JsonValue &p = record.properties;
+
+    restoreQualifiedNameState(node, p, nodes);
+
+    if (SgScopeStatement *scope = isSgScopeStatement(node)) {
+      scope->setCaseInsensitive(
+          p.boolOr("case_insensitive", scope->isCaseInsensitive()));
+    }
+
+    if (SgInitializedName *name = isSgInitializedName(node)) {
+      name->set_name_qualification_length(
+          static_cast<int>(p.at("name_qualification_length").asInt()));
+      name->set_type_elaboration_required(
+          p.at("type_elaboration_required").asBool());
+      name->set_global_qualification_required(
+          p.at("global_qualification_required").asBool());
+      name->set_name_qualification_length_for_type(
+          static_cast<int>(p.at("name_qualification_length_for_type").asInt()));
+      name->set_type_elaboration_required_for_type(
+          p.at("type_elaboration_required_for_type").asBool());
+      name->set_global_qualification_required_for_type(
+          p.at("global_qualification_required_for_type").asBool());
+    }
+
+    if (SgTemplateInstantiationTypedefDeclaration *tmpl =
+            isSgTemplateInstantiationTypedefDeclaration(node)) {
+      tmpl->set_templateName(SgName(
+          p.stringOr("template_name", tmpl->get_templateName().getString())));
+      tmpl->set_templateHeader(SgName(p.stringOr(
+          "template_header", tmpl->get_templateHeader().getString())));
+      tmpl->set_nameResetFromMangledForm(
+          p.boolOr("name_reset_from_mangled_form",
+                   tmpl->get_nameResetFromMangledForm()));
+      if (const JsonValue *template_arguments = p.find("template_arguments")) {
+        tmpl->get_templateArguments() =
+            templateArgumentListFromJson(*template_arguments, nodes, tmpl);
+      }
+      if (const JsonValue *deduced_template_arguments =
+              p.find("deduced_template_arguments")) {
+        tmpl->get_deducedTemplateArguments() = templateArgumentListFromJson(
+            *deduced_template_arguments, nodes, tmpl);
+      }
+    }
+    if (SgTemplateInstantiationFunctionDecl *tmpl =
+            isSgTemplateInstantiationFunctionDecl(node)) {
+      tmpl->set_templateName(SgName(
+          p.stringOr("template_name", tmpl->get_templateName().getString())));
+      tmpl->set_nameResetFromMangledForm(
+          p.boolOr("name_reset_from_mangled_form",
+                   tmpl->get_nameResetFromMangledForm()));
+      tmpl->set_template_argument_list_is_explicit(
+          p.boolOr("template_argument_list_is_explicit",
+                   tmpl->get_template_argument_list_is_explicit()));
+      if (const JsonValue *template_arguments = p.find("template_arguments")) {
+        tmpl->get_templateArguments() =
+            templateArgumentListFromJson(*template_arguments, nodes, tmpl);
+      }
+      if (const JsonValue *deduced_template_arguments =
+              p.find("deduced_template_arguments")) {
+        tmpl->get_deducedTemplateArguments() = templateArgumentListFromJson(
+            *deduced_template_arguments, nodes, tmpl);
+      }
+    }
+    if (SgTemplateInstantiationMemberFunctionDecl *tmpl =
+            isSgTemplateInstantiationMemberFunctionDecl(node)) {
+      tmpl->set_templateName(SgName(
+          p.stringOr("template_name", tmpl->get_templateName().getString())));
+      tmpl->set_nameResetFromMangledForm(
+          p.boolOr("name_reset_from_mangled_form",
+                   tmpl->get_nameResetFromMangledForm()));
+      tmpl->set_template_argument_list_is_explicit(
+          p.boolOr("template_argument_list_is_explicit",
+                   tmpl->get_template_argument_list_is_explicit()));
+      if (const JsonValue *template_arguments = p.find("template_arguments")) {
+        tmpl->get_templateArguments() =
+            templateArgumentListFromJson(*template_arguments, nodes, tmpl);
+      }
+      if (const JsonValue *deduced_template_arguments =
+              p.find("deduced_template_arguments")) {
+        tmpl->get_deducedTemplateArguments() = templateArgumentListFromJson(
+            *deduced_template_arguments, nodes, tmpl);
+      }
+    }
+
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+      decl->set_decl_attributes(
+          static_cast<unsigned int>(p.at("decl_attributes").asInt()));
+      decl->set_linkage(p.at("linkage").asString());
+      decl->get_declarationModifier().set_modifierVector(bitVectorFromJson(
+          p.at("declaration_modifier_vector"), "declaration_modifier_vector"));
+      decl->get_declarationModifier().get_typeModifier().set_modifierVector(
+          bitVectorFromJson(p.at("declaration_type_modifier_vector"),
+                            "declaration_type_modifier_vector"));
+      decl->get_declarationModifier().get_storageModifier().set_modifier(
+          static_cast<SgStorageModifier::storage_modifier_enum>(
+              p.at("declaration_storage_modifier").asInt()));
+      decl->get_declarationModifier().get_accessModifier().set_modifier(
+          static_cast<SgAccessModifier::access_modifier_enum>(
+              p.at("declaration_access_modifier").asInt()));
+      decl->get_declarationModifier().get_accessModifier().set_is_explicit(
+          p.boolOr("declaration_access_is_explicit", false));
+      decl->set_nameOnly(p.at("name_only").asBool());
+      decl->set_forward(p.at("forward").asBool());
+      decl->set_externBrace(p.at("extern_brace").asBool());
+      decl->set_skipElaborateType(p.at("skip_elaborate_type").asBool());
+      decl->set_binding_label(p.at("binding_label").asString());
+      decl->set_unparse_template_ast(p.at("unparse_template_ast").asBool());
+      decl->get_declarationModifier().set_gnu_attribute_section_name(
+          p.at("declaration_gnu_attribute_section_name").asString());
+      decl->get_declarationModifier().set_gnu_attribute_visability(
+          static_cast<SgDeclarationModifier::gnu_declaration_visability_enum>(
+              p.at("declaration_gnu_attribute_visability").asInt()));
+    }
+
+    if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+      decl->get_functionModifier().set_modifierVector(bitVectorFromJson(
+          p.at("function_modifier_vector"), "function_modifier_vector"));
+      decl->get_specialFunctionModifier().set_modifierVector(
+          bitVectorFromJson(p.at("special_function_modifier_vector"),
+                            "special_function_modifier_vector"));
+      decl->set_named_in_end_statement(p.at("named_in_end_statement").asBool());
+      decl->set_asm_name(p.at("asm_name").asString());
+      decl->set_oldStyleDefinition(p.at("old_style_definition").asBool());
+      decl->set_specialization(
+          static_cast<SgDeclarationStatement::template_specialization_enum>(
+              p.at("specialization").asInt()));
+      decl->set_requiresNameQualificationOnReturnType(
+          p.at("requires_name_qualification_on_return_type").asBool());
+      decl->set_gnu_extension_section(p.at("gnu_extension_section").asString());
+      decl->set_gnu_extension_alias(p.at("gnu_extension_alias").asString());
+      decl->set_gnu_extension_visability(
+          static_cast<
+              SgDeclarationStatement::gnu_extension_visability_attribute_enum>(
+              p.at("gnu_extension_visability").asInt()));
+      decl->set_name_qualification_length(
+          static_cast<int>(p.at("name_qualification_length").asInt()));
+      decl->set_type_elaboration_required(
+          p.at("type_elaboration_required").asBool());
+      decl->set_global_qualification_required(
+          p.at("global_qualification_required").asBool());
+      decl->set_name_qualification_length_for_return_type(static_cast<int>(
+          p.at("name_qualification_length_for_return_type").asInt()));
+      decl->set_type_elaboration_required_for_return_type(
+          p.at("type_elaboration_required_for_return_type").asBool());
+      decl->set_global_qualification_required_for_return_type(
+          p.at("global_qualification_required_for_return_type").asBool());
+      decl->set_prototypeIsWithoutParameters(
+          p.at("prototype_is_without_parameters").asBool());
+      decl->set_gnu_regparm_attribute(
+          static_cast<int>(p.at("gnu_regparm_attribute").asInt()));
+      decl->set_type_syntax_is_available(
+          p.at("type_syntax_is_available").asBool());
+      decl->set_using_C11_Noreturn_keyword(
+          p.at("using_c11_noreturn_keyword").asBool());
+      decl->set_is_constexpr(p.at("is_constexpr").asBool());
+      decl->set_using_new_function_return_type_syntax(
+          p.at("using_new_function_return_type_syntax").asBool());
+      decl->set_is_deduction_guide(p.at("is_deduction_guide").asBool());
+      decl->set_marked_as_frontend_normalization(
+          p.at("marked_as_frontend_normalization").asBool());
+      decl->set_is_implicit_function(p.at("is_implicit_function").asBool());
+      if (SgProcedureHeaderStatement *procedure =
+              isSgProcedureHeaderStatement(decl)) {
+        procedure->set_subprogram_kind(
+            static_cast<SgProcedureHeaderStatement::subprogram_kind_enum>(
+                p.at("subprogram_kind").asInt()));
+      }
+    }
+
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+      auto restore_declaration_qualification = [&](auto *qualified_decl) {
+        qualified_decl->set_name_qualification_length(
+            static_cast<int>(p.at("name_qualification_length").asInt()));
+        qualified_decl->set_type_elaboration_required(
+            p.at("type_elaboration_required").asBool());
+        qualified_decl->set_global_qualification_required(
+            p.at("global_qualification_required").asBool());
+      };
+      if (isSgFunctionDeclaration(decl) == nullptr) {
+        if (SgVariableDeclaration *qualified = isSgVariableDeclaration(decl)) {
+          restore_declaration_qualification(qualified);
+        } else if (SgEnumDeclaration *qualified = isSgEnumDeclaration(decl)) {
+          restore_declaration_qualification(qualified);
+        } else if (SgTypedefDeclaration *qualified =
+                       isSgTypedefDeclaration(decl)) {
+          restore_declaration_qualification(qualified);
+        } else if (SgUsingDirectiveStatement *qualified =
+                       isSgUsingDirectiveStatement(decl)) {
+          restore_declaration_qualification(qualified);
+        } else if (SgUsingDeclarationStatement *qualified =
+                       isSgUsingDeclarationStatement(decl)) {
+          restore_declaration_qualification(qualified);
+        } else if (SgClassDeclaration *qualified = isSgClassDeclaration(decl)) {
+          restore_declaration_qualification(qualified);
+        }
+      }
+      if (SgVariableDeclaration *variable = isSgVariableDeclaration(decl)) {
+        variable->set_requiresGlobalNameQualificationOnType(
+            p.at("requires_global_name_qualification_on_type").asBool());
+      }
+    }
+
+    if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
+      decl->set_isUnNamed(p.boolOr("is_unnamed", decl->get_isUnNamed()));
+      decl->set_isAutonomousDeclaration(p.boolOr(
+          "is_autonomous_declaration", decl->get_isAutonomousDeclaration()));
+      if (SgTemplateClassDeclaration *tmpl =
+              isSgTemplateClassDeclaration(decl)) {
+        std::string template_name =
+            p.stringOr("template_name", tmpl->get_templateName().getString());
+        if (template_name.empty()) {
+          template_name = decl->get_name().getString();
+        }
+        tmpl->set_templateName(SgName(template_name));
+      }
+      if (SgTemplateInstantiationDecl *tmpl =
+              isSgTemplateInstantiationDecl(decl)) {
+        std::string template_name =
+            p.stringOr("template_name", tmpl->get_templateName().getString());
+        if (template_name.empty()) {
+          template_name = decl->get_name().getString();
+          const size_t args = template_name.find('<');
+          if (args != std::string::npos) {
+            template_name = trim(template_name.substr(0, args));
+          }
+        }
+        tmpl->set_templateName(SgName(template_name));
+        tmpl->set_templateHeader(SgName(p.stringOr(
+            "template_header", tmpl->get_templateHeader().getString())));
+        tmpl->set_nameResetFromMangledForm(
+            p.boolOr("name_reset_from_mangled_form",
+                     tmpl->get_nameResetFromMangledForm()));
+        tmpl->set_constraintSatisfactionEvaluated(
+            p.boolOr("constraint_satisfaction_evaluated",
+                     tmpl->get_constraintSatisfactionEvaluated()));
+        tmpl->set_constraintSatisfactionSatisfied(
+            p.boolOr("constraint_satisfaction_satisfied",
+                     tmpl->get_constraintSatisfactionSatisfied()));
+        tmpl->set_constraintSatisfactionContainsErrors(
+            p.boolOr("constraint_satisfaction_contains_errors",
+                     tmpl->get_constraintSatisfactionContainsErrors()));
+        tmpl->set_constraintSatisfactionSubstitutionFailure(
+            p.boolOr("constraint_satisfaction_substitution_failure",
+                     tmpl->get_constraintSatisfactionSubstitutionFailure()));
+        tmpl->set_constraintSatisfactionSummary(
+            p.stringOr("constraint_satisfaction_summary",
+                       tmpl->get_constraintSatisfactionSummary()));
+        tmpl->set_sfinaeEvaluated(
+            p.boolOr("sfinae_evaluated", tmpl->get_sfinaeEvaluated()));
+        tmpl->set_sfinaeSubstitutionFailure(
+            p.boolOr("sfinae_substitution_failure",
+                     tmpl->get_sfinaeSubstitutionFailure()));
+        tmpl->set_sfinaeSummary(
+            p.stringOr("sfinae_summary", tmpl->get_sfinaeSummary()));
+        if (const JsonValue *template_arguments =
+                p.find("template_arguments")) {
+          tmpl->get_templateArguments() =
+              templateArgumentListFromJson(*template_arguments, nodes, tmpl);
+        }
+        if (const JsonValue *deduced_template_arguments =
+                p.find("deduced_template_arguments")) {
+          tmpl->get_deducedTemplateArguments() = templateArgumentListFromJson(
+              *deduced_template_arguments, nodes, tmpl);
+        }
+      }
+      if (SgClassDeclaration *first_nondef =
+              isSgClassDeclaration(decl->get_firstNondefiningDeclaration())) {
+        if (first_nondef != decl) {
+          decl->set_type(ensureClassTypeForDeclaration(first_nondef));
+        }
+      }
+      ensureClassTypeForDeclaration(decl);
+    } else if (SgBaseClass *base = isSgBaseClass(node)) {
+      base->set_isDirectBaseClass(
+          p.boolOr("is_direct_base_class", base->get_isDirectBaseClass()));
+      base->set_pack_expansion(
+          p.boolOr("pack_expansion", base->get_pack_expansion()));
+      if (base->get_baseClassModifier() != nullptr) {
+        base->get_baseClassModifier()->set_modifier(
+            static_cast<SgBaseClassModifier::baseclass_modifier_enum>(
+                p.intOr("base_class_modifier",
+                        base->get_baseClassModifier()->get_modifier())));
+        base->get_baseClassModifier()->get_accessModifier().set_modifier(
+            static_cast<SgAccessModifier::access_modifier_enum>(p.intOr(
+                "base_class_access_modifier", base->get_baseClassModifier()
+                                                  ->get_accessModifier()
+                                                  .get_modifier())));
+        base->get_baseClassModifier()->get_accessModifier().set_is_explicit(
+            p.boolOr("base_class_access_is_explicit",
+                     base->get_baseClassModifier()
+                         ->get_accessModifier()
+                         .get_is_explicit()));
+      }
+      base->set_name_qualification_length(static_cast<int>(p.intOr(
+          "name_qualification_length", base->get_name_qualification_length())));
+      base->set_type_elaboration_required(p.boolOr(
+          "type_elaboration_required", base->get_type_elaboration_required()));
+      base->set_global_qualification_required(
+          p.boolOr("global_qualification_required",
+                   base->get_global_qualification_required()));
+    } else if (SgNamespaceDeclarationStatement *decl =
+                   isSgNamespaceDeclarationStatement(node)) {
+      decl->set_isUnnamedNamespace(
+          p.boolOr("is_unnamed_namespace", decl->get_isUnnamedNamespace()));
+      decl->set_isInlinedNamespace(
+          p.boolOr("is_inlined_namespace", decl->get_isInlinedNamespace()));
+    } else if (SgImplicitStatement *stmt = isSgImplicitStatement(node)) {
+      stmt->set_implicit_none(
+          p.boolOr("implicit_none", stmt->get_implicit_none()));
+      stmt->set_implicit_spec(
+          static_cast<SgImplicitStatement::implicit_spec_enum>(
+              p.intOr("implicit_spec", stmt->get_implicit_spec())));
+    } else if (SgFortranIncludeLine *stmt = isSgFortranIncludeLine(node)) {
+      stmt->set_filename(p.stringOr("filename", stmt->get_filename()));
+    } else if (SgLabelStatement *stmt = isSgLabelStatement(node)) {
+      stmt->set_label(
+          SgName(p.stringOr("label", stmt->get_label().getString())));
+      stmt->set_gnu_extension_unused(
+          p.boolOr("gnu_extension_unused", stmt->get_gnu_extension_unused()));
+    } else if (SgIfStmt *stmt = isSgIfStmt(node)) {
+      stmt->set_string_label(
+          p.stringOr("string_label", stmt->get_string_label()));
+      stmt->set_has_end_statement(
+          p.boolOr("has_end_statement", stmt->get_has_end_statement()));
+      stmt->set_use_then_keyword(
+          p.boolOr("use_then_keyword", stmt->get_use_then_keyword()));
+      stmt->set_is_else_if_statement(
+          p.boolOr("is_else_if_statement", stmt->get_is_else_if_statement()));
+    } else if (SgWhileStmt *stmt = isSgWhileStmt(node)) {
+      stmt->set_string_label(
+          p.stringOr("string_label", stmt->get_string_label()));
+      stmt->set_has_end_statement(
+          p.boolOr("has_end_statement", stmt->get_has_end_statement()));
+    } else if (SgFortranDo *stmt = isSgFortranDo(node)) {
+      stmt->set_string_label(
+          p.stringOr("string_label", stmt->get_string_label()));
+      stmt->set_old_style(p.boolOr("old_style", stmt->get_old_style()));
+      stmt->set_has_end_statement(
+          p.boolOr("has_end_statement", stmt->get_has_end_statement()));
+    } else if (SgIOStatement *stmt = isSgIOStatement(node)) {
+      stmt->set_io_statement(static_cast<SgIOStatement::io_statement_enum>(
+          p.intOr("io_statement", stmt->get_io_statement())));
+    } else if (SgAttributeSpecificationStatement *stmt =
+                   isSgAttributeSpecificationStatement(node)) {
+      stmt->set_attribute_kind(
+          static_cast<SgAttributeSpecificationStatement::attribute_spec_enum>(
+              p.intOr("attribute_kind", stmt->get_attribute_kind())));
+      stmt->set_intent(static_cast<int>(p.intOr("intent", stmt->get_intent())));
+      if (const JsonValue *names = p.find("name_list")) {
+        stmt->get_name_list() = stringListFromJson(*names, "name_list");
+      }
+    } else if (SgInterfaceStatement *stmt = isSgInterfaceStatement(node)) {
+      stmt->set_name(SgName(p.stringOr("name", stmt->get_name().getString())));
+      stmt->set_generic_spec(
+          static_cast<SgInterfaceStatement::generic_spec_enum>(
+              p.intOr("generic_spec", stmt->get_generic_spec())));
+    } else if (SgInterfaceBody *body = isSgInterfaceBody(node)) {
+      body->set_function_name(SgName(
+          p.stringOr("function_name", body->get_function_name().getString())));
+      body->set_use_function_name(
+          p.boolOr("use_function_name", body->get_use_function_name()));
+    } else if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+      decl->set_template_parameter_position(
+          static_cast<int>(p.intOr("template_parameter_position",
+                                   decl->get_template_parameter_position())));
+      decl->set_template_parameter_depth(static_cast<int>(p.intOr(
+          "template_parameter_depth", decl->get_template_parameter_depth())));
+      decl->set_is_class_member(
+          p.boolOr("is_class_member", decl->get_is_class_member()));
+      decl->set_is_template_param(
+          p.boolOr("is_template_param", decl->get_is_template_param()));
+      decl->set_is_template_template_param(
+          p.boolOr("is_template_template_param",
+                   decl->get_is_template_template_param()));
+      decl->set_has_template_keyword(
+          p.boolOr("has_template_keyword", decl->get_has_template_keyword()));
+      decl->set_has_global_qualifier(
+          p.boolOr("has_global_qualifier", decl->get_has_global_qualifier()));
+      decl->set_suppress_typename(
+          p.boolOr("suppress_typename", decl->get_suppress_typename()));
+      decl->set_is_nonreal_template(
+          p.boolOr("is_nonreal_template", decl->get_is_nonreal_template()));
+      decl->set_is_concept(p.boolOr("is_concept", decl->get_is_concept()));
+      decl->set_is_nonreal_function(
+          p.boolOr("is_nonreal_function", decl->get_is_nonreal_function()));
+      if (decl->get_type() == nullptr) {
+        decl->set_type(new SgNonrealType(decl));
+      }
+      if (const JsonValue *type = p.find("type")) {
+        decl->get_type()->set_autonomous_declaration(
+            type->boolOr("autonomous_declaration",
+                         decl->get_type()->get_autonomous_declaration()));
+        attachJsonTypeText(decl->get_type(), *type);
+      }
+    } else if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+      decl->set_embedded(p.boolOr("embedded", decl->get_embedded()));
+      decl->set_isUnNamed(p.boolOr("is_unnamed", decl->get_isUnNamed()));
+      decl->set_isAutonomousDeclaration(p.boolOr(
+          "is_autonomous_declaration", decl->get_isAutonomousDeclaration()));
+      decl->set_isScopedEnum(
+          p.boolOr("is_scoped_enum", decl->get_isScopedEnum()));
+      if (const JsonValue *field_type = p.find("field_type")) {
+        decl->set_field_type(field_type->boolOr("present", false)
+                                 ? typeFromJson(*field_type, nodes)
+                                 : nullptr);
+      }
+      if (decl->get_type() == nullptr) {
+        decl->set_type(SgEnumType::createType(decl));
+      }
+    } else if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+      decl->set_typedefBaseTypeContainsDefiningDeclaration(
+          p.boolOr("typedef_base_type_contains_defining_declaration", false));
+      decl->set_isAutonomousDeclaration(p.boolOr(
+          "is_autonomous_declaration", decl->get_isAutonomousDeclaration()));
+      if (const JsonValue *type = p.find("base_type")) {
+        if (uint64_t target = singleEdgeTarget(record, "declaration")) {
+          SgDeclarationStatement *base_decl =
+              nodeByIdAs<SgDeclarationStatement>(nodes, target);
+          decl->set_base_type(typeFromJson(*type, nodes));
+          decl->set_declaration(base_decl);
+          if (base_decl->get_parent() == nullptr) {
+            base_decl->set_parent(decl);
+          }
+        } else {
+          decl->set_base_type(typeFromJson(*type, nodes));
+        }
+      }
+      if (decl->get_type() == nullptr) {
+        decl->set_type(new SgTypedefType(decl, nullptr));
+      }
+    } else if (SgInitializedName *name = isSgInitializedName(node)) {
+      if (const JsonValue *type = p.find("type")) {
+        name->set_typeptr(typeFromJson(*type, nodes));
+      }
+      name->get_storageModifier().set_modifier(
+          static_cast<SgStorageModifier::storage_modifier_enum>(
+              p.intOr("storage_modifier", SgStorageModifier::e_default)));
+      const std::string section = p.stringOr("gnu_attribute_section_name");
+      if (!section.empty()) {
+        name->set_gnu_attribute_section_name(section);
+      }
+    } else if (SgTemplateArgument *argument = isSgTemplateArgument(node)) {
+      argument->set_argumentType(
+          static_cast<SgTemplateArgument::template_argument_enum>(p.intOr(
+              "argument_type", SgTemplateArgument::argument_undefined)));
+      argument->set_isArrayBoundUnknownType(
+          p.boolOr("is_array_bound_unknown_type", false));
+      if (const JsonValue *type = p.find("type")) {
+        argument->set_type(nullableTypeFromJson(*type, nodes));
+      }
+      if (const JsonValue *expr = p.find("expression")) {
+        SgExpression *expression = expressionFromRef(*expr, nodes);
+        argument->set_expression(expression);
+        if (expression != nullptr) {
+          expression->set_parent(argument);
+        }
+      }
+      if (uint64_t target =
+              static_cast<uint64_t>(p.intOr("template_declaration", 0))) {
+        argument->set_templateDeclaration(
+            nodeByIdAs<SgDeclarationStatement>(nodes, target));
+      }
+      if (uint64_t target =
+              static_cast<uint64_t>(p.intOr("initialized_name", 0))) {
+        argument->set_initializedName(
+            nodeByIdAs<SgInitializedName>(nodes, target));
+      }
+      argument->set_explicitlySpecified(p.boolOr("explicitly_specified", true));
+      argument->set_is_pack_element(p.boolOr("is_pack_element", false));
+    } else if (SgTemplateParameter *parameter = isSgTemplateParameter(node)) {
+      parameter->set_parameterType(
+          static_cast<SgTemplateParameter::template_parameter_enum>(p.intOr(
+              "parameter_type", SgTemplateParameter::parameter_undefined)));
+      if (const JsonValue *type = p.find("type")) {
+        parameter->set_type(nullableTypeFromJson(*type, nodes));
+      }
+      if (const JsonValue *type = p.find("default_type_parameter")) {
+        parameter->set_defaultTypeParameter(nullableTypeFromJson(*type, nodes));
+      }
+      if (const JsonValue *expr = p.find("expression")) {
+        SgExpression *expression = expressionFromRef(*expr, nodes);
+        parameter->set_expression(expression);
+        if (expression != nullptr) {
+          expression->set_parent(parameter);
+        }
+      }
+      if (const JsonValue *expr = p.find("type_constraint")) {
+        SgExpression *expression = expressionFromRef(*expr, nodes);
+        parameter->set_typeConstraint(expression);
+        if (expression != nullptr) {
+          expression->set_parent(parameter);
+        }
+      }
+      if (const JsonValue *expr = p.find("default_expression_parameter")) {
+        SgExpression *expression = expressionFromRef(*expr, nodes);
+        parameter->set_defaultExpressionParameter(expression);
+        if (expression != nullptr) {
+          expression->set_parent(parameter);
+        }
+      }
+      if (uint64_t target =
+              static_cast<uint64_t>(p.intOr("template_declaration", 0))) {
+        parameter->set_templateDeclaration(
+            nodeByIdAs<SgDeclarationStatement>(nodes, target));
+      }
+      if (uint64_t target = static_cast<uint64_t>(
+              p.intOr("default_template_declaration_parameter", 0))) {
+        parameter->set_defaultTemplateDeclarationParameter(
+            nodeByIdAs<SgDeclarationStatement>(nodes, target));
+      }
+      if (uint64_t target =
+              static_cast<uint64_t>(p.intOr("initialized_name", 0))) {
+        parameter->set_initializedName(
+            nodeByIdAs<SgInitializedName>(nodes, target));
+      }
+      parameter->set_templateParameterKeyword(
+          static_cast<SgTemplateParameter::template_parameter_keyword_enum>(
+              p.intOr("template_parameter_keyword",
+                      SgTemplateParameter::keyword_unspecified)));
+      parameter->set_isAbbreviatedFunctionTemplateParameter(
+          p.boolOr("is_abbreviated_function_template_parameter", false));
+      parameter->set_is_parameter_pack(p.boolOr("is_parameter_pack", false));
+    } else if (SgExpression *expr = isSgExpression(node)) {
+      if (const JsonValue *type = p.find("type")) {
+        SgType *restored_type = typeFromJson(*type, nodes);
+        if (SgCastExp *cast = isSgCastExp(expr)) {
+          cast->set_type(restored_type);
+        } else if (SgTypeExpression *type_expr = isSgTypeExpression(expr)) {
+          type_expr->set_type(restored_type);
+        } else if (SgAggregateInitializer *init =
+                       isSgAggregateInitializer(expr)) {
+          init->set_expression_type(restored_type);
+        } else if (SgCompoundInitializer *init =
+                       isSgCompoundInitializer(expr)) {
+          init->set_expression_type(restored_type);
+        } else if (SgConstructorInitializer *init =
+                       isSgConstructorInitializer(expr)) {
+          init->set_expression_type(restored_type);
+        }
+      }
+      expr->set_lvalue(p.boolOr("lvalue", expr->get_lvalue()));
+      expr->set_need_paren(p.boolOr("need_paren", expr->get_need_paren()));
+      expr->set_global_qualified_name(
+          p.boolOr("global_qualified_name", expr->get_global_qualified_name()));
+      restoreExpressionQualificationFields(expr, p);
+      if (SgNewExp *new_expr = isSgNewExp(expr)) {
+        if (const JsonValue *type = p.find("specified_type")) {
+          new_expr->set_specified_type(typeFromJson(*type, nodes));
+        }
+        if (const JsonValue *type = p.find("type")) {
+          installNewExpressionResultType(new_expr, typeFromJson(*type, nodes),
+                                         *type);
+        }
+        new_expr->set_need_global_specifier(static_cast<short>(p.intOr(
+            "need_global_specifier", new_expr->get_need_global_specifier())));
+        new_expr->set_type_id_is_parenthesized(
+            p.boolOr("type_id_is_parenthesized",
+                     new_expr->get_type_id_is_parenthesized()));
+      }
+      if (SgDeleteExp *delete_expr = isSgDeleteExp(expr)) {
+        delete_expr->set_is_array(static_cast<short>(
+            p.intOr("is_array", delete_expr->get_is_array())));
+        delete_expr->set_need_global_specifier(static_cast<short>(
+            p.intOr("need_global_specifier",
+                    delete_expr->get_need_global_specifier())));
+      }
+      if (SgEnumVal *value = isSgEnumVal(expr)) {
+        if (uint64_t target =
+                static_cast<uint64_t>(p.intOr("declaration", 0))) {
+          value->set_declaration(nodeByIdAs<SgEnumDeclaration>(nodes, target));
+        }
+        value->set_requiresNameQualification(
+            p.boolOr("requires_name_qualification",
+                     value->get_requiresNameQualification()));
+      } else if (SgTemplateParameterVal *value =
+                     isSgTemplateParameterVal(expr)) {
+        value->set_template_parameter_position(static_cast<int>(
+            p.intOr("template_parameter_position",
+                    value->get_template_parameter_position())));
+        value->set_valueString(
+            p.stringOr("value_string", value->get_valueString()));
+        if (const JsonValue *type = p.find("type")) {
+          value->set_valueType(typeFromJson(*type, nodes));
+        }
+      }
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    const JsonValue &p = record.properties;
+
+    if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+      if (decl->get_parameterList() == nullptr) {
+        decl->set_parameterList(new SgFunctionParameterList());
+        decl->get_parameterList()->set_parent(decl);
+      }
+      if (const JsonValue *function_type = p.find("function_type")) {
+        if (SgFunctionType *restored_type =
+                isSgFunctionType(typeFromJson(*function_type, nodes))) {
+          decl->set_type(restored_type);
+          continue;
+        }
+      }
+      SgType *return_type = SageBuilder::buildIntType();
+      if (const JsonValue *type = p.find("return_type")) {
+        return_type = typeFromJson(*type, nodes);
+      }
+      decl->set_type(SageBuilder::buildFunctionType(return_type,
+                                                    decl->get_parameterList()));
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+      if (decl->get_scope() == nullptr) {
+        if (SgScopeStatement *scope = nearestScope(decl)) {
+          decl->set_scope(scope);
+        }
+      }
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgDeclarationStatement *decl =
+        isSgDeclarationStatement(nodeById(nodes, record.id));
+    if (decl == nullptr) {
+      continue;
+    }
+
+    SgDeclarationStatement *peers[] = {decl->get_definingDeclaration(),
+                                       decl->get_firstNondefiningDeclaration()};
+    for (SgDeclarationStatement *peer : peers) {
+      if (peer == nullptr || peer == decl) {
+        continue;
+      }
+      if (peer->get_scope() == nullptr && decl->get_scope() != nullptr) {
+        peer->set_scope(decl->get_scope());
+      }
+      if (peer->get_parent() == nullptr && decl->get_parent() != nullptr) {
+        peer->set_parent(decl->get_parent());
+      }
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    if (SgInitializedName *name = isSgInitializedName(node)) {
+      if (name->get_scope() == nullptr) {
+        SgScopeStatement *scope = nullptr;
+        if (SgDeclarationStatement *decl = name->get_declptr()) {
+          scope = decl->get_scope();
+        }
+        if (scope == nullptr) {
+          scope = nearestScope(name);
+        }
+        if (scope != nullptr) {
+          name->set_scope(scope);
+        }
+      }
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    if (SgVariableDeclaration *decl = isSgVariableDeclaration(node)) {
+      SgScopeStatement *scope = decl->get_scope();
+      if (scope != nullptr) {
+        for (SgInitializedName *name : decl->get_variables()) {
+          if (name != nullptr && name->get_scope() == nullptr) {
+            name->set_scope(scope);
+          }
+        }
+      }
+    } else if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+      SgScopeStatement *scope = decl->get_scope();
+      if (scope != nullptr) {
+        for (SgInitializedName *name : decl->get_enumerators()) {
+          if (name != nullptr && name->get_scope() == nullptr) {
+            name->set_scope(scope);
+          }
+        }
+      }
+    }
+  }
+
+  restoreRecordedScopeEdges(ast, nodes);
+  restoreSerializedSymbolTables(ast, nodes);
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    const JsonValue &p = record.properties;
+    if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+      if (const JsonValue *symbol_json = p.find("symbol")) {
+        ref->set_symbol(
+            isSgVariableSymbol(symbolFromJson(*symbol_json, nodes)));
+      } else {
+        const uint64_t decl_id =
+            static_cast<uint64_t>(p.intOr("symbol_declaration", 0));
+        if (decl_id != 0) {
+          SgInitializedName *decl =
+              isSgInitializedName(nodeById(nodes, decl_id));
+          if (decl != nullptr) {
+            ref->set_symbol(new SgVariableSymbol(decl));
+          }
+        }
+      }
+      if (ref->get_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgVarRefExp symbol");
+      }
+      normalizeAnonymousDataMemberReference(ref);
+    } else if (SgLabelRefExp *ref = isSgLabelRefExp(node)) {
+      if (const JsonValue *symbol_json = p.find("symbol")) {
+        ref->set_symbol(isSgLabelSymbol(symbolFromJson(*symbol_json, nodes)));
+      }
+      if (ref->get_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgLabelRefExp symbol");
+      }
+    } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(node)) {
+      SgMemberFunctionSymbol *symbol = nullptr;
+      if (const JsonValue *symbol_json = p.find("symbol")) {
+        symbol = isSgMemberFunctionSymbol(symbolFromJson(*symbol_json, nodes));
+        attachExternalSymbolBasisToScope(symbol, nearestScope(ref));
+      } else {
+        const uint64_t decl_id =
+            static_cast<uint64_t>(p.intOr("symbol_declaration", 0));
+        if (decl_id != 0) {
+          SgMemberFunctionDeclaration *decl =
+              isSgMemberFunctionDeclaration(nodeById(nodes, decl_id));
+          if (decl != nullptr) {
+            symbol = new SgMemberFunctionSymbol(decl);
+          }
+        }
+      }
+      ref->set_symbol_i(symbol);
+      ref->set_virtual_call(static_cast<int>(p.intOr("virtual_call", 0)));
+      ref->set_need_qualifier(
+          static_cast<int>(p.intOr("need_qualifier", true)));
+      if (ref->get_symbol_i() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgMemberFunctionRefExp symbol");
+      }
+    } else if (SgThisExp *expr = isSgThisExp(node)) {
+      const uint64_t class_decl_id =
+          static_cast<uint64_t>(p.intOr("class_symbol_declaration", 0));
+      if (class_decl_id != 0) {
+        expr->set_class_symbol(classSymbolForDeclaration(
+            isSgClassDeclaration(nodeById(nodes, class_decl_id))));
+      }
+      const uint64_t nonreal_decl_id =
+          static_cast<uint64_t>(p.intOr("nonreal_symbol_declaration", 0));
+      if (nonreal_decl_id != 0) {
+        expr->set_nonreal_symbol(nonrealSymbolForDeclaration(
+            isSgNonrealDecl(nodeById(nodes, nonreal_decl_id))));
+      }
+      expr->set_pobj_this(static_cast<int>(p.intOr("pobj_this", 0)));
+      if (expr->get_class_symbol() == nullptr &&
+          expr->get_nonreal_symbol() == nullptr) {
+        if (const JsonValue *type_json = p.find("type")) {
+          if (SgPointerType *pointer =
+                  isSgPointerType(typeFromJson(*type_json, nodes))) {
+            if (SgClassType *class_type =
+                    isSgClassType(pointer->get_base_type())) {
+              expr->set_class_symbol(classSymbolForDeclaration(
+                  isSgClassDeclaration(class_type->get_declaration())));
+            } else if (SgNonrealType *nonreal_type =
+                           isSgNonrealType(pointer->get_base_type())) {
+              expr->set_nonreal_symbol(nonrealSymbolForDeclaration(
+                  isSgNonrealDecl(nonreal_type->get_declaration())));
+            }
+          }
+        }
+      }
+      if (expr->get_class_symbol() == nullptr &&
+          expr->get_nonreal_symbol() == nullptr) {
+        throw std::runtime_error("AST JSON failed to resolve SgThisExp symbol");
+      }
+    } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(node)) {
+      const uint64_t decl_id =
+          static_cast<uint64_t>(p.intOr("symbol_declaration", 0));
+      if (decl_id != 0) {
+        ref->set_symbol(nonrealSymbolForDeclaration(
+            isSgNonrealDecl(nodeById(nodes, decl_id))));
+      }
+      if (ref->get_symbol() == nullptr) {
+        if (const JsonValue *type_json = p.find("type")) {
+          if (SgNonrealType *nonreal_type =
+                  isSgNonrealType(typeFromJson(*type_json, nodes))) {
+            ref->set_symbol(nonrealSymbolForDeclaration(
+                isSgNonrealDecl(nonreal_type->get_declaration())));
+          }
+        }
+      }
+      if (ref->get_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgNonrealRefExp symbol");
+      }
+      if (const JsonValue *template_arguments = p.find("template_arguments")) {
+        ref->get_templateArguments() =
+            templateArgumentListFromJson(*template_arguments, nodes, ref);
+      }
+      ref->set_constraintSatisfactionEvaluated(
+          p.boolOr("constraint_satisfaction_evaluated",
+                   ref->get_constraintSatisfactionEvaluated()));
+      ref->set_constraintSatisfactionSatisfied(
+          p.boolOr("constraint_satisfaction_satisfied",
+                   ref->get_constraintSatisfactionSatisfied()));
+      ref->set_constraintSatisfactionContainsErrors(
+          p.boolOr("constraint_satisfaction_contains_errors",
+                   ref->get_constraintSatisfactionContainsErrors()));
+      ref->set_constraintSatisfactionSubstitutionFailure(
+          p.boolOr("constraint_satisfaction_substitution_failure",
+                   ref->get_constraintSatisfactionSubstitutionFailure()));
+      ref->set_constraintSatisfactionSummary(
+          p.stringOr("constraint_satisfaction_summary",
+                     ref->get_constraintSatisfactionSummary()));
+      ref->set_sfinaeEvaluated(
+          p.boolOr("sfinae_evaluated", ref->get_sfinaeEvaluated()));
+      ref->set_sfinaeSubstitutionFailure(p.boolOr(
+          "sfinae_substitution_failure", ref->get_sfinaeSubstitutionFailure()));
+      ref->set_sfinaeSummary(
+          p.stringOr("sfinae_summary", ref->get_sfinaeSummary()));
+    } else if (SgTemplateFunctionRefExp *ref =
+                   isSgTemplateFunctionRefExp(node)) {
+      if (const JsonValue *symbol_json = p.find("symbol")) {
+        SgTemplateFunctionSymbol *symbol =
+            isSgTemplateFunctionSymbol(symbolFromJson(*symbol_json, nodes));
+        attachExternalSymbolBasisToScope(symbol, nearestScope(ref));
+        ref->set_symbol(symbol);
+      } else {
+        const uint64_t decl_id =
+            static_cast<uint64_t>(p.intOr("symbol_declaration", 0));
+        if (decl_id != 0) {
+          SgFunctionDeclaration *decl =
+              isSgFunctionDeclaration(nodeById(nodes, decl_id));
+          if (decl != nullptr) {
+            ref->set_symbol(new SgTemplateFunctionSymbol(decl));
+          }
+        }
+      }
+      if (ref->get_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgTemplateFunctionRefExp symbol");
+      }
+    } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(node)) {
+      const uint64_t decl_id =
+          static_cast<uint64_t>(p.intOr("symbol_declaration", 0));
+      SgFunctionDeclaration *external_decl = nullptr;
+      if (const JsonValue *symbol_json = p.find("symbol")) {
+        SgFunctionSymbol *symbol =
+            isSgFunctionSymbol(symbolFromJson(*symbol_json, nodes));
+        attachExternalSymbolBasisToScope(symbol, nearestScope(ref));
+        ref->set_symbol(symbol);
+      } else if (decl_id != 0) {
+        SgFunctionDeclaration *decl =
+            isSgFunctionDeclaration(nodeById(nodes, decl_id));
+        if (decl != nullptr) {
+          ref->set_symbol(new SgFunctionSymbol(decl));
+        }
+      } else if (const JsonValue *external = p.find("external_function")) {
+        external_decl = externalFunctionFromJson(*external, nodes);
+        if (external_decl != nullptr) {
+          external_decl->set_scope(nearestScope(ref));
+          ref->set_symbol(new SgFunctionSymbol(external_decl));
+        }
+      }
+      if (ref->get_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON failed to resolve SgFunctionRefExp symbol");
+      }
+    }
+  }
+
+  applyOmpAuxiliaryState(ast, nodes);
+}
+
+void rebuildConstructorOnlyNodes(const AstFileRecord &ast, NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    if (record.kind == "SgTemplateInstantiationDefn") {
+      const uint64_t parent = singleEdgeTarget(record, "parent");
+      if (parent == 0) {
+        throw std::runtime_error(
+            "AST JSON SgTemplateInstantiationDefn is missing parent edge");
+      }
+      SgTemplateInstantiationDecl *decl =
+          nodeByIdAs<SgTemplateInstantiationDecl>(nodes, parent);
+      SgTemplateInstantiationDefn *def = new SgTemplateInstantiationDefn(decl);
+      def->set_parent(decl);
+      decl->set_definition(def);
+      nodes[record.id] = def;
+      continue;
+    }
+
+    const JsonValue *type = record.properties.find("type");
+    if (type == nullptr) {
+      continue;
+    }
+    if (isJsonBinaryOpKind(record.kind)) {
+      nodes[record.id] =
+          buildBinaryOpForKind(record.kind, typeFromJson(*type, nodes));
+      continue;
+    }
+    if (isJsonUnaryOpKind(record.kind)) {
+      nodes[record.id] = buildUnaryOpForKind(
+          record.kind, typeFromJson(*type, nodes), record.properties);
+      continue;
+    }
+    if (record.kind == "SgFunctionCallExp") {
+      nodes[record.id] = new SgFunctionCallExp(
+          static_cast<SgExpression *>(nullptr),
+          static_cast<SgExprListExp *>(nullptr), typeFromJson(*type, nodes));
+      continue;
+    }
+    if (record.kind == "SgConditionalExp") {
+      nodes[record.id] = new SgConditionalExp(
+          static_cast<SgExpression *>(nullptr),
+          static_cast<SgExpression *>(nullptr),
+          static_cast<SgExpression *>(nullptr), typeFromJson(*type, nodes));
+      continue;
+    }
+    if (record.kind == "SgNewExp") {
+      const JsonValue *specified_type_json =
+          record.properties.find("specified_type");
+      SgType *specified_type = specified_type_json != nullptr
+                                   ? typeFromJson(*specified_type_json, nodes)
+                                   : SageBuilder::buildUnknownType();
+      SgNewExp *new_expr =
+          new SgNewExp(specified_type, static_cast<SgExprListExp *>(nullptr),
+                       static_cast<SgConstructorInitializer *>(nullptr),
+                       static_cast<SgExpression *>(nullptr),
+                       static_cast<short>(
+                           record.properties.intOr("need_global_specifier", 0)),
+                       static_cast<SgFunctionDeclaration *>(nullptr));
+      installNewExpressionResultType(new_expr, typeFromJson(*type, nodes),
+                                     *type);
+      new_expr->set_type_id_is_parenthesized(
+          record.properties.boolOr("type_id_is_parenthesized", false));
+      nodes[record.id] = new_expr;
+      continue;
+    }
+    if (record.kind == "SgConstructorInitializer") {
+      SgConstructorInitializer *replacement = new SgConstructorInitializer(
+          static_cast<SgMemberFunctionDeclaration *>(nullptr),
+          static_cast<SgExprListExp *>(nullptr), typeFromJson(*type, nodes),
+          record.properties.boolOr("need_name", false),
+          record.properties.boolOr("need_qualifier", false),
+          record.properties.boolOr("need_parenthesis_after_name", false),
+          record.properties.boolOr("associated_class_unknown", false));
+      nodes[record.id] = replacement;
+      continue;
+    }
+    if (record.kind == "SgAssignInitializer") {
+      SgAssignInitializer *replacement = new SgAssignInitializer(
+          static_cast<SgExpression *>(nullptr), typeFromJson(*type, nodes));
+      nodes[record.id] = replacement;
+    }
+  }
+}
+
+void restoreDeclarationIdentityEdges(const AstFileRecord &ast,
+                                     const NodeMap &nodes) {
+  auto attach_external_peer = [](SgDeclarationStatement *owner,
+                                 SgDeclarationStatement *peer) {
+    if (owner == nullptr || peer == nullptr) {
+      return;
+    }
+    if (peer->get_scope() == nullptr) {
+      peer->set_scope(owner->get_scope());
+    }
+    if (peer->get_parent() == nullptr) {
+      peer->set_parent(owner->get_parent());
+    }
+  };
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgDeclarationStatement *decl =
+        isSgDeclarationStatement(nodeById(nodes, record.id));
+    if (decl == nullptr) {
+      continue;
+    }
+    if (uint64_t target = singleEdgeTarget(record, "parent")) {
+      decl->set_parent(nodeById(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "scope")) {
+      decl->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "firstNondefiningDeclaration")) {
+      decl->set_firstNondefiningDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    } else if (SgDeclarationStatement *external =
+                   externalDeclarationReferenceFromJson(
+                       record.properties.find(
+                           "external_first_nondefining_declaration"),
+                       nodes, record.kind + ".firstNondefiningDeclaration")) {
+      attach_external_peer(decl, external);
+      decl->set_firstNondefiningDeclaration(external);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "definingDeclaration")) {
+      decl->set_definingDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    } else if (SgDeclarationStatement *external =
+                   externalDeclarationReferenceFromJson(
+                       record.properties.find("external_defining_declaration"),
+                       nodes, record.kind + ".definingDeclaration")) {
+      attach_external_peer(decl, external);
+      decl->set_definingDeclaration(external);
+    }
+  }
+}
+
+void restoreRecordedParentEdges(const AstFileRecord &ast,
+                                const NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    if (uint64_t target = singleEdgeTarget(record, "parent")) {
+      nodeById(nodes, record.id)->set_parent(nodeById(nodes, target));
+    }
+  }
+}
+
+void restoreRecordedScopeEdges(const AstFileRecord &ast, const NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    if (SgInitializedName *name = isSgInitializedName(node)) {
+      if (uint64_t target = singleEdgeTarget(record, "scope")) {
+        name->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+      }
+    }
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+      if (uint64_t target = singleEdgeTarget(record, "scope")) {
+        decl->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+      }
+    }
+    if (SgLabelStatement *label = isSgLabelStatement(node)) {
+      if (uint64_t target = singleEdgeTarget(record, "scope")) {
+        label->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+      }
+    }
+  }
+}
+
+SgSourceFile *reconstructSourceFile(const AstFileRecord &ast,
+                                    SgSourceFile *old_file) {
+  SgProject *project = owningProject(old_file);
+  ROSE_ASSERT(project != nullptr);
+  DeserializationProjectGuard project_guard(project);
+  restoreFileIdMapFromMetadata(ast.metadata);
+
+  NodeMap nodes;
+  nodes.reserve(ast.nodes.size());
+  for (const NodeRecord &record : ast.nodes) {
+    if (requiresDelayedRebuild(record)) {
+      continue;
+    }
+    SgNode *node = createNodeFromRecord(record, project, ast.metadata);
+    requireRestoredKind(node, record);
+    nodes.emplace(record.id, node);
+  }
+
+  restoreAvailableSourcePositionsAndScopes(ast, nodes);
+  rebuildConstructorOnlyNodes(ast, nodes);
+  restoreDeclarationIdentityEdges(ast, nodes);
+  for (const NodeRecord &record : ast.nodes) {
+    attachJsonNodeId(nodeById(nodes, record.id), record.id);
+  }
+  for (const NodeRecord &record : ast.nodes) {
+    requireRestoredKind(nodeById(nodes, record.id), record);
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    linkNodeEdges(record, nodes);
+  }
+  for (const NodeRecord &record : ast.nodes) {
+    if (SgClassDefinition *def =
+            isSgClassDefinition(nodeById(nodes, record.id))) {
+      SgNode *parent = def->get_parent();
+      if (parent == nullptr || isSgClassDeclaration(parent) == nullptr) {
+        std::ostringstream message;
+        message << "AST JSON reconstructed " << record.kind << " id "
+                << record.id << " without owning SgClassDeclaration";
+        throw std::runtime_error(message.str());
+      }
+    }
+  }
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    setNodeSourcePosition(node, record);
+    setNodeFlags(node, record);
+    attachPreprocessingInfo(node, record);
+    attachAstAttributes(node, record);
+    requireRestoredKind(nodeById(nodes, record.id), record);
+  }
+  applyTypesAndSymbols(ast, nodes);
+  restoreRecordedScopeEdges(ast, nodes);
+  restoreRecordedParentEdges(ast, nodes);
+  for (const NodeRecord &record : ast.nodes) {
+    if (SgClassDeclaration *decl =
+            isSgClassDeclaration(nodeById(nodes, record.id))) {
+      if (SgClassDefinition *def = decl->get_definition()) {
+        SgNode *parent = def->get_parent();
+        if (parent == nullptr || isSgClassDeclaration(parent) == nullptr) {
+          std::ostringstream message;
+          message << "AST JSON reconstructed " << record.kind << " id "
+                  << record.id
+                  << " with a definition lacking an owning declaration";
+          throw std::runtime_error(message.str());
+        }
+      }
+    }
+  }
+
+  SgSourceFile *file = isSgSourceFile(nodeById(nodes, ast.root_id));
+  ROSE_ASSERT(file != nullptr);
+  restoreFileIdMapFromMetadata(ast.metadata);
+  return file;
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeNodes.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeNodes.cpp
@@ -1,0 +1,3330 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+SgNode *createNodeFromRecord(const NodeRecord &record, SgProject *project,
+                             const JsonValue &metadata) {
+  const JsonValue &p = record.properties;
+  const std::string &kind = record.kind;
+  if (kind == "SgSourceFile") {
+    std::vector<std::string> args = commandLineFromMetadata(metadata);
+    SgSourceFile *file = new SgSourceFile(args, project);
+    file->set_sourceFileNameWithPath(p.stringOr(
+        "source_filename_with_path", metadata.stringOr("source_file")));
+    file->set_sourceFileNameWithoutPath(p.stringOr(
+        "source_filename_without_path", file->get_sourceFileNameWithoutPath()));
+    file->set_unparse_output_filename(p.stringOr(
+        "unparse_output_filename", metadata.stringOr("output_file")));
+    file->set_C_only(p.boolOr("C_only", file->get_C_only()));
+    file->set_Cxx_only(p.boolOr("Cxx_only", file->get_Cxx_only()));
+    file->set_Fortran_only(p.boolOr("Fortran_only", file->get_Fortran_only()));
+    file->set_CoArrayFortran_only(
+        p.boolOr("CoArrayFortran_only", file->get_CoArrayFortran_only()));
+    file->set_Cuda_only(p.boolOr("Cuda_only", file->get_Cuda_only()));
+    file->set_OpenCL_only(p.boolOr("OpenCL_only", file->get_OpenCL_only()));
+    file->set_requires_C_preprocessor(p.boolOr(
+        "requires_C_preprocessor", file->get_requires_C_preprocessor()));
+    file->set_inputFormat(
+        fileOutputFormatFromJson(p, "input_format", file->get_inputFormat()));
+    file->set_outputFormat(
+        fileOutputFormatFromJson(p, "output_format", file->get_outputFormat()));
+    file->set_backendCompileFormat(fileOutputFormatFromJson(
+        p, "backend_compile_format", file->get_backendCompileFormat()));
+    file->set_fortran_implicit_none(
+        p.boolOr("fortran_implicit_none", file->get_fortran_implicit_none()));
+    file->set_inputLanguage(
+        fileLanguageFromJson(p, "input_language", file->get_inputLanguage()));
+    file->set_outputLanguage(
+        fileLanguageFromJson(p, "output_language", file->get_outputLanguage()));
+    file->set_strict_language_handling(p.boolOr(
+        "strict_language_handling", file->get_strict_language_handling()));
+    file->set_sourceFileUsesCppFileExtension(
+        p.boolOr("source_uses_cpp_extension",
+                 file->get_sourceFileUsesCppFileExtension()));
+    file->set_sourceFileUsesFortranFileExtension(
+        p.boolOr("source_uses_fortran_extension",
+                 file->get_sourceFileUsesFortranFileExtension()));
+    file->set_sourceFileUsesFortran77FileExtension(
+        p.boolOr("source_uses_fortran77_extension",
+                 file->get_sourceFileUsesFortran77FileExtension()));
+    file->set_sourceFileUsesFortran90FileExtension(
+        p.boolOr("source_uses_fortran90_extension",
+                 file->get_sourceFileUsesFortran90FileExtension()));
+    file->set_sourceFileUsesFortran95FileExtension(
+        p.boolOr("source_uses_fortran95_extension",
+                 file->get_sourceFileUsesFortran95FileExtension()));
+    file->set_sourceFileUsesFortran2003FileExtension(
+        p.boolOr("source_uses_fortran2003_extension",
+                 file->get_sourceFileUsesFortran2003FileExtension()));
+    file->set_sourceFileUsesFortran2008FileExtension(
+        p.boolOr("source_uses_fortran2008_extension",
+                 file->get_sourceFileUsesFortran2008FileExtension()));
+    file->set_sourceFileUsesCoArrayFortranFileExtension(
+        p.boolOr("source_uses_coarray_fortran_extension",
+                 file->get_sourceFileUsesCoArrayFortranFileExtension()));
+    file->set_sourceFileTypeIsUnknown(p.boolOr(
+        "source_file_type_is_unknown", file->get_sourceFileTypeIsUnknown()));
+    file->set_experimental_flang_frontend(
+        p.boolOr("experimental_flang_frontend",
+                 file->get_experimental_flang_frontend()));
+    file->set_openmp(metadata.boolOr("openmp", false));
+    file->set_openmp_parse_only(metadata.boolOr("openmp_parse_only", false));
+    file->set_openmp_ast_only(metadata.boolOr("openmp_ast_only", false));
+    file->set_openmp_analyzing(metadata.boolOr("openmp_analyzing", false));
+    file->set_openmp_lowering(metadata.boolOr("openmp_lowering", false));
+    file->set_openmp_processed(metadata.boolOr("openmp_processed", false));
+    file->set_openacc(metadata.boolOr("openacc", false));
+    file->set_skipfinalCompileStep(
+        metadata.boolOr("skipfinalCompileStep", false));
+    file->set_suppress_variable_declaration_normalization(
+        metadata.boolOr("suppress_variable_declaration_normalization", false));
+    file->set_unparse_tokens(metadata.boolOr("unparse_tokens", false));
+    return file;
+  }
+  if (kind == "SgGlobal") {
+    return new SgGlobal();
+  }
+  if (kind == "SgBasicBlock") {
+    return new SgBasicBlock(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgInitializedName") {
+    return new SgInitializedName(nullptr, SgName(p.stringOr("name")),
+                                 SageBuilder::buildUnknownType(), nullptr,
+                                 nullptr, nullptr, nullptr);
+  }
+  if (kind == "SgVariableDeclaration") {
+    return new SgVariableDeclaration();
+  }
+  if (kind == "SgVariableDefinition") {
+    return new SgVariableDefinition(static_cast<Sg_File_Info *>(nullptr),
+                                    static_cast<SgInitializedName *>(nullptr),
+                                    static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgTemplateVariableDeclaration") {
+    return new SgTemplateVariableDeclaration();
+  }
+  if (kind == "SgProgramHeaderStatement") {
+    SgFunctionType *function_type = nullptr;
+    if (const JsonValue *type = p.find("function_type")) {
+      function_type = isSgFunctionType(earlyTypeFromJson(*type));
+    }
+    return new SgProgramHeaderStatement(SgName(p.stringOr("name")),
+                                        function_type, nullptr);
+  }
+  if (kind == "SgProcedureHeaderStatement") {
+    SgFunctionType *function_type = nullptr;
+    if (const JsonValue *type = p.find("function_type")) {
+      function_type = isSgFunctionType(earlyTypeFromJson(*type));
+    }
+    SgProcedureHeaderStatement *decl = new SgProcedureHeaderStatement(
+        SgName(p.stringOr("name")), function_type, nullptr);
+    decl->set_subprogram_kind(
+        static_cast<SgProcedureHeaderStatement::subprogram_kind_enum>(
+            p.intOr("subprogram_kind",
+                    SgProcedureHeaderStatement::e_function_subprogram_kind)));
+    return decl;
+  }
+  if (kind == "SgContainsStatement") {
+    return new SgContainsStatement();
+  }
+  if (kind == "SgFortranContinueStmt") {
+    return new SgFortranContinueStmt();
+  }
+  if (kind == "SgProcessControlStatement") {
+    SgProcessControlStatement *stmt =
+        new SgProcessControlStatement(static_cast<SgExpression *>(nullptr));
+    stmt->set_control_kind(static_cast<SgProcessControlStatement::control_enum>(
+        p.intOr("control_kind", SgProcessControlStatement::e_unknown)));
+    return stmt;
+  }
+  if (kind == "SgCommonBlock") {
+    return new SgCommonBlock(static_cast<Sg_File_Info *>(nullptr));
+  }
+  if (kind == "SgCommonBlockObject") {
+    SgCommonBlockObject *object =
+        new SgCommonBlockObject(static_cast<Sg_File_Info *>(nullptr));
+    object->set_block_name(p.stringOr("block_name"));
+    return object;
+  }
+  if (kind == "SgFortranIncludeLine") {
+    return new SgFortranIncludeLine(p.stringOr("filename"));
+  }
+  if (kind == "SgFunctionDeclaration") {
+    return new SgFunctionDeclaration(SgName(p.stringOr("name")), nullptr,
+                                     nullptr);
+  }
+  if (kind == "SgTemplateInstantiationFunctionDecl") {
+    SgTemplateArgumentPtrList arguments;
+    return new SgTemplateInstantiationFunctionDecl(
+        SgName(p.stringOr("name")), nullptr, nullptr, nullptr, arguments);
+  }
+  if (kind == "SgTemplateFunctionDeclaration") {
+    return new SgTemplateFunctionDeclaration(SgName(p.stringOr("name")),
+                                             nullptr, nullptr);
+  }
+  if (kind == "SgFunctionParameterList") {
+    return new SgFunctionParameterList();
+  }
+  if (kind == "SgFunctionDefinition") {
+    return new SgFunctionDefinition(static_cast<SgBasicBlock *>(nullptr));
+  }
+  if (kind == "SgTemplateFunctionDefinition") {
+    return new SgTemplateFunctionDefinition(
+        static_cast<SgBasicBlock *>(nullptr));
+  }
+  if (kind == "SgTypedefDeclaration") {
+    return new SgTypedefDeclaration(SgName(p.stringOr("name")),
+                                    SageBuilder::buildIntType(), nullptr,
+                                    nullptr, nullptr);
+  }
+  if (kind == "SgTemplateTypedefDeclaration") {
+    SgType *base_type = SageBuilder::buildUnknownType();
+    if (const JsonValue *type = p.find("base_type")) {
+      base_type = earlyTypeFromJson(*type);
+    }
+    return new SgTemplateTypedefDeclaration(
+        SgName(p.stringOr("name")), base_type, nullptr, nullptr, nullptr);
+  }
+  if (kind == "SgTemplateInstantiationTypedefDeclaration") {
+    SgTemplateArgumentPtrList arguments;
+    SgType *base_type = SageBuilder::buildUnknownType();
+    if (const JsonValue *type = p.find("base_type")) {
+      base_type = earlyTypeFromJson(*type);
+    }
+    return new SgTemplateInstantiationTypedefDeclaration(
+        SgName(p.stringOr("name")), base_type, nullptr, nullptr, nullptr,
+        nullptr, arguments);
+  }
+  if (kind == "SgModuleStatement") {
+    return new SgModuleStatement(
+        SgName(p.stringOr("name")),
+        static_cast<SgClassDeclaration::class_types>(
+            p.intOr("class_type", SgClassDeclaration::e_class)),
+        nullptr, nullptr);
+  }
+  if (kind == "SgDerivedTypeStatement") {
+    return new SgDerivedTypeStatement(
+        SgName(p.stringOr("name")),
+        static_cast<SgClassDeclaration::class_types>(
+            p.intOr("class_type", SgClassDeclaration::e_struct)),
+        nullptr, nullptr);
+  }
+  if (kind == "SgClassDeclaration") {
+    return new SgClassDeclaration(
+        SgName(p.stringOr("name")),
+        static_cast<SgClassDeclaration::class_types>(
+            p.intOr("class_type", SgClassDeclaration::e_struct)),
+        nullptr, nullptr);
+  }
+  if (kind == "SgClassDefinition") {
+    return new SgClassDefinition();
+  }
+  if (kind == "SgTemplateInstantiationDefn") {
+    throw std::runtime_error(
+        "AST JSON SgTemplateInstantiationDefn requires delayed construction");
+  }
+  if (kind == "SgBaseClass") {
+    return new SgBaseClass(nullptr, p.boolOr("is_direct_base_class", false));
+  }
+  if (kind == "SgExpBaseClass") {
+    return new SgExpBaseClass(nullptr, p.boolOr("is_direct_base_class", false),
+                              nullptr);
+  }
+  if (kind == "SgNonrealBaseClass") {
+    return new SgNonrealBaseClass(
+        nullptr, p.boolOr("is_direct_base_class", false), nullptr);
+  }
+  if (kind == "SgDeclarationScope") {
+    return new SgDeclarationScope();
+  }
+  if (kind == "SgFunctionParameterScope") {
+    return new SgFunctionParameterScope();
+  }
+  if (kind == "SgTemplateClassDefinition") {
+    return new SgTemplateClassDefinition();
+  }
+  if (kind == "SgNamespaceDeclarationStatement") {
+    return new SgNamespaceDeclarationStatement(
+        SgName(p.stringOr("name")), nullptr,
+        p.boolOr("is_unnamed_namespace", false));
+  }
+  if (kind == "SgNamespaceDefinitionStatement") {
+    SgNamespaceDefinitionStatement *def = new SgNamespaceDefinitionStatement(
+        static_cast<SgNamespaceDeclarationStatement *>(nullptr));
+    def->set_isUnionOfReentrantNamespaceDefinitions(
+        p.boolOr("is_union_of_reentrant_namespace_definitions", false));
+    return def;
+  }
+  if (kind == "SgEnumDeclaration") {
+    return new SgEnumDeclaration(SgName(p.stringOr("name")), nullptr);
+  }
+  if (kind == "SgCtorInitializerList") {
+    return new SgCtorInitializerList();
+  }
+  if (kind == "SgEmptyDeclaration") {
+    return new SgEmptyDeclaration();
+  }
+  if (kind == "SgUsingDirectiveStatement") {
+    return new SgUsingDirectiveStatement(
+        static_cast<SgNamespaceDeclarationStatement *>(nullptr));
+  }
+  if (kind == "SgUsingDeclarationStatement") {
+    return new SgUsingDeclarationStatement(
+        static_cast<SgDeclarationStatement *>(nullptr),
+        static_cast<SgInitializedName *>(nullptr));
+  }
+  if (kind == "SgUseStatement") {
+    return new SgUseStatement(SgName(p.stringOr("name")),
+                              p.boolOr("only_option", false),
+                              p.stringOr("module_nature"));
+  }
+  if (kind == "SgRenamePair") {
+    return new SgRenamePair(SgName(p.stringOr("local_name")),
+                            SgName(p.stringOr("use_name")));
+  }
+  if (kind == "SgToken") {
+    return new SgToken(
+        p.stringOr("lexeme_string"),
+        static_cast<unsigned int>(p.intOr("classification_code", 0)));
+  }
+  if (kind == "SgImplicitStatement") {
+    SgImplicitStatement *stmt =
+        new SgImplicitStatement(p.boolOr("implicit_none", false));
+    stmt->set_implicit_spec(
+        static_cast<SgImplicitStatement::implicit_spec_enum>(
+            p.intOr("implicit_spec", stmt->get_implicit_spec())));
+    return stmt;
+  }
+  if (kind == "SgMemberFunctionDeclaration") {
+    return new SgMemberFunctionDeclaration(SgName(p.stringOr("name")), nullptr,
+                                           nullptr);
+  }
+  if (kind == "SgTemplateInstantiationMemberFunctionDecl") {
+    SgTemplateArgumentPtrList arguments;
+    return new SgTemplateInstantiationMemberFunctionDecl(
+        SgName(p.stringOr("name")), nullptr, nullptr, nullptr, arguments);
+  }
+  if (kind == "SgTemplateMemberFunctionDeclaration") {
+    return new SgTemplateMemberFunctionDeclaration(SgName(p.stringOr("name")),
+                                                   nullptr, nullptr);
+  }
+  if (kind == "SgTemplateClassDeclaration") {
+    SgTemplateClassDeclaration *decl = new SgTemplateClassDeclaration(
+        SgName(p.stringOr("name")),
+        static_cast<SgClassDeclaration::class_types>(
+            p.intOr("class_type", SgClassDeclaration::e_class)),
+        nullptr, nullptr);
+    std::string template_name = p.stringOr("template_name");
+    if (template_name.empty()) {
+      template_name = p.stringOr("name");
+    }
+    decl->set_templateName(SgName(template_name));
+    return decl;
+  }
+  if (kind == "SgTemplateInstantiationDecl") {
+    SgTemplateArgumentPtrList arguments;
+    SgTemplateInstantiationDecl *decl = new SgTemplateInstantiationDecl(
+        SgName(p.stringOr("name")),
+        static_cast<SgClassDeclaration::class_types>(
+            p.intOr("class_type", SgClassDeclaration::e_class)),
+        nullptr, nullptr, nullptr, arguments);
+    std::string template_name = p.stringOr("template_name");
+    if (template_name.empty()) {
+      template_name = p.stringOr("name");
+      const size_t args = template_name.find('<');
+      if (args != std::string::npos) {
+        template_name = trim(template_name.substr(0, args));
+      }
+    }
+    decl->set_templateName(SgName(template_name));
+    decl->set_nameResetFromMangledForm(p.boolOr(
+        "name_reset_from_mangled_form", decl->get_nameResetFromMangledForm()));
+    return decl;
+  }
+  if (kind == "SgTemplateInstantiationDirectiveStatement") {
+    return new SgTemplateInstantiationDirectiveStatement(
+        static_cast<SgDeclarationStatement *>(nullptr));
+  }
+  if (kind == "SgNonrealDecl") {
+    const std::string name = p.stringOr("name", p.stringOr("unparse"));
+    return new SgNonrealDecl(SgName(name));
+  }
+  if (kind == "SgTypeExpression") {
+    return new SgTypeExpression(earlyTypeFromProperties(p));
+  }
+  if (kind == "SgAsteriskShapeExp") {
+    return new SgAsteriskShapeExp();
+  }
+  if (kind == "SgColonShapeExp") {
+    return new SgColonShapeExp();
+  }
+  if (kind == "SgExprStatement") {
+    return new SgExprStatement(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgReturnStmt") {
+    return new SgReturnStmt(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgBreakStmt") {
+    return new SgBreakStmt();
+  }
+  if (kind == "SgContinueStmt") {
+    return new SgContinueStmt();
+  }
+  if (kind == "SgGotoStatement") {
+    return new SgGotoStatement(static_cast<SgLabelStatement *>(nullptr));
+  }
+  if (kind == "SgForStatement") {
+    return new SgForStatement(static_cast<SgStatement *>(nullptr),
+                              static_cast<SgExpression *>(nullptr),
+                              static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgFortranDo") {
+    return new SgFortranDo(static_cast<SgExpression *>(nullptr),
+                           static_cast<SgExpression *>(nullptr),
+                           static_cast<SgExpression *>(nullptr),
+                           static_cast<SgBasicBlock *>(nullptr));
+  }
+  if (kind == "SgFortranNonblockedDo") {
+    return new SgFortranNonblockedDo(static_cast<SgExpression *>(nullptr),
+                                     static_cast<SgExpression *>(nullptr),
+                                     static_cast<SgExpression *>(nullptr),
+                                     static_cast<SgBasicBlock *>(nullptr),
+                                     static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgImpliedDo") {
+    return new SgImpliedDo(static_cast<Sg_File_Info *>(nullptr),
+                           static_cast<SgExpression *>(nullptr),
+                           static_cast<SgExpression *>(nullptr),
+                           static_cast<SgExpression *>(nullptr),
+                           static_cast<SgExprListExp *>(nullptr),
+                           static_cast<SgScopeStatement *>(nullptr));
+  }
+  if (kind == "SgAllocateStatement") {
+    return new SgAllocateStatement(static_cast<Sg_File_Info *>(nullptr));
+  }
+  if (kind == "SgNullifyStatement") {
+    return new SgNullifyStatement(static_cast<Sg_File_Info *>(nullptr));
+  }
+  if (kind == "SgDeallocateStatement") {
+    return new SgDeallocateStatement(static_cast<Sg_File_Info *>(nullptr));
+  }
+  if (kind == "SgForInitStatement") {
+    return new SgForInitStatement();
+  }
+  if (kind == "SgIfStmt") {
+    return new SgIfStmt(static_cast<SgStatement *>(nullptr),
+                        static_cast<SgStatement *>(nullptr),
+                        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgWhileStmt") {
+    return new SgWhileStmt(static_cast<SgStatement *>(nullptr),
+                           static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgDoWhileStmt") {
+    return new SgDoWhileStmt(static_cast<SgStatement *>(nullptr),
+                             static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgSwitchStatement") {
+    return new SgSwitchStatement(static_cast<SgStatement *>(nullptr),
+                                 static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgCaseOptionStmt") {
+    return new SgCaseOptionStmt(static_cast<SgExpression *>(nullptr),
+                                static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgDefaultOptionStmt") {
+    return new SgDefaultOptionStmt(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgNullStatement") {
+    return new SgNullStatement();
+  }
+  if (kind == "SgLabelStatement") {
+    return new SgLabelStatement(SgName(p.stringOr("label")),
+                                static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgPragma") {
+    return new SgPragma(p.stringOr("name"), nullptr, nullptr);
+  }
+  if (kind == "SgPragmaDeclaration") {
+    return new SgPragmaDeclaration(static_cast<SgPragma *>(nullptr));
+  }
+  if (kind == "SgAttributeSpecificationStatement") {
+    return new SgAttributeSpecificationStatement();
+  }
+  if (kind == "SgInterfaceStatement") {
+    return new SgInterfaceStatement(
+        SgName(p.stringOr("name")),
+        static_cast<SgInterfaceStatement::generic_spec_enum>(p.intOr(
+            "generic_spec", SgInterfaceStatement::e_default_interface_type)));
+  }
+  if (kind == "SgInterfaceBody") {
+    return new SgInterfaceBody(SgName(p.stringOr("function_name")),
+                               static_cast<SgFunctionDeclaration *>(nullptr),
+                               p.boolOr("use_function_name", false));
+  }
+  if (kind == "SgPrintStatement") {
+    return new SgPrintStatement();
+  }
+  if (kind == "SgReadStatement") {
+    return new SgReadStatement();
+  }
+  if (kind == "SgWriteStatement") {
+    return new SgWriteStatement();
+  }
+  if (kind == "SgOpenStatement") {
+    return new SgOpenStatement();
+  }
+  if (kind == "SgCloseStatement") {
+    return new SgCloseStatement();
+  }
+  if (kind == "SgFlushStatement") {
+    return new SgFlushStatement();
+  }
+  if (kind == "SgBackspaceStatement") {
+    return new SgBackspaceStatement();
+  }
+  if (kind == "SgRewindStatement") {
+    return new SgRewindStatement();
+  }
+  if (kind == "SgEndfileStatement") {
+    return new SgEndfileStatement();
+  }
+  if (kind == "SgWaitStatement") {
+    return new SgWaitStatement();
+  }
+  if (kind == "SgStaticAssertionDeclaration") {
+    return new SgStaticAssertionDeclaration(
+        static_cast<SgExpression *>(nullptr),
+        SgName(p.stringOr("string_literal")));
+  }
+  if (kind == "SgVarRefExp") {
+    return new SgVarRefExp(static_cast<SgVariableSymbol *>(nullptr));
+  }
+  if (kind == "SgLabelRefExp") {
+    return new SgLabelRefExp(static_cast<SgLabelSymbol *>(nullptr));
+  }
+  if (kind == "SgActualArgumentExpression") {
+    SgExpression *placeholder = new SgNullExpression();
+    SgActualArgumentExpression *actual = new SgActualArgumentExpression(
+        SgName(p.stringOr("argument_name")), placeholder);
+    placeholder->set_parent(actual);
+    return actual;
+  }
+  if (kind == "SgFunctionRefExp") {
+    return new SgFunctionRefExp(static_cast<SgFunctionSymbol *>(nullptr),
+                                static_cast<SgFunctionType *>(nullptr));
+  }
+  if (kind == "SgTemplateFunctionRefExp") {
+    return new SgTemplateFunctionRefExp(
+        static_cast<SgTemplateFunctionSymbol *>(nullptr));
+  }
+  if (kind == "SgMemberFunctionRefExp") {
+    return new SgMemberFunctionRefExp(
+        static_cast<SgMemberFunctionSymbol *>(nullptr),
+        static_cast<int>(p.intOr("virtual_call", 0)),
+        isSgFunctionType(earlyTypeFromProperties(p)),
+        static_cast<int>(p.intOr("need_qualifier", true)));
+  }
+  if (kind == "SgExprListExp") {
+    return new SgExprListExp();
+  }
+  if (kind == "SgFunctionCallExp") {
+    return new SgFunctionCallExp(static_cast<SgExpression *>(nullptr),
+                                 static_cast<SgExprListExp *>(nullptr),
+                                 SageBuilder::buildUnknownType());
+  }
+  if (kind == "SgAssignInitializer") {
+    return new SgAssignInitializer(static_cast<SgExpression *>(nullptr),
+                                   SageBuilder::buildUnknownType());
+  }
+  if (kind == "SgAggregateInitializer") {
+    return new SgAggregateInitializer(static_cast<SgExprListExp *>(nullptr),
+                                      earlyTypeFromProperties(p));
+  }
+  if (kind == "SgBracedInitializer") {
+    return new SgBracedInitializer(static_cast<SgExprListExp *>(nullptr),
+                                   earlyTypeFromProperties(p));
+  }
+  if (kind == "SgBoolValExp") {
+    return new SgBoolValExp(static_cast<int>(p.intOr("value", 0)));
+  }
+  if (kind == "SgShortVal") {
+    return new SgShortVal(static_cast<short>(p.intOr("value", 0)),
+                          p.stringOr("value_string"));
+  }
+  if (kind == "SgUnsignedShortVal") {
+    return new SgUnsignedShortVal(
+        static_cast<unsigned short>(p.intOr("value", 0)),
+        p.stringOr("value_string"));
+  }
+  if (kind == "SgIntVal") {
+    return new SgIntVal(static_cast<int>(p.intOr("value", 0)),
+                        p.stringOr("value_string"));
+  }
+  if (kind == "SgUnsignedIntVal") {
+    return new SgUnsignedIntVal(static_cast<unsigned int>(p.intOr("value", 0)),
+                                p.stringOr("value_string"));
+  }
+  if (kind == "SgLongIntVal") {
+    return new SgLongIntVal(static_cast<long>(p.intOr("value", 0)),
+                            p.stringOr("value_string"));
+  }
+  if (kind == "SgUnsignedLongVal") {
+    return new SgUnsignedLongVal(
+        static_cast<unsigned long>(p.intOr("value", 0)),
+        p.stringOr("value_string"));
+  }
+  if (kind == "SgLongLongIntVal") {
+    return new SgLongLongIntVal(p.intOr("value", 0),
+                                p.stringOr("value_string"));
+  }
+  if (kind == "SgUnsignedLongLongIntVal") {
+    return new SgUnsignedLongLongIntVal(
+        static_cast<unsigned long long>(p.intOr("value", 0)),
+        p.stringOr("value_string"));
+  }
+  if (kind == "SgCharVal") {
+    return new SgCharVal(static_cast<char>(p.intOr("value", 0)),
+                         p.stringOr("value_string"));
+  }
+  if (kind == "SgUnsignedCharVal") {
+    return new SgUnsignedCharVal(
+        static_cast<unsigned char>(p.intOr("value", 0)),
+        p.stringOr("value_string"));
+  }
+  if (kind == "SgFloatVal") {
+    const std::string value = p.stringOr("value", "0");
+    return new SgFloatVal(std::stof(value), value);
+  }
+  if (kind == "SgDoubleVal") {
+    const std::string value = p.stringOr("value", "0");
+    return new SgDoubleVal(std::stod(value), value);
+  }
+  if (kind == "SgComplexVal") {
+    SgType *precision_type = SageBuilder::buildUnknownType();
+    if (const JsonValue *type = p.find("precision_type")) {
+      precision_type = earlyTypeFromJson(*type);
+    }
+    return new SgComplexVal(static_cast<Sg_File_Info *>(nullptr),
+                            static_cast<SgValueExp *>(nullptr),
+                            static_cast<SgValueExp *>(nullptr), precision_type,
+                            p.stringOr("value_string"));
+  }
+  if (kind == "SgStringVal") {
+    SgStringVal *value = new SgStringVal(p.stringOr("value"));
+    value->set_wcharString(p.boolOr("wchar_string", false));
+    value->set_stringDelimiter(
+        static_cast<char>(p.intOr("string_delimiter", 0)));
+    value->set_is16bitString(p.boolOr("is_16bit_string", false));
+    value->set_is32bitString(p.boolOr("is_32bit_string", false));
+    value->set_isRawString(p.boolOr("is_raw_string", false));
+    value->set_raw_string_value(p.stringOr("raw_string_value"));
+    return value;
+  }
+  if (kind == "SgEnumVal") {
+    return new SgEnumVal(p.intOr("value", 0),
+                         static_cast<SgEnumDeclaration *>(nullptr),
+                         SgName(p.stringOr("name")));
+  }
+  if (kind == "SgTemplateParameterVal") {
+    SgTemplateParameterVal *value = new SgTemplateParameterVal(
+        static_cast<int>(p.intOr("template_parameter_position", -1)),
+        p.stringOr("value_string"));
+    value->set_valueType(SageBuilder::buildUnknownType());
+    return value;
+  }
+  if (kind == "SgThisExp") {
+    return new SgThisExp(static_cast<SgClassSymbol *>(nullptr),
+                         static_cast<SgNonrealSymbol *>(nullptr),
+                         static_cast<int>(p.intOr("pobj_this", 0)));
+  }
+  if (kind == "SgNonrealRefExp") {
+    return new SgNonrealRefExp(static_cast<SgNonrealSymbol *>(nullptr));
+  }
+  if (kind == "SgNullExpression") {
+    return new SgNullExpression();
+  }
+  if (kind == "SgNullptrValExp") {
+    return new SgNullptrValExp();
+  }
+  if (kind == "SgCastExp") {
+    return new SgCastExp(static_cast<SgExpression *>(nullptr),
+                         earlyTypeFromProperties(p),
+                         static_cast<SgCastExp::cast_type_enum>(
+                             p.intOr("cast_type", SgCastExp::e_C_style_cast)));
+  }
+  if (kind == "SgConstructorInitializer") {
+    // The final expression type can reference declarations by serialized node
+    // id. Allocate a valid placeholder now and rebuild it after all ids exist.
+    return new SgConstructorInitializer(
+        static_cast<SgMemberFunctionDeclaration *>(nullptr),
+        static_cast<SgExprListExp *>(nullptr), SageBuilder::buildUnknownType(),
+        p.boolOr("need_name", false), p.boolOr("need_qualifier", false),
+        p.boolOr("need_parenthesis_after_name", false), true);
+  }
+  if (kind == "SgSizeOfOp") {
+    return new SgSizeOfOp(static_cast<SgExpression *>(nullptr), nullptr,
+                          earlyTypeFromProperties(p));
+  }
+  if (kind == "SgConditionalExp") {
+    return new SgConditionalExp(static_cast<SgExpression *>(nullptr),
+                                static_cast<SgExpression *>(nullptr),
+                                static_cast<SgExpression *>(nullptr),
+                                earlyTypeFromProperties(p));
+  }
+  if (kind == "SgStatementExpression") {
+    return new SgStatementExpression(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgNewExp") {
+    SgNewExp *expr = new SgNewExp(
+        SageBuilder::buildUnknownType(), static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgConstructorInitializer *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<short>(p.intOr("need_global_specifier", 0)),
+        static_cast<SgFunctionDeclaration *>(nullptr));
+    expr->set_type_id_is_parenthesized(
+        p.boolOr("type_id_is_parenthesized", false));
+    return expr;
+  }
+  if (kind == "SgDeleteExp") {
+    return new SgDeleteExp(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<short>(p.intOr("is_array", 0)),
+        static_cast<short>(p.intOr("need_global_specifier", 0)),
+        static_cast<SgFunctionDeclaration *>(nullptr));
+  }
+  if (kind == "SgPackExpansionExpr") {
+    return new SgPackExpansionExpr(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgTypeTraitBuiltinOperator") {
+    return new SgTypeTraitBuiltinOperator(SgName(p.stringOr("name")));
+  }
+
+  if (SgBinaryOp *binary =
+          buildBinaryOpForKind(kind, SageBuilder::buildUnknownType())) {
+    return binary;
+  }
+
+  if (SgUnaryOp *unary =
+          buildUnaryOpForKind(kind, SageBuilder::buildUnknownType(), p)) {
+    return unary;
+  }
+  if (kind == "SgSubscriptExpression") {
+    return new SgSubscriptExpression(static_cast<SgExpression *>(nullptr),
+                                     static_cast<SgExpression *>(nullptr),
+                                     static_cast<SgExpression *>(nullptr));
+  }
+
+  if (kind == "SgTemplateArgument") {
+    return new SgTemplateArgument(
+        static_cast<SgTemplateArgument::template_argument_enum>(
+            p.intOr("argument_type", SgTemplateArgument::argument_undefined)),
+        p.boolOr("is_array_bound_unknown_type", false), nullptr, nullptr,
+        nullptr, p.boolOr("explicitly_specified", true));
+  }
+  if (kind == "SgTemplateParameter") {
+    return new SgTemplateParameter(
+        static_cast<SgTemplateParameter::template_parameter_enum>(p.intOr(
+            "parameter_type", SgTemplateParameter::parameter_undefined)),
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  }
+
+  if (kind == "SgOmpMapClause") {
+    return new SgOmpMapClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_map_operator_enum>(
+            p.intOr("operation", SgOmpClause::e_omp_map_unknown)));
+  }
+  if (kind == "SgOmpDependClause") {
+    return new SgOmpDependClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_depend_modifier_enum>(p.intOr(
+            "depend_modifier", SgOmpClause::e_omp_depend_modifier_unspecified)),
+        static_cast<SgOmpClause::omp_dependence_type_enum>(
+            p.intOr("dependence_type", SgOmpClause::e_omp_depend_unspecified)));
+  }
+  if (kind == "SgOmpAffinityClause") {
+    return new SgOmpAffinityClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_affinity_modifier_enum>(
+            p.intOr("affinity_modifier",
+                    SgOmpClause::e_omp_affinity_modifier_unspecified)));
+  }
+  if (kind == "SgOmpToClause") {
+    return new SgOmpToClause(static_cast<SgExprListExp *>(nullptr),
+                             static_cast<SgOmpClause::omp_to_kind_enum>(p.intOr(
+                                 "kind", SgOmpClause::e_omp_to_kind_unknown)));
+  }
+  if (kind == "SgOmpFromClause") {
+    return new SgOmpFromClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_from_kind_enum>(
+            p.intOr("kind", SgOmpClause::e_omp_from_kind_unknown)));
+  }
+  if (kind == "SgOmpDefaultClause") {
+    return new SgOmpDefaultClause(
+        static_cast<SgOmpClause::omp_default_option_enum>(
+            p.intOr("data_sharing", SgOmpClause::e_omp_default_unknown)),
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpProcBindClause") {
+    return new SgOmpProcBindClause(
+        static_cast<SgOmpClause::omp_proc_bind_policy_enum>(
+            p.intOr("policy", SgOmpClause::e_omp_proc_bind_policy_unknown)));
+  }
+  if (kind == "SgOmpNowaitClause") {
+    return new SgOmpNowaitClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpOrderedClause") {
+    return new SgOmpOrderedClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpCollapseClause") {
+    return new SgOmpCollapseClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpIfClause") {
+    return new SgOmpIfClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_if_modifier_enum>(
+            p.intOr("modifier", SgOmpClause::e_omp_if_modifier_unknown)));
+  }
+  if (kind == "SgOmpNumThreadsClause") {
+    return new SgOmpNumThreadsClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpNumTeamsClause") {
+    return new SgOmpNumTeamsClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpSafelenClause") {
+    return new SgOmpSafelenClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpSimdlenClause") {
+    return new SgOmpSimdlenClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpPrivateClause") {
+    return new SgOmpPrivateClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpFirstprivateClause") {
+    return new SgOmpFirstprivateClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpCopyinClause") {
+    return new SgOmpCopyinClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpLastprivateClause") {
+    return new SgOmpLastprivateClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_lastprivate_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_lastprivate_modifier_unspecified)));
+  }
+  if (kind == "SgOmpReductionClause") {
+    return new SgOmpReductionClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_reduction_modifier_enum>(
+            p.intOr("modifier", SgOmpClause::e_omp_reduction_modifier_unknown)),
+        static_cast<SgOmpClause::omp_reduction_identifier_enum>(
+            p.intOr("identifier", SgOmpClause::e_omp_reduction_unknown)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpLinearClause") {
+    return new SgOmpLinearClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_linear_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_linear_modifier_unspecified)));
+  }
+  if (kind == "SgOmpAlignedClause") {
+    return new SgOmpAlignedClause(static_cast<SgExprListExp *>(nullptr),
+                                  static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpSharedClause") {
+    return new SgOmpSharedClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpScheduleClause") {
+    return new SgOmpScheduleClause(
+        static_cast<SgOmpClause::omp_schedule_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_schedule_modifier_unspecified)),
+        static_cast<SgOmpClause::omp_schedule_modifier_enum>(p.intOr(
+            "modifier1", SgOmpClause::e_omp_schedule_modifier_unspecified)),
+        static_cast<SgOmpClause::omp_schedule_kind_enum>(
+            p.intOr("kind", SgOmpClause::e_omp_schedule_kind_unspecified)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpDistScheduleClause") {
+    return new SgOmpDistScheduleClause(
+        static_cast<SgOmpClause::omp_dist_schedule_kind_enum>(
+            p.intOr("kind", SgOmpClause::e_omp_dist_schedule_kind_unspecified)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpOrderClause") {
+    return new SgOmpOrderClause(
+        static_cast<SgOmpClause::omp_order_kind_enum>(
+            p.intOr("kind", SgOmpClause::e_omp_order_kind_unspecified)),
+        static_cast<SgOmpClause::omp_order_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_order_modifier_unspecified)));
+  }
+  if (kind == "SgOmpAtomicDefaultMemOrderClause") {
+    return new SgOmpAtomicDefaultMemOrderClause(
+        static_cast<SgOmpClause::omp_atomic_default_mem_order_kind_enum>(
+            p.intOr(
+                "kind",
+                SgOmpClause::e_omp_atomic_default_mem_order_kind_unspecified)));
+  }
+  if (kind == "SgOmpDefaultmapClause") {
+    return new SgOmpDefaultmapClause(
+        static_cast<SgOmpClause::omp_defaultmap_behavior_enum>(p.intOr(
+            "behavior", SgOmpClause::e_omp_defaultmap_behavior_unspecified)),
+        static_cast<SgOmpClause::omp_defaultmap_category_enum>(p.intOr(
+            "category", SgOmpClause::e_omp_defaultmap_category_unspecified)));
+  }
+  if (kind == "SgOmpBindClause") {
+    return new SgOmpBindClause(static_cast<SgOmpClause::omp_bind_binding_enum>(
+        p.intOr("binding", SgOmpClause::e_omp_bind_binding_unspecified)));
+  }
+  if (kind == "SgOmpParallelClause") {
+    return new SgOmpParallelClause();
+  }
+  if (kind == "SgOmpSectionsClause") {
+    return new SgOmpSectionsClause();
+  }
+  if (kind == "SgOmpForClause") {
+    return new SgOmpForClause();
+  }
+  if (kind == "SgOmpTaskgroupClause") {
+    return new SgOmpTaskgroupClause();
+  }
+  if (kind == "SgOmpFullClause") {
+    return new SgOmpFullClause();
+  }
+  if (kind == "SgOmpInbranchClause") {
+    return new SgOmpInbranchClause();
+  }
+  if (kind == "SgOmpNocontextClause") {
+    return new SgOmpNocontextClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpNovariantsClause") {
+    return new SgOmpNovariantsClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpPartialClause") {
+    return new SgOmpPartialClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpBeginClause") {
+    return new SgOmpBeginClause();
+  }
+  if (kind == "SgOmpEndClause") {
+    return new SgOmpEndClause();
+  }
+  if (kind == "SgOmpReadClause") {
+    return new SgOmpReadClause();
+  }
+  if (kind == "SgOmpWriteClause") {
+    return new SgOmpWriteClause();
+  }
+  if (kind == "SgOmpUpdateClause") {
+    return new SgOmpUpdateClause();
+  }
+  if (kind == "SgOmpCaptureClause") {
+    return new SgOmpCaptureClause();
+  }
+  if (kind == "SgOmpCompareClause") {
+    return new SgOmpCompareClause();
+  }
+  if (kind == "SgOmpSeqCstClause") {
+    return new SgOmpSeqCstClause();
+  }
+  if (kind == "SgOmpAcqRelClause") {
+    return new SgOmpAcqRelClause();
+  }
+  if (kind == "SgOmpReleaseClause") {
+    return new SgOmpReleaseClause();
+  }
+  if (kind == "SgOmpAcquireClause") {
+    return new SgOmpAcquireClause();
+  }
+  if (kind == "SgOmpRelaxedClause") {
+    return new SgOmpRelaxedClause();
+  }
+  if (kind == "SgOmpFailClause") {
+    return new SgOmpFailClause(
+        static_cast<SgOmpClause::omp_fail_memory_order_kind_enum>(
+            p.intOr("memory_order",
+                    SgOmpClause::e_omp_fail_memory_order_kind_unspecified)));
+  }
+  if (kind == "SgOmpCopyprivateClause") {
+    return new SgOmpCopyprivateClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpAllocateClause") {
+    return new SgOmpAllocateClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_allocate_modifier_enum>(
+            p.intOr("modifier", SgOmpClause::e_omp_allocate_modifier_unknown)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpAllocatorClause") {
+    return new SgOmpAllocatorClause(
+        static_cast<SgOmpClause::omp_allocator_modifier_enum>(
+            p.intOr("modifier", SgOmpClause::e_omp_allocator_modifier_unknown)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpAdjustArgsClause") {
+    return new SgOmpAdjustArgsClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_adjust_args_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_adjust_args_modifier_unknown)));
+  }
+  if (kind == "SgOmpInReductionClause") {
+    return new SgOmpInReductionClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_in_reduction_identifier_enum>(
+            p.intOr("identifier",
+                    SgOmpClause::e_omp_in_reduction_identifier_unspecified)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpTaskReductionClause") {
+    return new SgOmpTaskReductionClause(
+        static_cast<SgExprListExp *>(nullptr),
+        static_cast<SgOmpClause::omp_task_reduction_identifier_enum>(
+            p.intOr("identifier",
+                    SgOmpClause::e_omp_task_reduction_identifier_unspecified)),
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpUniformClause") {
+    return new SgOmpUniformClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpHintClause") {
+    return new SgOmpHintClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpNogroupClause") {
+    return new SgOmpNogroupClause();
+  }
+  if (kind == "SgOmpUntiedClause") {
+    return new SgOmpUntiedClause();
+  }
+  if (kind == "SgOmpMergeableClause") {
+    return new SgOmpMergeableClause();
+  }
+  if (kind == "SgOmpReverseOffloadClause") {
+    return new SgOmpReverseOffloadClause();
+  }
+  if (kind == "SgOmpUnifiedAddressClause") {
+    return new SgOmpUnifiedAddressClause();
+  }
+  if (kind == "SgOmpUnifiedSharedMemoryClause") {
+    return new SgOmpUnifiedSharedMemoryClause();
+  }
+  if (kind == "SgOmpDynamicAllocatorsClause") {
+    return new SgOmpDynamicAllocatorsClause();
+  }
+  if (kind == "SgOmpDepobjUpdateClause") {
+    return new SgOmpDepobjUpdateClause(
+        static_cast<SgOmpClause::omp_depobj_modifier_enum>(
+            p.intOr("modifier", SgOmpClause::e_omp_depobj_modifier_unknown)));
+  }
+  if (kind == "SgOmpDestroyClause") {
+    return new SgOmpDestroyClause();
+  }
+  if (kind == "SgOmpThreadLimitClause") {
+    return new SgOmpThreadLimitClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpUsesAllocatorsClause") {
+    return new SgOmpUsesAllocatorsClause();
+  }
+  if (kind == "SgOmpUsesAllocatorsDefination") {
+    SgOmpUsesAllocatorsDefination *definition =
+        new SgOmpUsesAllocatorsDefination();
+    definition->set_user_defined_allocator(nullptr);
+    definition->set_allocator_traits_array(nullptr);
+    return definition;
+  }
+  if (kind == "SgOmpWhenClause") {
+    return new SgOmpWhenClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_when_context_kind_enum>(p.intOr(
+            "device_kind", SgOmpClause::e_omp_when_context_kind_unknown)),
+        static_cast<SgOmpClause::omp_when_context_vendor_enum>(
+            p.intOr("implementation_vendor",
+                    SgOmpClause::e_omp_when_context_vendor_unspecified)),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpMatchClause") {
+    SgOmpMatchClause *clause = new SgOmpMatchClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_when_context_kind_enum>(p.intOr(
+            "device_kind", SgOmpClause::e_omp_when_context_kind_unknown)),
+        static_cast<SgOmpClause::omp_when_context_vendor_enum>(
+            p.intOr("implementation_vendor",
+                    SgOmpClause::e_omp_when_context_vendor_unspecified)),
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgExpression *>(nullptr));
+    clause->set_target_device_selector(
+        p.boolOr("target_device_selector", false));
+    return clause;
+  }
+  if (kind == "SgOmpNontemporalClause") {
+    return new SgOmpNontemporalClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpIsDevicePtrClause") {
+    return new SgOmpIsDevicePtrClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpUseDevicePtrClause") {
+    return new SgOmpUseDevicePtrClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpUseDeviceAddrClause") {
+    return new SgOmpUseDeviceAddrClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpHasDeviceAddrClause") {
+    return new SgOmpHasDeviceAddrClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpDetachClause") {
+    return new SgOmpDetachClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpNumTasksClause") {
+    return new SgOmpNumTasksClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_num_tasks_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_num_tasks_modifier_unspecified)));
+  }
+  if (kind == "SgOmpGrainsizeClause") {
+    return new SgOmpGrainsizeClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_grainsize_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_grainsize_modifier_unspecified)));
+  }
+  if (kind == "SgOmpSizesClause") {
+    return new SgOmpSizesClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpPriorityClause") {
+    return new SgOmpPriorityClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpFinalClause") {
+    return new SgOmpFinalClause(static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpNotinbranchClause") {
+    return new SgOmpNotinbranchClause();
+  }
+  if (kind == "SgOmpExclusiveClause") {
+    return new SgOmpExclusiveClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpInclusiveClause") {
+    return new SgOmpInclusiveClause(static_cast<SgExprListExp *>(nullptr));
+  }
+  if (kind == "SgOmpExtImplementationDefinedRequirementClause") {
+    return new SgOmpExtImplementationDefinedRequirementClause(
+        static_cast<SgExpression *>(nullptr));
+  }
+  if (kind == "SgOmpDeviceClause") {
+    return new SgOmpDeviceClause(
+        static_cast<SgExpression *>(nullptr),
+        static_cast<SgOmpClause::omp_device_modifier_enum>(p.intOr(
+            "modifier", SgOmpClause::e_omp_device_modifier_unspecified)));
+  }
+  if (kind == "SgOmpRequiresStatement") {
+    return new SgOmpRequiresStatement();
+  }
+  if (kind == "SgOmpBarrierStatement") {
+    return new SgOmpBarrierStatement();
+  }
+  if (kind == "SgOmpTaskwaitStatement") {
+    return new SgOmpTaskwaitStatement();
+  }
+  if (kind == "SgOmpOrderedDependStatement") {
+    return new SgOmpOrderedDependStatement();
+  }
+  if (kind == "SgOmpScanStatement") {
+    return new SgOmpScanStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpFlushStatement") {
+    return new SgOmpFlushStatement();
+  }
+  if (kind == "SgOmpDeclareSimdStatement") {
+    return new SgOmpDeclareSimdStatement();
+  }
+  if (kind == "SgOmpDeclareMapperStatement") {
+    return new SgOmpDeclareMapperStatement();
+  }
+  if (kind == "SgOmpDeclareTargetStatement") {
+    SgOmpDeclareTargetStatement *stmt = new SgOmpDeclareTargetStatement();
+    stmt->set_device_type_kind(
+        static_cast<SgOmpClause::omp_when_context_kind_enum>(p.intOr(
+            "device_type_kind", SgOmpClause::e_omp_when_context_kind_unknown)));
+    return stmt;
+  }
+  if (kind == "SgOmpEndDeclareTargetStatement") {
+    return new SgOmpEndDeclareTargetStatement();
+  }
+  if (kind == "SgOmpDeclareVariantStatement") {
+    return new SgOmpDeclareVariantStatement();
+  }
+  if (kind == "SgOmpBeginDeclareVariantStatement") {
+    SgOmpBeginDeclareVariantStatement *stmt =
+        new SgOmpBeginDeclareVariantStatement();
+    stmt->set_captured_region(p.stringOr("captured_region"));
+    return stmt;
+  }
+  if (kind == "SgOmpEndDeclareVariantStatement") {
+    return new SgOmpEndDeclareVariantStatement();
+  }
+  if (kind == "SgOmpThreadprivateStatement") {
+    return new SgOmpThreadprivateStatement();
+  }
+  if (kind == "SgOmpAllocateStatement") {
+    return new SgOmpAllocateStatement();
+  }
+  if (kind == "SgOmpTargetUpdateStatement") {
+    return new SgOmpTargetUpdateStatement();
+  }
+  if (kind == "SgOmpTargetEnterDataStatement") {
+    return new SgOmpTargetEnterDataStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetExitDataStatement") {
+    return new SgOmpTargetExitDataStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetStatement") {
+    return new SgOmpTargetStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetDataStatement") {
+    return new SgOmpTargetDataStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpParallelStatement") {
+    return new SgOmpParallelStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpForStatement") {
+    return new SgOmpForStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDoStatement") {
+    return new SgOmpDoStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpForSimdStatement") {
+    return new SgOmpForSimdStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpLoopStatement") {
+    return new SgOmpLoopStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpSimdStatement") {
+    return new SgOmpSimdStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpSingleStatement") {
+    return new SgOmpSingleStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTaskStatement") {
+    return new SgOmpTaskStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpMasterStatement") {
+    return new SgOmpMasterStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpParallelMasterStatement") {
+    return new SgOmpParallelMasterStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpMasterTaskloopStatement") {
+    return new SgOmpMasterTaskloopStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpMasterTaskloopSimdStatement") {
+    return new SgOmpMasterTaskloopSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpParallelMasterTaskloopStatement") {
+    return new SgOmpParallelMasterTaskloopStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpParallelMasterTaskloopSimdStatement") {
+    return new SgOmpParallelMasterTaskloopSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpSectionStatement") {
+    return new SgOmpSectionStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpSectionsStatement") {
+    return new SgOmpSectionsStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpCriticalStatement") {
+    return new SgOmpCriticalStatement(static_cast<SgStatement *>(nullptr),
+                                      SgName(p.stringOr("name")));
+  }
+  if (kind == "SgOmpAtomicStatement") {
+    return new SgOmpAtomicStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpOrderedStatement") {
+    return new SgOmpOrderedStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpParallelLoopStatement") {
+    return new SgOmpParallelLoopStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTaskgroupStatement") {
+    return new SgOmpTaskgroupStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTaskloopStatement") {
+    return new SgOmpTaskloopStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTaskloopSimdStatement") {
+    return new SgOmpTaskloopSimdStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTaskyieldStatement") {
+    return new SgOmpTaskyieldStatement();
+  }
+  if (kind == "SgOmpCancelStatement") {
+    return new SgOmpCancelStatement();
+  }
+  if (kind == "SgOmpCancellationPointStatement") {
+    return new SgOmpCancellationPointStatement();
+  }
+  if (kind == "SgOmpDepobjStatement") {
+    return new SgOmpDepobjStatement(static_cast<SgStatement *>(nullptr),
+                                    SgName(p.stringOr("name")));
+  }
+  if (kind == "SgOmpMetadirectiveStatement") {
+    return new SgOmpMetadirectiveStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDispatchStatement") {
+    return new SgOmpDispatchStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDistributeStatement") {
+    return new SgOmpDistributeStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpWorkdistributeStatement") {
+    return new SgOmpWorkdistributeStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDistributeSimdStatement") {
+    return new SgOmpDistributeSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDistributeParallelForStatement") {
+    return new SgOmpDistributeParallelForStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpDistributeParallelForSimdStatement") {
+    return new SgOmpDistributeParallelForSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetParallelStatement") {
+    return new SgOmpTargetParallelStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetParallelForStatement") {
+    return new SgOmpTargetParallelForStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetParallelForSimdStatement") {
+    return new SgOmpTargetParallelForSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetParallelLoopStatement") {
+    return new SgOmpTargetParallelLoopStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetSimdStatement") {
+    return new SgOmpTargetSimdStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsStatement") {
+    return new SgOmpTargetTeamsStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsStatement") {
+    return new SgOmpTeamsStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsDistributeStatement") {
+    return new SgOmpTeamsDistributeStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsDistributeSimdStatement") {
+    return new SgOmpTeamsDistributeSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsDistributeParallelForStatement") {
+    return new SgOmpTeamsDistributeParallelForStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsDistributeParallelForSimdStatement") {
+    return new SgOmpTeamsDistributeParallelForSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTeamsLoopStatement") {
+    return new SgOmpTeamsLoopStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpWorkshareStatement") {
+    return new SgOmpWorkshareStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpUnrollStatement") {
+    return new SgOmpUnrollStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTileStatement") {
+    return new SgOmpTileStatement(static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsDistributeStatement") {
+    return new SgOmpTargetTeamsDistributeStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsDistributeSimdStatement") {
+    return new SgOmpTargetTeamsDistributeSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsLoopStatement") {
+    return new SgOmpTargetTeamsLoopStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsDistributeParallelForStatement") {
+    return new SgOmpTargetTeamsDistributeParallelForStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+  if (kind == "SgOmpTargetTeamsDistributeParallelForSimdStatement") {
+    return new SgOmpTargetTeamsDistributeParallelForSimdStatement(
+        static_cast<SgStatement *>(nullptr));
+  }
+
+  throw std::runtime_error("AST JSON deserializer does not support Sage node " +
+                           kind);
+}
+
+std::vector<EdgeRecord> edgesFor(const NodeRecord &record,
+                                 const std::string &field) {
+  std::vector<EdgeRecord> result;
+  for (const EdgeRecord &edge : record.edges) {
+    if (edge.field == field) {
+      result.push_back(edge);
+    }
+  }
+  std::sort(result.begin(), result.end(),
+            [](const EdgeRecord &a, const EdgeRecord &b) {
+              return a.index < b.index;
+            });
+  return result;
+}
+
+uint64_t singleEdgeTarget(const NodeRecord &record, const std::string &field) {
+  std::vector<EdgeRecord> edges = edgesFor(record, field);
+  return edges.empty() ? 0 : edges.front().target;
+}
+
+SgBitVector bitVectorFromJson(const JsonValue &json,
+                              const std::string &field_name) {
+  if (json.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON " + field_name +
+                             " field is not a bool array");
+  }
+  SgBitVector bits;
+  bits.reserve(json.array.size());
+  for (const JsonValue &value : json.array) {
+    if (value.kind != JsonValue::Kind::Bool) {
+      throw std::runtime_error("AST JSON " + field_name +
+                               " contains a non-bool value");
+    }
+    bits.push_back(value.asBool());
+  }
+  return bits;
+}
+
+SgModuleStatement *externalModuleFromJson(const JsonValue &json) {
+  if (!json.boolOr("present", false)) {
+    return nullptr;
+  }
+  const std::string name = json.at("name").asString();
+  if (name.empty()) {
+    throw std::runtime_error("AST JSON external_module is missing module name");
+  }
+  SgModuleStatement *module =
+      new SgModuleStatement(SgName(name),
+                            static_cast<SgClassDeclaration::class_types>(
+                                json.at("class_type").asInt()),
+                            nullptr, nullptr);
+  installTransformationSourcePosition(module);
+  markAstJsonExternalModule(module, json.stringOr("source_file"));
+  return module;
+}
+
+SgFunctionDeclaration *externalFunctionFromJson(const JsonValue &json,
+                                                const NodeMap &nodes) {
+  if (!json.boolOr("present", false)) {
+    return nullptr;
+  }
+  const std::string name = json.at("name").asString();
+  if (name.empty()) {
+    throw std::runtime_error("AST JSON external_function is missing name");
+  }
+  const std::string source_file = json.at("source_file").asString();
+  if (source_file.empty()) {
+    throw std::runtime_error("AST JSON external_function " + name +
+                             " requires a non-empty source_file");
+  }
+  SgFunctionType *function_type =
+      isSgFunctionType(typeFromJson(json.at("function_type"), nodes));
+  if (function_type == nullptr) {
+    throw std::runtime_error(
+        "AST JSON external_function function_type is not a SgFunctionType");
+  }
+
+  SgFunctionDeclaration *decl = nullptr;
+  const std::string kind = json.at("kind").asString();
+  if (kind == "SgProcedureHeaderStatement") {
+    SgProcedureHeaderStatement *procedure =
+        new SgProcedureHeaderStatement(SgName(name), function_type, nullptr);
+    procedure->set_subprogram_kind(
+        static_cast<SgProcedureHeaderStatement::subprogram_kind_enum>(
+            json.intOr(
+                "subprogram_kind",
+                SgProcedureHeaderStatement::e_function_subprogram_kind)));
+    decl = procedure;
+  } else if (kind == "SgFunctionDeclaration") {
+    decl = new SgFunctionDeclaration(SgName(name), function_type, nullptr);
+  } else {
+    throw std::runtime_error(
+        "AST JSON external_function has unsupported declaration kind: " + kind);
+  }
+
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + name +
+                             " has no location");
+  }
+  restoreNodeSourcePositionFromJson(decl, *location,
+                                    "external_function " + name);
+  SgFunctionParameterList *parameter_list = decl->get_parameterList();
+  if (parameter_list == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + name +
+                             " constructor did not create a parameterList");
+  }
+  const JsonValue *parameter_list_location =
+      json.find("parameter_list_location");
+  if (parameter_list_location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + name +
+                             " has no parameter_list_location");
+  }
+  restoreNodeSourcePositionFromJson(parameter_list, *parameter_list_location,
+                                    "external_function parameterList " + name);
+  parameter_list->set_parent(decl);
+  if (json.boolOr("parameter_list_syntax_aliases_parameter_list", false)) {
+    decl->set_parameterList_syntax(parameter_list);
+  }
+  const JsonValue *function_parameter_scope =
+      json.find("function_parameter_scope");
+  if (function_parameter_scope == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + name +
+                             " has no function_parameter_scope");
+  }
+  SgFunctionParameterScope *parameter_scope =
+      externalFunctionParameterScopeFromJson(*function_parameter_scope, nodes,
+                                             name);
+  if (parameter_scope != nullptr) {
+    parameter_scope->set_parent(decl);
+    decl->set_functionParameterScope(parameter_scope);
+  }
+  decl->set_firstNondefiningDeclaration(decl);
+  decl->set_definingDeclaration(nullptr);
+  markAstJsonExternalFunction(decl, source_file);
+  return decl;
+}
+
+SgDeclarationStatement *externalDeclarationReferenceFromJson(
+    const JsonValue *json, const NodeMap &nodes, const std::string &context) {
+  if (json == nullptr || !json->boolOr("present", false)) {
+    return nullptr;
+  }
+  const std::string kind = json->at("kind").asString();
+  if (const JsonValue *external = json->find("external_function")) {
+    SgFunctionDeclaration *decl = externalFunctionFromJson(*external, nodes);
+    if (decl == nullptr) {
+      throw std::runtime_error("AST JSON " + context +
+                               " external_function reconstructed as null");
+    }
+    return decl;
+  }
+  if (const JsonValue *external = json->find("external_module")) {
+    SgModuleStatement *module = externalModuleFromJson(*external);
+    if (module == nullptr) {
+      throw std::runtime_error("AST JSON " + context +
+                               " external_module reconstructed as null");
+    }
+    return module;
+  }
+  if (const JsonValue *external = json->find("external_class")) {
+    SgClassDeclaration *decl = externalClassDeclarationFromJson(*external);
+    if (decl == nullptr) {
+      throw std::runtime_error("AST JSON " + context +
+                               " external_class reconstructed as null");
+    }
+    return decl;
+  }
+  throw std::runtime_error(
+      "AST JSON " + context +
+      " has unsupported external declaration kind: " + kind);
+}
+
+template <typename ListT, typename NodeT>
+void appendEdgeList(ListT &list, const NodeRecord &record,
+                    const std::string &field, const NodeMap &nodes,
+                    SgNode *parent, bool owns_children = true) {
+  for (const EdgeRecord &edge : edgesFor(record, field)) {
+    NodeT *child = nodeByIdAs<NodeT>(nodes, edge.target);
+    list.push_back(child);
+    if (owns_children) {
+      child->set_parent(parent);
+      if (SgDeclarationStatement *decl = isSgDeclarationStatement(child)) {
+        if (decl->get_scope() == nullptr) {
+          decl->set_scope(isSgScopeStatement(parent));
+        }
+      }
+    }
+  }
+}
+
+void setNodeSourcePosition(SgNode *node, const NodeRecord &record) {
+  const JsonValue *start = record.location.find("start");
+  const JsonValue *end = record.location.find("end");
+  Sg_File_Info *start_info =
+      start != nullptr ? buildFileInfo(*start, node) : nullptr;
+  Sg_File_Info *end_info = end != nullptr ? buildFileInfo(*end, node) : nullptr;
+
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    located->set_startOfConstruct(start_info);
+    located->set_endOfConstruct(end_info);
+  } else if (SgPragma *pragma = isSgPragma(node)) {
+    pragma->set_startOfConstruct(start_info);
+    pragma->set_endOfConstruct(end_info);
+  } else if (SgInitializedName *name = isSgInitializedName(node)) {
+    name->set_startOfConstruct(start_info);
+    name->set_endOfConstruct(end_info);
+  } else if (SgFile *file = isSgFile(node)) {
+    file->set_startOfConstruct(start_info);
+  }
+}
+
+void setNodeFlags(SgNode *node, const NodeRecord &record) {
+  node->set_containsTransformation(
+      record.flags.boolOr("contains_transformation", false));
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    located->set_containsTransformationToSurroundingWhitespace(
+        record.flags.boolOr("contains_transformation_to_surrounding_whitespace",
+                            false));
+  }
+}
+
+void restoreAvailableSourcePositionsAndScopes(const AstFileRecord &ast,
+                                              const NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    auto found = nodes.find(record.id);
+    if (found == nodes.end()) {
+      continue;
+    }
+    setNodeSourcePosition(found->second, record);
+    setNodeFlags(found->second, record);
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    auto found = nodes.find(record.id);
+    if (found == nodes.end()) {
+      continue;
+    }
+    if (uint64_t target = singleEdgeTarget(record, "parent")) {
+      auto parent = nodes.find(target);
+      if (parent != nodes.end()) {
+        found->second->set_parent(parent->second);
+      }
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    auto found = nodes.find(record.id);
+    if (found == nodes.end()) {
+      continue;
+    }
+    SgNode *node = found->second;
+    if (SgInitializedName *name = isSgInitializedName(node)) {
+      if (uint64_t target = singleEdgeTarget(record, "scope")) {
+        auto scope = nodes.find(target);
+        if (scope != nodes.end()) {
+          name->set_scope(isSgScopeStatement(scope->second));
+        }
+      }
+    }
+    if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+      if (uint64_t target = singleEdgeTarget(record, "scope")) {
+        auto scope = nodes.find(target);
+        if (scope != nodes.end()) {
+          decl->set_scope(isSgScopeStatement(scope->second));
+        }
+      }
+    }
+  }
+}
+
+void attachPreprocessingInfo(SgNode *node, const NodeRecord &record) {
+  SgLocatedNode *located = isSgLocatedNode(node);
+  if (located == nullptr ||
+      record.preprocessing.kind != JsonValue::Kind::Array) {
+    return;
+  }
+  auto make_info = [](const JsonValue &entry) {
+    if (entry.kind != JsonValue::Kind::Object) {
+      throw std::runtime_error("AST JSON preprocessing entry is not an object");
+    }
+    Sg_File_Info *file_info =
+        buildFileInfo(entry.at("file_info"), SgTypeDefault::createType());
+    if (file_info == nullptr) {
+      throw std::runtime_error(
+          "AST JSON preprocessing entry requires present file_info");
+    }
+    PreprocessingInfo *info = new PreprocessingInfo(
+        static_cast<PreprocessingInfo::DirectiveType>(
+            entry.intOr("directive", 0)),
+        entry.stringOr("text"), file_info->get_filenameString(),
+        file_info->get_line(), file_info->get_col(),
+        static_cast<int>(entry.intOr("lines", 1)),
+        static_cast<PreprocessingInfo::RelativePositionType>(
+            entry.intOr("relative", PreprocessingInfo::before)));
+    Sg_File_Info *constructor_file_info = info->get_file_info();
+    info->set_file_info(file_info);
+    delete constructor_file_info;
+    if (entry.boolOr("transformation", false)) {
+      info->setAsTransformation();
+    } else {
+      info->unsetAsTransformation();
+    }
+    return info;
+  };
+  AttachedPreprocessingInfoType *&infos =
+      located->getAttachedPreprocessingInfo();
+  if (infos == nullptr) {
+    infos = new AttachedPreprocessingInfoType;
+  } else {
+    infos->clear();
+  }
+  for (const JsonValue &entry : record.preprocessing.array) {
+    infos->push_back(make_info(entry));
+  }
+}
+
+void attachAstAttributes(SgNode *node, const NodeRecord &record) {
+  const JsonValue *attributes = record.properties.find("attributes");
+  if (node == nullptr || attributes == nullptr ||
+      attributes->kind != JsonValue::Kind::Array) {
+    return;
+  }
+  for (const JsonValue &entry : attributes->array) {
+    const std::string name = entry.stringOr("name");
+    const std::string type = entry.stringOr("type");
+    if (name.empty()) {
+      continue;
+    }
+    if (type == "AstIntAttribute") {
+      node->setAttribute(
+          name, new AstIntAttribute(static_cast<int>(entry.intOr("value", 0))));
+    } else if (type == "AstStringAttribute") {
+      node->setAttribute(
+          name, new AstValueAttribute<std::string>(entry.stringOr("value")));
+    } else if (type == "AstMarkerAttribute") {
+      node->setAttribute(name, new AstJsonMarkerAttribute());
+    } else {
+      throw std::runtime_error("AST JSON attribute type is unsupported: " +
+                               type);
+    }
+  }
+}
+
+void linkNodeEdges(const NodeRecord &record, const NodeMap &nodes) {
+  SgNode *node = nodeById(nodes, record.id);
+  if (uint64_t target = singleEdgeTarget(record, "parent")) {
+    node->set_parent(nodeById(nodes, target));
+  }
+  if (SgStatement *stmt = isSgStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "numeric_label")) {
+      SgLabelRefExp *label = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_numeric_label(label);
+      label->set_parent(stmt);
+    }
+  }
+
+  if (SgSourceFile *file = isSgSourceFile(node)) {
+    const uint64_t target = singleEdgeTarget(record, "globalScope");
+    if (target != 0) {
+      SgGlobal *global = nodeByIdAs<SgGlobal>(nodes, target);
+      file->set_globalScope(global);
+      global->set_parent(file);
+    }
+    appendEdgeList<SgTokenPtrList, SgToken>(file->get_token_list(), record,
+                                            "token_list", nodes, file);
+    return;
+  }
+  if (SgGlobal *global = isSgGlobal(node)) {
+    appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
+        global->get_declarations(), record, "declarations", nodes, global);
+    return;
+  }
+  if (SgNamespaceDefinitionStatement *def =
+          isSgNamespaceDefinitionStatement(node)) {
+    appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
+        def->get_declarations(), record, "declarations", nodes, def,
+        !def->get_isUnionOfReentrantNamespaceDefinitions());
+  }
+  if (SgDeclarationScope *scope = isSgDeclarationScope(node)) {
+    appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
+        scope->get_declarations(), record, "declarations", nodes, scope);
+  }
+  if (SgFunctionParameterScope *scope = isSgFunctionParameterScope(node)) {
+    appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
+        scope->get_declarations(), record, "declarations", nodes, scope);
+  }
+  if (SgBasicBlock *block = isSgBasicBlock(node)) {
+    appendEdgeList<SgStatementPtrList, SgStatement>(
+        block->get_statements(), record, "statements", nodes, block);
+    return;
+  }
+  if (SgFunctionParameterList *params = isSgFunctionParameterList(node)) {
+    appendEdgeList<SgInitializedNamePtrList, SgInitializedName>(
+        params->get_args(), record, "args", nodes, params);
+  }
+  if (SgExprListExp *exprs = isSgExprListExp(node)) {
+    appendEdgeList<SgExpressionPtrList, SgExpression>(
+        exprs->get_expressions(), record, "expressions", nodes, exprs);
+    return;
+  }
+  if (SgClassDefinition *def = isSgClassDefinition(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "declaration")) {
+      SgClassDeclaration *decl = nodeByIdAs<SgClassDeclaration>(nodes, target);
+      def->set_declaration(decl);
+      if (decl->get_definition() == nullptr) {
+        decl->set_definition(def);
+      }
+    }
+    appendEdgeList<SgBaseClassPtrList, SgBaseClass>(
+        def->get_inheritances(), record, "inheritances", nodes, def);
+    appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
+        def->get_members(), record, "members", nodes, def);
+    return;
+  }
+  if (SgBaseClass *base = isSgBaseClass(node)) {
+    uint64_t target = singleEdgeTarget(record, "base_class");
+    if (target == 0) {
+      target = static_cast<uint64_t>(record.properties.intOr("base_class", 0));
+    }
+    if (target != 0) {
+      base->set_base_class(nodeByIdAs<SgClassDeclaration>(nodes, target));
+    }
+    if (SgExpBaseClass *expr_base = isSgExpBaseClass(base)) {
+      if (uint64_t expr_target = singleEdgeTarget(record, "base_class_exp")) {
+        SgExpression *expr = nodeByIdAs<SgExpression>(nodes, expr_target);
+        expr_base->set_base_class_exp(expr);
+        expr->set_parent(expr_base);
+      } else if (const JsonValue *expr_json =
+                     record.properties.find("base_class_exp")) {
+        if (SgExpression *expr = expressionFromRef(*expr_json, nodes)) {
+          expr_base->set_base_class_exp(expr);
+          expr->set_parent(expr_base);
+        }
+      }
+    }
+    if (SgNonrealBaseClass *nonreal_base = isSgNonrealBaseClass(base)) {
+      uint64_t nonreal_target = singleEdgeTarget(record, "base_class_nonreal");
+      if (nonreal_target == 0) {
+        nonreal_target = static_cast<uint64_t>(
+            record.properties.intOr("base_class_nonreal", 0));
+      }
+      if (nonreal_target != 0) {
+        nonreal_base->set_base_class_nonreal(
+            nodeByIdAs<SgNonrealDecl>(nodes, nonreal_target));
+      }
+    }
+    return;
+  }
+  if (SgCtorInitializerList *ctors = isSgCtorInitializerList(node)) {
+    appendEdgeList<SgInitializedNamePtrList, SgInitializedName>(
+        ctors->get_ctors(), record, "ctors", nodes, ctors);
+  }
+  if (SgVariableDeclaration *decl = isSgVariableDeclaration(node)) {
+    appendEdgeList<SgInitializedNamePtrList, SgInitializedName>(
+        decl->get_variables(), record, "variables", nodes, decl);
+    if (uint64_t target =
+            singleEdgeTarget(record, "baseTypeDefiningDeclaration")) {
+      SgDeclarationStatement *base_decl =
+          nodeByIdAs<SgDeclarationStatement>(nodes, target);
+      decl->set_baseTypeDefiningDeclaration(base_decl);
+      base_decl->set_parent(decl);
+    }
+  }
+  if (SgVariableDefinition *def = isSgVariableDefinition(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "vardefn")) {
+      SgInitializedName *name = nodeByIdAs<SgInitializedName>(nodes, target);
+      def->set_vardefn(name);
+      name->set_definition(def);
+      def->set_parent(name);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "bitfield")) {
+      SgExpression *bitfield = nodeByIdAs<SgExpression>(nodes, target);
+      def->set_bitfield(bitfield);
+      bitfield->set_parent(def);
+    }
+  }
+  if (SgCommonBlock *stmt = isSgCommonBlock(node)) {
+    appendEdgeList<SgCommonBlockObjectPtrList, SgCommonBlockObject>(
+        stmt->get_block_list(), record, "block_list", nodes, stmt);
+  }
+  if (SgCommonBlockObject *object = isSgCommonBlockObject(node)) {
+    object->set_block_name(record.properties.stringOr("block_name"));
+    if (uint64_t target = singleEdgeTarget(record, "variable_reference_list")) {
+      SgExprListExp *list = nodeByIdAs<SgExprListExp>(nodes, target);
+      object->set_variable_reference_list(list);
+      list->set_parent(object);
+    }
+  }
+  if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+    appendEdgeList<SgInitializedNamePtrList, SgInitializedName>(
+        decl->get_enumerators(), record, "enumerators", nodes, decl);
+  }
+  if (SgImplicitStatement *stmt = isSgImplicitStatement(node)) {
+    appendEdgeList<SgInitializedNamePtrList, SgInitializedName>(
+        stmt->get_variables(), record, "variables", nodes, stmt);
+  }
+  if (SgForInitStatement *init = isSgForInitStatement(node)) {
+    appendEdgeList<SgStatementPtrList, SgStatement>(
+        init->get_init_stmt(), record, "init_stmt", nodes, init);
+  }
+  if (SgOmpClauseStatement *stmt = isSgOmpClauseStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+  } else if (SgOmpClauseBodyStatement *stmt =
+                 isSgOmpClauseBodyStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+  }
+  if (SgOmpDeclareSimdStatement *stmt = isSgOmpDeclareSimdStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+  }
+  if (SgOmpDeclareVariantStatement *stmt =
+          isSgOmpDeclareVariantStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+    if (uint64_t target = singleEdgeTarget(record, "variant_function_ref")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_variant_function_ref(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgOmpBeginDeclareVariantStatement *stmt =
+          isSgOmpBeginDeclareVariantStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+    stmt->set_captured_region(record.properties.stringOr("captured_region"));
+  }
+  if (SgOmpDeclareTargetStatement *stmt = isSgOmpDeclareTargetStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+    appendEdgeList<SgStatementPtrList, SgStatement>(
+        stmt->get_statements(), record, "statements", nodes, stmt);
+    stmt->set_device_type_kind(
+        static_cast<SgOmpClause::omp_when_context_kind_enum>(
+            record.properties.intOr(
+                "device_type_kind",
+                SgOmpClause::e_omp_when_context_kind_unknown)));
+  }
+  if (SgOmpDeclareMapperStatement *stmt = isSgOmpDeclareMapperStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_user_defined_identifier(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "mapper_type")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_mapper_type(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "mapper_variable")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_mapper_variable(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgOmpRequiresStatement *stmt = isSgOmpRequiresStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+  }
+  if (SgOmpTaskwaitStatement *stmt = isSgOmpTaskwaitStatement(node)) {
+    appendEdgeList<SgOmpClausePtrList, SgOmpClause>(stmt->get_clauses(), record,
+                                                    "clauses", nodes, stmt);
+  }
+  if (SgIOStatement *stmt = isSgIOStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "io_stmt_list")) {
+      SgExprListExp *expr = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_io_stmt_list(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "unit")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_unit(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "iostat")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_iostat(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "err")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_err(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "iomsg")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_iomsg(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgLabelStatement *stmt = isSgLabelStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "scope")) {
+      stmt->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "statement")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_statement(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgPrintStatement *stmt = isSgPrintStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "format")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_format(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgWriteStatement *stmt = isSgWriteStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "format")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_format(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgReadStatement *stmt = isSgReadStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "format")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_format(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgAttributeSpecificationStatement *stmt =
+          isSgAttributeSpecificationStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "parameter_list")) {
+      SgExprListExp *exprs = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_parameter_list(exprs);
+      exprs->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "bind_list")) {
+      SgExprListExp *exprs = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_bind_list(exprs);
+      exprs->set_parent(stmt);
+    }
+  }
+  if (SgInterfaceStatement *stmt = isSgInterfaceStatement(node)) {
+    appendEdgeList<SgInterfaceBodyPtrList, SgInterfaceBody>(
+        stmt->get_interface_body_list(), record, "interface_body_list", nodes,
+        stmt);
+    if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+      SgLabelRefExp *label = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_end_numeric_label(label);
+      label->set_parent(stmt);
+    }
+  }
+  if (SgInterfaceBody *body = isSgInterfaceBody(node)) {
+    uint64_t target = singleEdgeTarget(record, "functionDeclaration");
+    if (target == 0) {
+      target = static_cast<uint64_t>(
+          record.properties.intOr("function_declaration", 0));
+    }
+    if (target != 0) {
+      body->set_functionDeclaration(
+          nodeByIdAs<SgFunctionDeclaration>(nodes, target));
+    }
+  }
+
+  auto set_statement = [&](const std::string &field,
+                           void (SgStatement::*setter)(SgStatement *)) {
+    const uint64_t target = singleEdgeTarget(record, field);
+    if (target != 0) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      (isSgStatement(node)->*setter)(child);
+      child->set_parent(node);
+    }
+  };
+  (void)set_statement;
+
+  if (SgInitializedName *name = isSgInitializedName(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "initptr")) {
+      SgInitializer *init = nodeByIdAs<SgInitializer>(nodes, target);
+      name->set_initptr(init);
+      init->set_parent(name);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "declptr")) {
+      name->set_declptr(nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "prev_decl_item")) {
+      name->set_prev_decl_item(nodeByIdAs<SgInitializedName>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "scope")) {
+      name->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+    }
+  }
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "parent")) {
+      decl->set_parent(nodeById(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "scope")) {
+      decl->set_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "firstNondefiningDeclaration")) {
+      decl->set_firstNondefiningDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "definingDeclaration")) {
+      decl->set_definingDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "declarationScope")) {
+      decl->set_declarationScope(nodeByIdAs<SgDeclarationScope>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "nonreal_decl_scope")) {
+      decl->set_nonreal_decl_scope(
+          nodeByIdAs<SgDeclarationScope>(nodes, target));
+    }
+  }
+  auto link_result_name = [&](auto *decl) {
+    if (uint64_t target = singleEdgeTarget(record, "result_name")) {
+      SgInitializedName *name = nodeByIdAs<SgInitializedName>(nodes, target);
+      decl->set_result_name(name);
+      if (name->get_parent() == nullptr) {
+        name->set_parent(decl);
+      }
+      if (name->get_scope() == nullptr) {
+        name->set_scope(decl->get_scope() != nullptr ? decl->get_scope()
+                                                     : nearestScope(decl));
+      }
+    }
+  };
+  if (SgProcedureHeaderStatement *decl = isSgProcedureHeaderStatement(node)) {
+    link_result_name(decl);
+  }
+  if (SgEntryStatement *decl = isSgEntryStatement(node)) {
+    link_result_name(decl);
+  }
+  if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_tpl_args(), record, "tpl_args", nodes, decl);
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      decl->set_templateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "conceptConstraint")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      decl->set_conceptConstraint(expr);
+      expr->set_parent(decl);
+    }
+  }
+  if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "declaration")) {
+      SgDeclarationStatement *base_decl =
+          nodeByIdAs<SgDeclarationStatement>(nodes, target);
+      decl->set_declaration(base_decl);
+      if (base_decl->get_parent() == nullptr) {
+        base_decl->set_parent(decl);
+      }
+    }
+  }
+  if (SgTemplateInstantiationDirectiveStatement *decl =
+          isSgTemplateInstantiationDirectiveStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "declaration")) {
+      SgDeclarationStatement *instantiated_decl =
+          nodeByIdAs<SgDeclarationStatement>(nodes, target);
+      decl->set_declaration(instantiated_decl);
+      instantiated_decl->set_parent(decl);
+    }
+  }
+  if (SgUsingDirectiveStatement *decl = isSgUsingDirectiveStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "namespaceDeclaration")) {
+      decl->set_namespaceDeclaration(
+          nodeByIdAs<SgNamespaceDeclarationStatement>(nodes, target));
+    } else if (uint64_t target = static_cast<uint64_t>(
+                   record.properties.intOr("namespace_declaration", 0))) {
+      decl->set_namespaceDeclaration(
+          nodeByIdAs<SgNamespaceDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgUsingDeclarationStatement *decl = isSgUsingDeclarationStatement(node)) {
+    uint64_t target = singleEdgeTarget(record, "declaration");
+    if (target == 0) {
+      target = static_cast<uint64_t>(record.properties.intOr("declaration", 0));
+    }
+    if (target != 0) {
+      decl->set_declaration(nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    target = singleEdgeTarget(record, "initializedName");
+    if (target == 0) {
+      target =
+          static_cast<uint64_t>(record.properties.intOr("initialized_name", 0));
+    }
+    if (target != 0) {
+      decl->set_initializedName(nodeByIdAs<SgInitializedName>(nodes, target));
+    }
+  }
+  if (SgUseStatement *stmt = isSgUseStatement(node)) {
+    appendEdgeList<SgRenamePairPtrList, SgRenamePair>(
+        stmt->get_rename_list(), record, "rename_list", nodes, stmt);
+    if (uint64_t target = singleEdgeTarget(record, "module")) {
+      stmt->set_module(nodeByIdAs<SgModuleStatement>(nodes, target));
+    } else if (const JsonValue *external =
+                   record.properties.find("external_module")) {
+      stmt->set_module(externalModuleFromJson(*external));
+    }
+  }
+  auto set_template_requires_clause = [&](auto *decl) {
+    if (uint64_t target = singleEdgeTarget(record, "requiresClause")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      decl->set_requiresClause(expr);
+      expr->set_parent(decl);
+    }
+  };
+  if (SgTemplateVariableDeclaration *decl =
+          isSgTemplateVariableDeclaration(node)) {
+    appendEdgeList<SgTemplateParameterPtrList, SgTemplateParameter>(
+        decl->get_templateParameters(), record, "templateParameters", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateSpecializationArguments(), record,
+        "templateSpecializationArguments", nodes, decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_deducedTemplateArguments(), record,
+        "deducedTemplateArguments", nodes, decl);
+    if (uint64_t target =
+            singleEdgeTarget(record, "specializedTemplateDeclaration")) {
+      decl->set_specializedTemplateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgTemplateTypedefDeclaration *decl =
+          isSgTemplateTypedefDeclaration(node)) {
+    appendEdgeList<SgTemplateParameterPtrList, SgTemplateParameter>(
+        decl->get_templateParameters(), record, "templateParameters", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateSpecializationArguments(), record,
+        "templateSpecializationArguments", nodes, decl);
+    set_template_requires_clause(decl);
+  }
+  if (SgTemplateClassDeclaration *decl = isSgTemplateClassDeclaration(node)) {
+    appendEdgeList<SgTemplateParameterPtrList, SgTemplateParameter>(
+        decl->get_templateParameters(), record, "templateParameters", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateSpecializationArguments(), record,
+        "templateSpecializationArguments", nodes, decl);
+    set_template_requires_clause(decl);
+  }
+  if (SgTemplateFunctionDeclaration *decl =
+          isSgTemplateFunctionDeclaration(node)) {
+    appendEdgeList<SgTemplateParameterPtrList, SgTemplateParameter>(
+        decl->get_templateParameters(), record, "templateParameters", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateSpecializationArguments(), record,
+        "templateSpecializationArguments", nodes, decl);
+    set_template_requires_clause(decl);
+  }
+  if (SgTemplateMemberFunctionDeclaration *decl =
+          isSgTemplateMemberFunctionDeclaration(node)) {
+    appendEdgeList<SgTemplateParameterPtrList, SgTemplateParameter>(
+        decl->get_templateParameters(), record, "templateParameters", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateSpecializationArguments(), record,
+        "templateSpecializationArguments", nodes, decl);
+    set_template_requires_clause(decl);
+  }
+  if (SgTemplateParameter *parameter = isSgTemplateParameter(node)) {
+    auto set_expression =
+        [&](const std::string &field,
+            void (SgTemplateParameter::*setter)(SgExpression *)) {
+          if (uint64_t target = singleEdgeTarget(record, field)) {
+            SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+            (parameter->*setter)(expr);
+            expr->set_parent(parameter);
+          } else if (const JsonValue *value = record.properties.find(field)) {
+            if (SgExpression *expr = expressionFromRef(*value, nodes)) {
+              (parameter->*setter)(expr);
+              expr->set_parent(parameter);
+            }
+          }
+        };
+    set_expression("expression", &SgTemplateParameter::set_expression);
+    set_expression("typeConstraint", &SgTemplateParameter::set_typeConstraint);
+    set_expression("type_constraint", &SgTemplateParameter::set_typeConstraint);
+    set_expression("defaultExpressionParameter",
+                   &SgTemplateParameter::set_defaultExpressionParameter);
+    set_expression("default_expression_parameter",
+                   &SgTemplateParameter::set_defaultExpressionParameter);
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      parameter->set_templateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    } else if (uint64_t target = static_cast<uint64_t>(
+                   record.properties.intOr("template_declaration", 0))) {
+      parameter->set_templateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "defaultTemplateDeclarationParameter")) {
+      parameter->set_defaultTemplateDeclarationParameter(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    } else if (uint64_t target = static_cast<uint64_t>(record.properties.intOr(
+                   "default_template_declaration_parameter", 0))) {
+      parameter->set_defaultTemplateDeclarationParameter(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "initializedName")) {
+      parameter->set_initializedName(
+          nodeByIdAs<SgInitializedName>(nodes, target));
+    } else if (uint64_t target = static_cast<uint64_t>(
+                   record.properties.intOr("initialized_name", 0))) {
+      parameter->set_initializedName(
+          nodeByIdAs<SgInitializedName>(nodes, target));
+    }
+  }
+  if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "definition")) {
+      SgClassDefinition *def = nodeByIdAs<SgClassDefinition>(nodes, target);
+      decl->set_definition(def);
+      def->set_declaration(decl);
+      def->set_parent(decl);
+    }
+    if (SgModuleStatement *module = isSgModuleStatement(decl)) {
+      if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+        SgLabelRefExp *label = nodeByIdAs<SgLabelRefExp>(nodes, target);
+        module->set_end_numeric_label(label);
+        label->set_parent(module);
+      }
+    }
+    if (SgDerivedTypeStatement *derived = isSgDerivedTypeStatement(decl)) {
+      if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+        SgLabelRefExp *label = nodeByIdAs<SgLabelRefExp>(nodes, target);
+        derived->set_end_numeric_label(label);
+        label->set_parent(derived);
+      }
+    }
+  }
+  if (SgTemplateInstantiationDecl *decl = isSgTemplateInstantiationDecl(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      decl->set_templateDeclaration(
+          nodeByIdAs<SgTemplateClassDeclaration>(nodes, target));
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "specializedTemplateDeclaration")) {
+      decl->set_specializedTemplateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgTemplateInstantiationTypedefDeclaration *decl =
+          isSgTemplateInstantiationTypedefDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      decl->set_templateDeclaration(
+          nodeByIdAs<SgTemplateTypedefDeclaration>(nodes, target));
+    }
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateArguments(), record, "templateArguments", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_deducedTemplateArguments(), record,
+        "deducedTemplateArguments", nodes, decl);
+    if (uint64_t target =
+            singleEdgeTarget(record, "specializedTemplateDeclaration")) {
+      decl->set_specializedTemplateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgTemplateInstantiationFunctionDecl *decl =
+          isSgTemplateInstantiationFunctionDecl(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      decl->set_templateDeclaration(
+          nodeByIdAs<SgTemplateFunctionDeclaration>(nodes, target));
+    }
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateArguments(), record, "templateArguments", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_deducedTemplateArguments(), record,
+        "deducedTemplateArguments", nodes, decl);
+    if (uint64_t target =
+            singleEdgeTarget(record, "specializedTemplateDeclaration")) {
+      decl->set_specializedTemplateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgTemplateInstantiationMemberFunctionDecl *decl =
+          isSgTemplateInstantiationMemberFunctionDecl(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "templateDeclaration")) {
+      decl->set_templateDeclaration(
+          nodeByIdAs<SgTemplateMemberFunctionDeclaration>(nodes, target));
+    }
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_templateArguments(), record, "templateArguments", nodes,
+        decl);
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        decl->get_deducedTemplateArguments(), record,
+        "deducedTemplateArguments", nodes, decl);
+    if (uint64_t target =
+            singleEdgeTarget(record, "specializedTemplateDeclaration")) {
+      decl->set_specializedTemplateDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgNamespaceDeclarationStatement *decl =
+          isSgNamespaceDeclarationStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "definition")) {
+      SgNamespaceDefinitionStatement *def =
+          nodeByIdAs<SgNamespaceDefinitionStatement>(nodes, target);
+      decl->set_definition(def);
+      def->set_parent(decl);
+      def->set_namespaceDeclaration(decl);
+    }
+  }
+  if (SgNamespaceDefinitionStatement *def =
+          isSgNamespaceDefinitionStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "namespaceDeclaration")) {
+      def->set_namespaceDeclaration(
+          nodeByIdAs<SgNamespaceDeclarationStatement>(nodes, target));
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "previousNamespaceDefinition")) {
+      def->set_previousNamespaceDefinition(
+          nodeByIdAs<SgNamespaceDefinitionStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "nextNamespaceDefinition")) {
+      def->set_nextNamespaceDefinition(
+          nodeByIdAs<SgNamespaceDefinitionStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "global_definition")) {
+      def->set_global_definition(
+          nodeByIdAs<SgNamespaceDefinitionStatement>(nodes, target));
+    }
+  }
+  if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "parameterList")) {
+      SgFunctionParameterList *params =
+          nodeByIdAs<SgFunctionParameterList>(nodes, target);
+      decl->set_parameterList(params);
+      if (params->get_parent() == nullptr || params->get_parent() == decl) {
+        params->set_parent(decl);
+      }
+    }
+    if (uint64_t target = singleEdgeTarget(record, "parameterList_syntax")) {
+      decl->set_parameterList_syntax(
+          nodeByIdAs<SgFunctionParameterList>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "definition")) {
+      SgFunctionDefinition *def =
+          nodeByIdAs<SgFunctionDefinition>(nodes, target);
+      decl->set_definition(def);
+      def->set_parent(decl);
+      def->set_declaration(decl);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "functionParameterScope")) {
+      decl->set_functionParameterScope(
+          nodeByIdAs<SgFunctionParameterScope>(nodes, target));
+    } else if (const JsonValue *external_scope = record.properties.find(
+                   "external_function_parameter_scope")) {
+      if (!external_scope->boolOr("present", false)) {
+        throw std::runtime_error(
+            "AST JSON " + record.kind +
+            " external_function_parameter_scope is present but false");
+      }
+      const std::string source = record.properties.stringOr(
+          "external_function_parameter_scope_source");
+      SgFunctionDeclaration *peer = nullptr;
+      if (source == "firstNondefiningDeclaration") {
+        peer = isSgFunctionDeclaration(decl->get_firstNondefiningDeclaration());
+      } else if (source == "definingDeclaration") {
+        peer = isSgFunctionDeclaration(decl->get_definingDeclaration());
+      } else {
+        throw std::runtime_error(
+            "AST JSON " + record.kind +
+            " external_function_parameter_scope has unsupported source: " +
+            source);
+      }
+      if (peer == nullptr || peer->get_functionParameterScope() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON " + record.kind +
+            " cannot restore external functionParameterScope from " + source);
+      }
+      decl->set_functionParameterScope(peer->get_functionParameterScope());
+    }
+  }
+  if (SgMemberFunctionDeclaration *decl = isSgMemberFunctionDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "CtorInitializerList")) {
+      SgCtorInitializerList *ctors =
+          nodeByIdAs<SgCtorInitializerList>(nodes, target);
+      decl->set_CtorInitializerList(ctors);
+      ctors->set_parent(decl);
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "associatedClassDeclaration")) {
+      decl->set_associatedClassDeclaration(
+          nodeByIdAs<SgDeclarationStatement>(nodes, target));
+    }
+  }
+  if (SgFunctionDefinition *def = isSgFunctionDefinition(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgBasicBlock *body = nodeByIdAs<SgBasicBlock>(nodes, target);
+      def->set_body(body);
+      body->set_parent(def);
+    }
+  }
+  if (SgPragmaDeclaration *decl = isSgPragmaDeclaration(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "pragma")) {
+      SgPragma *pragma = nodeByIdAs<SgPragma>(nodes, target);
+      decl->set_pragma(pragma);
+    }
+  }
+  if (SgPragma *pragma = isSgPragma(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "parent")) {
+      pragma->set_parent(nodeById(nodes, target));
+    }
+  }
+  if (SgExprStatement *stmt = isSgExprStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "expression")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_expression(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgReturnStmt *stmt = isSgReturnStmt(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "expression")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_expression(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgBreakStmt *stmt = isSgBreakStmt(node)) {
+    stmt->set_do_string_label(record.properties.stringOr("do_string_label"));
+  }
+  if (SgContinueStmt *stmt = isSgContinueStmt(node)) {
+    stmt->set_do_string_label(record.properties.stringOr("do_string_label"));
+  }
+  if (SgProcessControlStatement *stmt = isSgProcessControlStatement(node)) {
+    stmt->set_control_kind(static_cast<SgProcessControlStatement::control_enum>(
+        record.properties.intOr("control_kind",
+                                SgProcessControlStatement::e_unknown)));
+    if (uint64_t target = singleEdgeTarget(record, "code")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_code(expr);
+      expr->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "quiet")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_quiet(expr);
+      expr->set_parent(stmt);
+    }
+  }
+  if (SgAllocateStatement *stmt = isSgAllocateStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "expr_list")) {
+      SgExprListExp *child = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_expr_list(child);
+      child->set_parent(stmt);
+    }
+    auto set_expression =
+        [&](const std::string &field,
+            void (SgAllocateStatement::*setter)(SgExpression *)) {
+          if (uint64_t target = singleEdgeTarget(record, field)) {
+            SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+            (stmt->*setter)(child);
+            child->set_parent(stmt);
+          }
+        };
+    set_expression("stat_expression",
+                   &SgAllocateStatement::set_stat_expression);
+    set_expression("errmsg_expression",
+                   &SgAllocateStatement::set_errmsg_expression);
+    set_expression("source_expression",
+                   &SgAllocateStatement::set_source_expression);
+    set_expression("mold_expression",
+                   &SgAllocateStatement::set_mold_expression);
+    set_expression("stream_expression",
+                   &SgAllocateStatement::set_stream_expression);
+    set_expression("pinned_expression",
+                   &SgAllocateStatement::set_pinned_expression);
+  }
+  if (SgDeallocateStatement *stmt = isSgDeallocateStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "expr_list")) {
+      SgExprListExp *child = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_expr_list(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "stat_expression")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_stat_expression(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "errmsg_expression")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_errmsg_expression(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgNullifyStatement *stmt = isSgNullifyStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "pointer_list")) {
+      SgExprListExp *child = nodeByIdAs<SgExprListExp>(nodes, target);
+      stmt->set_pointer_list(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgIfStmt *stmt = isSgIfStmt(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "conditional")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_conditional(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "true_body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_true_body(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "false_body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_false_body(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "else_numeric_label")) {
+      SgLabelRefExp *child = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_else_numeric_label(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+      SgLabelRefExp *child = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_end_numeric_label(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgForStatement *stmt = isSgForStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "for_init_stmt")) {
+      SgForInitStatement *child = nodeByIdAs<SgForInitStatement>(nodes, target);
+      stmt->set_for_init_stmt(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "test")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_test(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "increment")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_increment(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "loop_body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_loop_body(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgGotoStatement *stmt = isSgGotoStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "label")) {
+      stmt->set_label(nodeByIdAs<SgLabelStatement>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "label_expression")) {
+      SgLabelRefExp *label = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_label_expression(label);
+      label->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "selector_expression")) {
+      SgExpression *selector = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_selector_expression(selector);
+      selector->set_parent(stmt);
+    }
+  }
+  if (SgFortranDo *stmt = isSgFortranDo(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "initialization")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_initialization(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "bound")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_bound(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "increment")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_increment(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgBasicBlock *child = nodeByIdAs<SgBasicBlock>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+      SgLabelRefExp *child = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_end_numeric_label(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgFortranNonblockedDo *stmt = isSgFortranNonblockedDo(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "end_statement")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_end_statement(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgImpliedDo *expr = isSgImpliedDo(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "do_var_initialization")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_do_var_initialization(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "last_val")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_last_val(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "increment")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_increment(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "object_list")) {
+      SgExprListExp *child = nodeByIdAs<SgExprListExp>(nodes, target);
+      expr->set_object_list(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "implied_do_scope")) {
+      expr->set_implied_do_scope(nodeByIdAs<SgScopeStatement>(nodes, target));
+    }
+  }
+  if (SgWhileStmt *stmt = isSgWhileStmt(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "condition")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_condition(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "end_numeric_label")) {
+      SgLabelRefExp *child = nodeByIdAs<SgLabelRefExp>(nodes, target);
+      stmt->set_end_numeric_label(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgDoWhileStmt *stmt = isSgDoWhileStmt(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "condition")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_condition(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgSwitchStatement *stmt = isSgSwitchStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "item_selector")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_item_selector(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgBasicBlock *child = nodeByIdAs<SgBasicBlock>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgCaseOptionStmt *stmt = isSgCaseOptionStmt(node)) {
+    stmt->set_case_construct_name(
+        record.properties.stringOr("case_construct_name"));
+    if (uint64_t target = singleEdgeTarget(record, "key")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_key(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "key_range_end")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      stmt->set_key_range_end(child);
+      child->set_parent(stmt);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgDefaultOptionStmt *stmt = isSgDefaultOptionStmt(node)) {
+    stmt->set_default_construct_name(
+        record.properties.stringOr("default_construct_name"));
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgStatement *child = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_body(child);
+      child->set_parent(stmt);
+    }
+  }
+  if (SgOmpBodyStatement *stmt = isSgOmpBodyStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "body")) {
+      SgStatement *body = nodeByIdAs<SgStatement>(nodes, target);
+      stmt->set_body(body);
+      body->set_parent(stmt);
+    }
+  }
+  if (SgStaticAssertionDeclaration *decl =
+          isSgStaticAssertionDeclaration(node)) {
+    decl->set_string_literal(
+        SgName(record.properties.stringOr("string_literal")));
+    if (uint64_t target = singleEdgeTarget(record, "condition")) {
+      SgExpression *condition = nodeByIdAs<SgExpression>(nodes, target);
+      decl->set_condition(condition);
+      condition->set_parent(decl);
+    }
+  }
+  if (SgOmpExecStatement *stmt = isSgOmpExecStatement(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "omp_parent")) {
+      stmt->set_omp_parent(nodeByIdAs<SgStatement>(nodes, target));
+    }
+    for (const EdgeRecord &edge : edgesFor(record, "omp_children")) {
+      stmt->get_omp_children().push_back(
+          nodeByIdAs<SgStatement>(nodes, edge.target));
+    }
+  }
+  if (SgAssignInitializer *init = isSgAssignInitializer(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "operand_i")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      init->set_operand_i(expr);
+      expr->set_parent(init);
+    }
+  }
+  if (SgAggregateInitializer *init = isSgAggregateInitializer(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "initializers")) {
+      SgExprListExp *exprs = nodeByIdAs<SgExprListExp>(nodes, target);
+      init->set_initializers(exprs);
+      exprs->set_parent(init);
+    }
+  }
+  if (SgBracedInitializer *init = isSgBracedInitializer(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "initializers")) {
+      SgExprListExp *exprs = nodeByIdAs<SgExprListExp>(nodes, target);
+      init->set_initializers(exprs);
+      exprs->set_parent(init);
+    }
+  }
+  if (SgFunctionCallExp *call = isSgFunctionCallExp(node)) {
+    call->set_uses_operator_syntax(
+        record.properties.boolOr("uses_operator_syntax", false));
+    if (uint64_t target = singleEdgeTarget(record, "function")) {
+      SgExpression *function = nodeByIdAs<SgExpression>(nodes, target);
+      call->set_function(function);
+      function->set_parent(call);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "args")) {
+      SgExprListExp *args = nodeByIdAs<SgExprListExp>(nodes, target);
+      call->set_args(args);
+      args->set_parent(call);
+    }
+  }
+  if (SgActualArgumentExpression *actual = isSgActualArgumentExpression(node)) {
+    actual->set_argument_name(
+        SgName(record.properties.stringOr("argument_name")));
+    if (uint64_t target = singleEdgeTarget(record, "expression")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      if (SgExpression *old = actual->get_expression()) {
+        if (old != expr) {
+          old->set_parent(nullptr);
+        }
+      }
+      actual->set_expression(expr);
+      expr->set_parent(actual);
+    }
+  }
+  if (SgExpression *expr = isSgExpression(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "originalExpressionTree")) {
+      SgExpression *original = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_originalExpressionTree(original);
+    }
+  }
+  if (SgTypeTraitBuiltinOperator *op = isSgTypeTraitBuiltinOperator(node)) {
+    op->get_args().clear();
+    if (const JsonValue *args = record.properties.find("args")) {
+      if (args->kind != JsonValue::Kind::Array) {
+        throw std::runtime_error(
+            "AST JSON SgTypeTraitBuiltinOperator args is not an array");
+      }
+      for (const JsonValue &entry : args->array) {
+        SgNode *arg = nullptr;
+        const std::string kind = entry.stringOr("kind");
+        if (kind == "type") {
+          arg = typeFromJson(entry.at("type"), nodes);
+        } else if (kind == "node") {
+          arg = nodeById(nodes, static_cast<uint64_t>(entry.intOr("node", 0)));
+        } else {
+          throw std::runtime_error(
+              "AST JSON SgTypeTraitBuiltinOperator arg has unknown kind: " +
+              kind);
+        }
+        if (arg == nullptr) {
+          throw std::runtime_error(
+              "AST JSON SgTypeTraitBuiltinOperator arg resolved to null");
+        }
+        op->get_args().push_back(arg);
+        arg->set_parent(op);
+      }
+    }
+  }
+  if (SgUnaryOp *op = isSgUnaryOp(node)) {
+    op->set_mode(static_cast<SgUnaryOp::Sgop_mode>(
+        record.properties.intOr("mode", SgUnaryOp::prefix)));
+    if (uint64_t target = singleEdgeTarget(record, "operand_i")) {
+      SgExpression *operand = nodeByIdAs<SgExpression>(nodes, target);
+      op->set_operand_i(operand);
+      operand->set_parent(op);
+    }
+  }
+  if (SgBinaryOp *op = isSgBinaryOp(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "lhs_operand_i")) {
+      SgExpression *lhs = nodeByIdAs<SgExpression>(nodes, target);
+      op->set_lhs_operand_i(lhs);
+      lhs->set_parent(op);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "rhs_operand_i")) {
+      SgExpression *rhs = nodeByIdAs<SgExpression>(nodes, target);
+      op->set_rhs_operand_i(rhs);
+      rhs->set_parent(op);
+    }
+  }
+  if (SgComplexVal *value = isSgComplexVal(node)) {
+    if (const JsonValue *type = record.properties.find("precision_type")) {
+      value->set_precisionType(typeFromJson(*type, nodes));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "real_value")) {
+      SgValueExp *real = nodeByIdAs<SgValueExp>(nodes, target);
+      value->set_real_value(real);
+      real->set_parent(value);
+    } else if (const JsonValue *real_json =
+                   record.properties.find("real_value")) {
+      SgExpression *real = expressionFromRef(*real_json, nodes);
+      if (real != nullptr && isSgValueExp(real) == nullptr) {
+        throw std::runtime_error(
+            "AST JSON SgComplexVal real_value is not a SgValueExp");
+      }
+      value->set_real_value(isSgValueExp(real));
+      if (real != nullptr) {
+        real->set_parent(value);
+      }
+    }
+    if (uint64_t target = singleEdgeTarget(record, "imaginary_value")) {
+      SgValueExp *imag = nodeByIdAs<SgValueExp>(nodes, target);
+      value->set_imaginary_value(imag);
+      imag->set_parent(value);
+    } else if (const JsonValue *imag_json =
+                   record.properties.find("imaginary_value")) {
+      SgExpression *imag = expressionFromRef(*imag_json, nodes);
+      if (imag != nullptr && isSgValueExp(imag) == nullptr) {
+        throw std::runtime_error(
+            "AST JSON SgComplexVal imaginary_value is not a SgValueExp");
+      }
+      value->set_imaginary_value(isSgValueExp(imag));
+      if (imag != nullptr) {
+        imag->set_parent(value);
+      }
+    }
+    value->set_valueString(record.properties.stringOr("value_string"));
+  }
+  if (SgSubscriptExpression *expr = isSgSubscriptExpression(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "lowerBound")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_lowerBound(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "upperBound")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_upperBound(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "stride")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_stride(child);
+      child->set_parent(expr);
+    }
+  }
+  if (SgSizeOfOp *op = isSgSizeOfOp(node)) {
+    op->set_sizeOfContainsBaseTypeDefiningDeclaration(record.properties.boolOr(
+        "size_of_contains_base_type_defining_declaration", false));
+    op->set_is_objectless_nonstatic_data_member_reference(
+        record.properties.boolOr(
+            "is_objectless_nonstatic_data_member_reference", false));
+    op->set_is_sizeof_pack(record.properties.boolOr("is_sizeof_pack", false));
+    if (const JsonValue *type = record.properties.find("operand_type")) {
+      if (type->boolOr("present", false)) {
+        op->set_operand_type(typeFromJson(*type, nodes));
+      } else {
+        op->set_operand_type(nullptr);
+      }
+    }
+    if (uint64_t target = singleEdgeTarget(record, "operand_expr")) {
+      SgExpression *operand = nodeByIdAs<SgExpression>(nodes, target);
+      op->set_operand_expr(operand);
+      operand->set_parent(op);
+    }
+  }
+  if (SgConditionalExp *expr = isSgConditionalExp(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "conditional_exp")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_conditional_exp(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "true_exp")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_true_exp(child);
+      child->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "false_exp")) {
+      SgExpression *child = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_false_exp(child);
+      child->set_parent(expr);
+    }
+  }
+  if (SgStatementExpression *expr = isSgStatementExpression(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "statement")) {
+      SgStatement *stmt = nodeByIdAs<SgStatement>(nodes, target);
+      expr->set_statement(stmt);
+      stmt->set_parent(expr);
+    }
+  }
+  if (SgConstructorInitializer *init = isSgConstructorInitializer(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "declaration")) {
+      init->set_declaration(
+          nodeByIdAs<SgMemberFunctionDeclaration>(nodes, target));
+    }
+    if (uint64_t target = singleEdgeTarget(record, "args")) {
+      SgExprListExp *args = nodeByIdAs<SgExprListExp>(nodes, target);
+      init->set_args(args);
+      args->set_parent(init);
+    }
+  }
+  if (SgOmpVariablesClause *clause = isSgOmpVariablesClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "variables")) {
+      SgExprListExp *vars = nodeByIdAs<SgExprListExp>(nodes, target);
+      clause->set_variables(vars);
+      vars->set_parent(clause);
+    }
+  }
+  if (SgOmpExclusiveClause *clause = isSgOmpExclusiveClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "variables")) {
+      SgExprListExp *vars = nodeByIdAs<SgExprListExp>(nodes, target);
+      clause->set_variables(vars);
+      vars->set_parent(clause);
+    }
+  }
+  if (SgOmpExpressionClause *clause = isSgOmpExpressionClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "expression")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_expression(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpDefaultClause *clause = isSgOmpDefaultClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "variant_directive")) {
+      SgStatement *stmt = nodeByIdAs<SgStatement>(nodes, target);
+      clause->set_variant_directive(stmt);
+      stmt->set_parent(clause);
+    }
+  }
+  if (SgOmpReductionClause *clause = isSgOmpReductionClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_identifier(expr);
+      expr->set_parent(clause);
+    } else if (const JsonValue *identifier =
+                   record.properties.find("user_defined_identifier")) {
+      if (SgExpression *expr = expressionFromRef(*identifier, nodes)) {
+        clause->set_user_defined_identifier(expr);
+        expr->set_parent(clause);
+      }
+    }
+  }
+  if (SgOmpLinearClause *clause = isSgOmpLinearClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "step")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_step(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpAlignedClause *clause = isSgOmpAlignedClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "alignment")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_alignment(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpScheduleClause *clause = isSgOmpScheduleClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "chunk_size")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_chunk_size(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpDistScheduleClause *clause = isSgOmpDistScheduleClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "chunk_size")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_chunk_size(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpFlushStatement *stmt = isSgOmpFlushStatement(node)) {
+    appendEdgeList<SgExpressionPtrList, SgExpression>(
+        stmt->get_variables(), record, "variables", nodes, stmt);
+  }
+  if (SgOmpThreadprivateStatement *stmt = isSgOmpThreadprivateStatement(node)) {
+    appendEdgeList<SgExpressionPtrList, SgExpression>(
+        stmt->get_variables(), record, "variables", nodes, stmt);
+  }
+  if (SgOmpAllocateStatement *stmt = isSgOmpAllocateStatement(node)) {
+    appendEdgeList<SgExpressionPtrList, SgExpression>(
+        stmt->get_variables(), record, "variables", nodes, stmt);
+  }
+  if (SgOmpExtImplementationDefinedRequirementClause *clause =
+          isSgOmpExtImplementationDefinedRequirementClause(node)) {
+    if (uint64_t target =
+            singleEdgeTarget(record, "implementation_defined_requirement")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_implementation_defined_requirement(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpAllocateClause *clause = isSgOmpAllocateClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_modifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_modifier(expr);
+      expr->set_parent(clause);
+    } else if (const JsonValue *modifier =
+                   record.properties.find("user_defined_modifier")) {
+      if (SgExpression *expr = expressionFromRef(*modifier, nodes)) {
+        clause->set_user_defined_modifier(expr);
+        expr->set_parent(clause);
+      }
+    }
+  }
+  if (SgOmpAllocatorClause *clause = isSgOmpAllocatorClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_modifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_modifier(expr);
+      expr->set_parent(clause);
+    } else if (const JsonValue *modifier =
+                   record.properties.find("user_defined_modifier")) {
+      if (SgExpression *expr = expressionFromRef(*modifier, nodes)) {
+        clause->set_user_defined_modifier(expr);
+        expr->set_parent(clause);
+      }
+    }
+  }
+  if (SgOmpAdjustArgsClause *clause = isSgOmpAdjustArgsClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "arguments")) {
+      SgExprListExp *arguments = nodeByIdAs<SgExprListExp>(nodes, target);
+      clause->set_arguments(arguments);
+      arguments->set_parent(clause);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_modifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_modifier(expr);
+      expr->set_parent(clause);
+    } else if (const JsonValue *modifier =
+                   record.properties.find("user_defined_modifier")) {
+      if (SgExpression *expr = expressionFromRef(*modifier, nodes)) {
+        clause->set_user_defined_modifier(expr);
+        expr->set_parent(clause);
+      }
+    }
+  }
+  if (SgOmpInReductionClause *clause = isSgOmpInReductionClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_identifier(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpTaskReductionClause *clause = isSgOmpTaskReductionClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_user_defined_identifier(expr);
+      expr->set_parent(clause);
+    } else if (const JsonValue *identifier =
+                   record.properties.find("user_defined_identifier")) {
+      if (SgExpression *expr = expressionFromRef(*identifier, nodes)) {
+        clause->set_user_defined_identifier(expr);
+        expr->set_parent(clause);
+      }
+    }
+  }
+  if (SgOmpMapClause *clause = isSgOmpMapClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "mapper_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_mapper_identifier(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpToClause *clause = isSgOmpToClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "mapper_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_mapper_identifier(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpFromClause *clause = isSgOmpFromClause(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "mapper_identifier")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      clause->set_mapper_identifier(expr);
+      expr->set_parent(clause);
+    }
+  }
+  if (SgOmpWhenClause *clause = isSgOmpWhenClause(node)) {
+    auto set_expression = [&](const std::string &field,
+                              void (SgOmpWhenClause::*setter)(SgExpression *)) {
+      if (uint64_t target = singleEdgeTarget(record, field)) {
+        SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+        (clause->*setter)(expr);
+        expr->set_parent(clause);
+      } else if (const JsonValue *value = record.properties.find(field)) {
+        if (SgExpression *expr = expressionFromRef(*value, nodes)) {
+          (clause->*setter)(expr);
+          expr->set_parent(clause);
+        }
+      }
+    };
+    set_expression("user_condition", &SgOmpWhenClause::set_user_condition);
+    set_expression("user_condition_score",
+                   &SgOmpWhenClause::set_user_condition_score);
+    set_expression("device_arch", &SgOmpWhenClause::set_device_arch);
+    set_expression("device_isa", &SgOmpWhenClause::set_device_isa);
+    set_expression("device_num", &SgOmpWhenClause::set_device_num);
+    set_expression("implementation_user_defined",
+                   &SgOmpWhenClause::set_implementation_user_defined);
+    set_expression("implementation_extension",
+                   &SgOmpWhenClause::set_implementation_extension);
+    if (uint64_t target = singleEdgeTarget(record, "variant_directive")) {
+      SgStatement *stmt = nodeByIdAs<SgStatement>(nodes, target);
+      clause->set_variant_directive(stmt);
+      stmt->set_parent(clause);
+    }
+    appendEdgeList<SgStatementPtrList, SgStatement>(
+        clause->get_construct_directives(), record, "construct_directives",
+        nodes, clause);
+  }
+  if (SgOmpMatchClause *clause = isSgOmpMatchClause(node)) {
+    auto set_expression =
+        [&](const std::string &field,
+            void (SgOmpMatchClause::*setter)(SgExpression *)) {
+          if (uint64_t target = singleEdgeTarget(record, field)) {
+            SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+            (clause->*setter)(expr);
+            expr->set_parent(clause);
+          } else if (const JsonValue *value = record.properties.find(field)) {
+            if (SgExpression *expr = expressionFromRef(*value, nodes)) {
+              (clause->*setter)(expr);
+              expr->set_parent(clause);
+            }
+          }
+        };
+    set_expression("user_condition", &SgOmpMatchClause::set_user_condition);
+    set_expression("user_condition_score",
+                   &SgOmpMatchClause::set_user_condition_score);
+    set_expression("device_arch", &SgOmpMatchClause::set_device_arch);
+    set_expression("device_isa", &SgOmpMatchClause::set_device_isa);
+    set_expression("device_num", &SgOmpMatchClause::set_device_num);
+    set_expression("implementation_user_defined",
+                   &SgOmpMatchClause::set_implementation_user_defined);
+    set_expression("implementation_extension",
+                   &SgOmpMatchClause::set_implementation_extension);
+    clause->set_target_device_selector(
+        record.properties.boolOr("target_device_selector", false));
+    appendEdgeList<SgStatementPtrList, SgStatement>(
+        clause->get_construct_directives(), record, "construct_directives",
+        nodes, clause);
+  }
+  if (SgOmpUsesAllocatorsDefination *definition =
+          isSgOmpUsesAllocatorsDefination(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "user_defined_allocator")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      definition->set_user_defined_allocator(expr);
+      expr->set_parent(definition);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "allocator_traits_array")) {
+      SgExpression *expr = nodeByIdAs<SgExpression>(nodes, target);
+      definition->set_allocator_traits_array(expr);
+      expr->set_parent(definition);
+    }
+  }
+  if (SgNewExp *expr = isSgNewExp(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "placement_args")) {
+      SgExprListExp *args = nodeByIdAs<SgExprListExp>(nodes, target);
+      expr->set_placement_args(args);
+      args->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "constructor_args")) {
+      SgConstructorInitializer *args =
+          nodeByIdAs<SgConstructorInitializer>(nodes, target);
+      expr->set_constructor_args(args);
+      args->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "builtin_args")) {
+      SgExpression *args = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_builtin_args(args);
+      args->set_parent(expr);
+    }
+    if (uint64_t target = singleEdgeTarget(record, "newOperatorDeclaration")) {
+      expr->set_newOperatorDeclaration(
+          nodeByIdAs<SgFunctionDeclaration>(nodes, target));
+    }
+  }
+  if (SgDeleteExp *expr = isSgDeleteExp(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "variable")) {
+      SgExpression *variable = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_variable(variable);
+      variable->set_parent(expr);
+    }
+    if (uint64_t target =
+            singleEdgeTarget(record, "deleteOperatorDeclaration")) {
+      expr->set_deleteOperatorDeclaration(
+          nodeByIdAs<SgFunctionDeclaration>(nodes, target));
+    }
+  }
+  if (SgPackExpansionExpr *expr = isSgPackExpansionExpr(node)) {
+    if (uint64_t target = singleEdgeTarget(record, "pattern_expression")) {
+      SgExpression *pattern = nodeByIdAs<SgExpression>(nodes, target);
+      expr->set_pattern_expression(pattern);
+      pattern->set_parent(expr);
+    }
+  }
+  if (SgNonrealRefExp *expr = isSgNonrealRefExp(node)) {
+    appendEdgeList<SgTemplateArgumentPtrList, SgTemplateArgument>(
+        expr->get_templateArguments(), record, "templateArguments", nodes,
+        expr);
+  }
+}
+
+SgScopeStatement *nearestScope(SgNode *node) {
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (SgScopeStatement *scope = isSgScopeStatement(current)) {
+      return scope;
+    }
+  }
+  return nullptr;
+}
+
+SgSymbol *createSymbolForKindAndBasis(const std::string &kind, SgNode *basis);
+SgSymbol *createExternalSymbolFromJson(const JsonValue &json,
+                                       const NodeMap &nodes);
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeSymbols.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeSymbols.cpp
@@ -1,0 +1,1112 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+void restoreLabelSymbolFields(SgLabelSymbol *symbol, const JsonValue &json) {
+  if (symbol == nullptr) {
+    return;
+  }
+  symbol->set_numeric_label_value(json.intOr(
+      "label_numeric_label_value", symbol->get_numeric_label_value()));
+  symbol->set_label_type(static_cast<SgLabelSymbol::label_type_enum>(
+      json.intOr("label_type", static_cast<int>(symbol->get_label_type()))));
+  if (symbol->get_declaration() == nullptr &&
+      symbol->get_numeric_label_value() <= 0 &&
+      json.stringOr("symbol_name").empty()) {
+    if (SgLabelStatement *label =
+            isSgLabelStatement(symbol->get_fortran_statement())) {
+      symbol->set_declaration(label);
+      symbol->set_fortran_statement(nullptr);
+    }
+  }
+}
+
+SgScopeStatement *labelSymbolScopeForBasis(SgNode *basis) {
+  if (SgLabelStatement *label = isSgLabelStatement(basis)) {
+    if (label->get_scope() != nullptr) {
+      return label->get_scope();
+    }
+  }
+  for (SgNode *current = basis; current != nullptr;
+       current = current->get_parent()) {
+    if (SgFunctionDefinition *function = isSgFunctionDefinition(current)) {
+      return function;
+    }
+  }
+  return nearestScope(basis);
+}
+
+SgLabelSymbol *existingLabelSymbolFromJson(const JsonValue &json,
+                                           SgNode *basis) {
+  SgScopeStatement *scope = labelSymbolScopeForBasis(basis);
+  if (scope == nullptr) {
+    return nullptr;
+  }
+  const std::string name = json.stringOr("symbol_name");
+  if (name.empty()) {
+    return nullptr;
+  }
+  return scope->lookup_label_symbol(SgName(name));
+}
+
+std::string inferredSymbolKindForBasis(SgNode *basis) {
+  if (isSgInitializedName(basis) != nullptr) {
+    return "SgVariableSymbol";
+  }
+  if (isSgMemberFunctionDeclaration(basis) != nullptr) {
+    return "SgMemberFunctionSymbol";
+  }
+  if (isSgFunctionDeclaration(basis) != nullptr) {
+    return "SgFunctionSymbol";
+  }
+  if (isSgClassDeclaration(basis) != nullptr) {
+    return "SgClassSymbol";
+  }
+  if (isSgEnumDeclaration(basis) != nullptr) {
+    return "SgEnumSymbol";
+  }
+  if (isSgTypedefDeclaration(basis) != nullptr) {
+    return "SgTypedefSymbol";
+  }
+  if (isSgLabelStatement(basis) != nullptr) {
+    return "SgLabelSymbol";
+  }
+  if (isSgNonrealDecl(basis) != nullptr) {
+    return "SgNonrealSymbol";
+  }
+  if (isSgTemplateDeclaration(basis) != nullptr) {
+    return "SgTemplateSymbol";
+  }
+  return "";
+}
+
+SgSymbol *symbolFromJson(const JsonValue &json, const NodeMap &nodes) {
+  const uint64_t declaration_id =
+      static_cast<uint64_t>(json.intOr("symbol_declaration", 0));
+  if (declaration_id == 0) {
+    SgSymbol *external_symbol = createExternalSymbolFromJson(json, nodes);
+    if (external_symbol != nullptr) {
+      return external_symbol;
+    }
+    return nullptr;
+  }
+
+  SgNode *basis = nodeById(nodes, declaration_id);
+  SgSymbol *symbol = nullptr;
+  if (SgInitializedName *name = isSgInitializedName(basis)) {
+    SgScopeStatement *scope = name->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(name)) != nullptr) {
+      return symbol;
+    }
+  } else if (SgMemberFunctionDeclaration *decl =
+                 isSgMemberFunctionDeclaration(basis)) {
+    SgScopeStatement *scope = decl->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(decl)) != nullptr) {
+      return symbol;
+    }
+  } else if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(basis)) {
+    SgScopeStatement *scope = decl->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(decl)) != nullptr) {
+      return symbol;
+    }
+  } else if (SgClassDeclaration *decl = isSgClassDeclaration(basis)) {
+    SgScopeStatement *scope = decl->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(decl)) != nullptr) {
+      return symbol;
+    }
+  } else if (SgEnumDeclaration *decl = isSgEnumDeclaration(basis)) {
+    SgScopeStatement *scope = decl->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(decl)) != nullptr) {
+      return symbol;
+    }
+  } else if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(basis)) {
+    SgScopeStatement *scope = decl->get_scope();
+    if (scope != nullptr &&
+        (symbol = scope->find_symbol_from_declaration(decl)) != nullptr) {
+      return symbol;
+    }
+  } else if (isSgLabelStatement(basis) != nullptr ||
+             isSgStatement(basis) != nullptr) {
+    if (SgLabelSymbol *label = existingLabelSymbolFromJson(json, basis)) {
+      restoreLabelSymbolFields(label, json);
+      return label;
+    }
+  }
+
+  std::string kind = json.stringOr("symbol_kind");
+  if (kind.empty()) {
+    kind = inferredSymbolKindForBasis(basis);
+  }
+  if (kind.empty()) {
+    throw std::runtime_error("AST JSON cannot infer symbol kind for basis: " +
+                             std::string(basis->sage_class_name()));
+  }
+  symbol = createSymbolForKindAndBasis(kind, basis);
+  if (SgLabelSymbol *label_symbol = isSgLabelSymbol(symbol)) {
+    restoreLabelSymbolFields(label_symbol, json);
+  }
+  if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+    throw std::runtime_error(
+        "AST JSON cannot reconstruct detached symbol reference: " + kind);
+  }
+  return symbol;
+}
+
+SgSymbol *createSymbolForKindAndBasis(const std::string &kind, SgNode *basis) {
+  if (kind == "SgVariableSymbol") {
+    return new SgVariableSymbol(isSgInitializedName(basis));
+  }
+  if (kind == "SgTemplateVariableSymbol") {
+    return new SgTemplateVariableSymbol(isSgInitializedName(basis));
+  }
+  if (kind == "SgEnumFieldSymbol") {
+    return new SgEnumFieldSymbol(isSgInitializedName(basis));
+  }
+  if (kind == "SgIntrinsicSymbol") {
+    return new SgIntrinsicSymbol(isSgInitializedName(basis));
+  }
+  if (kind == "SgCommonSymbol") {
+    return new SgCommonSymbol(isSgInitializedName(basis));
+  }
+  if (kind == "SgFunctionSymbol") {
+    return new SgFunctionSymbol(isSgFunctionDeclaration(basis));
+  }
+  if (kind == "SgMemberFunctionSymbol") {
+    return new SgMemberFunctionSymbol(isSgFunctionDeclaration(basis));
+  }
+  if (kind == "SgTemplateFunctionSymbol") {
+    return new SgTemplateFunctionSymbol(isSgFunctionDeclaration(basis));
+  }
+  if (kind == "SgTemplateMemberFunctionSymbol") {
+    return new SgTemplateMemberFunctionSymbol(isSgFunctionDeclaration(basis));
+  }
+  if (kind == "SgClassSymbol") {
+    return new SgClassSymbol(isSgClassDeclaration(basis));
+  }
+  if (kind == "SgTemplateClassSymbol") {
+    return new SgTemplateClassSymbol(isSgClassDeclaration(basis));
+  }
+  if (kind == "SgEnumSymbol") {
+    return new SgEnumSymbol(isSgEnumDeclaration(basis));
+  }
+  if (kind == "SgTypedefSymbol") {
+    return new SgTypedefSymbol(isSgTypedefDeclaration(basis));
+  }
+  if (kind == "SgTemplateTypedefSymbol") {
+    return new SgTemplateTypedefSymbol(isSgTypedefDeclaration(basis));
+  }
+  if (kind == "SgLabelSymbol") {
+    if (SgLabelStatement *label = isSgLabelStatement(basis)) {
+      if (label->get_label().getString().empty()) {
+        SgLabelSymbol *symbol =
+            new SgLabelSymbol(static_cast<SgLabelStatement *>(nullptr));
+        symbol->set_fortran_statement(label);
+        return symbol;
+      }
+      return new SgLabelSymbol(label);
+    }
+    if (SgInitializedName *name = isSgInitializedName(basis)) {
+      return new SgLabelSymbol(name);
+    }
+    if (SgStatement *stmt = isSgStatement(basis)) {
+      SgLabelSymbol *symbol =
+          new SgLabelSymbol(static_cast<SgLabelStatement *>(nullptr));
+      symbol->set_fortran_statement(stmt);
+      return symbol;
+    }
+    return nullptr;
+  }
+  if (kind == "SgNamespaceSymbol") {
+    return new SgNamespaceSymbol(
+        isSgNamespaceDeclarationStatement(basis) != nullptr
+            ? isSgNamespaceDeclarationStatement(basis)->get_name()
+            : SgName(""),
+        isSgNamespaceDeclarationStatement(basis), nullptr, false);
+  }
+  if (kind == "SgModuleSymbol") {
+    return new SgModuleSymbol(isSgModuleStatement(basis));
+  }
+  if (kind == "SgInterfaceSymbol") {
+    return new SgInterfaceSymbol(isSgInterfaceStatement(basis));
+  }
+  if (kind == "SgNonrealSymbol") {
+    return new SgNonrealSymbol(isSgNonrealDecl(basis));
+  }
+  if (kind == "SgTemplateSymbol") {
+    return new SgTemplateSymbol(isSgTemplateDeclaration(basis));
+  }
+  return nullptr;
+}
+
+SgSymbol *createExternalSymbolFromJson(const JsonValue &json,
+                                       const NodeMap &nodes) {
+  const std::string kind = json.at("symbol_kind").asString();
+  SgNode *basis = nullptr;
+  if (const JsonValue *external = json.find("external_function")) {
+    basis = externalFunctionFromJson(*external, nodes);
+  } else if (const JsonValue *external = json.find("external_module")) {
+    basis = externalModuleFromJson(*external);
+  } else if (const JsonValue *external = json.find("external_class")) {
+    basis = externalClassDeclarationFromJson(*external);
+  }
+  if (basis == nullptr) {
+    return nullptr;
+  }
+  SgSymbol *symbol = createSymbolForKindAndBasis(kind, basis);
+  if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+    throw std::runtime_error(
+        "AST JSON cannot reconstruct external symbol reference: " + kind);
+  }
+  return symbol;
+}
+
+void attachExternalSymbolBasisToScope(SgSymbol *symbol,
+                                      SgScopeStatement *scope) {
+  if (symbol == nullptr || scope == nullptr) {
+    return;
+  }
+  SgNode *basis = symbol->get_symbol_basis();
+  if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(basis)) {
+    if (isAstJsonExternalFunction(decl)) {
+      decl->set_scope(scope);
+    }
+  } else if (SgModuleStatement *module = isSgModuleStatement(basis)) {
+    if (isAstJsonExternalModule(module)) {
+      module->set_scope(scope);
+      if (module->get_parent() == nullptr) {
+        module->set_parent(scope);
+      }
+    }
+  } else if (SgClassDeclaration *decl = isSgClassDeclaration(basis)) {
+    if (isAstJsonExternalClassDeclaration(decl)) {
+      decl->set_scope(scope);
+      if (decl->get_parent() == nullptr) {
+        decl->set_parent(scope);
+      }
+    }
+  }
+}
+
+SgSymbol *resolveExistingSymbolFromJson(const JsonValue &json,
+                                        const NodeMap &nodes) {
+  const uint64_t declaration_id =
+      static_cast<uint64_t>(json.at("symbol_declaration").asInt());
+  if (declaration_id == 0) {
+    SgSymbol *external_symbol = createExternalSymbolFromJson(json, nodes);
+    if (external_symbol != nullptr) {
+      return external_symbol;
+    }
+    throw std::runtime_error(
+        "AST JSON symbol reference has no symbol_declaration");
+  }
+
+  SgNode *basis = nodeById(nodes, declaration_id);
+  SgScopeStatement *scope = nullptr;
+  if (SgInitializedName *name = isSgInitializedName(basis)) {
+    scope = name->get_scope();
+  } else if (SgDeclarationStatement *decl = isSgDeclarationStatement(basis)) {
+    scope = decl->get_scope();
+  } else if (SgLabelStatement *label = isSgLabelStatement(basis)) {
+    scope = label->get_scope();
+  }
+  if (scope == nullptr) {
+    throw std::runtime_error(
+        "AST JSON symbol reference basis has no owning scope: " +
+        std::string(basis->sage_class_name()));
+  }
+
+  SgSymbol *symbol = nullptr;
+  if (SgInitializedName *name = isSgInitializedName(basis)) {
+    symbol = scope->find_symbol_from_declaration(name);
+  } else if (SgDeclarationStatement *decl = isSgDeclarationStatement(basis)) {
+    symbol = scope->find_symbol_from_declaration(decl);
+  } else if (SgLabelStatement *label = isSgLabelStatement(basis)) {
+    symbol = scope->find_symbol_from_declaration(label);
+  }
+  if (symbol == nullptr) {
+    throw std::runtime_error(
+        "AST JSON failed to resolve serialized symbol reference: " +
+        json.stringOr("symbol_name"));
+  }
+  return symbol;
+}
+
+struct DeferredSymbolTableEntry {
+  SgSymbolTable *table = nullptr;
+  SgName entry_name;
+  const JsonValue *entry_json = nullptr;
+};
+
+struct ExpectedSymbolTablePreference {
+  SgSymbolTable *table = nullptr;
+  SgName entry_name;
+  SgSymbol *symbol = nullptr;
+  bool lookup_preferred = false;
+};
+
+std::string symbolLookupPreferenceCategory(SgSymbol *symbol) {
+  if (symbol == nullptr) {
+    return "";
+  }
+  if (isSgVariableSymbol(symbol) != nullptr) {
+    return "variable";
+  }
+  if (isSgClassSymbol(symbol) != nullptr) {
+    return "class";
+  }
+  if (isSgEnumSymbol(symbol) != nullptr) {
+    return "enum";
+  }
+  if (isSgEnumFieldSymbol(symbol) != nullptr) {
+    return "enum_field";
+  }
+  if (isSgTypedefSymbol(symbol) != nullptr) {
+    return "typedef";
+  }
+  if (isSgLabelSymbol(symbol) != nullptr) {
+    return "label";
+  }
+  if (isSgNamespaceSymbol(symbol) != nullptr) {
+    return "namespace";
+  }
+  if (isSgFunctionSymbol(symbol) != nullptr) {
+    return "function";
+  }
+  return "";
+}
+
+bool symbolTablePreferencesMatch(
+    const std::vector<const ExpectedSymbolTablePreference *> &entries) {
+  for (const ExpectedSymbolTablePreference *entry : entries) {
+    ROSE_ASSERT(entry != nullptr);
+    ROSE_ASSERT(entry->table != nullptr);
+    ROSE_ASSERT(entry->symbol != nullptr);
+    if (symbolIsLookupPreferred(entry->table, entry->entry_name,
+                                entry->symbol) != entry->lookup_preferred) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void removeSymbolTablePreferenceGroup(
+    const std::vector<const ExpectedSymbolTablePreference *> &entries) {
+  for (const ExpectedSymbolTablePreference *entry : entries) {
+    ROSE_ASSERT(entry != nullptr);
+    ROSE_ASSERT(entry->table != nullptr);
+    ROSE_ASSERT(entry->symbol != nullptr);
+    if (!entry->table->find(entry->entry_name, entry->symbol)) {
+      std::ostringstream message;
+      message << "AST JSON cannot reorder missing symbol-table entry";
+      message << " entry=" << entry->entry_name.getString();
+      message << " symbol=" << entry->symbol->class_name();
+      message << " symbol_name=" << entry->symbol->get_name().getString();
+      throw std::runtime_error(message.str());
+    }
+    entry->table->remove(entry->symbol);
+  }
+}
+
+void insertSymbolTablePreferenceGroup(
+    const std::vector<const ExpectedSymbolTablePreference *> &entries) {
+  for (const ExpectedSymbolTablePreference *entry : entries) {
+    ROSE_ASSERT(entry != nullptr);
+    ROSE_ASSERT(entry->table != nullptr);
+    ROSE_ASSERT(entry->symbol != nullptr);
+    entry->table->insert(entry->entry_name, entry->symbol);
+  }
+}
+
+void enforceSymbolTablePreferences(
+    const std::vector<ExpectedSymbolTablePreference> &entries) {
+  struct PreferenceGroupKey {
+    SgSymbolTable *table = nullptr;
+    std::string entry_name;
+    std::string category;
+
+    bool operator<(const PreferenceGroupKey &rhs) const {
+      if (table != rhs.table) {
+        return std::less<SgSymbolTable *>()(table, rhs.table);
+      }
+      if (entry_name != rhs.entry_name) {
+        return entry_name < rhs.entry_name;
+      }
+      return category < rhs.category;
+    }
+  };
+
+  std::map<PreferenceGroupKey,
+           std::vector<const ExpectedSymbolTablePreference *>>
+      groups;
+  for (const ExpectedSymbolTablePreference &entry : entries) {
+    const std::string category = symbolLookupPreferenceCategory(entry.symbol);
+    if (category.empty()) {
+      continue;
+    }
+    PreferenceGroupKey key;
+    key.table = entry.table;
+    key.entry_name = entry.entry_name.getString();
+    key.category = category;
+    groups[key].push_back(&entry);
+  }
+
+  for (const auto &group_entry : groups) {
+    const std::vector<const ExpectedSymbolTablePreference *> &group =
+        group_entry.second;
+    if (group.size() < 2 || symbolTablePreferencesMatch(group)) {
+      continue;
+    }
+
+    std::vector<const ExpectedSymbolTablePreference *> preferred;
+    std::vector<const ExpectedSymbolTablePreference *> nonpreferred;
+    for (const ExpectedSymbolTablePreference *entry : group) {
+      if (entry->lookup_preferred) {
+        preferred.push_back(entry);
+      } else {
+        nonpreferred.push_back(entry);
+      }
+    }
+    if (preferred.size() != 1) {
+      std::ostringstream message;
+      message << "AST JSON cannot enforce symbol lookup preference";
+      message << " entry=" << group_entry.first.entry_name;
+      message << " category=" << group_entry.first.category;
+      message << " preferred_count=" << preferred.size();
+      throw std::runtime_error(message.str());
+    }
+
+    std::vector<const ExpectedSymbolTablePreference *> ordered;
+    ordered.reserve(group.size());
+    ordered.insert(ordered.end(), nonpreferred.begin(), nonpreferred.end());
+    ordered.insert(ordered.end(), preferred.begin(), preferred.end());
+    removeSymbolTablePreferenceGroup(group);
+    insertSymbolTablePreferenceGroup(ordered);
+    if (symbolTablePreferencesMatch(group)) {
+      continue;
+    }
+
+    ordered.clear();
+    ordered.insert(ordered.end(), preferred.begin(), preferred.end());
+    ordered.insert(ordered.end(), nonpreferred.begin(), nonpreferred.end());
+    removeSymbolTablePreferenceGroup(group);
+    insertSymbolTablePreferenceGroup(ordered);
+    if (symbolTablePreferencesMatch(group)) {
+      continue;
+    }
+
+    std::ostringstream message;
+    message << "AST JSON failed to enforce symbol lookup preference";
+    message << " entry=" << group_entry.first.entry_name;
+    message << " category=" << group_entry.first.category;
+    throw std::runtime_error(message.str());
+  }
+}
+
+void validateSymbolTablePreferences(
+    const std::vector<ExpectedSymbolTablePreference> &entries) {
+  for (const ExpectedSymbolTablePreference &entry : entries) {
+    ROSE_ASSERT(entry.table != nullptr);
+    ROSE_ASSERT(entry.symbol != nullptr);
+    const bool actual =
+        symbolIsLookupPreferred(entry.table, entry.entry_name, entry.symbol);
+    if (actual != entry.lookup_preferred) {
+      std::ostringstream message;
+      message << "AST JSON failed to restore symbol lookup preference";
+      message << " entry=" << entry.entry_name.getString();
+      message << " symbol=" << entry.symbol->class_name();
+      message << " symbol_name=" << entry.symbol->get_name().getString();
+      message << " expected="
+              << (entry.lookup_preferred ? "preferred" : "non-preferred");
+      message << " actual=" << (actual ? "preferred" : "non-preferred");
+      throw std::runtime_error(message.str());
+    }
+  }
+}
+
+SgSymbol *createDeferredSymbolTableSymbol(const JsonValue &entry,
+                                          const NodeMap &nodes) {
+  const std::string kind = entry.at("symbol_kind").asString();
+  if (kind == "SgAliasSymbol") {
+    const JsonValue *target = entry.find("alias_target");
+    if (target == nullptr) {
+      throw std::runtime_error(
+          "AST JSON SgAliasSymbol table entry has no alias_target");
+    }
+    SgAliasSymbol *symbol =
+        new SgAliasSymbol(resolveExistingSymbolFromJson(*target, nodes),
+                          entry.boolOr("alias_is_renamed", false),
+                          SgName(entry.stringOr("alias_new_name")));
+    if (const JsonValue *causal_nodes = entry.find("alias_causal_nodes")) {
+      if (causal_nodes->kind != JsonValue::Kind::Array) {
+        throw std::runtime_error(
+            "AST JSON alias_causal_nodes field is not an array");
+      }
+      for (const JsonValue &node_id : causal_nodes->array) {
+        const uint64_t id = static_cast<uint64_t>(node_id.asInt());
+        if (id != 0) {
+          symbol->get_causal_nodes().push_back(nodeById(nodes, id));
+        }
+      }
+    }
+    return symbol;
+  }
+  if (kind == "SgRenameSymbol") {
+    const JsonValue *original = entry.find("original_symbol");
+    if (original == nullptr) {
+      throw std::runtime_error(
+          "AST JSON SgRenameSymbol table entry has no original_symbol");
+    }
+    SgNode *basis = nodeById(
+        nodes, static_cast<uint64_t>(
+                   entry.at("symbol").at("symbol_declaration").asInt()));
+    return new SgRenameSymbol(isSgFunctionDeclaration(basis),
+                              resolveExistingSymbolFromJson(*original, nodes),
+                              SgName(entry.stringOr("rename_new_name")));
+  }
+  throw std::runtime_error("AST JSON deferred symbol kind is unsupported: " +
+                           kind);
+}
+
+void restoreSerializedSymbolTables(const AstFileRecord &ast,
+                                   const NodeMap &nodes) {
+  std::vector<DeferredSymbolTableEntry> deferred_entries;
+  std::vector<ExpectedSymbolTablePreference> expected_preferences;
+
+  for (const NodeRecord &record : ast.nodes) {
+    SgScopeStatement *scope = isSgScopeStatement(nodeById(nodes, record.id));
+    if (scope == nullptr) {
+      continue;
+    }
+
+    const JsonValue &entries = record.properties.at("symbol_table");
+    if (entries.kind != JsonValue::Kind::Array) {
+      throw std::runtime_error(
+          "AST JSON symbol_table field is not an array for " + record.kind);
+    }
+
+    const int table_size =
+        std::max<int>(17, static_cast<int>(entries.array.size() * 2 + 1));
+    SgSymbolTable *table = new SgSymbolTable(table_size);
+    table->set_parent(scope);
+    table->setCaseInsensitive(record.properties.boolOr(
+        "case_insensitive", table->isCaseInsensitive()));
+    scope->set_symbol_table(table);
+
+    std::vector<const JsonValue *> insertion_entries;
+    insertion_entries.reserve(entries.array.size());
+    for (const JsonValue &entry : entries.array) {
+      insertion_entries.push_back(&entry);
+    }
+    std::stable_sort(
+        insertion_entries.begin(), insertion_entries.end(),
+        [](const JsonValue *lhs, const JsonValue *rhs) {
+          const std::string lhs_name = lhs->at("entry_name").asString();
+          const std::string rhs_name = rhs->at("entry_name").asString();
+          const std::string lhs_kind = lhs->at("symbol_kind").asString();
+          const std::string rhs_kind = rhs->at("symbol_kind").asString();
+          const bool lhs_preferred = lhs->boolOr("lookup_preferred", false);
+          const bool rhs_preferred = rhs->boolOr("lookup_preferred", false);
+          if (lhs_name != rhs_name) {
+            return lhs_name < rhs_name;
+          }
+          if (lhs_kind != rhs_kind) {
+            return lhs_kind < rhs_kind;
+          }
+          if (lhs_preferred != rhs_preferred) {
+            return !lhs_preferred && rhs_preferred;
+          }
+          const uint64_t lhs_basis = static_cast<uint64_t>(
+              lhs->at("symbol").at("symbol_declaration").asInt());
+          const uint64_t rhs_basis = static_cast<uint64_t>(
+              rhs->at("symbol").at("symbol_declaration").asInt());
+          if (lhs_basis != rhs_basis) {
+            if (lhs_basis == 0) {
+              return false;
+            }
+            if (rhs_basis == 0) {
+              return true;
+            }
+            return lhs_basis < rhs_basis;
+          }
+          return false;
+        });
+    for (const JsonValue *entry_ptr : insertion_entries) {
+      const JsonValue &entry = *entry_ptr;
+      const std::string kind = entry.at("symbol_kind").asString();
+      const SgName entry_name(entry.at("entry_name").asString());
+      if (kind == "SgAliasSymbol" || kind == "SgRenameSymbol") {
+        DeferredSymbolTableEntry deferred;
+        deferred.table = table;
+        deferred.entry_name = entry_name;
+        deferred.entry_json = &entry;
+        deferred_entries.push_back(deferred);
+        continue;
+      }
+
+      const JsonValue &symbol_json = entry.at("symbol");
+      const uint64_t basis_id =
+          static_cast<uint64_t>(symbol_json.at("symbol_declaration").asInt());
+      if (basis_id == 0) {
+        SgSymbol *symbol = createExternalSymbolFromJson(symbol_json, nodes);
+        if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+          throw std::runtime_error(
+              "AST JSON failed to reconstruct external symbol table entry");
+        }
+        attachExternalSymbolBasisToScope(symbol, scope);
+        table->insert(entry_name, symbol);
+        expected_preferences.push_back(
+            {table, entry_name, symbol,
+             entry.boolOr("lookup_preferred", false)});
+        continue;
+      }
+      if (basis_id == 0) {
+        throw std::runtime_error(
+            "AST JSON symbol table entry has no symbol_declaration");
+      }
+      SgNode *basis = nodeById(nodes, basis_id);
+      SgSymbol *symbol = createSymbolForKindAndBasis(kind, basis);
+      if (SgLabelSymbol *label_symbol = isSgLabelSymbol(symbol)) {
+        restoreLabelSymbolFields(label_symbol, symbol_json);
+      }
+      if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+        std::ostringstream message;
+        message << "AST JSON cannot reconstruct symbol table entry"
+                << " kind=" << kind << " basis=" << basis->sage_class_name();
+        throw std::runtime_error(message.str());
+      }
+      if (SgNamespaceSymbol *namespace_symbol = isSgNamespaceSymbol(symbol)) {
+        namespace_symbol->set_isAlias(entry.boolOr(
+            "namespace_is_alias", namespace_symbol->get_isAlias()));
+        namespace_symbol->set_declaration(
+            isSgNamespaceDeclarationStatement(basis));
+        const uint64_t alias_id = static_cast<uint64_t>(
+            entry.intOr("namespace_alias_declaration", 0));
+        if (alias_id != 0) {
+          namespace_symbol->set_aliasDeclaration(
+              nodeByIdAs<SgNamespaceAliasDeclarationStatement>(nodes,
+                                                               alias_id));
+        }
+      }
+      attachExternalSymbolBasisToScope(symbol, scope);
+      table->insert(entry_name, symbol);
+      expected_preferences.push_back(
+          {table, entry_name, symbol, entry.boolOr("lookup_preferred", false)});
+    }
+  }
+
+  for (const DeferredSymbolTableEntry &deferred : deferred_entries) {
+    ROSE_ASSERT(deferred.table != nullptr);
+    ROSE_ASSERT(deferred.entry_json != nullptr);
+    SgSymbol *symbol =
+        createDeferredSymbolTableSymbol(*deferred.entry_json, nodes);
+    if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+      throw std::runtime_error(
+          "AST JSON failed to reconstruct deferred symbol table entry");
+    }
+    attachExternalSymbolBasisToScope(
+        symbol, isSgScopeStatement(deferred.table->get_parent()));
+    deferred.table->insert(deferred.entry_name, symbol);
+    expected_preferences.push_back(
+        {deferred.table, deferred.entry_name, symbol,
+         deferred.entry_json->boolOr("lookup_preferred", false)});
+  }
+
+  enforceSymbolTablePreferences(expected_preferences);
+  validateSymbolTablePreferences(expected_preferences);
+}
+
+SgClassSymbol *classSymbolForDeclaration(SgClassDeclaration *decl) {
+  if (decl == nullptr) {
+    return nullptr;
+  }
+  SgScopeStatement *scope = decl->get_scope();
+  if (scope != nullptr) {
+    if (SgClassSymbol *symbol =
+            isSgClassSymbol(scope->find_symbol_from_declaration(decl))) {
+      return symbol;
+    }
+  }
+  ensureClassTypeForDeclaration(decl);
+  SgClassSymbol *symbol = nullptr;
+  if (isSgTemplateClassDeclaration(decl) != nullptr ||
+      isSgTemplateInstantiationDecl(decl) != nullptr) {
+    symbol = new SgTemplateClassSymbol(decl);
+  } else {
+    symbol = new SgClassSymbol(decl);
+  }
+  return symbol;
+}
+
+bool declarationHasDefinition(SgDeclarationStatement *decl) {
+  if (SgFunctionDeclaration *function = isSgFunctionDeclaration(decl)) {
+    return function->get_definition() != nullptr;
+  }
+  if (SgClassDeclaration *class_decl = isSgClassDeclaration(decl)) {
+    return class_decl->get_definition() != nullptr;
+  }
+  return false;
+}
+
+SgNonrealSymbol *nonrealSymbolForDeclaration(SgNonrealDecl *decl) {
+  if (decl == nullptr) {
+    return nullptr;
+  }
+  SgScopeStatement *scope = decl->get_scope();
+  if (scope != nullptr) {
+    if (SgNonrealSymbol *symbol =
+            isSgNonrealSymbol(scope->find_symbol_from_declaration(decl))) {
+      return symbol;
+    }
+  }
+  if (decl->get_type() == nullptr) {
+    decl->set_type(new SgNonrealType(decl));
+  }
+  return new SgNonrealSymbol(decl);
+}
+
+std::map<SgSymbol *, std::vector<std::pair<SgExpression *, SgExpression *>>>
+arrayDimensionsFromJson(const JsonValue &json, const NodeMap &nodes) {
+  std::map<SgSymbol *, std::vector<std::pair<SgExpression *, SgExpression *>>>
+      result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &entry : json.array) {
+    const JsonValue *symbol_json = entry.find("symbol");
+    if (symbol_json == nullptr) {
+      continue;
+    }
+    SgSymbol *symbol = symbolFromJson(*symbol_json, nodes);
+    if (symbol == nullptr) {
+      throw std::runtime_error(
+          "AST JSON failed to resolve OMP array-section symbol");
+    }
+    std::vector<std::pair<SgExpression *, SgExpression *>> bounds;
+    const JsonValue *bounds_json = entry.find("bounds");
+    if (bounds_json != nullptr && bounds_json->kind == JsonValue::Kind::Array) {
+      for (const JsonValue &bound : bounds_json->array) {
+        const JsonValue *lower_json = bound.find("lower");
+        const JsonValue *upper_json = bound.find("upper");
+        bounds.emplace_back(
+            lower_json != nullptr ? expressionFromRef(*lower_json, nodes)
+                                  : nullptr,
+            upper_json != nullptr ? expressionFromRef(*upper_json, nodes)
+                                  : nullptr);
+      }
+    }
+    result[symbol] = std::move(bounds);
+  }
+  return result;
+}
+
+std::map<
+    SgSymbol *,
+    std::vector<std::pair<SgOmpClause::omp_map_dist_data_enum, SgExpression *>>>
+distDataPoliciesFromJson(const JsonValue &json, const NodeMap &nodes) {
+  std::map<SgSymbol *,
+           std::vector<
+               std::pair<SgOmpClause::omp_map_dist_data_enum, SgExpression *>>>
+      result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &entry : json.array) {
+    const JsonValue *symbol_json = entry.find("symbol");
+    if (symbol_json == nullptr) {
+      continue;
+    }
+    SgSymbol *symbol = symbolFromJson(*symbol_json, nodes);
+    if (symbol == nullptr) {
+      throw std::runtime_error(
+          "AST JSON failed to resolve OMP dist-data symbol");
+    }
+    std::vector<std::pair<SgOmpClause::omp_map_dist_data_enum, SgExpression *>>
+        policies;
+    const JsonValue *policies_json = entry.find("policies");
+    if (policies_json != nullptr &&
+        policies_json->kind == JsonValue::Kind::Array) {
+      for (const JsonValue &policy : policies_json->array) {
+        const JsonValue *expr_json = policy.find("expression");
+        policies.emplace_back(static_cast<SgOmpClause::omp_map_dist_data_enum>(
+                                  policy.intOr("policy", 0)),
+                              expr_json != nullptr
+                                  ? expressionFromRef(*expr_json, nodes)
+                                  : nullptr);
+      }
+    }
+    result[symbol] = std::move(policies);
+  }
+  return result;
+}
+
+std::list<std::list<SgExpression *>> iteratorFromJson(const JsonValue &json,
+                                                      const NodeMap &nodes) {
+  std::list<std::list<SgExpression *>> result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &iterator_json : json.array) {
+    std::list<SgExpression *> iterator;
+    if (iterator_json.kind == JsonValue::Kind::Array) {
+      for (const JsonValue &expr_json : iterator_json.array) {
+        iterator.push_back(expressionFromRef(expr_json, nodes));
+      }
+    }
+    result.push_back(std::move(iterator));
+  }
+  return result;
+}
+
+std::list<SgExpression *> expressionListFromJson(const JsonValue &json,
+                                                 const NodeMap &nodes) {
+  std::list<SgExpression *> result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &expr_json : json.array) {
+    result.push_back(expressionFromRef(expr_json, nodes));
+  }
+  return result;
+}
+
+SgTemplateArgumentPtrList templateArgumentListFromJson(const JsonValue &json,
+                                                       const NodeMap &nodes,
+                                                       SgNode *parent) {
+  SgTemplateArgumentPtrList result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &arg_json : json.array) {
+    const uint64_t id = static_cast<uint64_t>(arg_json.asInt());
+    if (id == 0) {
+      continue;
+    }
+    SgTemplateArgument *argument = nodeByIdAs<SgTemplateArgument>(nodes, id);
+    argument->set_parent(parent);
+    result.push_back(argument);
+  }
+  return result;
+}
+
+std::list<SgOmpUsesAllocatorsDefination *>
+usesAllocatorsDefinitionsFromJson(const JsonValue &json, const NodeMap &nodes,
+                                  SgOmpUsesAllocatorsClause *parent) {
+  std::list<SgOmpUsesAllocatorsDefination *> result;
+  if (json.kind != JsonValue::Kind::Array) {
+    return result;
+  }
+  for (const JsonValue &entry : json.array) {
+    const uint64_t id = static_cast<uint64_t>(entry.asInt());
+    if (id == 0) {
+      continue;
+    }
+    SgOmpUsesAllocatorsDefination *definition =
+        nodeByIdAs<SgOmpUsesAllocatorsDefination>(nodes, id);
+    definition->set_parent(parent);
+    result.push_back(definition);
+  }
+  return result;
+}
+
+void applyOmpAuxiliaryState(const AstFileRecord &ast, const NodeMap &nodes) {
+  for (const NodeRecord &record : ast.nodes) {
+    SgNode *node = nodeById(nodes, record.id);
+    const JsonValue &p = record.properties;
+
+    if (SgOmpClause *clause = isSgOmpClause(node)) {
+      clause->set_directive_name_modifier(
+          static_cast<SgOmpClause::omp_directive_name_modifier_enum>(
+              p.intOr("directive_name_modifier", 0)));
+    }
+
+    if (SgOmpMapClause *clause = isSgOmpMapClause(node)) {
+      clause->set_operation(static_cast<SgOmpClause::omp_map_operator_enum>(
+          p.intOr("operation", SgOmpClause::e_omp_map_unknown)));
+      clause->set_modifier1(static_cast<SgOmpClause::omp_map_modifier_enum>(
+          p.intOr("modifier1", SgOmpClause::e_omp_map_modifier_unspecified)));
+      clause->set_modifier2(static_cast<SgOmpClause::omp_map_modifier_enum>(
+          p.intOr("modifier2", SgOmpClause::e_omp_map_modifier_unspecified)));
+      clause->set_modifier3(static_cast<SgOmpClause::omp_map_modifier_enum>(
+          p.intOr("modifier3", SgOmpClause::e_omp_map_modifier_unspecified)));
+      if (const JsonValue *mapper = p.find("mapper_identifier")) {
+        clause->set_mapper_identifier(expressionFromRef(*mapper, nodes));
+      }
+      if (const JsonValue *dims = p.find("array_dimensions")) {
+        clause->set_array_dimensions(arrayDimensionsFromJson(*dims, nodes));
+      }
+      if (const JsonValue *policies = p.find("dist_data_policies")) {
+        clause->set_dist_data_policies(
+            distDataPoliciesFromJson(*policies, nodes));
+      }
+      if (const JsonValue *iterator = p.find("iterator")) {
+        clause->set_iterator(iteratorFromJson(*iterator, nodes));
+      }
+    } else if (SgOmpDependClause *clause = isSgOmpDependClause(node)) {
+      clause->set_depend_modifier(
+          static_cast<SgOmpClause::omp_depend_modifier_enum>(
+              p.intOr("depend_modifier",
+                      SgOmpClause::e_omp_depend_modifier_unspecified)));
+      clause->set_dependence_type(
+          static_cast<SgOmpClause::omp_dependence_type_enum>(p.intOr(
+              "dependence_type", SgOmpClause::e_omp_depend_unspecified)));
+      if (const JsonValue *dims = p.find("array_dimensions")) {
+        clause->set_array_dimensions(arrayDimensionsFromJson(*dims, nodes));
+      }
+      if (const JsonValue *iterator = p.find("iterator")) {
+        clause->set_iterator(iteratorFromJson(*iterator, nodes));
+      }
+      if (const JsonValue *vec = p.find("vec")) {
+        clause->set_vec(expressionListFromJson(*vec, nodes));
+      }
+    } else if (SgOmpAffinityClause *clause = isSgOmpAffinityClause(node)) {
+      clause->set_affinity_modifier(
+          static_cast<SgOmpClause::omp_affinity_modifier_enum>(
+              p.intOr("affinity_modifier",
+                      SgOmpClause::e_omp_affinity_modifier_unspecified)));
+      if (const JsonValue *dims = p.find("array_dimensions")) {
+        clause->set_array_dimensions(arrayDimensionsFromJson(*dims, nodes));
+      }
+      if (const JsonValue *iterator = p.find("iterator")) {
+        clause->set_iterator(iteratorFromJson(*iterator, nodes));
+      }
+    } else if (SgOmpToClause *clause = isSgOmpToClause(node)) {
+      clause->set_kind(static_cast<SgOmpClause::omp_to_kind_enum>(
+          p.intOr("kind", SgOmpClause::e_omp_to_kind_unknown)));
+      if (const JsonValue *mapper = p.find("mapper_identifier")) {
+        clause->set_mapper_identifier(expressionFromRef(*mapper, nodes));
+      }
+      if (const JsonValue *dims = p.find("array_dimensions")) {
+        clause->set_array_dimensions(arrayDimensionsFromJson(*dims, nodes));
+      }
+      if (const JsonValue *iterator = p.find("iterator")) {
+        clause->set_iterator(iteratorFromJson(*iterator, nodes));
+      }
+    } else if (SgOmpFromClause *clause = isSgOmpFromClause(node)) {
+      clause->set_kind(static_cast<SgOmpClause::omp_from_kind_enum>(
+          p.intOr("kind", SgOmpClause::e_omp_from_kind_unknown)));
+      if (const JsonValue *mapper = p.find("mapper_identifier")) {
+        clause->set_mapper_identifier(expressionFromRef(*mapper, nodes));
+      }
+      if (const JsonValue *dims = p.find("array_dimensions")) {
+        clause->set_array_dimensions(arrayDimensionsFromJson(*dims, nodes));
+      }
+      if (const JsonValue *iterator = p.find("iterator")) {
+        clause->set_iterator(iteratorFromJson(*iterator, nodes));
+      }
+    } else if (SgOmpOrderClause *clause = isSgOmpOrderClause(node)) {
+      clause->set_kind(static_cast<SgOmpClause::omp_order_kind_enum>(
+          p.intOr("kind", SgOmpClause::e_omp_order_kind_unspecified)));
+      clause->set_modifier(static_cast<SgOmpClause::omp_order_modifier_enum>(
+          p.intOr("modifier", SgOmpClause::e_omp_order_modifier_unspecified)));
+    } else if (SgOmpAtomicDefaultMemOrderClause *clause =
+                   isSgOmpAtomicDefaultMemOrderClause(node)) {
+      clause->set_kind(
+          static_cast<
+              SgOmpClause::omp_atomic_default_mem_order_kind_enum>(p.intOr(
+              "kind",
+              SgOmpClause::e_omp_atomic_default_mem_order_kind_unspecified)));
+    } else if (SgOmpDefaultmapClause *clause = isSgOmpDefaultmapClause(node)) {
+      clause->set_behavior(
+          static_cast<SgOmpClause::omp_defaultmap_behavior_enum>(p.intOr(
+              "behavior", SgOmpClause::e_omp_defaultmap_behavior_unspecified)));
+      clause->set_category(
+          static_cast<SgOmpClause::omp_defaultmap_category_enum>(p.intOr(
+              "category", SgOmpClause::e_omp_defaultmap_category_unspecified)));
+    } else if (SgOmpBindClause *clause = isSgOmpBindClause(node)) {
+      clause->set_binding(static_cast<SgOmpClause::omp_bind_binding_enum>(
+          p.intOr("binding", SgOmpClause::e_omp_bind_binding_unspecified)));
+    } else if (SgOmpFailClause *clause = isSgOmpFailClause(node)) {
+      clause->set_memory_order(
+          static_cast<SgOmpClause::omp_fail_memory_order_kind_enum>(
+              p.intOr("memory_order",
+                      SgOmpClause::e_omp_fail_memory_order_kind_unspecified)));
+    } else if (SgOmpLinearClause *clause = isSgOmpLinearClause(node)) {
+      clause->set_modifier(static_cast<SgOmpClause::omp_linear_modifier_enum>(
+          p.intOr("modifier", SgOmpClause::e_omp_linear_modifier_unspecified)));
+    } else if (SgOmpReductionClause *clause = isSgOmpReductionClause(node)) {
+      clause->set_modifier(
+          static_cast<SgOmpClause::omp_reduction_modifier_enum>(p.intOr(
+              "modifier", SgOmpClause::e_omp_reduction_modifier_unknown)));
+      clause->set_identifier(
+          static_cast<SgOmpClause::omp_reduction_identifier_enum>(
+              p.intOr("identifier", SgOmpClause::e_omp_reduction_unknown)));
+    } else if (SgOmpAllocateClause *clause = isSgOmpAllocateClause(node)) {
+      clause->set_modifier(static_cast<SgOmpClause::omp_allocate_modifier_enum>(
+          p.intOr("modifier", SgOmpClause::e_omp_allocate_modifier_unknown)));
+    } else if (SgOmpAllocatorClause *clause = isSgOmpAllocatorClause(node)) {
+      clause->set_modifier(
+          static_cast<SgOmpClause::omp_allocator_modifier_enum>(p.intOr(
+              "modifier", SgOmpClause::e_omp_allocator_modifier_unknown)));
+    } else if (SgOmpAdjustArgsClause *clause = isSgOmpAdjustArgsClause(node)) {
+      clause->set_modifier(
+          static_cast<SgOmpClause::omp_adjust_args_modifier_enum>(p.intOr(
+              "modifier", SgOmpClause::e_omp_adjust_args_modifier_unknown)));
+    } else if (SgOmpInReductionClause *clause =
+                   isSgOmpInReductionClause(node)) {
+      clause->set_identifier(
+          static_cast<SgOmpClause::omp_in_reduction_identifier_enum>(
+              p.intOr("identifier",
+                      SgOmpClause::e_omp_in_reduction_identifier_unspecified)));
+    } else if (SgOmpTaskReductionClause *clause =
+                   isSgOmpTaskReductionClause(node)) {
+      clause->set_identifier(
+          static_cast<SgOmpClause::omp_task_reduction_identifier_enum>(p.intOr(
+              "identifier",
+              SgOmpClause::e_omp_task_reduction_identifier_unspecified)));
+    } else if (SgOmpDepobjUpdateClause *clause =
+                   isSgOmpDepobjUpdateClause(node)) {
+      clause->set_modifier(static_cast<SgOmpClause::omp_depobj_modifier_enum>(
+          p.intOr("modifier", SgOmpClause::e_omp_depobj_modifier_unknown)));
+    } else if (SgOmpDistScheduleClause *clause =
+                   isSgOmpDistScheduleClause(node)) {
+      clause->set_kind(static_cast<SgOmpClause::omp_dist_schedule_kind_enum>(
+          p.intOr("kind", SgOmpClause::e_omp_dist_schedule_kind_unspecified)));
+    } else if (SgOmpNumTasksClause *clause = isSgOmpNumTasksClause(node)) {
+      clause->set_modifier(
+          static_cast<SgOmpClause::omp_num_tasks_modifier_enum>(p.intOr(
+              "modifier", SgOmpClause::e_omp_num_tasks_modifier_unspecified)));
+    } else if (SgOmpGrainsizeClause *clause = isSgOmpGrainsizeClause(node)) {
+      clause->set_modifier(
+          static_cast<SgOmpClause::omp_grainsize_modifier_enum>(p.intOr(
+              "modifier", SgOmpClause::e_omp_grainsize_modifier_unspecified)));
+    } else if (SgOmpWhenClause *clause = isSgOmpWhenClause(node)) {
+      clause->set_target_device_selector(p.boolOr(
+          "target_device_selector", clause->get_target_device_selector()));
+      clause->set_device_kind(
+          static_cast<SgOmpClause::omp_when_context_kind_enum>(p.intOr(
+              "device_kind", SgOmpClause::e_omp_when_context_kind_unknown)));
+      clause->set_implementation_vendor(
+          static_cast<SgOmpClause::omp_when_context_vendor_enum>(
+              p.intOr("implementation_vendor",
+                      SgOmpClause::e_omp_when_context_vendor_unspecified)));
+    } else if (SgOmpUsesAllocatorsDefination *definition =
+                   isSgOmpUsesAllocatorsDefination(node)) {
+      definition->set_allocator(
+          static_cast<SgOmpClause::omp_uses_allocators_allocator_enum>(
+              p.intOr("allocator",
+                      SgOmpClause::e_omp_uses_allocators_allocator_unknown)));
+    } else if (SgOmpUsesAllocatorsClause *clause =
+                   isSgOmpUsesAllocatorsClause(node)) {
+      if (const JsonValue *definitions =
+              p.find("uses_allocators_definitions")) {
+        clause->set_uses_allocators_defination(
+            usesAllocatorsDefinitionsFromJson(*definitions, nodes, clause));
+      }
+    } else if (SgOmpDeclareMapperStatement *stmt =
+                   isSgOmpDeclareMapperStatement(node)) {
+      stmt->set_identifier(
+          static_cast<SgOmpClause::omp_declare_mapper_identifier_enum>(p.intOr(
+              "identifier",
+              SgOmpClause::e_omp_declare_mapper_identifier_unspecified)));
+    }
+  }
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeTypes.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeTypes.cpp
@@ -1,0 +1,2101 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+Sg_File_Info *buildFileInfo(const JsonValue &json, SgNode *parent) {
+  if (json.kind != JsonValue::Kind::Object || !json.boolOr("present", false)) {
+    return nullptr;
+  }
+  auto special_file_id = [](const std::string &name, int &file_id) -> bool {
+    if (name == "COPY") {
+      file_id = Sg_File_Info::COPY_FILE_ID;
+      return true;
+    }
+    if (name == "NULL_FILE") {
+      file_id = Sg_File_Info::NULL_FILE_ID;
+      return true;
+    }
+    if (name == "transformation") {
+      file_id = Sg_File_Info::TRANSFORMATION_FILE_ID;
+      return true;
+    }
+    if (name == "compilerGenerated") {
+      file_id = Sg_File_Info::COMPILER_GENERATED_FILE_ID;
+      return true;
+    }
+    return false;
+  };
+  const std::string raw_filename =
+      json.stringOr("raw_filename", json.stringOr("filename"));
+  const int raw_line =
+      static_cast<int>(json.intOr("raw_line", json.intOr("line", 0)));
+  const int raw_column =
+      static_cast<int>(json.intOr("raw_column", json.intOr("column", 0)));
+  int raw_constructor_file_id = 0;
+  std::unique_ptr<Sg_File_Info> info(
+      special_file_id(raw_filename, raw_constructor_file_id)
+          ? new Sg_File_Info(raw_constructor_file_id, raw_line, raw_column)
+          : new Sg_File_Info(raw_filename, raw_line, raw_column));
+  const JsonValue *physical_file_id_value = json.find("physical_file_id");
+  const int physical_file_id =
+      physical_file_id_value != nullptr
+          ? static_cast<int>(physical_file_id_value->asInt())
+          : 0;
+  const int physical_internal_file_id = static_cast<int>(
+      json.intOr("physical_internal_file_id", physical_file_id));
+  const std::string physical_raw_filename =
+      json.stringOr("physical_raw_filename");
+  const std::string physical_filename = json.stringOr("physical_filename");
+  if (physical_file_id >= 0) {
+    const std::string registered_name = !physical_raw_filename.empty()
+                                            ? physical_raw_filename
+                                            : physical_filename;
+    requireFileIdMapping(physical_file_id, registered_name,
+                         "file info physical_file_id");
+  }
+
+  if (physical_internal_file_id >= 0) {
+    const std::string registered_name = filenameForFileId(
+        physical_internal_file_id, "file info physical_internal_file_id");
+    requireFileIdMapping(physical_internal_file_id, registered_name,
+                         "file info physical_internal_file_id");
+    info->set_physical_file_id(physical_internal_file_id);
+  } else if (physical_internal_file_id < 0) {
+    info->set_physical_file_id(physical_internal_file_id);
+  } else if (!physical_raw_filename.empty()) {
+    info->set_physical_filename(physical_raw_filename);
+  } else if (!physical_filename.empty()) {
+    info->set_physical_filename(physical_filename);
+  }
+  info->set_physical_line(json.intOr("physical_line", 0));
+  info->set_source_sequence_number(
+      static_cast<unsigned int>(json.intOr("source_sequence", 0)));
+  if (json.boolOr("compiler_generated", false)) {
+    info->setCompilerGenerated();
+  } else {
+    info->unsetCompilerGenerated();
+  }
+  if (json.boolOr("transformation", false)) {
+    info->setTransformation();
+  } else {
+    info->unsetTransformation();
+  }
+  if (json.boolOr("frontend_specific", false)) {
+    info->setFrontendSpecific();
+  } else {
+    info->unsetFrontendSpecific();
+  }
+  if (json.boolOr("shared", false)) {
+    info->setShared();
+  } else {
+    info->unsetShared();
+  }
+  if (json.boolOr("source_position_unavailable_in_frontend", false)) {
+    info->setSourcePositionUnavailableInFrontend();
+  } else {
+    info->unsetSourcePositionUnavailableInFrontend();
+  }
+  if (json.boolOr("comment_or_directive", false)) {
+    info->setCommentOrDirective();
+  } else {
+    info->unsetCommentOrDirective();
+  }
+  if (json.boolOr("token", false)) {
+    info->setToken();
+  } else {
+    info->unsetToken();
+  }
+  if (json.boolOr("default_argument", false)) {
+    info->setDefaultArgument();
+  } else {
+    info->unsetDefaultArgument();
+  }
+  if (json.boolOr("implicit_cast", false)) {
+    info->setImplicitCast();
+  } else {
+    info->unsetImplicitCast();
+  }
+  const JsonValue *file_id_value = json.find("file_id");
+  if (file_id_value != nullptr) {
+    const int file_id = static_cast<int>(file_id_value->asInt());
+    int raw_special_file_id = 0;
+    const bool raw_is_special =
+        special_file_id(raw_filename, raw_special_file_id);
+    const bool special_reported_by_flags =
+        (file_id == Sg_File_Info::TRANSFORMATION_FILE_ID &&
+         info->isTransformation()) ||
+        (file_id == Sg_File_Info::COMPILER_GENERATED_FILE_ID &&
+         info->isCompilerGenerated() && !info->isFrontendSpecific());
+    if (file_id < 0 && ((raw_is_special && raw_special_file_id == file_id) ||
+                        !special_reported_by_flags)) {
+      info->set_file_id(file_id);
+    }
+  }
+  if (json.boolOr("output_in_code_generation", false)) {
+    info->setOutputInCodeGeneration();
+  } else {
+    info->unsetOutputInCodeGeneration();
+  }
+  info->set_parent(parent);
+  return info.release();
+}
+
+bool sameClassDeclarationFamily(SgClassDeclaration *lhs,
+                                SgClassDeclaration *rhs) {
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  if (lhs == rhs) {
+    return true;
+  }
+  std::array<SgClassDeclaration *, 3> lhs_family = {
+      lhs, isSgClassDeclaration(lhs->get_definingDeclaration()),
+      isSgClassDeclaration(lhs->get_firstNondefiningDeclaration())};
+  std::array<SgClassDeclaration *, 3> rhs_family = {
+      rhs, isSgClassDeclaration(rhs->get_definingDeclaration()),
+      isSgClassDeclaration(rhs->get_firstNondefiningDeclaration())};
+  for (SgClassDeclaration *lhs_member : lhs_family) {
+    if (lhs_member == nullptr) {
+      continue;
+    }
+    for (SgClassDeclaration *rhs_member : rhs_family) {
+      if (lhs_member == rhs_member) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+SgClassType *ensureClassTypeForDeclaration(SgClassDeclaration *decl) {
+  if (decl == nullptr) {
+    throw std::runtime_error("AST JSON class type requires a declaration");
+  }
+  SgClassType *type = decl->get_type();
+  SgClassDeclaration *type_decl =
+      type != nullptr ? isSgClassDeclaration(type->get_declaration()) : nullptr;
+  if (type == nullptr || !sameClassDeclarationFamily(decl, type_decl)) {
+    type = new SgClassType(decl);
+    decl->set_type(type);
+  }
+  return type;
+}
+
+SgNode *nodeById(const NodeMap &nodes, uint64_t id) {
+  auto found = nodes.find(id);
+  if (found == nodes.end()) {
+    throw std::runtime_error("AST JSON references node id that was not built " +
+                             std::to_string(id));
+  }
+  return found->second;
+}
+
+void restoreQualifiedNameState(SgNode *node, const JsonValue &properties,
+                               const NodeMap &nodes) {
+  const JsonValue &state = properties.at("qualified_name_state");
+  if (state.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error(
+        "AST JSON qualified_name_state field is not an object");
+  }
+
+  SgNode::get_globalQualifiedNameMapForNames().erase(node);
+  SgNode::get_globalQualifiedNameMapForTypes().erase(node);
+  SgNode::get_globalQualifiedNameMapForTemplateHeaders().erase(node);
+  SgNode::get_globalTypeNameMap().erase(node);
+  SgNode::get_globalQualifiedNameMapForMapsOfTypes().erase(node);
+
+  if (const JsonValue *value = state.find("name_prefix")) {
+    const std::string prefix = value->asString();
+    if (shouldSerializeNamePrefix(node, prefix)) {
+      SgNode::get_globalQualifiedNameMapForNames()[node] = prefix;
+    }
+  }
+  if (const JsonValue *value = state.find("type_prefix")) {
+    SgNode::get_globalQualifiedNameMapForTypes()[node] = value->asString();
+  }
+  if (const JsonValue *value = state.find("template_header")) {
+    SgNode::get_globalQualifiedNameMapForTemplateHeaders()[node] =
+        value->asString();
+  }
+  if (const JsonValue *value = state.find("type_name")) {
+    SgNode::get_globalTypeNameMap()[node] = value->asString();
+  }
+  if (const JsonValue *entries = state.find("type_map_prefixes")) {
+    if (entries->kind != JsonValue::Kind::Array) {
+      throw std::runtime_error(
+          "AST JSON type_map_prefixes field is not an array");
+    }
+    SgUnorderedMapNodeToString restored_entries;
+    for (const JsonValue &entry : entries->array) {
+      if (entry.kind != JsonValue::Kind::Object) {
+        throw std::runtime_error(
+            "AST JSON type_map_prefixes entry is not an object");
+      }
+      const uint64_t target_id =
+          static_cast<uint64_t>(entry.at("node").asInt());
+      restored_entries[nodeById(nodes, target_id)] =
+          entry.at("prefix").asString();
+    }
+    SgNode::get_globalQualifiedNameMapForMapsOfTypes()[node] =
+        std::move(restored_entries);
+  }
+}
+
+void requireRestoredKind(SgNode *node, const NodeRecord &record) {
+  const std::string actual =
+      node != nullptr ? node->sage_class_name() : std::string("<null>");
+  if (actual != record.kind) {
+    throw std::runtime_error("AST JSON restored node kind mismatch for id " +
+                             std::to_string(record.id) + ": expected " +
+                             record.kind + ", got " + actual);
+  }
+}
+
+bool requiresDelayedRebuild(const NodeRecord &record) {
+  return record.kind == "SgTemplateInstantiationDefn";
+}
+
+SgScopeStatement *nearestScope(SgNode *node);
+
+SgDeclType *buildDeclType(SgExpression *base_expression,
+                          const JsonValue &type) {
+  if (base_expression == nullptr) {
+    throw std::runtime_error(
+        "AST JSON SgDeclType requires a structured base_expression node");
+  }
+  SgDeclType *decl_type = new SgDeclType(base_expression);
+  base_expression->set_parent(decl_type);
+  decl_type->set_is_gnu_decltype(type.boolOr("is_gnu_decltype", false));
+  return isSgDeclType(attachJsonTypeText(decl_type, type));
+}
+
+SgType *primitiveTypeFromKind(const std::string &kind) {
+  if (kind == "SgTypeVoid")
+    return SageBuilder::buildVoidType();
+  if (kind == "SgTypeBool")
+    return SageBuilder::buildBoolType();
+  if (kind == "SgTypeChar")
+    return SageBuilder::buildCharType();
+  if (kind == "SgTypeSignedChar")
+    return SageBuilder::buildSignedCharType();
+  if (kind == "SgTypeUnsignedChar")
+    return SageBuilder::buildUnsignedCharType();
+  if (kind == "SgTypeShort")
+    return SageBuilder::buildShortType();
+  if (kind == "SgTypeSignedShort")
+    return SageBuilder::buildSignedShortType();
+  if (kind == "SgTypeUnsignedShort")
+    return SageBuilder::buildUnsignedShortType();
+  if (kind == "SgTypeInt")
+    return SageBuilder::buildIntType();
+  if (kind == "SgTypeSignedInt")
+    return SageBuilder::buildSignedIntType();
+  if (kind == "SgTypeUnsignedInt")
+    return SageBuilder::buildUnsignedIntType();
+  if (kind == "SgTypeLong")
+    return SageBuilder::buildLongType();
+  if (kind == "SgTypeSignedLong")
+    return SageBuilder::buildSignedLongType();
+  if (kind == "SgTypeUnsignedLong")
+    return SageBuilder::buildUnsignedLongType();
+  if (kind == "SgTypeLongLong")
+    return SageBuilder::buildLongLongType();
+  if (kind == "SgTypeSignedLongLong")
+    return SageBuilder::buildSignedLongLongType();
+  if (kind == "SgTypeUnsignedLongLong")
+    return SageBuilder::buildUnsignedLongLongType();
+  if (kind == "SgTypeFloat")
+    return SageBuilder::buildFloatType();
+  if (kind == "SgTypeDouble")
+    return SageBuilder::buildDoubleType();
+  if (kind == "SgTypeLongDouble")
+    return SageBuilder::buildLongDoubleType();
+  if (kind == "SgTypeFloat16")
+    return SageBuilder::buildFloat16Type();
+  if (kind == "SgTypeFloat80")
+    return SageBuilder::buildFloat80Type();
+  if (kind == "SgTypeFloat128")
+    return SageBuilder::buildFloat128Type();
+  if (kind == "SgTypeFp16")
+    return SageBuilder::buildFp16Type();
+  if (kind == "SgTypeBFloat16")
+    return SageBuilder::buildBFloat16Type();
+  if (kind == "SgTypeFloat32")
+    return SageBuilder::buildFloat32Type();
+  if (kind == "SgTypeFloat64")
+    return SageBuilder::buildFloat64Type();
+  if (kind == "SgTypeFloat32x")
+    return SageBuilder::buildFloat32xType();
+  if (kind == "SgTypeFloat64x")
+    return SageBuilder::buildFloat64xType();
+  if (kind == "SgTypeWchar")
+    return SageBuilder::buildWcharType();
+  if (kind == "SgTypeChar16")
+    return SageBuilder::buildChar16Type();
+  if (kind == "SgTypeChar32")
+    return SageBuilder::buildChar32Type();
+  if (kind == "SgAutoType")
+    return SageBuilder::buildAutoType();
+  return nullptr;
+}
+
+SgType *earlyTypeFromJson(const JsonValue &type) {
+  if (type.kind != JsonValue::Kind::Object || !type.boolOr("present", false)) {
+    return SageBuilder::buildUnknownType();
+  }
+
+  const std::string kind = type.stringOr("kind");
+  if (kind == "SgTypeDefault") {
+    return attachJsonTypeText(SgTypeDefault::createType(), type);
+  }
+  if (kind == "SgTypeUnknown") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgTypeEllipse") {
+    return attachJsonTypeText(SgTypeEllipse::createType(), type);
+  }
+  if (kind == "SgTypeNullptr") {
+    return attachJsonTypeText(SageBuilder::buildNullptrType(), type);
+  }
+  if (kind == "SgTypeLabel") {
+    return attachJsonTypeText(
+        SgTypeLabel::createType(SgName(type.stringOr("name"))), type);
+  }
+  if (kind == "SgTypeFloat128") {
+    return attachJsonTypeText(SageBuilder::buildFloat128Type(), type);
+  }
+  if (kind == "SgTypeSigned128bitInteger") {
+    return attachJsonTypeText(SageBuilder::buildSigned128bitIntegerType(),
+                              type);
+  }
+  if (kind == "SgTypeUnsigned128bitInteger") {
+    return attachJsonTypeText(SageBuilder::buildUnsigned128bitIntegerType(),
+                              type);
+  }
+  if (SgType *primitive = primitiveTypeFromKind(kind)) {
+    return attachJsonTypeText(primitive, type);
+  }
+  if (kind == "SgTypeString") {
+    return attachJsonTypeText(new SgTypeString(nullptr), type);
+  }
+  if (kind == "SgTypeComplex") {
+    return attachJsonTypeText(
+        SgTypeComplex::createType(earlyTypeFromJson(type.at("base"))), type);
+  }
+  if (kind == "SgPointerMemberType") {
+    return attachJsonTypeText(SgPointerMemberType::createType(
+                                  earlyTypeFromJson(type.at("base")),
+                                  earlyTypeFromJson(type.at("class_type"))),
+                              type);
+  }
+  if (kind == "SgPointerType") {
+    SgType *base = earlyTypeFromJson(type.at("base"));
+    return attachJsonTypeText(buildCachedJsonPointerType(base), type);
+  }
+  if (kind == "SgReferenceType") {
+    SgType *base = earlyTypeFromJson(type.at("base"));
+    SgReferenceType *reference = new SgReferenceType(base);
+    installReferenceCache(base, reference);
+    return attachJsonTypeText(reference, type);
+  }
+  if (kind == "SgRvalueReferenceType") {
+    SgType *base = earlyTypeFromJson(type.at("base"));
+    SgRvalueReferenceType *reference = new SgRvalueReferenceType(base);
+    installRvalueReferenceCache(base, reference);
+    return attachJsonTypeText(reference, type);
+  }
+  if (kind == "SgArrayType") {
+    SgArrayType *array =
+        new SgArrayType(earlyTypeFromJson(type.at("base")), nullptr);
+    array->set_is_variable_length_array(
+        type.boolOr("is_variable_length_array", false));
+    return attachJsonTypeText(array, type);
+  }
+  if (kind == "SgModifierType") {
+    SgType *base = earlyTypeFromJson(type.at("base"));
+    SgModifierType *modifier = new SgModifierType(base);
+    SgTypeModifier &type_modifier = modifier->get_typeModifier();
+    SgConstVolatileModifier &cv = type_modifier.get_constVolatileModifier();
+    if (type.boolOr("modifier_const", false)) {
+      cv.setConst();
+    }
+    if (type.boolOr("modifier_volatile", false)) {
+      cv.setVolatile();
+    }
+    if (type.boolOr("modifier_restrict", false)) {
+      type_modifier.setRestrict();
+    }
+    return attachJsonTypeText(modifier, type);
+  }
+  if (kind == "SgTypedefType") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgClassType") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgEnumType") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgNonrealType") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgDeclType") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), type);
+  }
+  if (kind == "SgTemplateType") {
+    SgTemplateType *template_type = new SgTemplateType(
+        SgName(type.stringOr("name", type.stringOr("text"))));
+    template_type->set_template_parameter_position(
+        static_cast<int>(type.intOr("template_parameter_position", -1)));
+    template_type->set_template_parameter_depth(
+        static_cast<int>(type.intOr("template_parameter_depth", -1)));
+    if (const JsonValue *class_json = type.find("class_type")) {
+      template_type->set_class_type(class_json->boolOr("present", false)
+                                        ? earlyTypeFromJson(*class_json)
+                                        : nullptr);
+    } else {
+      template_type->set_class_type(nullptr);
+    }
+    if (const JsonValue *parent_class_json = type.find("parent_class_type")) {
+      template_type->set_parent_class_type(
+          parent_class_json->boolOr("present", false)
+              ? earlyTypeFromJson(*parent_class_json)
+              : nullptr);
+    } else {
+      template_type->set_parent_class_type(nullptr);
+    }
+    return attachJsonTypeText(template_type, type);
+  }
+  if (kind == "SgMemberFunctionType") {
+    SgType *return_type = SageBuilder::buildIntType();
+    if (const JsonValue *return_json = type.find("return_type")) {
+      return_type = earlyTypeFromJson(*return_json);
+    }
+    SgType *class_type = nullptr;
+    if (const JsonValue *class_json = type.find("class_type")) {
+      class_type = earlyTypeFromJson(*class_json);
+    }
+    SgFunctionParameterTypeList *arguments = new SgFunctionParameterTypeList();
+    if (const JsonValue *argument_json = type.find("arguments")) {
+      if (argument_json->kind == JsonValue::Kind::Array) {
+        for (const JsonValue &argument : argument_json->array) {
+          arguments->append_argument(earlyTypeFromJson(argument));
+        }
+      }
+    }
+    SgMemberFunctionType *member_type = new SgMemberFunctionType(
+        return_type, type.boolOr("has_ellipses", false), class_type,
+        static_cast<unsigned int>(type.intOr("mfunc_specifier", 0)));
+    member_type->set_argument_list(arguments);
+    arguments->set_parent(member_type);
+    return attachJsonTypeText(member_type, type);
+  }
+  if (kind == "SgFunctionType") {
+    SgType *return_type = SageBuilder::buildIntType();
+    if (const JsonValue *return_json = type.find("return_type")) {
+      return_type = earlyTypeFromJson(*return_json);
+    }
+    SgFunctionParameterTypeList *arguments = new SgFunctionParameterTypeList();
+    if (const JsonValue *argument_json = type.find("arguments")) {
+      if (argument_json->kind == JsonValue::Kind::Array) {
+        for (const JsonValue &argument : argument_json->array) {
+          arguments->append_argument(earlyTypeFromJson(argument));
+        }
+      }
+    }
+    SgFunctionType *function_type =
+        new SgFunctionType(return_type, type.boolOr("has_ellipses", false));
+    function_type->set_argument_list(arguments);
+    arguments->set_parent(function_type);
+    return attachJsonTypeText(function_type, type);
+  }
+  throw std::runtime_error("AST JSON deserializer does not support Sage type " +
+                           kind + " during early construction");
+}
+
+SgType *earlyTypeFromProperties(const JsonValue &properties) {
+  const JsonValue *type = properties.find("type");
+  if (type == nullptr) {
+    return SageBuilder::buildUnknownType();
+  }
+  return earlyTypeFromJson(*type);
+}
+
+bool isJsonBinaryOpKind(const std::string &kind) {
+  static const std::unordered_set<std::string> kinds = {"SgAssignOp",
+                                                        "SgAddOp",
+                                                        "SgSubtractOp",
+                                                        "SgMultiplyOp",
+                                                        "SgDivideOp",
+                                                        "SgModOp",
+                                                        "SgLessThanOp",
+                                                        "SgLessOrEqualOp",
+                                                        "SgGreaterThanOp",
+                                                        "SgGreaterOrEqualOp",
+                                                        "SgEqualityOp",
+                                                        "SgNotEqualOp",
+                                                        "SgLshiftOp",
+                                                        "SgRshiftOp",
+                                                        "SgAndOp",
+                                                        "SgOrOp",
+                                                        "SgBitAndOp",
+                                                        "SgBitOrOp",
+                                                        "SgBitXorOp",
+                                                        "SgCommaOpExp",
+                                                        "SgDotExp",
+                                                        "SgArrowExp",
+                                                        "SgPntrArrRefExp",
+                                                        "SgPlusAssignOp",
+                                                        "SgMinusAssignOp",
+                                                        "SgMultAssignOp",
+                                                        "SgDivAssignOp",
+                                                        "SgModAssignOp",
+                                                        "SgAndAssignOp",
+                                                        "SgIorAssignOp",
+                                                        "SgXorAssignOp",
+                                                        "SgLshiftAssignOp",
+                                                        "SgRshiftAssignOp",
+                                                        "SgConcatenationOp",
+                                                        "SgExponentiationOp",
+                                                        "SgPointerAssignOp"};
+  return kinds.find(kind) != kinds.end();
+}
+
+SgBinaryOp *buildBinaryOpForKind(const std::string &kind, SgType *expr_type) {
+  SgExpression *null_expr = nullptr;
+  if (kind == "SgAssignOp")
+    return new SgAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgAddOp")
+    return new SgAddOp(null_expr, null_expr, expr_type);
+  if (kind == "SgSubtractOp")
+    return new SgSubtractOp(null_expr, null_expr, expr_type);
+  if (kind == "SgMultiplyOp")
+    return new SgMultiplyOp(null_expr, null_expr, expr_type);
+  if (kind == "SgDivideOp")
+    return new SgDivideOp(null_expr, null_expr, expr_type);
+  if (kind == "SgModOp")
+    return new SgModOp(null_expr, null_expr, expr_type);
+  if (kind == "SgLessThanOp")
+    return new SgLessThanOp(null_expr, null_expr, expr_type);
+  if (kind == "SgLessOrEqualOp")
+    return new SgLessOrEqualOp(null_expr, null_expr, expr_type);
+  if (kind == "SgGreaterThanOp")
+    return new SgGreaterThanOp(null_expr, null_expr, expr_type);
+  if (kind == "SgGreaterOrEqualOp")
+    return new SgGreaterOrEqualOp(null_expr, null_expr, expr_type);
+  if (kind == "SgEqualityOp")
+    return new SgEqualityOp(null_expr, null_expr, expr_type);
+  if (kind == "SgNotEqualOp")
+    return new SgNotEqualOp(null_expr, null_expr, expr_type);
+  if (kind == "SgLshiftOp")
+    return new SgLshiftOp(null_expr, null_expr, expr_type);
+  if (kind == "SgRshiftOp")
+    return new SgRshiftOp(null_expr, null_expr, expr_type);
+  if (kind == "SgAndOp")
+    return new SgAndOp(null_expr, null_expr, expr_type);
+  if (kind == "SgOrOp")
+    return new SgOrOp(null_expr, null_expr, expr_type);
+  if (kind == "SgBitAndOp")
+    return new SgBitAndOp(null_expr, null_expr, expr_type);
+  if (kind == "SgBitOrOp")
+    return new SgBitOrOp(null_expr, null_expr, expr_type);
+  if (kind == "SgBitXorOp")
+    return new SgBitXorOp(null_expr, null_expr, expr_type);
+  if (kind == "SgCommaOpExp")
+    return new SgCommaOpExp(null_expr, null_expr, expr_type);
+  if (kind == "SgDotExp")
+    return new SgDotExp(null_expr, null_expr, expr_type);
+  if (kind == "SgArrowExp")
+    return new SgArrowExp(null_expr, null_expr, expr_type);
+  if (kind == "SgPntrArrRefExp")
+    return new SgPntrArrRefExp(null_expr, null_expr, expr_type);
+  if (kind == "SgConcatenationOp")
+    return new SgConcatenationOp(null_expr, null_expr, expr_type);
+  if (kind == "SgExponentiationOp")
+    return new SgExponentiationOp(null_expr, null_expr, expr_type);
+  if (kind == "SgPointerAssignOp")
+    return new SgPointerAssignOp(static_cast<Sg_File_Info *>(nullptr),
+                                 null_expr, null_expr, expr_type);
+  if (kind == "SgPlusAssignOp")
+    return new SgPlusAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgMinusAssignOp")
+    return new SgMinusAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgMultAssignOp")
+    return new SgMultAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgDivAssignOp")
+    return new SgDivAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgModAssignOp")
+    return new SgModAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgAndAssignOp")
+    return new SgAndAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgIorAssignOp")
+    return new SgIorAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgXorAssignOp")
+    return new SgXorAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgLshiftAssignOp")
+    return new SgLshiftAssignOp(null_expr, null_expr, expr_type);
+  if (kind == "SgRshiftAssignOp")
+    return new SgRshiftAssignOp(null_expr, null_expr, expr_type);
+  return nullptr;
+}
+
+bool isJsonUnaryOpKind(const std::string &kind) {
+  static const std::unordered_set<std::string> kinds = {
+      "SgAddressOfOp", "SgPointerDerefExp", "SgNotOp",   "SgBitComplementOp",
+      "SgPlusPlusOp",  "SgMinusMinusOp",    "SgMinusOp", "SgUnaryAddOp"};
+  return kinds.find(kind) != kinds.end();
+}
+
+SgUnaryOp *buildUnaryOpForKind(const std::string &kind, SgType *expr_type,
+                               const JsonValue &properties) {
+  SgExpression *null_expr = nullptr;
+  if (kind == "SgAddressOfOp") {
+    return new SgAddressOfOp(null_expr, expr_type);
+  }
+  if (kind == "SgPointerDerefExp") {
+    return new SgPointerDerefExp(null_expr, expr_type);
+  }
+  if (kind == "SgNotOp") {
+    return new SgNotOp(null_expr, expr_type);
+  }
+  if (kind == "SgBitComplementOp") {
+    return new SgBitComplementOp(null_expr, expr_type);
+  }
+  if (kind == "SgPlusPlusOp") {
+    SgPlusPlusOp *op = new SgPlusPlusOp(null_expr, expr_type);
+    op->set_mode(static_cast<SgUnaryOp::Sgop_mode>(
+        properties.intOr("mode", SgUnaryOp::prefix)));
+    return op;
+  }
+  if (kind == "SgMinusMinusOp") {
+    SgMinusMinusOp *op = new SgMinusMinusOp(null_expr, expr_type);
+    op->set_mode(static_cast<SgUnaryOp::Sgop_mode>(
+        properties.intOr("mode", SgUnaryOp::prefix)));
+    return op;
+  }
+  if (kind == "SgMinusOp") {
+    return new SgMinusOp(null_expr, expr_type);
+  }
+  if (kind == "SgUnaryAddOp") {
+    return new SgUnaryAddOp(null_expr, expr_type);
+  }
+  return nullptr;
+}
+
+void setOwnedExpressionSourcePosition(SgExpression *expr,
+                                      const JsonValue &location) {
+  if (location.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error(
+        "AST JSON type-owned expression location is not an object");
+  }
+  SgLocatedNode *located = isSgLocatedNode(expr);
+  if (located == nullptr) {
+    throw std::runtime_error("AST JSON type-owned expression is not located");
+  }
+  const JsonValue *start = location.find("start");
+  const JsonValue *end = location.find("end");
+  if (start == nullptr || end == nullptr) {
+    throw std::runtime_error(
+        "AST JSON type-owned expression is missing source location");
+  }
+  std::unique_ptr<Sg_File_Info> start_info(buildFileInfo(*start, expr));
+  std::unique_ptr<Sg_File_Info> end_info(buildFileInfo(*end, expr));
+  located->set_startOfConstruct(start_info.release());
+  located->set_endOfConstruct(end_info.release());
+}
+
+SgExpression *expressionFromRef(const JsonValue &json, const NodeMap &nodes);
+SgSymbol *symbolFromJson(const JsonValue &json, const NodeMap &nodes);
+
+void restoreOwnedExpressionProperties(SgExpression *expr,
+                                      const JsonValue &properties,
+                                      const NodeMap &nodes) {
+  if (const JsonValue *type = properties.find("type")) {
+    SgType *restored_type = typeFromJson(*type, nodes);
+    if (SgCastExp *cast = isSgCastExp(expr)) {
+      cast->set_type(restored_type);
+    } else if (SgTypeExpression *type_expr = isSgTypeExpression(expr)) {
+      type_expr->set_type(restored_type);
+    } else if (SgAggregateInitializer *init = isSgAggregateInitializer(expr)) {
+      init->set_expression_type(restored_type);
+    } else if (SgCompoundInitializer *init = isSgCompoundInitializer(expr)) {
+      init->set_expression_type(restored_type);
+    } else if (SgConstructorInitializer *init =
+                   isSgConstructorInitializer(expr)) {
+      init->set_expression_type(restored_type);
+    }
+  }
+  expr->set_lvalue(properties.boolOr("lvalue", expr->get_lvalue()));
+  expr->set_need_paren(properties.boolOr("need_paren", expr->get_need_paren()));
+  expr->set_global_qualified_name(properties.boolOr(
+      "global_qualified_name", expr->get_global_qualified_name()));
+  restoreExpressionQualificationFields(expr, properties);
+
+  if (SgSubscriptExpression *subscript = isSgSubscriptExpression(expr)) {
+    auto restore_child = [&](const std::string &field, auto setter) {
+      if (const JsonValue *value = properties.find(field)) {
+        SgExpression *child = expressionFromRef(*value, nodes);
+        (subscript->*setter)(child);
+        if (child != nullptr) {
+          child->set_parent(subscript);
+        }
+      }
+    };
+    restore_child("lower_bound", &SgSubscriptExpression::set_lowerBound);
+    restore_child("upper_bound", &SgSubscriptExpression::set_upperBound);
+    restore_child("stride", &SgSubscriptExpression::set_stride);
+  }
+  if (SgUnaryOp *unary = isSgUnaryOp(expr)) {
+    if (const JsonValue *value = properties.find("operand")) {
+      SgExpression *operand = expressionFromRef(*value, nodes);
+      if (operand == nullptr) {
+        throw std::runtime_error(
+            "AST JSON type-owned unary expression is missing operand");
+      }
+      unary->set_operand_i(operand);
+      operand->set_parent(unary);
+    }
+  }
+  if (SgBinaryOp *binary = isSgBinaryOp(expr)) {
+    auto require_binary_child = [&](const std::string &field) {
+      const JsonValue *value = properties.find(field);
+      if (value == nullptr) {
+        throw std::runtime_error("AST JSON type-owned binary expression is "
+                                 "missing " +
+                                 field);
+      }
+      SgExpression *child = expressionFromRef(*value, nodes);
+      if (child == nullptr) {
+        throw std::runtime_error("AST JSON type-owned binary expression has "
+                                 "null " +
+                                 field);
+      }
+      return child;
+    };
+    SgExpression *lhs = require_binary_child("lhs_operand");
+    SgExpression *rhs = require_binary_child("rhs_operand");
+    binary->set_lhs_operand_i(lhs);
+    lhs->set_parent(binary);
+    binary->set_rhs_operand_i(rhs);
+    rhs->set_parent(binary);
+  }
+  if (SgComplexVal *value = isSgComplexVal(expr)) {
+    if (const JsonValue *type = properties.find("precision_type")) {
+      value->set_precisionType(typeFromJson(*type, nodes));
+    }
+    if (const JsonValue *real_json = properties.find("real_value")) {
+      SgExpression *real = expressionFromRef(*real_json, nodes);
+      if (real != nullptr && isSgValueExp(real) == nullptr) {
+        throw std::runtime_error(
+            "AST JSON SgComplexVal real_value is not a SgValueExp");
+      }
+      value->set_real_value(isSgValueExp(real));
+      if (real != nullptr) {
+        real->set_parent(value);
+      }
+    }
+    if (const JsonValue *imag_json = properties.find("imaginary_value")) {
+      SgExpression *imag = expressionFromRef(*imag_json, nodes);
+      if (imag != nullptr && isSgValueExp(imag) == nullptr) {
+        throw std::runtime_error(
+            "AST JSON SgComplexVal imaginary_value is not a SgValueExp");
+      }
+      value->set_imaginary_value(isSgValueExp(imag));
+      if (imag != nullptr) {
+        imag->set_parent(value);
+      }
+    }
+    value->set_valueString(properties.stringOr("value_string"));
+  }
+
+  if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+    if (const JsonValue *symbol_json = properties.find("symbol")) {
+      ref->set_symbol(isSgVariableSymbol(symbolFromJson(*symbol_json, nodes)));
+    } else {
+      const uint64_t decl_id =
+          static_cast<uint64_t>(properties.intOr("symbol_declaration", 0));
+      if (decl_id == 0) {
+        throw std::runtime_error(
+            "AST JSON type-owned SgVarRefExp has no symbol declaration");
+      }
+      SgInitializedName *decl = isSgInitializedName(nodeById(nodes, decl_id));
+      if (decl != nullptr) {
+        ref->set_symbol(new SgVariableSymbol(decl));
+      }
+    }
+    if (ref->get_symbol() == nullptr) {
+      throw std::runtime_error(
+          "AST JSON failed to resolve type-owned SgVarRefExp symbol");
+    }
+    normalizeAnonymousDataMemberReference(ref);
+  }
+}
+
+SgExpression *expressionFromRef(const JsonValue &json, const NodeMap &nodes) {
+  if (json.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON expression reference is not an object");
+  }
+  const JsonValue *node_value = json.find("node");
+  if (node_value == nullptr) {
+    throw std::runtime_error("AST JSON expression reference is missing node");
+  }
+  const uint64_t id = static_cast<uint64_t>(json.intOr("node", 0));
+  if (id != 0) {
+    return nodeByIdAs<SgExpression>(nodes, id);
+  }
+  if (const JsonValue *owned_kind = json.find("owned_kind")) {
+    NodeRecord record;
+    record.kind = owned_kind->asString();
+    record.variant = 0;
+    record.flags = json.at("flags");
+    record.location = json.at("location");
+    record.properties = json.at("properties");
+    record.preprocessing = record.properties.find("preprocessing") != nullptr
+                               ? *record.properties.find("preprocessing")
+                               : JsonValue::arrayValue({});
+    SgNode *node =
+        createNodeFromRecord(record, nullptr, JsonValue::objectValue({}));
+    SgExpression *expr = isSgExpression(node);
+    if (expr == nullptr) {
+      throw std::runtime_error(
+          "AST JSON type-owned record did not rebuild an expression");
+    }
+    if (record.flags.boolOr("contains_transformation", false)) {
+      expr->set_containsTransformation(true);
+    } else {
+      expr->set_containsTransformation(false);
+    }
+    if (SgLocatedNode *located = isSgLocatedNode(expr)) {
+      if (record.flags.boolOr(
+              "contains_transformation_to_surrounding_whitespace", false)) {
+        located->set_containsTransformationToSurroundingWhitespace(true);
+      } else {
+        located->set_containsTransformationToSurroundingWhitespace(false);
+      }
+    }
+    setOwnedExpressionSourcePosition(expr, record.location);
+    restoreOwnedExpressionProperties(expr, record.properties, nodes);
+    return expr;
+  }
+  return nullptr;
+}
+
+SgExprListExp *exprListExpFromTypeJson(const JsonValue &json,
+                                       const NodeMap &nodes) {
+  if (json.kind != JsonValue::Kind::Object || !json.boolOr("present", false)) {
+    return nullptr;
+  }
+  const std::string kind = json.at("kind").asString();
+  if (kind != "SgExprListExp") {
+    throw std::runtime_error(
+        "AST JSON SgArrayType dim_info is not SgExprListExp: " + kind);
+  }
+
+  NodeRecord record;
+  record.kind = kind;
+  record.variant = 0;
+  record.flags = json.at("flags");
+  record.location = json.at("location");
+  record.properties = json.at("properties");
+  record.preprocessing = record.properties.find("preprocessing") != nullptr
+                             ? *record.properties.find("preprocessing")
+                             : JsonValue::arrayValue({});
+
+  SgNode *node =
+      createNodeFromRecord(record, nullptr, JsonValue::objectValue({}));
+  SgExprListExp *list = isSgExprListExp(node);
+  if (list == nullptr) {
+    throw std::runtime_error(
+        "AST JSON SgArrayType dim_info did not rebuild an expression list");
+  }
+
+  if (record.flags.boolOr("contains_transformation", false)) {
+    list->set_containsTransformation(true);
+  } else {
+    list->set_containsTransformation(false);
+  }
+  if (record.flags.boolOr("contains_transformation_to_surrounding_whitespace",
+                          false)) {
+    list->set_containsTransformationToSurroundingWhitespace(true);
+  } else {
+    list->set_containsTransformationToSurroundingWhitespace(false);
+  }
+  setOwnedExpressionSourcePosition(list, record.location);
+  restoreOwnedExpressionProperties(list, record.properties, nodes);
+
+  const JsonValue &expressions = json.at("expressions");
+  if (expressions.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error(
+        "AST JSON SgArrayType dim_info expressions field is not an array");
+  }
+  for (const JsonValue &expr_json : expressions.array) {
+    SgExpression *expr = expressionFromRef(expr_json, nodes);
+    if (expr == nullptr) {
+      throw std::runtime_error(
+          "AST JSON SgArrayType dim_info contains a null expression");
+    }
+    list->append_expression(expr);
+  }
+  return list;
+}
+
+bool sameAstJsonPath(const std::string &lhs, const std::string &rhs) {
+  if (lhs.empty() || rhs.empty()) {
+    return false;
+  }
+  if (lhs == rhs) {
+    return true;
+  }
+
+  const std::filesystem::path lhs_path(lhs);
+  const std::filesystem::path rhs_path(rhs);
+  if (lhs_path.lexically_normal() == rhs_path.lexically_normal()) {
+    return true;
+  }
+
+  std::error_code lhs_error;
+  std::error_code rhs_error;
+  const bool lhs_exists = std::filesystem::exists(lhs_path, lhs_error);
+  const bool rhs_exists = std::filesystem::exists(rhs_path, rhs_error);
+  if (!lhs_exists || !rhs_exists || lhs_error || rhs_error) {
+    return false;
+  }
+
+  std::error_code canonical_lhs_error;
+  std::error_code canonical_rhs_error;
+  const std::filesystem::path canonical_lhs =
+      std::filesystem::weakly_canonical(lhs_path, canonical_lhs_error);
+  const std::filesystem::path canonical_rhs =
+      std::filesystem::weakly_canonical(rhs_path, canonical_rhs_error);
+  return !canonical_lhs_error && !canonical_rhs_error &&
+         canonical_lhs == canonical_rhs;
+}
+
+bool sourceFileMatchesExternalRecord(SgSourceFile *file,
+                                     const std::string &source_file) {
+  if (file == nullptr || source_file.empty()) {
+    return false;
+  }
+  return sameAstJsonPath(file->getFileName(), source_file) ||
+         sameAstJsonPath(file->get_sourceFileNameWithPath(), source_file);
+}
+
+bool externalClassCandidateMatches(SgClassDeclaration *candidate,
+                                   const JsonValue &json) {
+  if (candidate == nullptr) {
+    return false;
+  }
+
+  const std::string expected_kind = json.at("kind").asString();
+  const std::string expected_name = json.at("name").asString();
+  const int expected_class_type =
+      static_cast<int>(json.at("class_type").asInt());
+  const std::string expected_module = json.at("module_name").asString();
+  const bool expected_has_definition = json.at("has_definition").asBool();
+  const bool expected_is_first_nondefining =
+      json.at("is_first_nondefining").asBool();
+
+  return candidate->sage_class_name() == expected_kind &&
+         candidate->get_name().getString() == expected_name &&
+         static_cast<int>(candidate->get_class_type()) == expected_class_type &&
+         moduleNameForNode(candidate) == expected_module &&
+         classDeclarationHasDefinition(candidate) == expected_has_definition &&
+         classDeclarationIsFirstNondefining(candidate) ==
+             expected_is_first_nondefining;
+}
+
+const std::vector<SgClassDeclaration *> &
+structuralClassDeclarationsForSource(SgSourceFile *source) {
+  ROSE_ASSERT(source != nullptr);
+  auto found = currentDeserializationClassDeclarationCache.find(source);
+  if (found != currentDeserializationClassDeclarationCache.end()) {
+    return found->second;
+  }
+
+  std::vector<SgClassDeclaration *> declarations;
+  std::unordered_set<SgClassDeclaration *> seen;
+  auto add_candidate = [&](SgClassDeclaration *decl) {
+    if (decl != nullptr && seen.insert(decl).second) {
+      declarations.push_back(decl);
+    }
+  };
+  auto add_symbol_basis = [&](SgSymbol *symbol) {
+    add_candidate(
+        isSgClassDeclaration(const_cast<SgNode *>(symbolBasis(symbol))));
+    if (SgAliasSymbol *alias = isSgAliasSymbol(symbol)) {
+      add_candidate(isSgClassDeclaration(
+          const_cast<SgNode *>(symbolBasis(alias->get_alias()))));
+    }
+  };
+
+  RoseAst ast(source);
+  for (RoseAst::iterator it = ast.begin().withoutNullValues(); it != ast.end();
+       ++it) {
+    add_candidate(isSgClassDeclaration(*it));
+    SgScopeStatement *scope = isSgScopeStatement(*it);
+    SgSymbolTable *table =
+        scope != nullptr ? scope->get_symbol_table() : nullptr;
+    if (table == nullptr || table->get_table() == nullptr) {
+      continue;
+    }
+    for (const std::pair<const SgName, SgSymbol *> &entry :
+         *table->get_table()) {
+      add_symbol_basis(entry.second);
+    }
+  }
+
+  auto inserted = currentDeserializationClassDeclarationCache.emplace(
+      source, std::move(declarations));
+  ROSE_ASSERT(inserted.second);
+  return inserted.first->second;
+}
+
+void validateExternalClassDeclarationInProject(const JsonValue &json) {
+  if (currentDeserializationProject == nullptr) {
+    return;
+  }
+
+  const std::string source_file = json.at("source_file").asString();
+  SgClassDeclaration *matched = nullptr;
+  bool saw_source_file = false;
+  for (SgFile *file : currentDeserializationProject->get_fileList()) {
+    SgSourceFile *source = isSgSourceFile(file);
+    if (!sourceFileMatchesExternalRecord(source, source_file)) {
+      continue;
+    }
+    saw_source_file = true;
+
+    for (SgClassDeclaration *candidate :
+         structuralClassDeclarationsForSource(source)) {
+      if (!externalClassCandidateMatches(candidate, json)) {
+        continue;
+      }
+      if (matched != nullptr) {
+        throw std::runtime_error(
+            "AST JSON external class declaration is ambiguous in source file " +
+            source_file + ": " + json.at("kind").asString() + " " +
+            json.at("name").asString());
+      }
+      matched = candidate;
+    }
+  }
+
+  if (saw_source_file && matched == nullptr) {
+    throw std::runtime_error("AST JSON external class declaration was not "
+                             "found in loaded source file " +
+                             source_file + ": " + json.at("kind").asString() +
+                             " " + json.at("name").asString());
+  }
+}
+
+void installTransformationSourcePosition(SgLocatedNode *node) {
+  if (node == nullptr) {
+    return;
+  }
+
+  Sg_File_Info *start =
+      Sg_File_Info::generateDefaultFileInfoForTransformationNode();
+  Sg_File_Info *end =
+      Sg_File_Info::generateDefaultFileInfoForTransformationNode();
+  start->set_parent(node);
+  end->set_parent(node);
+  node->set_startOfConstruct(start);
+  node->set_endOfConstruct(end);
+  node->set_file_info(start);
+}
+
+bool nodeSupportsRestoredSourcePosition(SgNode *node) {
+  return isSgLocatedNode(node) != nullptr ||
+         isSgInitializedName(node) != nullptr || isSgPragma(node) != nullptr ||
+         isSgFile(node) != nullptr;
+}
+
+void restoreNodeSourcePositionFromJson(SgNode *node, const JsonValue &location,
+                                       const std::string &context) {
+  if (node == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a node with source position");
+  }
+  if (location.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON " + context +
+                             " location must be an object");
+  }
+  if (!nodeSupportsRestoredSourcePosition(node)) {
+    throw std::runtime_error("AST JSON " + context +
+                             " node kind has no restorable source position: " +
+                             node->sage_class_name());
+  }
+  const JsonValue *start = location.find("start");
+  if (start == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " location has no start field");
+  }
+  std::unique_ptr<Sg_File_Info> start_info(buildFileInfo(*start, node));
+  if (start_info == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a present startOfConstruct");
+  }
+  const JsonValue *end = location.find("end");
+  std::unique_ptr<Sg_File_Info> end_info(
+      end != nullptr ? buildFileInfo(*end, node) : nullptr);
+  Sg_File_Info *start_raw = start_info.release();
+  Sg_File_Info *end_raw = end_info.release();
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    located->set_startOfConstruct(start_raw);
+    located->set_endOfConstruct(end_raw);
+    located->set_file_info(start_raw);
+  } else if (SgInitializedName *name = isSgInitializedName(node)) {
+    name->set_startOfConstruct(start_raw);
+    name->set_endOfConstruct(end_raw);
+    name->set_file_info(start_raw);
+  } else if (SgPragma *pragma = isSgPragma(node)) {
+    pragma->set_startOfConstruct(start_raw);
+    pragma->set_endOfConstruct(end_raw);
+  } else if (SgFile *file = isSgFile(node)) {
+    file->set_startOfConstruct(start_raw);
+  }
+}
+
+void restoreOptionalNodeSourcePositionFromJson(SgNode *node,
+                                               const JsonValue &location,
+                                               const std::string &context) {
+  if (node == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a node with source position");
+  }
+  if (location.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON " + context +
+                             " location must be an object");
+  }
+  const JsonValue *start = location.find("start");
+  const JsonValue *end = location.find("end");
+  if ((start != nullptr || end != nullptr) &&
+      !nodeSupportsRestoredSourcePosition(node)) {
+    throw std::runtime_error("AST JSON " + context +
+                             " node kind has no restorable source position: " +
+                             node->sage_class_name());
+  }
+  std::unique_ptr<Sg_File_Info> start_info(
+      start != nullptr ? buildFileInfo(*start, node) : nullptr);
+  std::unique_ptr<Sg_File_Info> end_info(
+      end != nullptr ? buildFileInfo(*end, node) : nullptr);
+  Sg_File_Info *start_raw = start_info.release();
+  Sg_File_Info *end_raw = end_info.release();
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    located->set_startOfConstruct(start_raw);
+    located->set_endOfConstruct(end_raw);
+    located->set_file_info(start_raw);
+  } else if (SgInitializedName *name = isSgInitializedName(node)) {
+    name->set_startOfConstruct(start_raw);
+    name->set_endOfConstruct(end_raw);
+    name->set_file_info(start_raw);
+  } else if (SgPragma *pragma = isSgPragma(node)) {
+    pragma->set_startOfConstruct(start_raw);
+    pragma->set_endOfConstruct(end_raw);
+  } else if (SgFile *file = isSgFile(node)) {
+    file->set_startOfConstruct(start_raw);
+  }
+}
+
+SgBitVector bitVectorFromJson(const JsonValue &json,
+                              const std::string &field_name);
+SgModuleStatement *externalModuleFromJson(const JsonValue &json);
+SgSymbol *createSymbolForKindAndBasis(const std::string &kind, SgNode *basis);
+SgSymbol *createExternalSymbolFromJson(const JsonValue &json,
+                                       const NodeMap &nodes);
+SgSymbol *symbolFromJson(const JsonValue &json, const NodeMap &nodes);
+void restoreLabelSymbolFields(SgLabelSymbol *symbol, const JsonValue &json);
+void attachExternalSymbolBasisToScope(SgSymbol *symbol,
+                                      SgScopeStatement *scope);
+
+void restoreExternalDeclarationStatementFields(SgDeclarationStatement *decl,
+                                               const JsonValue &json,
+                                               const std::string &context) {
+  if (decl == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a declaration statement");
+  }
+  decl->set_decl_attributes(
+      static_cast<unsigned int>(json.at("decl_attributes").asInt()));
+  decl->set_linkage(json.at("linkage").asString());
+  decl->get_declarationModifier().set_modifierVector(
+      bitVectorFromJson(json.at("declaration_modifier_vector"),
+                        context + " declaration_modifier_vector"));
+  decl->get_declarationModifier().get_typeModifier().set_modifierVector(
+      bitVectorFromJson(json.at("declaration_type_modifier_vector"),
+                        context + " declaration_type_modifier_vector"));
+  decl->get_declarationModifier().get_storageModifier().set_modifier(
+      static_cast<SgStorageModifier::storage_modifier_enum>(
+          json.at("declaration_storage_modifier").asInt()));
+  decl->get_declarationModifier().get_accessModifier().set_modifier(
+      static_cast<SgAccessModifier::access_modifier_enum>(
+          json.at("declaration_access_modifier").asInt()));
+  decl->get_declarationModifier().get_accessModifier().set_is_explicit(
+      json.boolOr("declaration_access_is_explicit", false));
+  decl->set_nameOnly(json.at("name_only").asBool());
+  decl->set_forward(json.at("forward").asBool());
+  decl->set_externBrace(json.at("extern_brace").asBool());
+  decl->set_skipElaborateType(json.at("skip_elaborate_type").asBool());
+  decl->set_binding_label(json.at("binding_label").asString());
+  decl->set_unparse_template_ast(json.at("unparse_template_ast").asBool());
+  decl->get_declarationModifier().set_gnu_attribute_section_name(
+      json.at("declaration_gnu_attribute_section_name").asString());
+  decl->get_declarationModifier().set_gnu_attribute_visability(
+      static_cast<SgDeclarationModifier::gnu_declaration_visability_enum>(
+          json.at("declaration_gnu_attribute_visability").asInt()));
+
+  const bool first_is_self = json.at("first_nondefining_is_self").asBool();
+  const bool first_is_null = json.at("first_nondefining_is_null").asBool();
+  const bool defining_is_self =
+      json.at("defining_declaration_is_self").asBool();
+  const bool defining_is_null =
+      json.at("defining_declaration_is_null").asBool();
+  if (first_is_self == first_is_null) {
+    throw std::runtime_error(
+        "AST JSON " + context +
+        " first-nondefining declaration state is not exclusive");
+  }
+  if (defining_is_self == defining_is_null) {
+    throw std::runtime_error("AST JSON " + context +
+                             " defining declaration state is not exclusive");
+  }
+  decl->set_firstNondefiningDeclaration(first_is_self ? decl : nullptr);
+  decl->set_definingDeclaration(defining_is_self ? decl : nullptr);
+}
+
+SgInitializedName *externalInitializedNameFromJson(const JsonValue &json,
+                                                   const NodeMap &nodes,
+                                                   SgVariableDeclaration *decl,
+                                                   SgScopeStatement *scope,
+                                                   const std::string &context) {
+  const std::string name = json.at("name").asString();
+  SgType *type = typeFromJson(json.at("type"), nodes);
+  SgInitializedName *initialized_name = new SgInitializedName(
+      nullptr, SgName(name), type, nullptr, nullptr, nullptr, nullptr);
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " initializedName has no location");
+  }
+  restoreNodeSourcePositionFromJson(initialized_name, *location,
+                                    context + " initializedName " + name);
+  initialized_name->set_parent(decl);
+  initialized_name->set_declptr(decl);
+  initialized_name->set_scope(scope);
+  initialized_name->get_storageModifier().set_modifier(
+      static_cast<SgStorageModifier::storage_modifier_enum>(
+          json.intOr("storage_modifier", SgStorageModifier::e_default)));
+  const std::string section = json.stringOr("gnu_attribute_section_name");
+  if (!section.empty()) {
+    initialized_name->set_gnu_attribute_section_name(section);
+  }
+  initialized_name->set_name_qualification_length(
+      static_cast<int>(json.intOr("name_qualification_length", 0)));
+  initialized_name->set_type_elaboration_required(
+      json.boolOr("type_elaboration_required", false));
+  initialized_name->set_global_qualification_required(
+      json.boolOr("global_qualification_required", false));
+  initialized_name->set_name_qualification_length_for_type(
+      static_cast<int>(json.intOr("name_qualification_length_for_type", 0)));
+  initialized_name->set_type_elaboration_required_for_type(
+      json.boolOr("type_elaboration_required_for_type", false));
+  initialized_name->set_global_qualification_required_for_type(
+      json.boolOr("global_qualification_required_for_type", false));
+  return initialized_name;
+}
+
+SgVariableDeclaration *
+externalVariableDeclarationFromJson(const JsonValue &json, const NodeMap &nodes,
+                                    SgFunctionParameterScope *scope,
+                                    const std::string &function_name) {
+  const std::string kind = json.at("kind").asString();
+  if (kind != "SgVariableDeclaration") {
+    throw std::runtime_error(
+        "AST JSON external_function " + function_name +
+        " functionParameterScope declaration kind is unsupported: " + kind);
+  }
+  SgVariableDeclaration *decl = new SgVariableDeclaration();
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " variable declaration has no location");
+  }
+  restoreNodeSourcePositionFromJson(decl, *location,
+                                    "external_function variableDeclaration " +
+                                        function_name);
+  decl->set_parent(scope);
+  decl->set_scope(scope);
+  restoreExternalDeclarationStatementFields(
+      decl, json,
+      "external_function " + function_name + " variableDeclaration");
+  decl->set_requiresGlobalNameQualificationOnType(
+      json.boolOr("requires_global_name_qualification_on_type", false));
+  decl->set_name_qualification_length(
+      static_cast<int>(json.intOr("name_qualification_length", 0)));
+  decl->set_type_elaboration_required(
+      json.boolOr("type_elaboration_required", false));
+  decl->set_global_qualification_required(
+      json.boolOr("global_qualification_required", false));
+
+  const JsonValue &variables = json.at("variables");
+  if (variables.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " variable declaration variables is not an array");
+  }
+  for (const JsonValue &variable : variables.array) {
+    SgInitializedName *initialized_name = externalInitializedNameFromJson(
+        variable, nodes, decl, scope,
+        "external_function " + function_name + " variableDeclaration");
+    decl->get_variables().push_back(initialized_name);
+  }
+  return decl;
+}
+
+SgRenamePair *externalRenamePairFromJson(const JsonValue &json,
+                                         SgUseStatement *parent,
+                                         const std::string &function_name) {
+  const std::string kind = json.at("kind").asString();
+  if (kind != "SgRenamePair") {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " SgUseStatement rename_list entry has "
+                             "unsupported kind: " +
+                             kind);
+  }
+  SgRenamePair *rename =
+      new SgRenamePair(SgName(json.at("local_name").asString()),
+                       SgName(json.at("use_name").asString()));
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " SgUseStatement rename pair has no location");
+  }
+  restoreOptionalNodeSourcePositionFromJson(
+      rename, *location,
+      "external_function " + function_name + " SgUseStatement rename pair");
+  rename->set_parent(parent);
+  return rename;
+}
+
+SgUseStatement *externalUseStatementFromJson(const JsonValue &json,
+                                             const NodeMap &nodes,
+                                             SgFunctionParameterScope *scope,
+                                             const std::string &function_name) {
+  const std::string kind = json.at("kind").asString();
+  if (kind != "SgUseStatement") {
+    throw std::runtime_error(
+        "AST JSON external_function " + function_name +
+        " functionParameterScope declaration kind is unsupported: " + kind);
+  }
+  SgUseStatement *stmt = new SgUseStatement(SgName(json.at("name").asString()),
+                                            json.boolOr("only_option", false),
+                                            json.stringOr("module_nature"));
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " use statement has no location");
+  }
+  restoreNodeSourcePositionFromJson(
+      stmt, *location, "external_function useStatement " + function_name);
+  stmt->set_parent(scope);
+  stmt->set_scope(scope);
+  restoreExternalDeclarationStatementFields(
+      stmt, json, "external_function " + function_name + " useStatement");
+
+  const uint64_t module_id = static_cast<uint64_t>(json.intOr("module", 0));
+  if (module_id != 0) {
+    stmt->set_module(nodeByIdAs<SgModuleStatement>(nodes, module_id));
+  } else if (const JsonValue *external_module = json.find("external_module")) {
+    stmt->set_module(externalModuleFromJson(*external_module));
+  }
+
+  const JsonValue &rename_list = json.at("rename_list");
+  if (rename_list.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " SgUseStatement rename_list is not an array");
+  }
+  for (const JsonValue &rename_json : rename_list.array) {
+    stmt->get_rename_list().push_back(
+        externalRenamePairFromJson(rename_json, stmt, function_name));
+  }
+  return stmt;
+}
+
+SgDeclarationStatement *externalParameterScopeDeclarationFromJson(
+    const JsonValue &json, const NodeMap &nodes,
+    SgFunctionParameterScope *scope, const std::string &function_name) {
+  const std::string kind = json.at("kind").asString();
+  if (kind == "SgVariableDeclaration") {
+    return externalVariableDeclarationFromJson(json, nodes, scope,
+                                               function_name);
+  }
+  if (kind == "SgUseStatement") {
+    return externalUseStatementFromJson(json, nodes, scope, function_name);
+  }
+  throw std::runtime_error(
+      "AST JSON external_function " + function_name +
+      " functionParameterScope declaration kind is unsupported: " + kind);
+}
+
+SgFunctionParameterScope *
+externalFunctionParameterScopeFromJson(const JsonValue &json,
+                                       const NodeMap &nodes,
+                                       const std::string &function_name) {
+  if (!json.boolOr("present", false)) {
+    return nullptr;
+  }
+  SgFunctionParameterScope *scope = new SgFunctionParameterScope();
+  const JsonValue *location = json.find("location");
+  if (location == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " functionParameterScope has no location");
+  }
+  restoreNodeSourcePositionFromJson(
+      scope, *location,
+      "external_function functionParameterScope " + function_name);
+
+  std::vector<std::vector<SgInitializedName *>> variables_by_declaration;
+  std::vector<SgDeclarationStatement *> declarations_by_index;
+  const JsonValue &declarations = json.at("declarations");
+  if (declarations.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " functionParameterScope declarations is not an "
+                             "array");
+  }
+  for (const JsonValue &declaration : declarations.array) {
+    SgDeclarationStatement *decl = externalParameterScopeDeclarationFromJson(
+        declaration, nodes, scope, function_name);
+    scope->append_declaration(decl);
+    declarations_by_index.push_back(decl);
+    std::vector<SgInitializedName *> names;
+    if (SgVariableDeclaration *variable = isSgVariableDeclaration(decl)) {
+      for (SgInitializedName *name : variable->get_variables()) {
+        names.push_back(name);
+      }
+    }
+    variables_by_declaration.push_back(names);
+  }
+
+  if (json.boolOr("symbol_table_present", false)) {
+    SgSymbolTable *table = new SgSymbolTable(17);
+    table->set_parent(scope);
+    table->setCaseInsensitive(
+        json.boolOr("symbol_table_case_insensitive", false));
+    scope->set_symbol_table(table);
+    const JsonValue *symbol_table = json.find("symbol_table");
+    if (symbol_table == nullptr ||
+        symbol_table->kind != JsonValue::Kind::Array) {
+      throw std::runtime_error(
+          "AST JSON external_function " + function_name +
+          " functionParameterScope symbol_table is missing or not an array");
+    }
+    if (static_cast<int64_t>(symbol_table->array.size()) !=
+        json.intOr("symbol_table_size", 0)) {
+      throw std::runtime_error(
+          "AST JSON external_function " + function_name +
+          " functionParameterScope symbol_table size does not match metadata");
+    }
+    std::vector<const JsonValue *> insertion_entries;
+    insertion_entries.reserve(symbol_table->array.size());
+    for (const JsonValue &entry : symbol_table->array) {
+      insertion_entries.push_back(&entry);
+    }
+    for (const JsonValue *entry_ptr : insertion_entries) {
+      const JsonValue &entry = *entry_ptr;
+      const std::string symbol_kind = entry.at("symbol_kind").asString();
+      const SgName entry_name(entry.at("entry_name").asString());
+      if (const JsonValue *declaration_index_value =
+              entry.find("declaration_index")) {
+        const size_t declaration_index =
+            static_cast<size_t>(declaration_index_value->asInt());
+        const size_t variable_index =
+            static_cast<size_t>(entry.at("variable_index").asInt());
+        if (declaration_index >= variables_by_declaration.size() ||
+            variable_index >=
+                variables_by_declaration[declaration_index].size()) {
+          throw std::runtime_error(
+              "AST JSON external_function " + function_name +
+              " functionParameterScope symbol_table indexes are out of range");
+        }
+        if (symbol_kind != "SgVariableSymbol") {
+          throw std::runtime_error(
+              "AST JSON external_function " + function_name +
+              " functionParameterScope indexed symbol kind is unsupported: " +
+              symbol_kind);
+        }
+        SgInitializedName *declaration =
+            variables_by_declaration[declaration_index][variable_index];
+        table->insert(entry_name, new SgVariableSymbol(declaration));
+        continue;
+      }
+      const JsonValue *symbol_json = entry.find("symbol");
+      if (symbol_json == nullptr) {
+        throw std::runtime_error(
+            "AST JSON external_function " + function_name +
+            " functionParameterScope symbol_table entry has neither nested "
+            "variable indexes nor a structured symbol reference: " +
+            entry_name.getString());
+      }
+      const std::string referenced_kind =
+          symbol_json->at("symbol_kind").asString();
+      if (referenced_kind != symbol_kind) {
+        throw std::runtime_error(
+            "AST JSON external_function " + function_name +
+            " functionParameterScope symbol_table kind mismatch for " +
+            entry_name.getString() + ": entry=" + symbol_kind +
+            " symbol=" + referenced_kind);
+      }
+      if (symbol_kind == "SgAliasSymbol") {
+        const JsonValue *target = entry.find("alias_target");
+        if (target == nullptr) {
+          throw std::runtime_error(
+              "AST JSON external_function " + function_name +
+              " functionParameterScope SgAliasSymbol has no alias_target: " +
+              entry_name.getString());
+        }
+        SgSymbol *target_symbol = symbolFromJson(*target, nodes);
+        if (target_symbol == nullptr ||
+            target_symbol->get_symbol_basis() == nullptr) {
+          throw std::runtime_error(
+              "AST JSON external_function " + function_name +
+              " functionParameterScope cannot reconstruct alias target for " +
+              entry_name.getString());
+        }
+        SgAliasSymbol *alias = new SgAliasSymbol(
+            target_symbol, entry.boolOr("alias_is_renamed", false),
+            SgName(entry.stringOr("alias_new_name")));
+        if (const JsonValue *causal_nodes = entry.find("alias_causal_nodes")) {
+          if (causal_nodes->kind != JsonValue::Kind::Array) {
+            throw std::runtime_error(
+                "AST JSON external_function " + function_name +
+                " functionParameterScope alias_causal_nodes is not an array");
+          }
+          for (const JsonValue &causal_node : causal_nodes->array) {
+            if (causal_node.kind != JsonValue::Kind::Object) {
+              throw std::runtime_error(
+                  "AST JSON external_function " + function_name +
+                  " functionParameterScope alias causal node is not an object");
+            }
+            const uint64_t node_id =
+                static_cast<uint64_t>(causal_node.intOr("node", 0));
+            const int64_t declaration_index =
+                causal_node.intOr("declaration_index", -1);
+            if (node_id != 0) {
+              alias->get_causal_nodes().push_back(nodeById(nodes, node_id));
+            } else if (declaration_index >= 0 &&
+                       static_cast<size_t>(declaration_index) <
+                           declarations_by_index.size()) {
+              alias->get_causal_nodes().push_back(
+                  declarations_by_index[static_cast<size_t>(
+                      declaration_index)]);
+            } else if (declaration_index >= 0) {
+              throw std::runtime_error(
+                  "AST JSON external_function " + function_name +
+                  " functionParameterScope alias causal declaration index is "
+                  "out of range");
+            }
+          }
+        }
+        attachExternalSymbolBasisToScope(alias, scope);
+        table->insert(entry_name, alias);
+        continue;
+      }
+      if (symbol_kind == "SgRenameSymbol") {
+        const JsonValue *original = entry.find("original_symbol");
+        if (original == nullptr) {
+          throw std::runtime_error("AST JSON external_function " +
+                                   function_name +
+                                   " functionParameterScope SgRenameSymbol has "
+                                   "no original_symbol: " +
+                                   entry_name.getString());
+        }
+        const uint64_t basis_id = static_cast<uint64_t>(
+            symbol_json->at("symbol_declaration").asInt());
+        if (basis_id == 0) {
+          throw std::runtime_error(
+              "AST JSON external_function " + function_name +
+              " functionParameterScope SgRenameSymbol has no collected "
+              "function declaration basis: " +
+              entry_name.getString());
+        }
+        SgRenameSymbol *rename = new SgRenameSymbol(
+            nodeByIdAs<SgFunctionDeclaration>(nodes, basis_id),
+            symbolFromJson(*original, nodes),
+            SgName(entry.stringOr("rename_new_name")));
+        table->insert(entry_name, rename);
+        continue;
+      }
+      const uint64_t basis_id =
+          static_cast<uint64_t>(symbol_json->at("symbol_declaration").asInt());
+      SgSymbol *symbol = nullptr;
+      if (basis_id == 0) {
+        symbol = createExternalSymbolFromJson(*symbol_json, nodes);
+      } else {
+        SgNode *basis = nodeById(nodes, basis_id);
+        symbol = createSymbolForKindAndBasis(symbol_kind, basis);
+        if (SgLabelSymbol *label_symbol = isSgLabelSymbol(symbol)) {
+          restoreLabelSymbolFields(label_symbol, *symbol_json);
+        }
+      }
+      if (symbol == nullptr || symbol->get_symbol_basis() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON external_function " + function_name +
+            " functionParameterScope cannot reconstruct symbol_table entry " +
+            entry_name.getString() + " kind=" + symbol_kind);
+      }
+      attachExternalSymbolBasisToScope(symbol, scope);
+      table->insert(entry_name, symbol);
+    }
+  }
+  return scope;
+}
+
+SgClassDeclaration *newClassDeclarationForExternalRecord(
+    const std::string &kind, const std::string &name,
+    SgClassDeclaration::class_types class_type) {
+  if (kind == "SgDerivedTypeStatement") {
+    return new SgDerivedTypeStatement(SgName(name), class_type, nullptr,
+                                      nullptr);
+  }
+  if (kind == "SgModuleStatement") {
+    return new SgModuleStatement(SgName(name), class_type, nullptr, nullptr);
+  }
+  if (kind == "SgClassDeclaration") {
+    return new SgClassDeclaration(SgName(name), class_type, nullptr, nullptr);
+  }
+  throw std::runtime_error(
+      "AST JSON external class declaration has unsupported declaration kind: " +
+      kind);
+}
+
+SgClassDeclaration *externalClassDeclarationFromJson(const JsonValue &json) {
+  if (!json.boolOr("present", false)) {
+    return nullptr;
+  }
+
+  const std::string kind = json.at("kind").asString();
+  const std::string name = json.at("name").asString();
+  const std::string source_file = json.at("source_file").asString();
+  if (kind.empty() || name.empty() || source_file.empty()) {
+    throw std::runtime_error("AST JSON external class declaration requires "
+                             "kind, name, and source_file");
+  }
+  validateExternalClassDeclarationInProject(json);
+
+  const auto class_type = static_cast<SgClassDeclaration::class_types>(
+      json.at("class_type").asInt());
+  const std::string module_name = json.at("module_name").asString();
+  const bool has_definition = json.at("has_definition").asBool();
+  const bool is_first_nondefining = json.at("is_first_nondefining").asBool();
+
+  SgModuleStatement *module = nullptr;
+  SgClassDefinition *module_definition = nullptr;
+  if (!module_name.empty() && kind != "SgModuleStatement") {
+    module = new SgModuleStatement(SgName(module_name),
+                                   SgClassDeclaration::e_fortran_module,
+                                   nullptr, nullptr);
+    installTransformationSourcePosition(module);
+    module_definition = new SgClassDefinition();
+    installTransformationSourcePosition(module_definition);
+    module->set_definition(module_definition);
+    module_definition->set_declaration(module);
+    module_definition->set_parent(module);
+    module->set_firstNondefiningDeclaration(module);
+    module->set_definingDeclaration(module);
+    module->set_type(new SgClassType(module));
+    markAstJsonExternalModule(module, source_file);
+  }
+
+  SgClassDeclaration *decl =
+      newClassDeclarationForExternalRecord(kind, name, class_type);
+  installTransformationSourcePosition(decl);
+  decl->set_parent(module_definition);
+  decl->set_scope(module_definition);
+  markAstJsonExternalClassDeclaration(decl, source_file);
+
+  SgClassDeclaration *first_nondefining = decl;
+  SgClassDeclaration *defining = has_definition ? decl : nullptr;
+  if (has_definition) {
+    SgClassDefinition *definition = new SgClassDefinition();
+    installTransformationSourcePosition(definition);
+    definition->set_declaration(decl);
+    definition->set_parent(decl);
+    decl->set_definition(definition);
+    if (!is_first_nondefining) {
+      first_nondefining =
+          newClassDeclarationForExternalRecord(kind, name, class_type);
+      installTransformationSourcePosition(first_nondefining);
+      first_nondefining->set_parent(module_definition);
+      first_nondefining->set_scope(module_definition);
+      markAstJsonExternalClassDeclaration(first_nondefining, source_file);
+      first_nondefining->set_firstNondefiningDeclaration(first_nondefining);
+      first_nondefining->set_definingDeclaration(decl);
+    }
+  }
+
+  decl->set_firstNondefiningDeclaration(first_nondefining);
+  decl->set_definingDeclaration(defining);
+  decl->set_type(new SgClassType(decl));
+  if (first_nondefining != decl) {
+    first_nondefining->set_type(new SgClassType(first_nondefining));
+  }
+
+  if (module_definition != nullptr) {
+    module_definition->get_members().push_back(first_nondefining);
+    if (decl != first_nondefining) {
+      module_definition->get_members().push_back(decl);
+    }
+  }
+
+  return decl;
+}
+
+SgType *typeFromJson(const JsonValue &json, const NodeMap &nodes) {
+  if (json.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON type record is not an object");
+  }
+  if (!json.boolOr("present", false)) {
+    throw std::runtime_error("AST JSON required type record is absent");
+  }
+
+  const std::string kind = json.stringOr("kind");
+  if (kind == "SgTypeDefault") {
+    return attachJsonTypeText(SgTypeDefault::createType(), json);
+  }
+  if (kind == "SgTypeUnknown") {
+    return attachJsonTypeText(SageBuilder::buildUnknownType(), json);
+  }
+  if (kind == "SgTypeEllipse") {
+    return attachJsonTypeText(SgTypeEllipse::createType(), json);
+  }
+  if (kind == "SgTypeNullptr") {
+    return attachJsonTypeText(SageBuilder::buildNullptrType(), json);
+  }
+  if (kind == "SgTypeLabel") {
+    return attachJsonTypeText(
+        SgTypeLabel::createType(SgName(json.stringOr("name"))), json);
+  }
+  if (kind == "SgTypeFloat128") {
+    return attachJsonTypeText(SageBuilder::buildFloat128Type(), json);
+  }
+  if (kind == "SgTypeSigned128bitInteger") {
+    return attachJsonTypeText(SageBuilder::buildSigned128bitIntegerType(),
+                              json);
+  }
+  if (kind == "SgTypeUnsigned128bitInteger") {
+    return attachJsonTypeText(SageBuilder::buildUnsigned128bitIntegerType(),
+                              json);
+  }
+  if (SgType *primitive = primitiveTypeFromKind(kind)) {
+    return attachJsonTypeText(primitive, json);
+  }
+  if (kind == "SgTypeString") {
+    SgExpression *length = nullptr;
+    if (const JsonValue *length_json = json.find("length_expression")) {
+      length = expressionFromRef(*length_json, nodes);
+    }
+    SgExpression *type_kind = nullptr;
+    if (const JsonValue *kind_json = json.find("type_kind")) {
+      type_kind = expressionFromRef(*kind_json, nodes);
+    }
+    SgTypeString *string_type = new SgTypeString(length);
+    string_type->set_type_kind(type_kind);
+    const SgName mangled = string_type->get_mangled();
+
+    SgTypeTable *type_table = SgNode::get_globalTypeTable();
+    ROSE_ASSERT(type_table != nullptr);
+    if (type_table->lookup_type(mangled) != nullptr) {
+      type_table->remove_type(mangled);
+    }
+
+    if (length != nullptr) {
+      length->set_parent(string_type);
+    }
+    if (type_kind != nullptr) {
+      type_kind->set_parent(string_type);
+    }
+    type_table->insert_type(mangled, string_type);
+    return attachJsonTypeText(string_type, json);
+  }
+  if (kind == "SgTypeComplex") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    SgExpression *type_kind = nullptr;
+    if (const JsonValue *kind_json = json.find("type_kind")) {
+      type_kind = expressionFromRef(*kind_json, nodes);
+    }
+    SgTypeComplex *complex_type = SgTypeComplex::createType(base, type_kind);
+    if (type_kind != nullptr) {
+      type_kind->set_parent(complex_type);
+    }
+    return attachJsonTypeText(complex_type, json);
+  }
+  if (kind == "SgPointerType") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    return attachJsonTypeText(buildCachedJsonPointerType(base), json);
+  }
+  if (kind == "SgPointerMemberType") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    SgType *class_type = typeFromJson(json.at("class_type"), nodes);
+    return attachJsonTypeText(SgPointerMemberType::createType(base, class_type),
+                              json);
+  }
+  if (kind == "SgReferenceType") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    SgReferenceType *reference = new SgReferenceType(base);
+    installReferenceCache(base, reference);
+    return attachJsonTypeText(reference, json);
+  }
+  if (kind == "SgRvalueReferenceType") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    SgRvalueReferenceType *reference = new SgRvalueReferenceType(base);
+    installRvalueReferenceCache(base, reference);
+    return attachJsonTypeText(reference, json);
+  }
+  if (kind == "SgArrayType") {
+    SgExpression *index = nullptr;
+    if (const JsonValue *index_json = json.find("index")) {
+      index = expressionFromRef(*index_json, nodes);
+    }
+    SgArrayType *array =
+        new SgArrayType(typeFromJson(json.at("base"), nodes), index);
+    if (index != nullptr && array->get_index() != index) {
+      array->set_index(index);
+    }
+    if (index != nullptr) {
+      index->set_parent(array);
+    }
+    if (const JsonValue *dim_info = json.find("dim_info")) {
+      SgExprListExp *dimensions = exprListExpFromTypeJson(*dim_info, nodes);
+      array->set_dim_info(dimensions);
+      if (dimensions != nullptr) {
+        dimensions->set_parent(array);
+      }
+    }
+    array->set_rank(static_cast<int>(json.intOr("rank", array->get_rank())));
+    array->set_number_of_elements(static_cast<int>(
+        json.intOr("number_of_elements", array->get_number_of_elements())));
+    array->set_isCoArray(json.boolOr("is_coarray", array->get_isCoArray()));
+    array->set_is_variable_length_array(json.boolOr(
+        "is_variable_length_array", array->get_is_variable_length_array()));
+    const SgName mangled = array->get_mangled();
+    SgTypeTable *type_table = SgNode::get_globalTypeTable();
+    ROSE_ASSERT(type_table != nullptr);
+    if (type_table->lookup_type(mangled) != nullptr) {
+      type_table->remove_type(mangled);
+    }
+    type_table->insert_type(mangled, array);
+    return attachJsonTypeText(array, json);
+  }
+  if (kind == "SgModifierType") {
+    SgType *base = typeFromJson(json.at("base"), nodes);
+    SgModifierType *modifier = new SgModifierType(base);
+    SgTypeModifier &type_modifier = modifier->get_typeModifier();
+    SgConstVolatileModifier &cv = type_modifier.get_constVolatileModifier();
+    if (json.boolOr("modifier_const", false)) {
+      cv.setConst();
+    }
+    if (json.boolOr("modifier_volatile", false)) {
+      cv.setVolatile();
+    }
+    if (json.boolOr("modifier_restrict", false)) {
+      type_modifier.setRestrict();
+    }
+    return attachJsonTypeText(modifier, json);
+  }
+  if (kind == "SgTypedefType") {
+    const uint64_t decl_id =
+        static_cast<uint64_t>(json.intOr("declaration", 0));
+    if (decl_id != 0) {
+      if (SgTypedefDeclaration *decl =
+              isSgTypedefDeclaration(nodeById(nodes, decl_id))) {
+        if (decl->get_type() == nullptr) {
+          decl->set_type(new SgTypedefType(decl, nullptr));
+        }
+        decl->get_type()->set_autonomous_declaration(
+            json.boolOr("autonomous_declaration",
+                        decl->get_type()->get_autonomous_declaration()));
+        return attachJsonTypeText(decl->get_type(), json);
+      }
+    }
+    throw std::runtime_error(
+        "AST JSON SgTypedefType requires a valid declaration id");
+  }
+  if (kind == "SgClassType") {
+    const uint64_t decl_id =
+        static_cast<uint64_t>(json.intOr("declaration", 0));
+    if (decl_id != 0) {
+      if (SgClassDeclaration *decl =
+              isSgClassDeclaration(nodeById(nodes, decl_id))) {
+        SgClassType *class_type = ensureClassTypeForDeclaration(decl);
+        class_type->set_autonomous_declaration(
+            json.boolOr("autonomous_declaration",
+                        class_type->get_autonomous_declaration()));
+        return attachJsonTypeText(class_type, json);
+      }
+    }
+    if (const JsonValue *external_declaration =
+            json.find("external_declaration")) {
+      SgClassDeclaration *decl =
+          externalClassDeclarationFromJson(*external_declaration);
+      SgClassType *class_type = ensureClassTypeForDeclaration(decl);
+      class_type->set_autonomous_declaration(json.boolOr(
+          "autonomous_declaration", class_type->get_autonomous_declaration()));
+      return attachJsonTypeText(class_type, json);
+    }
+    throw std::runtime_error(
+        "AST JSON SgClassType requires a declaration id or an "
+        "external_declaration record");
+  }
+  if (kind == "SgEnumType") {
+    const uint64_t decl_id =
+        static_cast<uint64_t>(json.intOr("declaration", 0));
+    if (decl_id != 0) {
+      if (SgEnumDeclaration *decl =
+              isSgEnumDeclaration(nodeById(nodes, decl_id))) {
+        if (decl->get_type() == nullptr) {
+          if (decl->get_scope() == nullptr) {
+            decl->set_scope(nearestScope(decl));
+          }
+          decl->set_type(SgEnumType::createType(decl));
+        }
+        decl->get_type()->set_autonomous_declaration(
+            json.boolOr("autonomous_declaration",
+                        decl->get_type()->get_autonomous_declaration()));
+        return attachJsonTypeText(decl->get_type(), json);
+      }
+    }
+    throw std::runtime_error(
+        "AST JSON SgEnumType requires a valid declaration id");
+  }
+  if (kind == "SgNonrealType") {
+    const uint64_t decl_id =
+        static_cast<uint64_t>(json.intOr("declaration", 0));
+    if (decl_id != 0) {
+      if (SgNonrealDecl *decl = isSgNonrealDecl(nodeById(nodes, decl_id))) {
+        if (decl->get_type() == nullptr) {
+          decl->set_type(new SgNonrealType(decl));
+        }
+        decl->get_type()->set_autonomous_declaration(
+            json.boolOr("autonomous_declaration",
+                        decl->get_type()->get_autonomous_declaration()));
+        return attachJsonTypeText(decl->get_type(), json);
+      }
+    }
+    throw std::runtime_error(
+        "AST JSON SgNonrealType requires a valid declaration id");
+  }
+  if (kind == "SgDeclType") {
+    SgExpression *base_expression = nullptr;
+    if (const JsonValue *base_json = json.find("base_expression")) {
+      base_expression = expressionFromRef(*base_json, nodes);
+    }
+    return buildDeclType(base_expression, json);
+  }
+  if (kind == "SgTemplateType") {
+    SgTemplateType *template_type = new SgTemplateType(
+        SgName(json.stringOr("name", json.stringOr("text"))));
+    template_type->set_template_parameter_position(
+        static_cast<int>(json.intOr("template_parameter_position", -1)));
+    template_type->set_template_parameter_depth(
+        static_cast<int>(json.intOr("template_parameter_depth", -1)));
+    if (const JsonValue *class_json = json.find("class_type")) {
+      template_type->set_class_type(class_json->boolOr("present", false)
+                                        ? typeFromJson(*class_json, nodes)
+                                        : nullptr);
+    } else {
+      template_type->set_class_type(nullptr);
+    }
+    if (const JsonValue *parent_class_json = json.find("parent_class_type")) {
+      template_type->set_parent_class_type(
+          parent_class_json->boolOr("present", false)
+              ? typeFromJson(*parent_class_json, nodes)
+              : nullptr);
+    } else {
+      template_type->set_parent_class_type(nullptr);
+    }
+    return attachJsonTypeText(template_type, json);
+  }
+  if (kind == "SgMemberFunctionType") {
+    SgType *return_type = SageBuilder::buildIntType();
+    if (const JsonValue *return_json = json.find("return_type")) {
+      return_type = typeFromJson(*return_json, nodes);
+    }
+    SgType *class_type = nullptr;
+    if (const JsonValue *class_json = json.find("class_type")) {
+      class_type = typeFromJson(*class_json, nodes);
+    }
+    SgFunctionParameterTypeList *arguments = new SgFunctionParameterTypeList();
+    if (const JsonValue *argument_json = json.find("arguments")) {
+      if (argument_json->kind != JsonValue::Kind::Array) {
+        throw std::runtime_error(
+            "AST JSON member function type arguments field is not an array");
+      }
+      for (const JsonValue &argument : argument_json->array) {
+        arguments->append_argument(typeFromJson(argument, nodes));
+      }
+    }
+    SgMemberFunctionType *member_type = new SgMemberFunctionType(
+        return_type, json.boolOr("has_ellipses", false), class_type,
+        static_cast<unsigned int>(json.intOr("mfunc_specifier", 0)));
+    member_type->set_argument_list(arguments);
+    arguments->set_parent(member_type);
+    return attachJsonTypeText(member_type, json);
+  }
+  if (kind == "SgFunctionType") {
+    SgType *return_type = SageBuilder::buildIntType();
+    if (const JsonValue *return_json = json.find("return_type")) {
+      return_type = typeFromJson(*return_json, nodes);
+    }
+    SgFunctionParameterTypeList *arguments = new SgFunctionParameterTypeList();
+    if (const JsonValue *argument_json = json.find("arguments")) {
+      if (argument_json->kind != JsonValue::Kind::Array) {
+        throw std::runtime_error(
+            "AST JSON function type arguments field is not an array");
+      }
+      for (const JsonValue &argument : argument_json->array) {
+        arguments->append_argument(typeFromJson(argument, nodes));
+      }
+    }
+    SgFunctionType *function_type =
+        new SgFunctionType(return_type, json.boolOr("has_ellipses", false));
+    function_type->set_argument_list(arguments);
+    arguments->set_parent(function_type);
+    return attachJsonTypeText(function_type, json);
+  }
+  throw std::runtime_error("AST JSON deserializer does not support Sage type " +
+                           kind);
+}
+
+SgType *nullableTypeFromJson(const JsonValue &json, const NodeMap &nodes) {
+  if (json.kind != JsonValue::Kind::Object || !json.boolOr("present", false)) {
+    return nullptr;
+  }
+  return typeFromJson(json, nodes);
+}
+
+SgFile::languageOption_enum
+fileLanguageFromJson(const JsonValue &properties, const std::string &key,
+                     SgFile::languageOption_enum fallback) {
+  const int64_t value = properties.intOr(key, static_cast<int64_t>(fallback));
+  if (value < static_cast<int64_t>(SgFile::e_error_language) ||
+      value >= static_cast<int64_t>(SgFile::e_last_language)) {
+    throw std::runtime_error(
+        "AST JSON SgSourceFile language enum is invalid: " + key);
+  }
+  return static_cast<SgFile::languageOption_enum>(value);
+}
+
+SgFile::outputFormatOption_enum
+fileOutputFormatFromJson(const JsonValue &properties, const std::string &key,
+                         SgFile::outputFormatOption_enum fallback) {
+  const int64_t value = properties.intOr(key, static_cast<int64_t>(fallback));
+  if (value < static_cast<int64_t>(SgFile::e_unknown_output_format) ||
+      value > static_cast<int64_t>(SgFile::e_free_form_output_format)) {
+    throw std::runtime_error(
+        "AST JSON SgSourceFile output-format enum is invalid: " + key);
+  }
+  return static_cast<SgFile::outputFormatOption_enum>(value);
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonFormat.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonFormat.cpp
@@ -1,0 +1,563 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+const char *const kFormat = "rex-sage-ast-json";
+const int kSchemaVersion = 27;
+
+class JsonParser {
+public:
+  explicit JsonParser(const std::string &input) : input_(input) {}
+
+  JsonValue parse() {
+    JsonValue value = parseValue();
+    skipWhitespace();
+    if (pos_ != input_.size()) {
+      fail("trailing data after JSON value");
+    }
+    return value;
+  }
+
+private:
+  const std::string &input_;
+  size_t pos_ = 0;
+
+  [[noreturn]] void fail(const std::string &message) const {
+    std::ostringstream out;
+    out << "invalid AST JSON at byte " << pos_ << ": " << message;
+    throw std::runtime_error(out.str());
+  }
+
+  void skipWhitespace() {
+    while (pos_ < input_.size() &&
+           std::isspace(static_cast<unsigned char>(input_[pos_]))) {
+      ++pos_;
+    }
+  }
+
+  bool consume(char expected) {
+    skipWhitespace();
+    if (pos_ < input_.size() && input_[pos_] == expected) {
+      ++pos_;
+      return true;
+    }
+    return false;
+  }
+
+  void require(char expected) {
+    if (!consume(expected)) {
+      std::string message = "expected '";
+      message += expected;
+      message += "'";
+      fail(message);
+    }
+  }
+
+  JsonValue parseValue() {
+    skipWhitespace();
+    if (pos_ >= input_.size()) {
+      fail("unexpected end of input");
+    }
+
+    const char c = input_[pos_];
+    if (c == '"') {
+      return JsonValue::string(parseString());
+    }
+    if (c == '{') {
+      return parseObject();
+    }
+    if (c == '[') {
+      return parseArray();
+    }
+    if (startsWith("true")) {
+      pos_ += 4;
+      return JsonValue::boolean(true);
+    }
+    if (startsWith("false")) {
+      pos_ += 5;
+      return JsonValue::boolean(false);
+    }
+    if (startsWith("null")) {
+      pos_ += 4;
+      return JsonValue::null();
+    }
+    if (c == '-' || std::isdigit(static_cast<unsigned char>(c))) {
+      return parseNumber();
+    }
+    fail("unexpected JSON value");
+  }
+
+  bool startsWith(const char *keyword) const {
+    const size_t length = std::char_traits<char>::length(keyword);
+    return input_.compare(pos_, length, keyword) == 0;
+  }
+
+  JsonValue parseObject() {
+    require('{');
+    std::map<std::string, JsonValue> object;
+    skipWhitespace();
+    if (consume('}')) {
+      return JsonValue::objectValue(std::move(object));
+    }
+    while (true) {
+      skipWhitespace();
+      if (pos_ >= input_.size() || input_[pos_] != '"') {
+        fail("expected object key");
+      }
+      std::string key = parseString();
+      require(':');
+      object.emplace(std::move(key), parseValue());
+      if (consume('}')) {
+        break;
+      }
+      require(',');
+    }
+    return JsonValue::objectValue(std::move(object));
+  }
+
+  JsonValue parseArray() {
+    require('[');
+    std::vector<JsonValue> array;
+    skipWhitespace();
+    if (consume(']')) {
+      return JsonValue::arrayValue(std::move(array));
+    }
+    while (true) {
+      array.push_back(parseValue());
+      if (consume(']')) {
+        break;
+      }
+      require(',');
+    }
+    return JsonValue::arrayValue(std::move(array));
+  }
+
+  JsonValue parseNumber() {
+    const size_t begin = pos_;
+    if (input_[pos_] == '-') {
+      ++pos_;
+    }
+    while (pos_ < input_.size() &&
+           std::isdigit(static_cast<unsigned char>(input_[pos_]))) {
+      ++pos_;
+    }
+    if (pos_ < input_.size() && input_[pos_] == '.') {
+      ++pos_;
+      while (pos_ < input_.size() &&
+             std::isdigit(static_cast<unsigned char>(input_[pos_]))) {
+        ++pos_;
+      }
+    }
+    if (pos_ < input_.size() && (input_[pos_] == 'e' || input_[pos_] == 'E')) {
+      ++pos_;
+      if (pos_ < input_.size() &&
+          (input_[pos_] == '+' || input_[pos_] == '-')) {
+        ++pos_;
+      }
+      while (pos_ < input_.size() &&
+             std::isdigit(static_cast<unsigned char>(input_[pos_]))) {
+        ++pos_;
+      }
+    }
+    if (begin == pos_) {
+      fail("malformed number");
+    }
+    return JsonValue::number(input_.substr(begin, pos_ - begin));
+  }
+
+  std::string parseString() {
+    require('"');
+    std::string result;
+    while (pos_ < input_.size()) {
+      char c = input_[pos_++];
+      if (c == '"') {
+        return result;
+      }
+      if (c != '\\') {
+        result += c;
+        continue;
+      }
+      if (pos_ >= input_.size()) {
+        fail("unterminated escape sequence");
+      }
+      const char escaped = input_[pos_++];
+      switch (escaped) {
+      case '"':
+      case '\\':
+      case '/':
+        result += escaped;
+        break;
+      case 'b':
+        result += '\b';
+        break;
+      case 'f':
+        result += '\f';
+        break;
+      case 'n':
+        result += '\n';
+        break;
+      case 'r':
+        result += '\r';
+        break;
+      case 't':
+        result += '\t';
+        break;
+      case 'u':
+        if (pos_ + 4 > input_.size()) {
+          fail("short unicode escape");
+        }
+        // The writer only emits \\u00XX for control bytes. Preserve other
+        // escapes as '?' because Sage source text in this path is
+        // byte-oriented.
+        if (input_[pos_] == '0' && input_[pos_ + 1] == '0') {
+          const std::string hex = input_.substr(pos_ + 2, 2);
+          result += static_cast<char>(std::stoi(hex, nullptr, 16));
+        } else {
+          result += '?';
+        }
+        pos_ += 4;
+        break;
+      default:
+        fail("unsupported escape sequence");
+      }
+    }
+    fail("unterminated string");
+  }
+};
+
+JsonValue parseJson(const std::string &json) {
+  return JsonParser(json).parse();
+}
+
+const NodeRecord &AstFileRecord::node(uint64_t id) const {
+  auto found = index_by_id.find(id);
+  if (found == index_by_id.end()) {
+    throw std::runtime_error("AST JSON references unknown node id " +
+                             std::to_string(id));
+  }
+  return nodes[found->second];
+}
+
+bool startsWith(const std::string &s, const std::string &prefix) {
+  return s.rfind(prefix, 0) == 0;
+}
+
+std::string sanitizePathComponent(std::string name) {
+  for (char &c : name) {
+    unsigned char uc = static_cast<unsigned char>(c);
+    if (!std::isalnum(uc) && c != '_' && c != '-' && c != '.') {
+      c = '_';
+    }
+  }
+  if (name.empty()) {
+    return "ast";
+  }
+  return name;
+}
+
+uint64_t fnv1a64(const std::string &value) {
+  uint64_t hash = 14695981039346656037ull;
+  for (unsigned char c : value) {
+    hash ^= c;
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+std::string hex64(uint64_t value) {
+  std::ostringstream out;
+  out << std::hex << std::setw(16) << std::setfill('0') << value;
+  return out.str();
+}
+
+uint64_t processId() { return static_cast<uint64_t>(::getpid()); }
+
+std::vector<std::string> commandLine(const SgSourceFile *file) {
+  if (file == nullptr) {
+    return {};
+  }
+  return file->get_originalCommandLineArgumentList();
+}
+
+bool argumentSelectsCheckpoint(const std::string &value,
+                               Checkpoint checkpoint) {
+  return value == "all" || value == checkpointName(checkpoint);
+}
+
+bool hasCheckpointArgument(const SgSourceFile *file, Checkpoint checkpoint) {
+  const std::string prefix = "-rex:ast-json-checkpoint=";
+  for (const std::string &arg : commandLine(file)) {
+    if (startsWith(arg, prefix) &&
+        argumentSelectsCheckpoint(arg.substr(prefix.size()), checkpoint)) {
+      return true;
+    }
+  }
+
+  const char *env = std::getenv("REX_AST_JSON_CHECKPOINT");
+  return env != nullptr && argumentSelectsCheckpoint(env, checkpoint);
+}
+
+std::string commandLineValue(const SgSourceFile *file,
+                             const std::string &prefix) {
+  for (const std::string &arg : commandLine(file)) {
+    if (startsWith(arg, prefix)) {
+      return arg.substr(prefix.size());
+    }
+  }
+  return "";
+}
+
+std::string defaultOutputDirectory(const SgSourceFile *file) {
+  std::string from_arg = commandLineValue(file, "-rex:ast-json-dir=");
+  if (!from_arg.empty()) {
+    return from_arg;
+  }
+
+  const char *env = std::getenv("REX_AST_JSON_DIR");
+  if (env != nullptr && env[0] != '\0') {
+    return env;
+  }
+
+  return ".rex-ast-json";
+}
+
+std::string trim(const std::string &input) {
+  size_t begin = 0;
+  while (begin < input.size() &&
+         std::isspace(static_cast<unsigned char>(input[begin]))) {
+    ++begin;
+  }
+  size_t end = input.size();
+  while (end > begin &&
+         std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+    --end;
+  }
+  return input.substr(begin, end - begin);
+}
+
+std::string jsonString(const std::string &input) {
+  std::ostringstream out;
+  out << '"';
+  for (unsigned char c : input) {
+    switch (c) {
+    case '"':
+      out << "\\\"";
+      break;
+    case '\\':
+      out << "\\\\";
+      break;
+    case '\b':
+      out << "\\b";
+      break;
+    case '\f':
+      out << "\\f";
+      break;
+    case '\n':
+      out << "\\n";
+      break;
+    case '\r':
+      out << "\\r";
+      break;
+    case '\t':
+      out << "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        out << "\\u";
+        const char *digits = "0123456789abcdef";
+        out << '0' << '0' << digits[(c >> 4) & 0xf] << digits[c & 0xf];
+      } else {
+        out << static_cast<char>(c);
+      }
+      break;
+    }
+  }
+  out << '"';
+  return out.str();
+}
+
+void indent(std::ostream &out, int level) {
+  for (int i = 0; i < level; ++i) {
+    out << ' ';
+  }
+}
+
+void writeStringField(std::ostream &out, int level, const char *name,
+                      const std::string &value, bool comma) {
+  indent(out, level);
+  out << jsonString(name) << ": " << jsonString(value);
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void writeIntegerField(std::ostream &out, int level, const char *name,
+                       int64_t value, bool comma) {
+  indent(out, level);
+  out << jsonString(name) << ": " << value;
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void writeBoolField(std::ostream &out, int level, const char *name, bool value,
+                    bool comma) {
+  indent(out, level);
+  out << jsonString(name) << ": " << (value ? "true" : "false");
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void requireFileIdMapping(int id, const std::string &filename,
+                          const std::string &context) {
+  if (id < 0) {
+    throw std::runtime_error("AST JSON " + context +
+                             " uses negative file id as a registered filename");
+  }
+  if (filename.empty()) {
+    throw std::runtime_error("AST JSON " + context +
+                             " has an empty registered filename");
+  }
+
+  std::map<int, std::string> &id_to_name = Sg_File_Info::get_fileidtoname_map();
+  std::map<std::string, int> &name_to_id = Sg_File_Info::get_nametofileid_map();
+
+  auto id_entry = id_to_name.find(id);
+  if (id_entry != id_to_name.end() && id_entry->second != filename) {
+    std::ostringstream message;
+    message << "AST JSON " << context << " conflicts with existing file id "
+            << id << ": existing " << id_entry->second << ", JSON " << filename;
+    throw std::runtime_error(message.str());
+  }
+
+  auto name_entry = name_to_id.find(filename);
+  if (name_entry != name_to_id.end() && name_entry->second != id) {
+    std::ostringstream message;
+    message << "AST JSON " << context
+            << " conflicts with existing filename id for " << filename
+            << ": existing " << name_entry->second << ", JSON " << id;
+    throw std::runtime_error(message.str());
+  }
+
+  id_to_name[id] = filename;
+  name_to_id[filename] = id;
+}
+
+std::string filenameForFileId(int id, const std::string &context) {
+  const std::map<int, std::string> &id_to_name =
+      Sg_File_Info::get_fileidtoname_map();
+  auto found = id_to_name.find(id);
+  if (found == id_to_name.end()) {
+    std::ostringstream message;
+    message << "AST JSON " << context << " references unregistered file id "
+            << id;
+    throw std::runtime_error(message.str());
+  }
+  return found->second;
+}
+
+std::string rawStringField(const std::string &name, const std::string &value) {
+  return jsonString(name) + ": " + jsonString(value);
+}
+
+std::string rawIntegerField(const std::string &name, int64_t value) {
+  return jsonString(name) + ": " + std::to_string(value);
+}
+
+std::string rawBoolField(const std::string &name, bool value) {
+  return jsonString(name) + ": " + (value ? "true" : "false");
+}
+
+std::string rawBitVectorJson(const SgBitVector &bits) {
+  std::ostringstream out;
+  out << '[';
+  for (size_t i = 0; i < bits.size(); ++i) {
+    if (i != 0) {
+      out << ", ";
+    }
+    out << (bits[i] ? "true" : "false");
+  }
+  out << ']';
+  return out.str();
+}
+
+std::string rawStringListJson(const SgStringList &values) {
+  std::ostringstream out;
+  out << '[';
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i != 0) {
+      out << ", ";
+    }
+    out << jsonString(values[i]);
+  }
+  out << ']';
+  return out.str();
+}
+
+SgStringList stringListFromJson(const JsonValue &value,
+                                const std::string &field_name) {
+  if (value.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON " + field_name +
+                             " field is not an array");
+  }
+  SgStringList result;
+  result.reserve(value.array.size());
+  for (const JsonValue &entry : value.array) {
+    result.push_back(entry.asString());
+  }
+  return result;
+}
+
+void writeFileIdMapJson(std::ostream &out, int level, bool comma) {
+  const std::map<int, std::string> &file_id_map =
+      Sg_File_Info::get_fileidtoname_map();
+
+  int expected_id = 0;
+  for (const auto &entry : file_id_map) {
+    if (entry.first != expected_id) {
+      std::ostringstream message;
+      message << "AST JSON cannot serialize sparse Sg_File_Info file id map: "
+              << "expected id " << expected_id << ", found " << entry.first;
+      throw std::runtime_error(message.str());
+    }
+    if (entry.second.empty()) {
+      std::ostringstream message;
+      message << "AST JSON cannot serialize empty filename for file id "
+              << entry.first;
+      throw std::runtime_error(message.str());
+    }
+    ++expected_id;
+  }
+
+  indent(out, level);
+  out << jsonString("file_id_map") << ": [\n";
+  for (auto entry = file_id_map.begin(); entry != file_id_map.end(); ++entry) {
+    indent(out, level + 2);
+    out << "{\n";
+    writeIntegerField(out, level + 4, "id", entry->first);
+    writeStringField(out, level + 4, "filename", entry->second, false);
+    indent(out, level + 2);
+    out << '}';
+    if (std::next(entry) != file_id_map.end()) {
+      out << ',';
+    }
+    out << '\n';
+  }
+  indent(out, level);
+  out << ']';
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void writeRawObject(std::ostream &out, int level,
+                    const std::vector<std::string> &fields, bool comma);
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonPrivate.h
+++ b/src/frontend/SageIII/astJson/sageAstJsonPrivate.h
@@ -1,0 +1,601 @@
+#ifndef ROSE_SAGE_AST_JSON_PRIVATE_H
+#define ROSE_SAGE_AST_JSON_PRIVATE_H
+
+#include "sageAstJson.h"
+
+#include "RoseAst.h"
+#include "sage3basic.h"
+#include "sageBuilder.h"
+#include "sageInterface.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <unistd.h>
+
+namespace Rose {
+namespace AstJson {
+
+extern const char *const kFormat;
+extern const int kSchemaVersion;
+
+extern const char *const kAstJsonTypeTextAttribute;
+extern const char *const kAstJsonExternalFunctionAttribute;
+extern const char *const kAstJsonExternalModuleAttribute;
+extern const char *const kAstJsonExternalClassDeclarationAttribute;
+extern const char *const kAstJsonExternalSourceFileAttribute;
+
+extern SgSourceFile *collectionBoundaryFile;
+extern SgProject *currentDeserializationProject;
+extern std::unordered_map<SgSourceFile *, std::vector<SgClassDeclaration *>>
+    currentDeserializationClassDeclarationCache;
+extern const SgNode *currentTypeSerializationNode;
+extern bool serializingTypeOwnedExpression;
+
+struct JsonValue {
+  enum class Kind { Null, Bool, Number, String, Array, Object };
+
+  Kind kind = Kind::Null;
+  bool bool_value = false;
+  std::string text;
+  std::vector<JsonValue> array;
+  std::map<std::string, JsonValue> object;
+
+  static JsonValue null() { return JsonValue(); }
+
+  static JsonValue boolean(bool value) {
+    JsonValue result;
+    result.kind = Kind::Bool;
+    result.bool_value = value;
+    return result;
+  }
+
+  static JsonValue number(std::string value) {
+    JsonValue result;
+    result.kind = Kind::Number;
+    result.text = std::move(value);
+    return result;
+  }
+
+  static JsonValue string(std::string value) {
+    JsonValue result;
+    result.kind = Kind::String;
+    result.text = std::move(value);
+    return result;
+  }
+
+  static JsonValue arrayValue(std::vector<JsonValue> value) {
+    JsonValue result;
+    result.kind = Kind::Array;
+    result.array = std::move(value);
+    return result;
+  }
+
+  static JsonValue objectValue(std::map<std::string, JsonValue> value) {
+    JsonValue result;
+    result.kind = Kind::Object;
+    result.object = std::move(value);
+    return result;
+  }
+
+  const JsonValue &at(const std::string &key) const {
+    if (kind != Kind::Object) {
+      throw std::runtime_error(
+          "AST JSON value is not an object while reading " + key);
+    }
+    auto found = object.find(key);
+    if (found == object.end()) {
+      throw std::runtime_error("AST JSON object is missing key: " + key);
+    }
+    return found->second;
+  }
+
+  const JsonValue *find(const std::string &key) const {
+    if (kind != Kind::Object) {
+      return nullptr;
+    }
+    auto found = object.find(key);
+    return found == object.end() ? nullptr : &found->second;
+  }
+
+  std::string asString() const {
+    if (kind != Kind::String) {
+      throw std::runtime_error("AST JSON value is not a string");
+    }
+    return text;
+  }
+
+  std::string stringOr(const std::string &key,
+                       const std::string &fallback = "") const {
+    const JsonValue *value = find(key);
+    if (value == nullptr || value->kind == Kind::Null) {
+      return fallback;
+    }
+    return value->asString();
+  }
+
+  int64_t asInt() const {
+    if (kind != Kind::Number) {
+      throw std::runtime_error("AST JSON value is not a number");
+    }
+    return std::stoll(text);
+  }
+
+  int64_t intOr(const std::string &key, int64_t fallback = 0) const {
+    const JsonValue *value = find(key);
+    if (value == nullptr || value->kind == Kind::Null) {
+      return fallback;
+    }
+    return value->asInt();
+  }
+
+  bool asBool() const {
+    if (kind != Kind::Bool) {
+      throw std::runtime_error("AST JSON value is not a bool");
+    }
+    return bool_value;
+  }
+
+  bool boolOr(const std::string &key, bool fallback = false) const {
+    const JsonValue *value = find(key);
+    if (value == nullptr || value->kind == Kind::Null) {
+      return fallback;
+    }
+    return value->asBool();
+  }
+};
+
+struct EdgeRecord {
+  std::string field;
+  uint64_t target = 0;
+  uint64_t index = 0;
+};
+
+struct NodeRecord {
+  uint64_t id = 0;
+  std::string kind;
+  int64_t variant = 0;
+  JsonValue flags;
+  JsonValue location;
+  JsonValue properties;
+  JsonValue preprocessing;
+  std::vector<EdgeRecord> edges;
+};
+
+struct AstFileRecord {
+  uint64_t root_id = 0;
+  std::string root_kind;
+  std::string checkpoint;
+  JsonValue metadata;
+  std::vector<NodeRecord> nodes;
+  std::unordered_map<uint64_t, size_t> index_by_id;
+
+  const NodeRecord &node(uint64_t id) const;
+};
+
+using NodeMap = std::unordered_map<uint64_t, SgNode *>;
+
+struct SymbolTableEntryJson {
+  std::string entry_name;
+  std::string symbol_kind;
+  uint64_t basis_id = 0;
+  bool lookup_preferred = false;
+  std::string json;
+};
+
+class AstJsonMarkerAttribute : public AstAttribute {
+public:
+  AstAttribute *copy() const override { return new AstJsonMarkerAttribute(); }
+
+  OwnershipPolicy getOwnershipPolicy() const override {
+    return CONTAINER_OWNERSHIP;
+  }
+
+  std::string attribute_class_name() const override {
+    return "AstJsonMarkerAttribute";
+  }
+};
+
+class TypeSerializationContext {
+public:
+  explicit TypeSerializationContext(const SgNode *node);
+  ~TypeSerializationContext();
+
+private:
+  const SgNode *previous_;
+};
+
+class CollectionBoundaryGuard {
+public:
+  explicit CollectionBoundaryGuard(SgSourceFile *file);
+  ~CollectionBoundaryGuard();
+
+private:
+  SgSourceFile *previous_;
+};
+
+class DeserializationProjectGuard {
+public:
+  explicit DeserializationProjectGuard(SgProject *project);
+  ~DeserializationProjectGuard();
+
+private:
+  SgProject *previous_;
+};
+
+struct GlobalQualificationStateSnapshot {
+  typedef typename std::remove_reference<
+      decltype(SgNode::get_globalQualifiedNameMapForNames())>::type NamesMap;
+  typedef typename std::remove_reference<
+      decltype(SgNode::get_globalQualifiedNameMapForTypes())>::type TypesMap;
+  typedef typename std::remove_reference<
+      decltype(SgNode::get_globalQualifiedNameMapForTemplateHeaders())>::type
+      TemplateHeadersMap;
+  typedef typename std::remove_reference<
+      decltype(SgNode::get_globalTypeNameMap())>::type TypeNamesMap;
+  typedef typename std::remove_reference<
+      decltype(SgNode::get_globalQualifiedNameMapForMapsOfTypes())>::type
+      TypeMapsMap;
+
+  NamesMap names;
+  TypesMap types;
+  TemplateHeadersMap template_headers;
+  TypeNamesMap type_names;
+  TypeMapsMap type_maps;
+  bool restored = false;
+
+  GlobalQualificationStateSnapshot();
+  ~GlobalQualificationStateSnapshot();
+  void restore();
+};
+
+bool startsWith(const std::string &s, const std::string &prefix);
+std::string sanitizePathComponent(std::string name);
+uint64_t fnv1a64(const std::string &value);
+std::string hex64(uint64_t value);
+uint64_t processId();
+std::vector<std::string> commandLine(const SgSourceFile *file);
+bool argumentSelectsCheckpoint(const std::string &value, Checkpoint checkpoint);
+bool hasCheckpointArgument(const SgSourceFile *file, Checkpoint checkpoint);
+std::string commandLineValue(const SgSourceFile *file,
+                             const std::string &option);
+std::string defaultOutputDirectory(const SgSourceFile *file);
+std::string trim(const std::string &input);
+JsonValue parseJson(const std::string &json);
+std::string jsonString(const std::string &input);
+void indent(std::ostream &out, int level);
+void writeStringField(std::ostream &out, int level, const char *name,
+                      const std::string &value, bool comma = true);
+void writeIntegerField(std::ostream &out, int level, const char *name,
+                       int64_t value, bool comma = true);
+void writeBoolField(std::ostream &out, int level, const char *name, bool value,
+                    bool comma = true);
+void requireFileIdMapping(int id, const std::string &filename,
+                          const std::string &context);
+std::string filenameForFileId(int id, const std::string &context);
+std::string rawStringField(const std::string &name, const std::string &value);
+std::string rawIntegerField(const std::string &name, int64_t value);
+std::string rawBoolField(const std::string &name, bool value);
+std::string rawBitVectorJson(const SgBitVector &bits);
+std::string rawStringListJson(const SgStringList &values);
+SgStringList stringListFromJson(const JsonValue &value,
+                                const std::string &context);
+void writeFileIdMapJson(std::ostream &out, int level, bool comma = true);
+void writeRawObject(std::ostream &out, int level,
+                    const std::vector<std::string> &fields, bool comma = true);
+
+uint64_t idFor(const std::unordered_map<const SgNode *, uint64_t> &ids,
+               const SgNode *node);
+uint64_t canonicalTypedefDeclarationId(
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const SgTypedefDeclaration *decl);
+bool edgeTargetIsInParentChain(const SgNode *node, const SgNode *target);
+bool isAnonymousQualificationPrefix(const std::string &prefix);
+bool hasExplicitReferenceQualification(const SgVarRefExp *ref);
+bool isRightHandSideOfMemberAccess(const SgNode *node);
+bool shouldSerializeNamePrefix(SgNode *node, const std::string &prefix);
+bool isAnonymousDataMemberReference(SgVarRefExp *ref);
+void clearReferenceNameQualification(SgVarRefExp *ref);
+void normalizeAnonymousDataMemberReference(SgVarRefExp *ref);
+std::string rawQualifiedNameStateJson(
+    SgNode *node, const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string astJsonStringAttribute(SgNode *node, const char *name);
+bool hasAstJsonAttribute(SgNode *node, const char *name);
+bool isAstJsonExternalFunction(SgFunctionDeclaration *decl);
+bool isAstJsonExternalModule(SgModuleStatement *module);
+bool isAstJsonExternalClassDeclaration(SgClassDeclaration *decl);
+void markAstJsonExternalFunction(SgFunctionDeclaration *decl,
+                                 const std::string &source_file);
+void markAstJsonExternalModule(SgModuleStatement *module,
+                               const std::string &source_file);
+void markAstJsonExternalClassDeclaration(SgClassDeclaration *decl,
+                                         const std::string &source_file);
+void attachJsonNodeId(SgNode *node, uint64_t id);
+uint64_t preservedJsonNodeId(SgNode *node);
+std::string jsonTypeText(SgType *type);
+void installPointerCache(SgType *base, SgPointerType *pointer);
+void installReferenceCache(SgType *base, SgReferenceType *reference);
+void installRvalueReferenceCache(SgType *base,
+                                 SgRvalueReferenceType *reference);
+SgType *attachJsonTypeText(SgType *type, const JsonValue &json);
+SgPointerType *buildCachedJsonPointerType(SgType *base,
+                                          const JsonValue *json = nullptr);
+void installNewExpressionResultType(SgNewExp *expr, SgType *restored_type,
+                                    const JsonValue &json);
+void writeFileInfoJson(std::ostream &out, int level, const Sg_File_Info *info,
+                       bool comma = true);
+std::string rawFileInfoJson(const Sg_File_Info *info);
+std::string rawLocationJson(SgNode *node);
+std::string rawRequiredLocationJson(SgNode *node, const std::string &context);
+std::string rawNodeFlagsJson(SgNode *node);
+std::string rawTypeOwnedExpressionRef(
+    SgExpression *expr,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawTypeOwnedExpressionListJson(
+    const SgExpressionPtrList &expressions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawTypeOwnedExprListExpJson(
+    SgExprListExp *expr_list,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawExpressionRef(SgExpression *expression,
+                 const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawTypeTraitArgsJson(const SgNodePtrList &args,
+                     const std::unordered_map<const SgNode *, uint64_t> &ids);
+const SgNode *symbolBasis(const SgSymbol *symbol);
+std::string symbolName(const SgSymbol *symbol);
+std::string
+rawSymbolRef(SgSymbol *symbol,
+             const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawSymbolTableJson(SgScopeStatement *scope,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids);
+bool symbolIsLookupPreferred(SgSymbolTable *table, const SgName &name,
+                             SgSymbol *symbol);
+
+uint64_t varRefSymbolDeclarationId(
+    SgVarRefExp *ref, const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawTypeJson(SgType *type,
+            const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawOmpArrayDimensionsJson(
+    const std::map<SgSymbol *,
+                   std::vector<std::pair<SgExpression *, SgExpression *>>>
+        &array_dimensions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawOmpDistDataPoliciesJson(
+    const std::map<SgSymbol *,
+                   std::vector<std::pair<SgOmpClause::omp_map_dist_data_enum,
+                                         SgExpression *>>> &policies,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawOmpExpressionListJson(
+    const std::list<SgExpression *> &expressions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawOmpIteratorJson(const std::list<std::list<SgExpression *>> &iterators,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawTemplateArgumentListJson(
+    const SgTemplateArgumentPtrList &arguments,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawOmpUsesAllocatorsDefinitionsJson(
+    const std::list<SgOmpUsesAllocatorsDefination *> &definitions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawAstAttributesJson(SgNode *node);
+void addExpressionType(std::vector<std::string> &fields, SgExpression *expr,
+                       const std::unordered_map<const SgNode *, uint64_t> &ids);
+void addExpressionQualificationFields(std::vector<std::string> &fields,
+                                      SgExpression *expr);
+void restoreExpressionQualificationFields(SgExpression *expr,
+                                          const JsonValue &properties);
+void addLocatedPreprocessing(std::vector<std::string> &fields,
+                             const SgLocatedNode *node);
+bool insideCollectionBoundary(SgNode *node);
+std::vector<SgNode *> collectNodes(SgNode *root);
+void clearGlobalQualificationState();
+std::string safeNodeText(SgNode *node);
+std::string sourceFileNameForNode(SgNode *node);
+std::string sourceFileNameForExternalFunction(SgFunctionDeclaration *decl);
+std::string moduleNameForNode(SgNode *node);
+bool classDeclarationHasDefinition(SgClassDeclaration *decl);
+bool classDeclarationIsFirstNondefining(SgClassDeclaration *decl);
+bool isStructuralAstChildOfParent(SgNode *node);
+bool hasNonStructuralExternalMarkerAncestor(SgNode *node);
+
+std::string rawExternalClassDeclarationJson(SgClassDeclaration *decl);
+std::string
+rawExternalModuleJson(SgModuleStatement *module,
+                      const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawExternalFunctionJson(SgFunctionDeclaration *decl,
+                        const std::unordered_map<const SgNode *, uint64_t> &ids,
+                        bool force_external = false);
+std::string rawExternalFunctionParameterScopeJson(
+    SgFunctionParameterScope *scope,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name);
+bool declarationNeedsExternalReferenceRecord(
+    SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string externalFunctionParameterScopeSource(
+    SgFunctionDeclaration *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+bool functionParameterScopeNeedsExternalReferenceRecord(
+    SgFunctionDeclaration *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawExternalDeclarationReferenceJson(
+    SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawExternalInitializedNameJson(
+    SgInitializedName *name,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+void appendRawExternalDeclarationStatementFields(
+    std::vector<std::string> &fields, SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawExternalVariableDeclarationJson(
+    SgVariableDeclaration *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string rawExternalUseStatementJson(
+    SgUseStatement *stmt,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+bool isExternalUseModuleEdge(
+    SgNode *source, SgNode *target, const std::string &field,
+    const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawNodeProperties(SgNode *node,
+                  const std::unordered_map<const SgNode *, uint64_t> &ids);
+
+void writeNodeJson(std::ostream &out, SgNode *node,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids,
+                   bool comma);
+void writeMetadataJson(std::ostream &out, SgSourceFile *file,
+                       Checkpoint checkpoint, bool comma);
+std::string buildJson(SgNode *root, Checkpoint checkpoint, SgSourceFile *file);
+
+std::filesystem::path temporaryWritePath(const std::filesystem::path &path);
+void writeFile(const std::filesystem::path &path, const std::string &content);
+std::string readFile(const std::filesystem::path &path);
+AstFileRecord parseAstFileJson(const std::string &json,
+                               const std::string &expected_checkpoint);
+bool hasEdgeTarget(const NodeRecord &record, const std::string &field,
+                   uint64_t target);
+uint64_t firstEdgeTarget(const NodeRecord &record, const std::string &field);
+std::string semanticSignature(const AstFileRecord &ast);
+std::filesystem::path checkpointPath(SgSourceFile *file, Checkpoint checkpoint,
+                                     const Options &options);
+void replaceFileInProject(SgSourceFile *old_file, SgSourceFile *new_file);
+SgProject *owningProject(SgSourceFile *file);
+std::vector<std::string> commandLineFromMetadata(const JsonValue &metadata);
+void restoreFileIdMapFromMetadata(const JsonValue &metadata);
+
+SgNode *nodeById(const NodeMap &nodes, uint64_t id);
+
+template <typename T> T *nodeByIdAs(const NodeMap &nodes, uint64_t id) {
+  SgNode *raw_node = nodeById(nodes, id);
+  T *node = dynamic_cast<T *>(raw_node);
+  if (node == nullptr) {
+    throw std::runtime_error(
+        "AST JSON node id has unexpected Sage type " + std::to_string(id) +
+        ": expected " + typeid(T).name() + ", got " +
+        (raw_node != nullptr ? raw_node->sage_class_name() : "<null>"));
+  }
+  return node;
+}
+
+bool sameClassDeclarationFamily(SgClassDeclaration *lhs,
+                                SgClassDeclaration *rhs);
+void restoreQualifiedNameState(SgNode *node, const JsonValue &properties,
+                               const NodeMap &nodes);
+void requireRestoredKind(SgNode *node, const NodeRecord &record);
+bool requiresDelayedRebuild(const NodeRecord &record);
+SgType *typeFromJson(const JsonValue &json, const NodeMap &nodes);
+SgType *nullableTypeFromJson(const JsonValue &json, const NodeMap &nodes);
+SgType *earlyTypeFromJson(const JsonValue &type);
+SgType *earlyTypeFromProperties(const JsonValue &properties);
+bool isJsonBinaryOpKind(const std::string &kind);
+SgBinaryOp *buildBinaryOpForKind(const std::string &kind, SgType *expr_type);
+bool isJsonUnaryOpKind(const std::string &kind);
+SgUnaryOp *buildUnaryOpForKind(const std::string &kind, SgType *expr_type,
+                               const JsonValue &properties);
+SgFile::languageOption_enum
+fileLanguageFromJson(const JsonValue &properties, const std::string &key,
+                     SgFile::languageOption_enum fallback);
+SgFile::outputFormatOption_enum
+fileOutputFormatFromJson(const JsonValue &properties, const std::string &key,
+                         SgFile::outputFormatOption_enum fallback);
+Sg_File_Info *buildFileInfo(const JsonValue &json, SgNode *parent);
+void installTransformationSourcePosition(SgLocatedNode *node);
+void restoreNodeSourcePositionFromJson(SgNode *node, const JsonValue &location,
+                                       const std::string &context);
+void restoreOptionalNodeSourcePositionFromJson(SgNode *node,
+                                               const JsonValue &properties,
+                                               const std::string &field);
+SgBitVector bitVectorFromJson(const JsonValue &json,
+                              const std::string &context);
+
+SgNode *createNodeFromRecord(const NodeRecord &record, SgProject *project,
+                             const JsonValue &metadata);
+SgSymbol *createExternalSymbolFromJson(const JsonValue &json,
+                                       const NodeMap &nodes);
+void restoreExternalDeclarationStatementFields(SgDeclarationStatement *decl,
+                                               const JsonValue &json,
+                                               const NodeMap &nodes);
+SgClassType *ensureClassTypeForDeclaration(SgClassDeclaration *decl);
+SgExpression *expressionFromRef(const JsonValue &json, const NodeMap &nodes);
+SgSymbol *symbolFromJson(const JsonValue &json, const NodeMap &nodes);
+SgModuleStatement *externalModuleFromJson(const JsonValue &json);
+SgFunctionDeclaration *externalFunctionFromJson(const JsonValue &json,
+                                                const NodeMap &nodes);
+SgClassDeclaration *externalClassDeclarationFromJson(const JsonValue &json);
+SgDeclarationStatement *externalDeclarationReferenceFromJson(
+    const JsonValue *json, const NodeMap &nodes, const std::string &context);
+SgFunctionParameterScope *
+externalFunctionParameterScopeFromJson(const JsonValue &json,
+                                       const NodeMap &nodes,
+                                       const std::string &function_name);
+SgSymbol *createSymbolForKindAndBasis(const std::string &kind, SgNode *basis);
+std::vector<EdgeRecord> edgesFor(const NodeRecord &record,
+                                 const std::string &field);
+uint64_t singleEdgeTarget(const NodeRecord &record, const std::string &field);
+void setNodeSourcePosition(SgNode *node, const NodeRecord &record);
+void setNodeFlags(SgNode *node, const NodeRecord &record);
+void restoreAvailableSourcePositionsAndScopes(const AstFileRecord &ast,
+                                              const NodeMap &nodes);
+void attachPreprocessingInfo(SgNode *node, const NodeRecord &record);
+void attachAstAttributes(SgNode *node, const NodeRecord &record);
+void linkNodeEdges(const NodeRecord &record, const NodeMap &nodes);
+SgScopeStatement *nearestScope(SgNode *node);
+
+void restoreLabelSymbolFields(SgLabelSymbol *symbol, const JsonValue &json);
+SgClassSymbol *classSymbolForDeclaration(SgClassDeclaration *decl);
+SgNonrealSymbol *nonrealSymbolForDeclaration(SgNonrealDecl *decl);
+void attachExternalSymbolBasisToScope(SgSymbol *symbol,
+                                      SgScopeStatement *scope);
+void restoreSerializedSymbolTables(const AstFileRecord &ast,
+                                   const NodeMap &nodes);
+bool declarationHasDefinition(SgDeclarationStatement *decl);
+std::list<std::list<SgExpression *>> iteratorFromJson(const JsonValue &json,
+                                                      const NodeMap &nodes);
+std::list<SgExpression *> expressionListFromJson(const JsonValue &json,
+                                                 const NodeMap &nodes);
+SgTemplateArgumentPtrList templateArgumentListFromJson(const JsonValue &json,
+                                                       const NodeMap &nodes,
+                                                       SgNode *parent);
+void applyOmpAuxiliaryState(const AstFileRecord &ast, const NodeMap &nodes);
+
+void applyTypesAndSymbols(const AstFileRecord &ast, const NodeMap &nodes);
+void rebuildConstructorOnlyNodes(const AstFileRecord &ast, NodeMap &nodes);
+void restoreDeclarationIdentityEdges(const AstFileRecord &ast,
+                                     const NodeMap &nodes);
+void restoreRecordedParentEdges(const AstFileRecord &ast, const NodeMap &nodes);
+void restoreRecordedScopeEdges(const AstFileRecord &ast, const NodeMap &nodes);
+SgSourceFile *reconstructSourceFile(const AstFileRecord &ast,
+                                    SgSourceFile *old_file);
+
+} // namespace AstJson
+} // namespace Rose
+
+#endif

--- a/src/frontend/SageIII/astJson/sageAstJsonProject.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonProject.cpp
@@ -1,0 +1,746 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+std::filesystem::path temporaryWritePath(const std::filesystem::path &path) {
+  static uint64_t counter = 0;
+  std::ostringstream name;
+  name << "." << path.filename().string() << ".tmp." << processId() << "."
+       << ++counter;
+  return path.parent_path() / name.str();
+}
+
+void writeFile(const std::filesystem::path &path, const std::string &content) {
+  if (!path.parent_path().empty()) {
+    std::filesystem::create_directories(path.parent_path());
+  }
+  const std::filesystem::path temporary_path = temporaryWritePath(path);
+  std::ofstream out(temporary_path);
+  if (!out) {
+    throw std::runtime_error("failed to open AST JSON file for writing: " +
+                             temporary_path.string());
+  }
+  out << content;
+  if (!out) {
+    throw std::runtime_error("failed to write AST JSON file: " +
+                             temporary_path.string());
+  }
+  out.close();
+  if (!out) {
+    throw std::runtime_error("failed to close AST JSON file after writing: " +
+                             temporary_path.string());
+  }
+  std::error_code ec;
+  std::filesystem::rename(temporary_path, path, ec);
+  if (ec) {
+    std::filesystem::remove(temporary_path);
+    throw std::runtime_error("failed to publish AST JSON file " +
+                             path.string() + ": " + ec.message());
+  }
+}
+
+std::string readFile(const std::filesystem::path &path) {
+  std::ifstream in(path);
+  if (!in) {
+    throw std::runtime_error("failed to read AST JSON file: " + path.string());
+  }
+  std::ostringstream out;
+  out << in.rdbuf();
+  if (!in.eof() && in.fail()) {
+    throw std::runtime_error("failed while reading AST JSON file: " +
+                             path.string());
+  }
+  return out.str();
+}
+
+AstFileRecord parseAstFileJson(const std::string &json,
+                               const std::string &expected_checkpoint) {
+  JsonValue root = parseJson(json);
+  if (root.at("format").asString() != kFormat) {
+    throw std::runtime_error("AST JSON format marker is invalid");
+  }
+  if (root.at("schema_version").asInt() != kSchemaVersion) {
+    throw std::runtime_error("AST JSON schema_version is unsupported");
+  }
+
+  AstFileRecord result;
+  result.root_id = static_cast<uint64_t>(root.at("root_id").asInt());
+  result.root_kind = root.at("root_kind").asString();
+  result.metadata = root.at("metadata");
+  result.checkpoint = result.metadata.at("checkpoint").asString();
+  if (result.checkpoint != expected_checkpoint) {
+    throw std::runtime_error("AST JSON checkpoint name does not match request");
+  }
+
+  const JsonValue &nodes = root.at("nodes");
+  if (nodes.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON nodes field is not an array");
+  }
+  result.nodes.reserve(nodes.array.size());
+  for (const JsonValue &node_value : nodes.array) {
+    NodeRecord record;
+    record.id = static_cast<uint64_t>(node_value.at("id").asInt());
+    record.kind = node_value.at("kind").asString();
+    record.variant = node_value.at("variant").asInt();
+    record.flags = node_value.at("flags");
+    record.location = node_value.at("location");
+    record.properties = node_value.at("properties");
+    record.preprocessing = record.properties.find("preprocessing") != nullptr
+                               ? *record.properties.find("preprocessing")
+                               : JsonValue::arrayValue({});
+
+    const JsonValue &edges = node_value.at("edges");
+    if (edges.kind != JsonValue::Kind::Array) {
+      throw std::runtime_error("AST JSON node edges field is not an array");
+    }
+    for (const JsonValue &edge_value : edges.array) {
+      EdgeRecord edge;
+      edge.field = edge_value.at("field").asString();
+      edge.index = static_cast<uint64_t>(edge_value.intOr("index", 0));
+      edge.target = static_cast<uint64_t>(edge_value.at("target").asInt());
+      record.edges.push_back(std::move(edge));
+    }
+
+    if (!result.index_by_id.emplace(record.id, result.nodes.size()).second) {
+      throw std::runtime_error("AST JSON contains duplicate node id " +
+                               std::to_string(record.id));
+    }
+    result.nodes.push_back(std::move(record));
+  }
+
+  if (root.at("node_count").asInt() !=
+      static_cast<int64_t>(result.nodes.size())) {
+    throw std::runtime_error("AST JSON node_count does not match nodes array");
+  }
+  if (result.root_kind != "SgSourceFile") {
+    throw std::runtime_error("AST JSON checkpoint root is not SgSourceFile");
+  }
+  return result;
+}
+
+void appendComparableValue(std::ostream &out, const JsonValue &value);
+
+bool isDerivedTypeTextObject(const JsonValue &value) {
+  if (value.kind != JsonValue::Kind::Object ||
+      !value.boolOr("present", false)) {
+    return false;
+  }
+  const std::string kind = value.stringOr("kind");
+  return kind == "SgPointerType" || kind == "SgPointerMemberType" ||
+         kind == "SgReferenceType" || kind == "SgRvalueReferenceType" ||
+         kind == "SgArrayType" || kind == "SgModifierType" ||
+         kind == "SgFunctionType" || kind == "SgMemberFunctionType";
+}
+
+void appendComparableObject(std::ostream &out, const JsonValue &value,
+                            const std::set<std::string> &ignored_keys = {}) {
+  if (value.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON comparable value is not an object");
+  }
+  out << '{';
+  bool first = true;
+  for (const auto &entry : value.object) {
+    if (ignored_keys.count(entry.first) != 0 || entry.first == "declaration" ||
+        (entry.first == "text" && isDerivedTypeTextObject(value))) {
+      continue;
+    }
+    if (!first) {
+      out << ',';
+    }
+    out << jsonString(entry.first) << ':';
+    appendComparableValue(out, entry.second);
+    first = false;
+  }
+  out << '}';
+}
+
+void appendComparableValue(std::ostream &out, const JsonValue &value) {
+  switch (value.kind) {
+  case JsonValue::Kind::Null:
+    out << "null";
+    break;
+  case JsonValue::Kind::Bool:
+    out << (value.bool_value ? "true" : "false");
+    break;
+  case JsonValue::Kind::Number:
+    out << value.text;
+    break;
+  case JsonValue::Kind::String:
+    out << jsonString(value.text);
+    break;
+  case JsonValue::Kind::Array:
+    out << '[';
+    for (size_t i = 0; i < value.array.size(); ++i) {
+      if (i != 0) {
+        out << ',';
+      }
+      appendComparableValue(out, value.array[i]);
+    }
+    out << ']';
+    break;
+  case JsonValue::Kind::Object:
+    appendComparableObject(out, value);
+    break;
+  }
+}
+
+void appendComparablePreprocessing(std::ostream &out, const JsonValue &value) {
+  if (value.kind != JsonValue::Kind::Array) {
+    appendComparableValue(out, value);
+    return;
+  }
+  std::vector<std::string> entries;
+  entries.reserve(value.array.size());
+  for (const JsonValue &entry : value.array) {
+    std::ostringstream item;
+    appendComparableValue(item, entry);
+    entries.push_back(item.str());
+  }
+  std::sort(entries.begin(), entries.end());
+  out << '[';
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (i != 0) {
+      out << ',';
+    }
+    out << entries[i];
+  }
+  out << ']';
+}
+
+void appendComparableProperties(std::ostream &out, const JsonValue &value) {
+  if (value.kind != JsonValue::Kind::Object) {
+    throw std::runtime_error("AST JSON properties value is not an object");
+  }
+  out << '{';
+  bool first = true;
+  for (const auto &entry : value.object) {
+    if (entry.first == "unparse") {
+      continue;
+    }
+    if (!first) {
+      out << ',';
+    }
+    out << jsonString(entry.first) << ':';
+    if (entry.first == "preprocessing") {
+      appendComparablePreprocessing(out, entry.second);
+    } else {
+      appendComparableValue(out, entry.second);
+    }
+    first = false;
+  }
+  out << '}';
+}
+
+bool hasEdgeTarget(const NodeRecord &record, const std::string &field,
+                   uint64_t target) {
+  for (const EdgeRecord &candidate : record.edges) {
+    if (candidate.field == field && candidate.target == target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+uint64_t firstEdgeTarget(const NodeRecord &record, const std::string &field) {
+  for (const EdgeRecord &candidate : record.edges) {
+    if (candidate.field == field) {
+      return candidate.target;
+    }
+  }
+  return 0;
+}
+
+bool isScopeDerivedFromParentChain(
+    const NodeRecord &record, const EdgeRecord &edge,
+    const std::unordered_map<uint64_t, const NodeRecord *> &records_by_id) {
+  if (edge.field != "scope") {
+    return false;
+  }
+
+  std::unordered_set<uint64_t> seen;
+  uint64_t current = firstEdgeTarget(record, "parent");
+  while (current != 0 && seen.insert(current).second) {
+    if (current == edge.target) {
+      return true;
+    }
+
+    auto found = records_by_id.find(current);
+    if (found == records_by_id.end()) {
+      return false;
+    }
+    current = firstEdgeTarget(*found->second, "parent");
+  }
+
+  return false;
+}
+
+bool isInitializedNameScopeDerivedFromDeclaration(
+    const NodeRecord &record, const EdgeRecord &edge,
+    const std::unordered_map<uint64_t, const NodeRecord *> &records_by_id) {
+  if (record.kind != "SgInitializedName" || edge.field != "scope") {
+    return false;
+  }
+  const uint64_t decl_id = firstEdgeTarget(record, "declptr");
+  if (decl_id == 0) {
+    return false;
+  }
+  auto found = records_by_id.find(decl_id);
+  if (found == records_by_id.end()) {
+    return false;
+  }
+  const NodeRecord &decl_record = *found->second;
+  return hasEdgeTarget(decl_record, "scope", edge.target) ||
+         hasEdgeTarget(decl_record, "parent", edge.target);
+}
+
+bool ignoreComparableEdge(
+    const NodeRecord &record, const EdgeRecord &edge,
+    const std::unordered_map<uint64_t, const NodeRecord *> &records_by_id) {
+  if (edge.field == "parent") {
+    return true;
+  }
+  if (edge.field == "scope" && hasEdgeTarget(record, "parent", edge.target)) {
+    return true;
+  }
+  if (isScopeDerivedFromParentChain(record, edge, records_by_id)) {
+    return true;
+  }
+  if (isInitializedNameScopeDerivedFromDeclaration(record, edge,
+                                                   records_by_id)) {
+    return true;
+  }
+  if (edge.target == record.id &&
+      (edge.field == "firstNondefiningDeclaration" ||
+       edge.field == "definingDeclaration")) {
+    return true;
+  }
+  return false;
+}
+
+std::string semanticSignature(const AstFileRecord &ast) {
+  std::ostringstream out;
+  out << "format=" << kFormat << '\n';
+  out << "schema=" << kSchemaVersion << '\n';
+  out << "checkpoint=" << ast.checkpoint << '\n';
+  out << "root=" << ast.root_id << ":" << ast.root_kind << '\n';
+  out << "metadata=";
+  appendComparableObject(out, ast.metadata);
+  out << '\n';
+
+  std::unordered_map<uint64_t, const NodeRecord *> records_by_id;
+  records_by_id.reserve(ast.nodes.size());
+  for (const NodeRecord &record : ast.nodes) {
+    records_by_id.emplace(record.id, &record);
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    out << "node " << record.id << ' ' << record.kind << ' ' << record.variant
+        << '\n';
+    out << "flags=";
+    appendComparableObject(out, record.flags);
+    out << '\n';
+    out << "location=";
+    appendComparableObject(out, record.location);
+    out << '\n';
+    out << "properties=";
+    appendComparableProperties(out, record.properties);
+    out << '\n';
+
+    std::vector<EdgeRecord> edges;
+    for (const EdgeRecord &edge : record.edges) {
+      if (!ignoreComparableEdge(record, edge, records_by_id)) {
+        edges.push_back(edge);
+      }
+    }
+    std::sort(edges.begin(), edges.end(),
+              [](const EdgeRecord &lhs, const EdgeRecord &rhs) {
+                if (lhs.field != rhs.field) {
+                  return lhs.field < rhs.field;
+                }
+                if (lhs.index != rhs.index) {
+                  return lhs.index < rhs.index;
+                }
+                return lhs.target < rhs.target;
+              });
+    out << "edges=[";
+    for (size_t i = 0; i < edges.size(); ++i) {
+      if (i != 0) {
+        out << ',';
+      }
+      out << edges[i].field << ':' << edges[i].index << "->" << edges[i].target;
+    }
+    out << "]\n";
+  }
+  return out.str();
+}
+
+std::filesystem::path checkpointPath(SgSourceFile *file, Checkpoint checkpoint,
+                                     const Options &options) {
+  static uint64_t counter = 0;
+  const std::string source_path = file->get_sourceFileNameWithPath();
+  const std::string base = sanitizePathComponent(
+      StringUtility::stripPathFromFileName(file->get_sourceFileNameWithPath()));
+  const std::string source_id = hex64(fnv1a64(source_path));
+  std::ostringstream name;
+  name << "rex_ast_" << checkpointName(checkpoint) << "_" << base << "_"
+       << source_id << "_p" << processId() << "_" << ++counter << ".json";
+  return std::filesystem::path(options.outputDirectory) / name.str();
+}
+
+SgProject *owningProject(SgSourceFile *file) {
+  if (file == nullptr || file->get_parent() == nullptr) {
+    return nullptr;
+  }
+  SgFileList *file_list = isSgFileList(file->get_parent());
+  if (file_list == nullptr) {
+    return nullptr;
+  }
+  return isSgProject(file_list->get_parent());
+}
+
+bool nodeParentChainReferencesSourceFile(SgNode *node, SgSourceFile *file) {
+  if (node == nullptr || file == nullptr) {
+    return false;
+  }
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (current == file) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool symbolReferencesSourceFile(SgSymbol *symbol, SgSourceFile *file) {
+  if (symbol == nullptr || file == nullptr) {
+    return false;
+  }
+  if (nodeParentChainReferencesSourceFile(symbol, file)) {
+    return true;
+  }
+  return nodeParentChainReferencesSourceFile(
+      const_cast<SgNode *>(symbolBasis(symbol)), file);
+}
+
+struct SourceFileReferenceScanner {
+  explicit SourceFileReferenceScanner(SgSourceFile *file) : file(file) {}
+
+  bool references(SgType *type) {
+    if (type == nullptr || file == nullptr) {
+      return false;
+    }
+    if (!seen_types.insert(type).second) {
+      return false;
+    }
+    if (nodeParentChainReferencesSourceFile(type, file)) {
+      return true;
+    }
+
+    if (SgPointerMemberType *member_pointer = isSgPointerMemberType(type)) {
+      return references(member_pointer->get_base_type()) ||
+             references(member_pointer->get_class_type());
+    }
+    if (SgPointerType *pointer = isSgPointerType(type)) {
+      return references(pointer->get_base_type());
+    }
+    if (SgReferenceType *reference = isSgReferenceType(type)) {
+      return references(reference->get_base_type());
+    }
+    if (SgRvalueReferenceType *reference = isSgRvalueReferenceType(type)) {
+      return references(reference->get_base_type());
+    }
+    if (SgTypeString *string_type = isSgTypeString(type)) {
+      return references(string_type->get_lengthExpression()) ||
+             references(string_type->get_type_kind());
+    }
+    if (SgTypeComplex *complex_type = isSgTypeComplex(type)) {
+      return references(complex_type->get_base_type()) ||
+             references(complex_type->get_type_kind());
+    }
+    if (SgArrayType *array = isSgArrayType(type)) {
+      return references(array->get_base_type()) ||
+             references(array->get_index()) ||
+             references(array->get_dim_info());
+    }
+    if (SgModifierType *modifier = isSgModifierType(type)) {
+      return references(modifier->get_base_type());
+    }
+    if (SgTypedefType *typedef_type = isSgTypedefType(type)) {
+      return nodeParentChainReferencesSourceFile(
+          typedef_type->get_declaration(), file);
+    }
+    if (SgClassType *class_type = isSgClassType(type)) {
+      return nodeParentChainReferencesSourceFile(class_type->get_declaration(),
+                                                 file);
+    }
+    if (SgEnumType *enum_type = isSgEnumType(type)) {
+      return nodeParentChainReferencesSourceFile(enum_type->get_declaration(),
+                                                 file);
+    }
+    if (SgNonrealType *nonreal_type = isSgNonrealType(type)) {
+      return nodeParentChainReferencesSourceFile(
+          nonreal_type->get_declaration(), file);
+    }
+    if (SgTemplateType *template_type = isSgTemplateType(type)) {
+      return references(template_type->get_class_type()) ||
+             references(template_type->get_parent_class_type());
+    }
+    if (SgMemberFunctionType *member_type = isSgMemberFunctionType(type)) {
+      if (references(member_type->get_return_type()) ||
+          references(member_type->get_class_type())) {
+        return true;
+      }
+      for (SgType *argument : member_type->get_arguments()) {
+        if (references(argument)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (SgFunctionType *function_type = isSgFunctionType(type)) {
+      if (references(function_type->get_return_type())) {
+        return true;
+      }
+      for (SgType *argument : function_type->get_arguments()) {
+        if (references(argument)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (SgDeclType *decl_type = isSgDeclType(type)) {
+      return references(decl_type->get_base_expression());
+    }
+
+    return false;
+  }
+
+  bool references(SgExpression *expr) {
+    if (expr == nullptr || file == nullptr) {
+      return false;
+    }
+    if (!seen_expressions.insert(expr).second) {
+      return false;
+    }
+    if (nodeParentChainReferencesSourceFile(expr, file)) {
+      return true;
+    }
+
+    if (referencesExpressionLocalLinks(expr)) {
+      return true;
+    }
+
+    RoseAst ast(expr);
+    for (RoseAst::iterator it = ast.begin().withoutNullValues();
+         it != ast.end(); ++it) {
+      SgExpression *child = isSgExpression(*it);
+      if (child == nullptr || child == expr) {
+        continue;
+      }
+      if (references(child)) {
+        return true;
+      }
+      if (isSgBaseClass(*it) != nullptr) {
+        it.skipChildrenOnForward();
+      }
+    }
+    return false;
+  }
+
+  bool referencesExpressionLocalLinks(SgExpression *expr) {
+    if (SgVarRefExp *ref = isSgVarRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol(), file);
+    }
+    if (SgFunctionRefExp *ref = isSgFunctionRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol(), file) ||
+             references(ref->get_type());
+    }
+    if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol(), file) ||
+             references(ref->get_type());
+    }
+    if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol_i(), file) ||
+             references(ref->get_type());
+    }
+    if (SgTemplateMemberFunctionRefExp *ref =
+            isSgTemplateMemberFunctionRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol_i(), file) ||
+             references(ref->get_type());
+    }
+    if (SgClassNameRefExp *ref = isSgClassNameRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol(), file) ||
+             references(ref->get_type());
+    }
+    if (SgNonrealRefExp *ref = isSgNonrealRefExp(expr)) {
+      return symbolReferencesSourceFile(ref->get_symbol(), file) ||
+             references(ref->get_type());
+    }
+    if (SgThisExp *this_expr = isSgThisExp(expr)) {
+      return symbolReferencesSourceFile(this_expr->get_class_symbol(), file) ||
+             symbolReferencesSourceFile(this_expr->get_nonreal_symbol(),
+                                        file) ||
+             references(this_expr->get_type());
+    }
+    if (SgEnumVal *value = isSgEnumVal(expr)) {
+      return nodeParentChainReferencesSourceFile(value->get_declaration(),
+                                                 file) ||
+             references(value->get_type());
+    }
+    if (SgConstructorInitializer *init = isSgConstructorInitializer(expr)) {
+      return nodeParentChainReferencesSourceFile(init->get_declaration(),
+                                                 file) ||
+             references(init->get_type());
+    }
+    if (SgNewExp *new_expr = isSgNewExp(expr)) {
+      return references(new_expr->get_specified_type());
+    }
+    if (SgTypeExpression *type_expr = isSgTypeExpression(expr)) {
+      return references(type_expr->get_type());
+    }
+    return references(expr->get_type());
+  }
+
+  SgSourceFile *file = nullptr;
+  std::unordered_set<SgType *> seen_types;
+  std::unordered_set<SgExpression *> seen_expressions;
+};
+
+void purgeStaleTypeEntriesFromTable(SgSymbolTable *table,
+                                    SgSourceFile *old_file,
+                                    bool function_type_table) {
+  if (table == nullptr || table->get_table() == nullptr ||
+      old_file == nullptr) {
+    return;
+  }
+
+  std::vector<SgName> stale_names;
+  std::set<std::string> seen_names;
+  for (const auto &entry : *table->get_table()) {
+    SgFunctionTypeSymbol *symbol = isSgFunctionTypeSymbol(entry.second);
+    if (symbol == nullptr || symbol->get_type() == nullptr) {
+      continue;
+    }
+    SourceFileReferenceScanner scanner(old_file);
+    if (!scanner.references(symbol->get_type())) {
+      continue;
+    }
+    const std::string name = entry.first.getString();
+    if (seen_names.insert(name).second) {
+      stale_names.push_back(entry.first);
+    }
+  }
+
+  for (const SgName &name : stale_names) {
+    if (function_type_table) {
+      table->remove_function_type(name);
+    } else {
+      SgNode::get_globalTypeTable()->remove_type(name);
+    }
+  }
+}
+
+void purgeStaleCheckpointTypeCaches(SgSourceFile *old_file) {
+  if (old_file == nullptr) {
+    return;
+  }
+
+  SgTypeTable *type_table = SgNode::get_globalTypeTable();
+  ROSE_ASSERT(type_table != nullptr);
+  purgeStaleTypeEntriesFromTable(type_table->get_type_table(), old_file, false);
+
+  SgFunctionTypeTable *function_type_table =
+      SgNode::get_globalFunctionTypeTable();
+  ROSE_ASSERT(function_type_table != nullptr);
+  purgeStaleTypeEntriesFromTable(function_type_table->get_function_type_table(),
+                                 old_file, true);
+}
+
+void replaceFileInProject(SgSourceFile *old_file, SgSourceFile *new_file) {
+  ROSE_ASSERT(old_file != nullptr);
+  ROSE_ASSERT(new_file != nullptr);
+  SgProject *project = owningProject(old_file);
+  ROSE_ASSERT(project != nullptr);
+
+  SgFileList *file_list_node = isSgFileList(old_file->get_parent());
+  ROSE_ASSERT(file_list_node != nullptr);
+  SgFilePtrList &files = project->get_fileList();
+  bool replaced = false;
+  for (SgFile *&entry : files) {
+    if (entry == old_file) {
+      entry = new_file;
+      replaced = true;
+      break;
+    }
+  }
+  ROSE_ASSERT(replaced);
+
+  new_file->set_parent(file_list_node);
+  if (new_file->get_globalScope() != nullptr) {
+    new_file->get_globalScope()->set_parent(new_file);
+  }
+  old_file->set_parent(nullptr);
+  purgeStaleCheckpointTypeCaches(old_file);
+}
+
+std::vector<std::string> commandLineFromMetadata(const JsonValue &metadata) {
+  const JsonValue *array = metadata.find("command_line");
+  std::vector<std::string> result;
+  if (array != nullptr && array->kind == JsonValue::Kind::Array) {
+    for (const JsonValue &value : array->array) {
+      result.push_back(value.asString());
+    }
+  }
+  if (result.empty()) {
+    result.push_back("cc");
+    result.push_back(metadata.stringOr("source_file"));
+  }
+  return result;
+}
+
+void restoreFileIdMapFromMetadata(const JsonValue &metadata) {
+  const JsonValue &entries = metadata.at("file_id_map");
+  if (entries.kind != JsonValue::Kind::Array) {
+    throw std::runtime_error("AST JSON metadata file_id_map is not an array");
+  }
+
+  std::map<int, std::string> id_to_name;
+  std::map<std::string, int> name_to_id;
+  int64_t expected_id = 0;
+  for (const JsonValue &entry : entries.array) {
+    if (entry.kind != JsonValue::Kind::Object) {
+      throw std::runtime_error(
+          "AST JSON metadata file_id_map entry is not an object");
+    }
+    const int64_t id64 = entry.at("id").asInt();
+    if (id64 != expected_id) {
+      std::ostringstream message;
+      message << "AST JSON metadata file_id_map must be dense and sorted: "
+              << "expected id " << expected_id << ", found " << id64;
+      throw std::runtime_error(message.str());
+    }
+    if (id64 > std::numeric_limits<int>::max()) {
+      throw std::runtime_error(
+          "AST JSON metadata file_id_map id overflows int");
+    }
+    const std::string filename = entry.at("filename").asString();
+    if (filename.empty()) {
+      std::ostringstream message;
+      message << "AST JSON metadata file_id_map has empty filename for id "
+              << id64;
+      throw std::runtime_error(message.str());
+    }
+    if (!name_to_id.emplace(filename, static_cast<int>(id64)).second) {
+      throw std::runtime_error(
+          "AST JSON metadata file_id_map has duplicate filename: " + filename);
+    }
+    id_to_name[static_cast<int>(id64)] = filename;
+    ++expected_id;
+  }
+  Sg_File_Info::set_fileidtoname_map(id_to_name);
+  Sg_File_Info::set_nametofileid_map(name_to_id);
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonSerializeExternal.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonSerializeExternal.cpp
@@ -1,0 +1,1871 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+std::string rawExternalClassDeclarationJson(SgClassDeclaration *decl) {
+  std::vector<std::string> fields;
+  fields.push_back(rawBoolField("present", decl != nullptr));
+  if (decl != nullptr) {
+    fields.push_back(rawStringField("kind", decl->sage_class_name()));
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(rawIntegerField("class_type", decl->get_class_type()));
+    fields.push_back(
+        rawStringField("source_file", sourceFileNameForNode(decl)));
+    fields.push_back(rawStringField("module_name", moduleNameForNode(decl)));
+    fields.push_back(
+        rawBoolField("has_definition", classDeclarationHasDefinition(decl)));
+    fields.push_back(rawBoolField("is_first_nondefining",
+                                  classDeclarationIsFirstNondefining(decl)));
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string
+rawExternalModuleJson(SgModuleStatement *module,
+                      const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+  const bool external = module != nullptr && (isAstJsonExternalModule(module) ||
+                                              idFor(ids, module) == 0);
+  fields.push_back(rawBoolField("present", external));
+  if (external) {
+    fields.push_back(rawStringField("name", module->get_name().getString()));
+    fields.push_back(rawIntegerField("class_type", module->get_class_type()));
+    fields.push_back(
+        rawStringField("source_file", sourceFileNameForNode(module)));
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawExternalFunctionParameterScopeJson(
+    SgFunctionParameterScope *scope,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name);
+
+std::string
+rawExternalFunctionJson(SgFunctionDeclaration *decl,
+                        const std::unordered_map<const SgNode *, uint64_t> &ids,
+                        bool force_external) {
+  std::vector<std::string> fields;
+  const bool external =
+      decl != nullptr &&
+      (force_external || isAstJsonExternalFunction(decl) ||
+       (idFor(ids, decl) == 0 && !insideCollectionBoundary(decl)));
+  fields.push_back(rawBoolField("present", external));
+  if (external) {
+    fields.push_back(rawStringField("kind", decl->sage_class_name()));
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(
+        rawStringField("source_file", sourceFileNameForExternalFunction(decl)));
+    fields.push_back(
+        jsonString("location") + ": " +
+        rawRequiredLocationJson(decl, "external_function " +
+                                          decl->get_name().getString()));
+    SgFunctionParameterList *parameter_list = decl->get_parameterList();
+    if (parameter_list == nullptr) {
+      throw std::runtime_error("AST JSON external_function " +
+                               decl->get_name().getString() +
+                               " requires a parameterList");
+    }
+    fields.push_back(jsonString("parameter_list_location") + ": " +
+                     rawRequiredLocationJson(
+                         parameter_list, "external_function parameterList " +
+                                             decl->get_name().getString()));
+    SgFunctionParameterList *syntax_list = decl->get_parameterList_syntax();
+    if (syntax_list != nullptr && syntax_list != parameter_list) {
+      throw std::runtime_error(
+          "AST JSON external_function " + decl->get_name().getString() +
+          " has a distinct parameterList_syntax that is not yet serialized");
+    }
+    fields.push_back(
+        rawBoolField("parameter_list_syntax_aliases_parameter_list",
+                     syntax_list == parameter_list));
+    fields.push_back(jsonString("function_parameter_scope") + ": " +
+                     rawExternalFunctionParameterScopeJson(
+                         decl->get_functionParameterScope(), ids,
+                         decl->get_name().getString()));
+    fields.push_back(jsonString("function_type") + ": " +
+                     rawTypeJson(decl->get_type(), ids));
+    if (SgProcedureHeaderStatement *procedure =
+            isSgProcedureHeaderStatement(decl)) {
+      fields.push_back(
+          rawIntegerField("subprogram_kind", procedure->get_subprogram_kind()));
+    }
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+bool declarationNeedsExternalReferenceRecord(
+    SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  return decl != nullptr && idFor(ids, decl) == 0 &&
+         (hasNonStructuralExternalMarkerAncestor(decl) ||
+          ((isSgFunctionDeclaration(decl) != nullptr ||
+            isSgModuleStatement(decl) != nullptr ||
+            isSgClassDeclaration(decl) != nullptr) &&
+           !isStructuralAstChildOfParent(decl)));
+}
+
+std::string externalFunctionParameterScopeSource(
+    SgFunctionDeclaration *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  if (decl == nullptr || decl->get_functionParameterScope() == nullptr ||
+      idFor(ids, decl->get_functionParameterScope()) != 0) {
+    return "";
+  }
+
+  auto has_external_scope = [&](SgDeclarationStatement *candidate) -> bool {
+    SgFunctionDeclaration *function = isSgFunctionDeclaration(candidate);
+    return function != nullptr &&
+           function->get_functionParameterScope() ==
+               decl->get_functionParameterScope() &&
+           declarationNeedsExternalReferenceRecord(function, ids);
+  };
+
+  if (has_external_scope(decl->get_firstNondefiningDeclaration())) {
+    return "firstNondefiningDeclaration";
+  }
+  if (has_external_scope(decl->get_definingDeclaration())) {
+    return "definingDeclaration";
+  }
+  return "";
+}
+
+bool functionParameterScopeNeedsExternalReferenceRecord(
+    SgFunctionDeclaration *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  return !externalFunctionParameterScopeSource(decl, ids).empty();
+}
+
+std::string rawExternalDeclarationReferenceJson(
+    SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+  const bool present = declarationNeedsExternalReferenceRecord(decl, ids);
+  fields.push_back(rawBoolField("present", present));
+  if (present) {
+    fields.push_back(rawStringField("kind", decl->sage_class_name()));
+    if (SgFunctionDeclaration *function_decl = isSgFunctionDeclaration(decl)) {
+      fields.push_back(jsonString("external_function") + ": " +
+                       rawExternalFunctionJson(function_decl, ids, true));
+    } else if (SgModuleStatement *module = isSgModuleStatement(decl)) {
+      fields.push_back(jsonString("external_module") + ": " +
+                       rawExternalModuleJson(module, ids));
+    } else if (SgClassDeclaration *class_decl = isSgClassDeclaration(decl)) {
+      fields.push_back(jsonString("external_class") + ": " +
+                       rawExternalClassDeclarationJson(class_decl));
+    } else {
+      throw std::runtime_error(
+          std::string("AST JSON external declaration reference has unsupported "
+                      "kind: ") +
+          decl->sage_class_name());
+    }
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawExternalInitializedNameJson(
+    SgInitializedName *name,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name) {
+  if (name == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " has a null initialized name");
+  }
+  if (name->get_initptr() != nullptr) {
+    throw std::runtime_error(
+        "AST JSON external_function " + function_name +
+        " has an initialized name with an initializer that is not yet "
+        "serialized: " +
+        name->get_name().getString());
+  }
+  std::vector<std::string> fields;
+  fields.push_back(rawStringField("name", name->get_name().getString()));
+  fields.push_back(
+      jsonString("location") + ": " +
+      rawRequiredLocationJson(name, "external_function initializedName " +
+                                        function_name +
+                                        "::" + name->get_name().getString()));
+  fields.push_back(jsonString("type") + ": " +
+                   rawTypeJson(name->get_typeptr(), ids));
+  fields.push_back(rawIntegerField(
+      "storage_modifier",
+      static_cast<int>(name->get_storageModifier().get_modifier())));
+  fields.push_back(rawStringField("gnu_attribute_section_name",
+                                  name->get_gnu_attribute_section_name()));
+  fields.push_back(rawIntegerField("name_qualification_length",
+                                   name->get_name_qualification_length()));
+  fields.push_back(rawBoolField("type_elaboration_required",
+                                name->get_type_elaboration_required()));
+  fields.push_back(rawBoolField("global_qualification_required",
+                                name->get_global_qualification_required()));
+  fields.push_back(
+      rawIntegerField("name_qualification_length_for_type",
+                      name->get_name_qualification_length_for_type()));
+  fields.push_back(
+      rawBoolField("type_elaboration_required_for_type",
+                   name->get_type_elaboration_required_for_type()));
+  fields.push_back(
+      rawBoolField("global_qualification_required_for_type",
+                   name->get_global_qualification_required_for_type()));
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+void appendRawExternalDeclarationStatementFields(
+    std::vector<std::string> &fields, SgDeclarationStatement *decl,
+    const std::string &context) {
+  if (decl == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a declaration statement");
+  }
+  SgDeclarationStatement *first_nondefining =
+      decl->get_firstNondefiningDeclaration();
+  SgDeclarationStatement *defining = decl->get_definingDeclaration();
+  if (first_nondefining != nullptr && first_nondefining != decl) {
+    throw std::runtime_error(
+        "AST JSON " + context +
+        " has a firstNondefiningDeclaration that is not self or null");
+  }
+  if (defining != nullptr && defining != decl) {
+    throw std::runtime_error(
+        "AST JSON " + context +
+        " has a definingDeclaration that is not self or null");
+  }
+  if (decl->get_declarationScope() != nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " has a declarationScope that is not yet "
+                             "serialized for nested external declarations");
+  }
+  if (decl->get_nonreal_decl_scope() != nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " has a nonreal_decl_scope that is not yet "
+                             "serialized for nested external declarations");
+  }
+
+  const SgStorageModifier &storage =
+      decl->get_declarationModifier().get_storageModifier();
+  fields.push_back(
+      rawIntegerField("decl_attributes", decl->get_decl_attributes()));
+  fields.push_back(rawStringField("linkage", decl->get_linkage()));
+  fields.push_back(
+      jsonString("declaration_modifier_vector") + ": " +
+      rawBitVectorJson(decl->get_declarationModifier().get_modifierVector()));
+  fields.push_back(jsonString("declaration_type_modifier_vector") + ": " +
+                   rawBitVectorJson(decl->get_declarationModifier()
+                                        .get_typeModifier()
+                                        .get_modifierVector()));
+  fields.push_back(rawIntegerField("declaration_storage_modifier",
+                                   static_cast<int>(storage.get_modifier())));
+  fields.push_back(
+      rawIntegerField("declaration_access_modifier",
+                      static_cast<int>(decl->get_declarationModifier()
+                                           .get_accessModifier()
+                                           .get_modifier())));
+  fields.push_back(rawBoolField(
+      "declaration_access_is_explicit",
+      decl->get_declarationModifier().get_accessModifier().get_is_explicit()));
+  fields.push_back(rawBoolField("name_only", decl->get_nameOnly()));
+  fields.push_back(rawBoolField("forward", decl->get_forward()));
+  fields.push_back(rawBoolField("extern_brace", decl->get_externBrace()));
+  fields.push_back(
+      rawBoolField("skip_elaborate_type", decl->get_skipElaborateType()));
+  fields.push_back(rawStringField("binding_label", decl->get_binding_label()));
+  fields.push_back(
+      rawBoolField("unparse_template_ast", decl->get_unparse_template_ast()));
+  fields.push_back(rawStringField(
+      "declaration_gnu_attribute_section_name",
+      decl->get_declarationModifier().get_gnu_attribute_section_name()));
+  fields.push_back(rawIntegerField(
+      "declaration_gnu_attribute_visability",
+      static_cast<int>(
+          decl->get_declarationModifier().get_gnu_attribute_visability())));
+  fields.push_back(
+      rawBoolField("first_nondefining_is_self", first_nondefining == decl));
+  fields.push_back(
+      rawBoolField("first_nondefining_is_null", first_nondefining == nullptr));
+  fields.push_back(
+      rawBoolField("defining_declaration_is_self", defining == decl));
+  fields.push_back(
+      rawBoolField("defining_declaration_is_null", defining == nullptr));
+}
+
+std::string rawExternalVariableDeclarationJson(
+    SgVariableDeclaration *variable,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name) {
+  if (variable == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " has a null parameter-scope variable "
+                             "declaration");
+  }
+  if (variable->get_baseTypeDefiningDeclaration() != nullptr) {
+    throw std::runtime_error(
+        "AST JSON external_function " + function_name +
+        " parameter-scope variable declaration has a base type defining "
+        "declaration that is not yet serialized");
+  }
+  std::vector<std::string> fields;
+  fields.push_back(rawStringField("kind", variable->sage_class_name()));
+  fields.push_back(
+      jsonString("location") + ": " +
+      rawRequiredLocationJson(
+          variable, "external_function variableDeclaration " + function_name));
+  appendRawExternalDeclarationStatementFields(
+      fields, variable,
+      "external_function " + function_name + " variableDeclaration");
+  fields.push_back(
+      rawBoolField("requires_global_name_qualification_on_type",
+                   variable->get_requiresGlobalNameQualificationOnType()));
+  fields.push_back(rawIntegerField("name_qualification_length",
+                                   variable->get_name_qualification_length()));
+  fields.push_back(rawBoolField("type_elaboration_required",
+                                variable->get_type_elaboration_required()));
+  fields.push_back(rawBoolField("global_qualification_required",
+                                variable->get_global_qualification_required()));
+  std::ostringstream variables;
+  variables << jsonString("variables") << ": [";
+  const SgInitializedNamePtrList &names = variable->get_variables();
+  if (!names.empty()) {
+    variables << '\n';
+    for (size_t i = 0; i < names.size(); ++i) {
+      indent(variables, 4);
+      variables << rawExternalInitializedNameJson(names[i], ids, function_name);
+      if (i + 1 != names.size()) {
+        variables << ',';
+      }
+      variables << '\n';
+    }
+    indent(variables, 2);
+  }
+  variables << "]";
+  fields.push_back(variables.str());
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawExternalRenamePairJson(SgRenamePair *rename,
+                                      const std::string &function_name) {
+  if (rename == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " has a null SgUseStatement rename pair");
+  }
+  std::vector<std::string> fields;
+  fields.push_back(rawStringField("kind", rename->sage_class_name()));
+  fields.push_back(jsonString("location") + ": " + rawLocationJson(rename));
+  fields.push_back(
+      rawStringField("local_name", rename->get_local_name().getString()));
+  fields.push_back(
+      rawStringField("use_name", rename->get_use_name().getString()));
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawExternalUseStatementJson(
+    SgUseStatement *stmt,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name) {
+  if (stmt == nullptr) {
+    throw std::runtime_error("AST JSON external_function " + function_name +
+                             " has a null parameter-scope use statement");
+  }
+
+  const uint64_t module_id = idFor(ids, stmt->get_module());
+  std::vector<std::string> fields;
+  fields.push_back(rawStringField("kind", stmt->sage_class_name()));
+  fields.push_back(
+      jsonString("location") + ": " +
+      rawRequiredLocationJson(stmt, "external_function useStatement " +
+                                        function_name));
+  appendRawExternalDeclarationStatementFields(
+      fields, stmt, "external_function " + function_name + " useStatement");
+  fields.push_back(rawStringField("name", stmt->get_name().getString()));
+  fields.push_back(rawBoolField("only_option", stmt->get_only_option()));
+  fields.push_back(rawStringField("module_nature", stmt->get_module_nature()));
+  fields.push_back(rawIntegerField("module", module_id));
+  fields.push_back(jsonString("external_module") + ": " +
+                   rawExternalModuleJson(stmt->get_module(), ids));
+  std::ostringstream rename_list;
+  rename_list << jsonString("rename_list") << ": [";
+  const SgRenamePairPtrList &renames = stmt->get_rename_list();
+  if (!renames.empty()) {
+    rename_list << '\n';
+    for (size_t i = 0; i < renames.size(); ++i) {
+      indent(rename_list, 4);
+      rename_list << rawExternalRenamePairJson(renames[i], function_name);
+      if (i + 1 != renames.size()) {
+        rename_list << ',';
+      }
+      rename_list << '\n';
+    }
+    indent(rename_list, 2);
+  }
+  rename_list << "]";
+  fields.push_back(rename_list.str());
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawExternalParameterScopeDeclarationJson(
+    SgDeclarationStatement *decl,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name) {
+  if (SgVariableDeclaration *variable = isSgVariableDeclaration(decl)) {
+    return rawExternalVariableDeclarationJson(variable, ids, function_name);
+  }
+  if (SgUseStatement *stmt = isSgUseStatement(decl)) {
+    return rawExternalUseStatementJson(stmt, ids, function_name);
+  }
+  throw std::runtime_error("AST JSON external_function " + function_name +
+                           " functionParameterScope declaration kind is not "
+                           "supported: " +
+                           (decl != nullptr
+                                ? std::string(decl->sage_class_name())
+                                : std::string("<null>")));
+}
+
+std::string rawExternalFunctionParameterScopeJson(
+    SgFunctionParameterScope *scope,
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const std::string &function_name) {
+  std::vector<std::string> fields;
+  fields.push_back(rawBoolField("present", scope != nullptr));
+  if (scope != nullptr) {
+    std::map<SgInitializedName *, std::pair<size_t, size_t>> variable_indices;
+    std::map<SgDeclarationStatement *, size_t> declaration_indices;
+    std::ostringstream declarations;
+    declarations << jsonString("declarations") << ": [";
+    const SgDeclarationStatementPtrList &decls = scope->get_declarations();
+    if (!decls.empty()) {
+      declarations << '\n';
+      for (size_t i = 0; i < decls.size(); ++i) {
+        if (decls[i] != nullptr) {
+          declaration_indices[decls[i]] = i;
+        }
+        SgVariableDeclaration *variable = isSgVariableDeclaration(decls[i]);
+        if (variable != nullptr) {
+          const SgInitializedNamePtrList &names = variable->get_variables();
+          for (size_t j = 0; j < names.size(); ++j) {
+            if (names[j] != nullptr) {
+              variable_indices[names[j]] = std::make_pair(i, j);
+            }
+          }
+        }
+        indent(declarations, 4);
+        declarations << rawExternalParameterScopeDeclarationJson(decls[i], ids,
+                                                                 function_name);
+        if (i + 1 != decls.size()) {
+          declarations << ',';
+        }
+        declarations << '\n';
+      }
+      indent(declarations, 2);
+    }
+    declarations << "]";
+    SgSymbolTable *table = scope->get_symbol_table();
+    const size_t table_size = table != nullptr && table->get_table() != nullptr
+                                  ? table->get_table()->size()
+                                  : 0;
+    fields.push_back(jsonString("location") + ": " +
+                     rawRequiredLocationJson(
+                         scope, "external_function functionParameterScope " +
+                                    function_name));
+    fields.push_back(declarations.str());
+    fields.push_back(
+        rawIntegerField("symbol_table_size", static_cast<int64_t>(table_size)));
+    fields.push_back(rawBoolField("symbol_table_present", table != nullptr));
+    if (table != nullptr) {
+      fields.push_back(rawBoolField("symbol_table_case_insensitive",
+                                    table->isCaseInsensitive()));
+      std::ostringstream entries;
+      entries << jsonString("symbol_table") << ": [";
+      if (table->get_table() != nullptr && !table->get_table()->empty()) {
+        std::vector<SymbolTableEntryJson> serialized_entries;
+        for (const std::pair<const SgName, SgSymbol *> &entry :
+             *table->get_table()) {
+          SgSymbol *symbol = entry.second;
+          if (symbol == nullptr) {
+            throw std::runtime_error(
+                "AST JSON external_function " + function_name +
+                " functionParameterScope symbol table has a null entry: " +
+                entry.first.getString());
+          }
+          SgVariableSymbol *variable_symbol = isSgVariableSymbol(symbol);
+          SgInitializedName *declaration =
+              variable_symbol != nullptr ? variable_symbol->get_declaration()
+                                         : nullptr;
+          auto index = variable_indices.find(declaration);
+          std::vector<std::string> entry_fields;
+          entry_fields.push_back(
+              rawStringField("entry_name", entry.first.getString()));
+          entry_fields.push_back(
+              rawStringField("symbol_kind", symbol->class_name()));
+          entry_fields.push_back(rawBoolField(
+              "lookup_preferred",
+              symbolIsLookupPreferred(table, entry.first, symbol)));
+          if (variable_symbol != nullptr && index != variable_indices.end()) {
+            entry_fields.push_back(
+                rawIntegerField("declaration_index",
+                                static_cast<int64_t>(index->second.first)));
+            entry_fields.push_back(rawIntegerField(
+                "variable_index", static_cast<int64_t>(index->second.second)));
+          } else {
+            entry_fields.push_back(jsonString("symbol") + ": " +
+                                   rawSymbolRef(symbol, ids));
+          }
+          if (SgAliasSymbol *alias = isSgAliasSymbol(symbol)) {
+            if (alias->get_alias() == nullptr) {
+              throw std::runtime_error("AST JSON external_function " +
+                                       function_name +
+                                       " functionParameterScope SgAliasSymbol "
+                                       "has no alias target: " +
+                                       entry.first.getString());
+            }
+            entry_fields.push_back(jsonString("alias_target") + ": " +
+                                   rawSymbolRef(alias->get_alias(), ids));
+            entry_fields.push_back(
+                rawBoolField("alias_is_renamed", alias->get_isRenamed()));
+            entry_fields.push_back(rawStringField(
+                "alias_new_name", alias->get_new_name().getString()));
+            std::ostringstream causal_nodes;
+            causal_nodes << jsonString("alias_causal_nodes") << ": [";
+            const SgNodePtrList &nodes = alias->get_causal_nodes();
+            if (!nodes.empty()) {
+              causal_nodes << '\n';
+              for (size_t i = 0; i < nodes.size(); ++i) {
+                SgNode *causal_node = nodes[i];
+                const uint64_t causal_id = idFor(ids, causal_node);
+                auto declaration_index = declaration_indices.find(
+                    isSgDeclarationStatement(causal_node));
+                if (causal_node != nullptr && causal_id == 0 &&
+                    declaration_index == declaration_indices.end()) {
+                  throw std::runtime_error(
+                      "AST JSON external_function " + function_name +
+                      " functionParameterScope SgAliasSymbol causal node is "
+                      "neither collected nor a nested declaration: " +
+                      causal_node->sage_class_name());
+                }
+                std::vector<std::string> causal_fields;
+                causal_fields.push_back(
+                    rawIntegerField("node", static_cast<int64_t>(causal_id)));
+                causal_fields.push_back(rawIntegerField(
+                    "declaration_index",
+                    declaration_index != declaration_indices.end()
+                        ? static_cast<int64_t>(declaration_index->second)
+                        : static_cast<int64_t>(-1)));
+                indent(causal_nodes, 6);
+                writeRawObject(causal_nodes, 6, causal_fields, false);
+                if (i + 1 != nodes.size()) {
+                  causal_nodes << ',';
+                }
+                causal_nodes << '\n';
+              }
+              indent(causal_nodes, 4);
+            }
+            causal_nodes << "]";
+            entry_fields.push_back(causal_nodes.str());
+          }
+          if (SgRenameSymbol *rename = isSgRenameSymbol(symbol)) {
+            if (rename->get_original_symbol() == nullptr) {
+              throw std::runtime_error(
+                  "AST JSON external_function " + function_name +
+                  " functionParameterScope "
+                  "SgRenameSymbol has no original symbol: " +
+                  entry.first.getString());
+            }
+            entry_fields.push_back(
+                jsonString("original_symbol") + ": " +
+                rawSymbolRef(rename->get_original_symbol(), ids));
+            entry_fields.push_back(rawStringField(
+                "rename_new_name", rename->get_new_name().getString()));
+          }
+          std::ostringstream entry_out;
+          writeRawObject(entry_out, 0, entry_fields, false);
+          std::string entry_json = entry_out.str();
+          if (!entry_json.empty() && entry_json.back() == '\n') {
+            entry_json.pop_back();
+          }
+
+          SymbolTableEntryJson serialized;
+          serialized.entry_name = entry.first.getString();
+          serialized.symbol_kind = symbol->class_name();
+          serialized.basis_id = idFor(ids, symbolBasis(symbol));
+          serialized.lookup_preferred =
+              symbolIsLookupPreferred(table, entry.first, symbol);
+          serialized.json = std::move(entry_json);
+          serialized_entries.push_back(std::move(serialized));
+        }
+
+        std::stable_sort(serialized_entries.begin(), serialized_entries.end(),
+                         [](const SymbolTableEntryJson &lhs,
+                            const SymbolTableEntryJson &rhs) {
+                           if (lhs.basis_id != rhs.basis_id) {
+                             if (lhs.basis_id == 0) {
+                               return false;
+                             }
+                             if (rhs.basis_id == 0) {
+                               return true;
+                             }
+                             return lhs.basis_id < rhs.basis_id;
+                           }
+                           if (lhs.lookup_preferred != rhs.lookup_preferred) {
+                             return lhs.lookup_preferred &&
+                                    !rhs.lookup_preferred;
+                           }
+                           if (lhs.entry_name != rhs.entry_name) {
+                             return lhs.entry_name < rhs.entry_name;
+                           }
+                           return lhs.symbol_kind < rhs.symbol_kind;
+                         });
+
+        entries << '\n';
+        for (size_t i = 0; i < serialized_entries.size(); ++i) {
+          indent(entries, 4);
+          entries << serialized_entries[i].json;
+          if (i + 1 != serialized_entries.size()) {
+            entries << ',';
+          }
+          entries << '\n';
+        }
+        indent(entries, 2);
+      }
+      entries << "]";
+      fields.push_back(entries.str());
+    }
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+bool isExternalUseModuleEdge(
+    SgNode *source, SgNode *target, const std::string &field,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  return field == "module" && isSgUseStatement(source) != nullptr &&
+         isSgModuleStatement(target) != nullptr && idFor(ids, target) == 0;
+}
+
+std::string
+rawNodeProperties(SgNode *node,
+                  const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+  fields.push_back(rawStringField("unparse", safeNodeText(node)));
+  fields.push_back(jsonString("attributes") + ": " +
+                   rawAstAttributesJson(node));
+  fields.push_back(jsonString("qualified_name_state") + ": " +
+                   rawQualifiedNameStateJson(node, ids));
+  if (SgScopeStatement *scope = isSgScopeStatement(node)) {
+    fields.push_back(
+        rawBoolField("case_insensitive", scope->isCaseInsensitive()));
+    fields.push_back(jsonString("symbol_table") + ": " +
+                     rawSymbolTableJson(scope, ids));
+  }
+
+  if (SgSourceFile *file = isSgSourceFile(node)) {
+    fields.push_back(rawStringField("source_filename_with_path",
+                                    file->get_sourceFileNameWithPath()));
+    fields.push_back(rawStringField("source_filename_without_path",
+                                    file->get_sourceFileNameWithoutPath()));
+    fields.push_back(rawStringField("unparse_output_filename",
+                                    file->get_unparse_output_filename()));
+    fields.push_back(rawBoolField("C_only", file->get_C_only()));
+    fields.push_back(rawBoolField("Cxx_only", file->get_Cxx_only()));
+    fields.push_back(rawBoolField("Fortran_only", file->get_Fortran_only()));
+    fields.push_back(
+        rawBoolField("CoArrayFortran_only", file->get_CoArrayFortran_only()));
+    fields.push_back(rawBoolField("Cuda_only", file->get_Cuda_only()));
+    fields.push_back(rawBoolField("OpenCL_only", file->get_OpenCL_only()));
+    fields.push_back(rawBoolField("requires_C_preprocessor",
+                                  file->get_requires_C_preprocessor()));
+    fields.push_back(rawIntegerField("input_format", file->get_inputFormat()));
+    fields.push_back(
+        rawIntegerField("output_format", file->get_outputFormat()));
+    fields.push_back(rawIntegerField("backend_compile_format",
+                                     file->get_backendCompileFormat()));
+    fields.push_back(rawBoolField("fortran_implicit_none",
+                                  file->get_fortran_implicit_none()));
+    fields.push_back(
+        rawIntegerField("input_language", file->get_inputLanguage()));
+    fields.push_back(
+        rawIntegerField("output_language", file->get_outputLanguage()));
+    fields.push_back(rawBoolField("strict_language_handling",
+                                  file->get_strict_language_handling()));
+    fields.push_back(rawBoolField("source_uses_cpp_extension",
+                                  file->get_sourceFileUsesCppFileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran_extension",
+                     file->get_sourceFileUsesFortranFileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran77_extension",
+                     file->get_sourceFileUsesFortran77FileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran90_extension",
+                     file->get_sourceFileUsesFortran90FileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran95_extension",
+                     file->get_sourceFileUsesFortran95FileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran2003_extension",
+                     file->get_sourceFileUsesFortran2003FileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_fortran2008_extension",
+                     file->get_sourceFileUsesFortran2008FileExtension()));
+    fields.push_back(
+        rawBoolField("source_uses_coarray_fortran_extension",
+                     file->get_sourceFileUsesCoArrayFortranFileExtension()));
+    fields.push_back(rawBoolField("source_file_type_is_unknown",
+                                  file->get_sourceFileTypeIsUnknown()));
+    fields.push_back(rawBoolField("experimental_flang_frontend",
+                                  file->get_experimental_flang_frontend()));
+  } else if (SgToken *token = isSgToken(node)) {
+    fields.push_back(
+        rawStringField("lexeme_string", token->get_lexeme_string()));
+    fields.push_back(rawIntegerField(
+        "classification_code",
+        static_cast<int64_t>(token->get_classification_code())));
+  } else if (SgInitializedName *name = isSgInitializedName(node)) {
+    fields.push_back(rawStringField("name", name->get_name().getString()));
+    fields.push_back(jsonString("type") + ": " +
+                     rawTypeJson(name->get_typeptr(), ids));
+    fields.push_back(rawIntegerField(
+        "storage_modifier",
+        static_cast<int>(name->get_storageModifier().get_modifier())));
+    fields.push_back(rawStringField("gnu_attribute_section_name",
+                                    name->get_gnu_attribute_section_name()));
+    fields.push_back(rawIntegerField("name_qualification_length",
+                                     name->get_name_qualification_length()));
+    fields.push_back(rawBoolField("type_elaboration_required",
+                                  name->get_type_elaboration_required()));
+    fields.push_back(rawBoolField("global_qualification_required",
+                                  name->get_global_qualification_required()));
+    fields.push_back(
+        rawIntegerField("name_qualification_length_for_type",
+                        name->get_name_qualification_length_for_type()));
+    fields.push_back(
+        rawBoolField("type_elaboration_required_for_type",
+                     name->get_type_elaboration_required_for_type()));
+    fields.push_back(
+        rawBoolField("global_qualification_required_for_type",
+                     name->get_global_qualification_required_for_type()));
+  } else if (SgFunctionDeclaration *decl = isSgFunctionDeclaration(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(jsonString("function_type") + ": " +
+                     rawTypeJson(decl->get_type(), ids));
+    if (functionParameterScopeNeedsExternalReferenceRecord(decl, ids)) {
+      fields.push_back(
+          rawStringField("external_function_parameter_scope_source",
+                         externalFunctionParameterScopeSource(decl, ids)));
+      fields.push_back(jsonString("external_function_parameter_scope") + ": " +
+                       rawExternalFunctionParameterScopeJson(
+                           decl->get_functionParameterScope(), ids,
+                           decl->get_name().getString()));
+    }
+    fields.push_back(jsonString("return_type") + ": " +
+                     rawTypeJson(decl->get_type() != nullptr
+                                     ? decl->get_type()->get_return_type()
+                                     : nullptr,
+                                 ids));
+    fields.push_back(
+        jsonString("function_modifier_vector") + ": " +
+        rawBitVectorJson(decl->get_functionModifier().get_modifierVector()));
+    fields.push_back(
+        jsonString("special_function_modifier_vector") + ": " +
+        rawBitVectorJson(
+            decl->get_specialFunctionModifier().get_modifierVector()));
+    fields.push_back(rawBoolField("named_in_end_statement",
+                                  decl->get_named_in_end_statement()));
+    fields.push_back(rawStringField("asm_name", decl->get_asm_name()));
+    fields.push_back(
+        rawBoolField("old_style_definition", decl->get_oldStyleDefinition()));
+    fields.push_back(rawIntegerField(
+        "specialization", static_cast<int>(decl->get_specialization())));
+    fields.push_back(
+        rawBoolField("requires_name_qualification_on_return_type",
+                     decl->get_requiresNameQualificationOnReturnType()));
+    fields.push_back(rawStringField("gnu_extension_section",
+                                    decl->get_gnu_extension_section()));
+    fields.push_back(
+        rawStringField("gnu_extension_alias", decl->get_gnu_extension_alias()));
+    fields.push_back(rawIntegerField(
+        "gnu_extension_visability",
+        static_cast<int>(decl->get_gnu_extension_visability())));
+    fields.push_back(rawIntegerField("name_qualification_length",
+                                     decl->get_name_qualification_length()));
+    fields.push_back(rawBoolField("type_elaboration_required",
+                                  decl->get_type_elaboration_required()));
+    fields.push_back(rawBoolField("global_qualification_required",
+                                  decl->get_global_qualification_required()));
+    fields.push_back(
+        rawIntegerField("name_qualification_length_for_return_type",
+                        decl->get_name_qualification_length_for_return_type()));
+    fields.push_back(
+        rawBoolField("type_elaboration_required_for_return_type",
+                     decl->get_type_elaboration_required_for_return_type()));
+    fields.push_back(rawBoolField(
+        "global_qualification_required_for_return_type",
+        decl->get_global_qualification_required_for_return_type()));
+    fields.push_back(rawBoolField("prototype_is_without_parameters",
+                                  decl->get_prototypeIsWithoutParameters()));
+    fields.push_back(rawIntegerField("gnu_regparm_attribute",
+                                     decl->get_gnu_regparm_attribute()));
+    fields.push_back(rawBoolField("type_syntax_is_available",
+                                  decl->get_type_syntax_is_available()));
+    fields.push_back(rawBoolField("using_c11_noreturn_keyword",
+                                  decl->get_using_C11_Noreturn_keyword()));
+    fields.push_back(rawBoolField("is_constexpr", decl->get_is_constexpr()));
+    fields.push_back(
+        rawBoolField("using_new_function_return_type_syntax",
+                     decl->get_using_new_function_return_type_syntax()));
+    fields.push_back(
+        rawBoolField("is_deduction_guide", decl->get_is_deduction_guide()));
+    fields.push_back(
+        rawBoolField("marked_as_frontend_normalization",
+                     decl->get_marked_as_frontend_normalization()));
+    fields.push_back(
+        rawBoolField("is_implicit_function", decl->get_is_implicit_function()));
+    if (SgProcedureHeaderStatement *procedure =
+            isSgProcedureHeaderStatement(decl)) {
+      fields.push_back(
+          rawIntegerField("subprogram_kind", procedure->get_subprogram_kind()));
+    }
+    if (SgTemplateInstantiationFunctionDecl *tmpl =
+            isSgTemplateInstantiationFunctionDecl(decl)) {
+      fields.push_back(rawStringField("template_name",
+                                      tmpl->get_templateName().getString()));
+      fields.push_back(rawBoolField("name_reset_from_mangled_form",
+                                    tmpl->get_nameResetFromMangledForm()));
+      fields.push_back(
+          rawBoolField("template_argument_list_is_explicit",
+                       tmpl->get_template_argument_list_is_explicit()));
+      fields.push_back(
+          jsonString("template_arguments") + ": " +
+          rawTemplateArgumentListJson(tmpl->get_templateArguments(), ids));
+      fields.push_back(jsonString("deduced_template_arguments") + ": " +
+                       rawTemplateArgumentListJson(
+                           tmpl->get_deducedTemplateArguments(), ids));
+    }
+    if (SgTemplateInstantiationMemberFunctionDecl *tmpl =
+            isSgTemplateInstantiationMemberFunctionDecl(decl)) {
+      fields.push_back(rawStringField("template_name",
+                                      tmpl->get_templateName().getString()));
+      fields.push_back(rawBoolField("name_reset_from_mangled_form",
+                                    tmpl->get_nameResetFromMangledForm()));
+      fields.push_back(
+          rawBoolField("template_argument_list_is_explicit",
+                       tmpl->get_template_argument_list_is_explicit()));
+      fields.push_back(
+          jsonString("template_arguments") + ": " +
+          rawTemplateArgumentListJson(tmpl->get_templateArguments(), ids));
+      fields.push_back(jsonString("deduced_template_arguments") + ": " +
+                       rawTemplateArgumentListJson(
+                           tmpl->get_deducedTemplateArguments(), ids));
+    }
+  } else if (SgTypedefDeclaration *decl = isSgTypedefDeclaration(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(jsonString("base_type") + ": " +
+                     rawTypeJson(decl->get_base_type(), ids));
+    fields.push_back(
+        rawBoolField("typedef_base_type_contains_defining_declaration",
+                     decl->get_typedefBaseTypeContainsDefiningDeclaration()));
+    fields.push_back(rawBoolField("is_autonomous_declaration",
+                                  decl->get_isAutonomousDeclaration()));
+    if (SgTemplateInstantiationTypedefDeclaration *tmpl =
+            isSgTemplateInstantiationTypedefDeclaration(decl)) {
+      fields.push_back(rawStringField("template_name",
+                                      tmpl->get_templateName().getString()));
+      fields.push_back(rawStringField("template_header",
+                                      tmpl->get_templateHeader().getString()));
+      fields.push_back(rawBoolField("name_reset_from_mangled_form",
+                                    tmpl->get_nameResetFromMangledForm()));
+      fields.push_back(
+          jsonString("template_arguments") + ": " +
+          rawTemplateArgumentListJson(tmpl->get_templateArguments(), ids));
+      fields.push_back(jsonString("deduced_template_arguments") + ": " +
+                       rawTemplateArgumentListJson(
+                           tmpl->get_deducedTemplateArguments(), ids));
+    }
+  } else if (SgClassDeclaration *decl = isSgClassDeclaration(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(rawIntegerField("class_type", decl->get_class_type()));
+    fields.push_back(rawBoolField("is_unnamed", decl->get_isUnNamed()));
+    fields.push_back(rawBoolField("is_autonomous_declaration",
+                                  decl->get_isAutonomousDeclaration()));
+    if (SgTemplateClassDeclaration *tmpl = isSgTemplateClassDeclaration(decl)) {
+      fields.push_back(rawStringField("template_name",
+                                      tmpl->get_templateName().getString()));
+    }
+    if (SgTemplateInstantiationDecl *tmpl =
+            isSgTemplateInstantiationDecl(decl)) {
+      fields.push_back(rawStringField("template_name",
+                                      tmpl->get_templateName().getString()));
+      fields.push_back(rawStringField("template_header",
+                                      tmpl->get_templateHeader().getString()));
+      fields.push_back(rawBoolField("name_reset_from_mangled_form",
+                                    tmpl->get_nameResetFromMangledForm()));
+      fields.push_back(
+          rawBoolField("constraint_satisfaction_evaluated",
+                       tmpl->get_constraintSatisfactionEvaluated()));
+      fields.push_back(
+          rawBoolField("constraint_satisfaction_satisfied",
+                       tmpl->get_constraintSatisfactionSatisfied()));
+      fields.push_back(
+          rawBoolField("constraint_satisfaction_contains_errors",
+                       tmpl->get_constraintSatisfactionContainsErrors()));
+      fields.push_back(
+          rawBoolField("constraint_satisfaction_substitution_failure",
+                       tmpl->get_constraintSatisfactionSubstitutionFailure()));
+      fields.push_back(
+          rawStringField("constraint_satisfaction_summary",
+                         tmpl->get_constraintSatisfactionSummary()));
+      fields.push_back(
+          rawBoolField("sfinae_evaluated", tmpl->get_sfinaeEvaluated()));
+      fields.push_back(rawBoolField("sfinae_substitution_failure",
+                                    tmpl->get_sfinaeSubstitutionFailure()));
+      fields.push_back(
+          rawStringField("sfinae_summary", tmpl->get_sfinaeSummary()));
+      fields.push_back(
+          jsonString("template_arguments") + ": " +
+          rawTemplateArgumentListJson(tmpl->get_templateArguments(), ids));
+      fields.push_back(jsonString("deduced_template_arguments") + ": " +
+                       rawTemplateArgumentListJson(
+                           tmpl->get_deducedTemplateArguments(), ids));
+    }
+  } else if (SgEnumDeclaration *decl = isSgEnumDeclaration(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(rawBoolField("embedded", decl->get_embedded()));
+    fields.push_back(rawBoolField("is_unnamed", decl->get_isUnNamed()));
+    fields.push_back(rawBoolField("is_autonomous_declaration",
+                                  decl->get_isAutonomousDeclaration()));
+    fields.push_back(rawBoolField("is_scoped_enum", decl->get_isScopedEnum()));
+    fields.push_back(jsonString("field_type") + ": " +
+                     rawTypeJson(decl->get_field_type(), ids));
+  } else if (SgNamespaceDeclarationStatement *decl =
+                 isSgNamespaceDeclarationStatement(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(
+        rawBoolField("is_unnamed_namespace", decl->get_isUnnamedNamespace()));
+    fields.push_back(
+        rawBoolField("is_inlined_namespace", decl->get_isInlinedNamespace()));
+  } else if (SgNamespaceDefinitionStatement *def =
+                 isSgNamespaceDefinitionStatement(node)) {
+    fields.push_back(
+        rawBoolField("is_union_of_reentrant_namespace_definitions",
+                     def->get_isUnionOfReentrantNamespaceDefinitions()));
+  } else if (SgUsingDirectiveStatement *stmt =
+                 isSgUsingDirectiveStatement(node)) {
+    SgNamespaceDeclarationStatement *decl = stmt->get_namespaceDeclaration();
+    fields.push_back(
+        rawIntegerField("namespace_declaration", idFor(ids, decl)));
+    fields.push_back(rawStringField(
+        "namespace_name", decl != nullptr ? decl->get_name().getString() : ""));
+    fields.push_back(
+        rawBoolField("namespace_is_unnamed",
+                     decl != nullptr ? decl->get_isUnnamedNamespace() : false));
+  } else if (SgUsingDeclarationStatement *stmt =
+                 isSgUsingDeclarationStatement(node)) {
+    SgDeclarationStatement *decl = stmt->get_declaration();
+    SgInitializedName *name = stmt->get_initializedName();
+    fields.push_back(rawIntegerField("declaration", idFor(ids, decl)));
+    fields.push_back(
+        rawStringField("declaration_name",
+                       decl != nullptr ? SageInterface::get_name(decl) : ""));
+    fields.push_back(rawIntegerField("initialized_name", idFor(ids, name)));
+    fields.push_back(
+        rawStringField("initialized_name_name",
+                       name != nullptr ? name->get_name().getString() : ""));
+    fields.push_back(
+        jsonString("initialized_name_type") + ": " +
+        rawTypeJson(name != nullptr ? name->get_typeptr() : nullptr, ids));
+  } else if (SgUseStatement *stmt = isSgUseStatement(node)) {
+    fields.push_back(rawStringField("name", stmt->get_name().getString()));
+    fields.push_back(rawBoolField("only_option", stmt->get_only_option()));
+    fields.push_back(
+        rawStringField("module_nature", stmt->get_module_nature()));
+    fields.push_back(rawIntegerField("module", idFor(ids, stmt->get_module())));
+    fields.push_back(jsonString("external_module") + ": " +
+                     rawExternalModuleJson(stmt->get_module(), ids));
+  } else if (SgNonrealDecl *decl = isSgNonrealDecl(node)) {
+    fields.push_back(rawStringField("name", decl->get_name().getString()));
+    fields.push_back(jsonString("type") + ": " +
+                     rawTypeJson(decl->get_type(), ids));
+    fields.push_back(rawIntegerField("template_parameter_position",
+                                     decl->get_template_parameter_position()));
+    fields.push_back(rawIntegerField("template_parameter_depth",
+                                     decl->get_template_parameter_depth()));
+    fields.push_back(
+        rawBoolField("is_class_member", decl->get_is_class_member()));
+    fields.push_back(
+        rawBoolField("is_template_param", decl->get_is_template_param()));
+    fields.push_back(rawBoolField("is_template_template_param",
+                                  decl->get_is_template_template_param()));
+    fields.push_back(
+        rawBoolField("has_template_keyword", decl->get_has_template_keyword()));
+    fields.push_back(
+        rawBoolField("has_global_qualifier", decl->get_has_global_qualifier()));
+    fields.push_back(
+        rawBoolField("suppress_typename", decl->get_suppress_typename()));
+    fields.push_back(
+        rawBoolField("is_nonreal_template", decl->get_is_nonreal_template()));
+    fields.push_back(rawBoolField("is_concept", decl->get_is_concept()));
+    fields.push_back(
+        rawBoolField("is_nonreal_function", decl->get_is_nonreal_function()));
+    fields.push_back(jsonString("tpl_args") + ": " +
+                     rawTemplateArgumentListJson(decl->get_tpl_args(), ids));
+  } else if (SgBaseClass *base = isSgBaseClass(node)) {
+    fields.push_back(
+        rawIntegerField("base_class", idFor(ids, base->get_base_class())));
+    fields.push_back(
+        rawBoolField("is_direct_base_class", base->get_isDirectBaseClass()));
+    fields.push_back(
+        rawBoolField("pack_expansion", base->get_pack_expansion()));
+    fields.push_back(rawIntegerField(
+        "base_class_modifier",
+        base->get_baseClassModifier() != nullptr
+            ? static_cast<int>(base->get_baseClassModifier()->get_modifier())
+            : static_cast<int>(SgBaseClassModifier::e_unknown)));
+    fields.push_back(
+        rawIntegerField("base_class_access_modifier",
+                        base->get_baseClassModifier() != nullptr
+                            ? static_cast<int>(base->get_baseClassModifier()
+                                                   ->get_accessModifier()
+                                                   .get_modifier())
+                            : static_cast<int>(SgAccessModifier::e_unknown)));
+    fields.push_back(rawBoolField("base_class_access_is_explicit",
+                                  base->get_baseClassModifier() != nullptr
+                                      ? base->get_baseClassModifier()
+                                            ->get_accessModifier()
+                                            .get_is_explicit()
+                                      : false));
+    fields.push_back(rawIntegerField("name_qualification_length",
+                                     base->get_name_qualification_length()));
+    fields.push_back(rawBoolField("type_elaboration_required",
+                                  base->get_type_elaboration_required()));
+    fields.push_back(rawBoolField("global_qualification_required",
+                                  base->get_global_qualification_required()));
+    if (SgExpBaseClass *expr_base = isSgExpBaseClass(base)) {
+      fields.push_back(jsonString("base_class_exp") + ": " +
+                       rawExpressionRef(expr_base->get_base_class_exp(), ids));
+    }
+    if (SgNonrealBaseClass *nonreal_base = isSgNonrealBaseClass(base)) {
+      fields.push_back(
+          rawIntegerField("base_class_nonreal",
+                          idFor(ids, nonreal_base->get_base_class_nonreal())));
+    }
+  } else if (SgPragma *pragma = isSgPragma(node)) {
+    fields.push_back(rawStringField("name", pragma->get_name()));
+  } else if (SgTypeTraitBuiltinOperator *op =
+                 isSgTypeTraitBuiltinOperator(node)) {
+    fields.push_back(rawStringField("name", op->get_name().getString()));
+    fields.push_back(jsonString("args") + ": " +
+                     rawTypeTraitArgsJson(op->get_args(), ids));
+  } else if (SgRenamePair *rename = isSgRenamePair(node)) {
+    fields.push_back(
+        rawStringField("local_name", rename->get_local_name().getString()));
+    fields.push_back(
+        rawStringField("use_name", rename->get_use_name().getString()));
+  } else if (SgCommonBlockObject *object = isSgCommonBlockObject(node)) {
+    fields.push_back(rawStringField("block_name", object->get_block_name()));
+  }
+
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+    const SgStorageModifier &storage =
+        decl->get_declarationModifier().get_storageModifier();
+    fields.push_back(
+        rawIntegerField("decl_attributes", decl->get_decl_attributes()));
+    fields.push_back(rawStringField("linkage", decl->get_linkage()));
+    fields.push_back(
+        jsonString("declaration_modifier_vector") + ": " +
+        rawBitVectorJson(decl->get_declarationModifier().get_modifierVector()));
+    fields.push_back(jsonString("declaration_type_modifier_vector") + ": " +
+                     rawBitVectorJson(decl->get_declarationModifier()
+                                          .get_typeModifier()
+                                          .get_modifierVector()));
+    fields.push_back(rawIntegerField("declaration_storage_modifier",
+                                     static_cast<int>(storage.get_modifier())));
+    fields.push_back(
+        rawIntegerField("declaration_access_modifier",
+                        static_cast<int>(decl->get_declarationModifier()
+                                             .get_accessModifier()
+                                             .get_modifier())));
+    fields.push_back(rawBoolField("declaration_access_is_explicit",
+                                  decl->get_declarationModifier()
+                                      .get_accessModifier()
+                                      .get_is_explicit()));
+    fields.push_back(rawBoolField("name_only", decl->get_nameOnly()));
+    fields.push_back(rawBoolField("forward", decl->get_forward()));
+    fields.push_back(rawBoolField("extern_brace", decl->get_externBrace()));
+    fields.push_back(
+        rawBoolField("skip_elaborate_type", decl->get_skipElaborateType()));
+    fields.push_back(
+        rawStringField("binding_label", decl->get_binding_label()));
+    fields.push_back(
+        rawBoolField("unparse_template_ast", decl->get_unparse_template_ast()));
+    fields.push_back(rawStringField(
+        "declaration_gnu_attribute_section_name",
+        decl->get_declarationModifier().get_gnu_attribute_section_name()));
+    fields.push_back(rawIntegerField(
+        "declaration_gnu_attribute_visability",
+        static_cast<int>(
+            decl->get_declarationModifier().get_gnu_attribute_visability())));
+    fields.push_back(jsonString("external_first_nondefining_declaration") +
+                     ": " +
+                     rawExternalDeclarationReferenceJson(
+                         decl->get_firstNondefiningDeclaration(), ids));
+    fields.push_back(jsonString("external_defining_declaration") + ": " +
+                     rawExternalDeclarationReferenceJson(
+                         decl->get_definingDeclaration(), ids));
+  }
+
+  if (SgExpression *expr = isSgExpression(node)) {
+    addExpressionType(fields, expr, ids);
+    fields.push_back(rawBoolField("lvalue", expr->get_lvalue()));
+    fields.push_back(rawBoolField("need_paren", expr->get_need_paren()));
+    fields.push_back(rawBoolField("global_qualified_name",
+                                  expr->get_global_qualified_name()));
+    addExpressionQualificationFields(fields, expr);
+    if (SgFunctionCallExp *call = isSgFunctionCallExp(expr)) {
+      fields.push_back(rawBoolField("uses_operator_syntax",
+                                    call->get_uses_operator_syntax()));
+    }
+    if (SgTypeExpression *type_expr = isSgTypeExpression(expr)) {
+      fields.push_back(
+          rawStringField("type_spelling", type_expr->unparseToString()));
+    } else if (SgSubscriptExpression *subscript =
+                   isSgSubscriptExpression(expr)) {
+      if (serializingTypeOwnedExpression) {
+        fields.push_back(
+            jsonString("lower_bound") + ": " +
+            rawTypeOwnedExpressionRef(subscript->get_lowerBound(), ids));
+        fields.push_back(
+            jsonString("upper_bound") + ": " +
+            rawTypeOwnedExpressionRef(subscript->get_upperBound(), ids));
+        fields.push_back(
+            jsonString("stride") + ": " +
+            rawTypeOwnedExpressionRef(subscript->get_stride(), ids));
+      }
+    }
+    if (serializingTypeOwnedExpression) {
+      if (SgUnaryOp *unary = isSgUnaryOp(expr)) {
+        fields.push_back(
+            jsonString("operand") + ": " +
+            rawTypeOwnedExpressionRef(unary->get_operand_i(), ids));
+      }
+      if (SgBinaryOp *binary = isSgBinaryOp(expr)) {
+        fields.push_back(
+            jsonString("lhs_operand") + ": " +
+            rawTypeOwnedExpressionRef(binary->get_lhs_operand_i(), ids));
+        fields.push_back(
+            jsonString("rhs_operand") + ": " +
+            rawTypeOwnedExpressionRef(binary->get_rhs_operand_i(), ids));
+      }
+    }
+  }
+
+  if (SgTemplateArgument *argument = isSgTemplateArgument(node)) {
+    fields.push_back(
+        rawIntegerField("argument_type", argument->get_argumentType()));
+    fields.push_back(rawBoolField("is_array_bound_unknown_type",
+                                  argument->get_isArrayBoundUnknownType()));
+    fields.push_back(jsonString("type") + ": " +
+                     rawTypeJson(argument->get_type(), ids));
+    fields.push_back(jsonString("expression") + ": " +
+                     rawExpressionRef(argument->get_expression(), ids));
+    fields.push_back(
+        rawIntegerField("template_declaration",
+                        idFor(ids, argument->get_templateDeclaration())));
+    fields.push_back(rawIntegerField(
+        "initialized_name", idFor(ids, argument->get_initializedName())));
+    fields.push_back(rawBoolField("explicitly_specified",
+                                  argument->get_explicitlySpecified()));
+    fields.push_back(
+        rawBoolField("is_pack_element", argument->get_is_pack_element()));
+  }
+  if (SgTemplateParameter *parameter = isSgTemplateParameter(node)) {
+    fields.push_back(
+        rawIntegerField("parameter_type", parameter->get_parameterType()));
+    fields.push_back(jsonString("type") + ": " +
+                     rawTypeJson(parameter->get_type(), ids));
+    fields.push_back(jsonString("default_type_parameter") + ": " +
+                     rawTypeJson(parameter->get_defaultTypeParameter(), ids));
+    fields.push_back(jsonString("expression") + ": " +
+                     rawExpressionRef(parameter->get_expression(), ids));
+    fields.push_back(jsonString("type_constraint") + ": " +
+                     rawExpressionRef(parameter->get_typeConstraint(), ids));
+    fields.push_back(
+        jsonString("default_expression_parameter") + ": " +
+        rawExpressionRef(parameter->get_defaultExpressionParameter(), ids));
+    fields.push_back(
+        rawIntegerField("template_declaration",
+                        idFor(ids, parameter->get_templateDeclaration())));
+    fields.push_back(rawIntegerField(
+        "default_template_declaration_parameter",
+        idFor(ids, parameter->get_defaultTemplateDeclarationParameter())));
+    fields.push_back(rawIntegerField(
+        "initialized_name", idFor(ids, parameter->get_initializedName())));
+    fields.push_back(
+        rawIntegerField("template_parameter_keyword",
+                        parameter->get_templateParameterKeyword()));
+    fields.push_back(
+        rawBoolField("is_abbreviated_function_template_parameter",
+                     parameter->get_isAbbreviatedFunctionTemplateParameter()));
+    fields.push_back(
+        rawBoolField("is_parameter_pack", parameter->get_is_parameter_pack()));
+  }
+
+  if (SgActualArgumentExpression *actual = isSgActualArgumentExpression(node)) {
+    fields.push_back(rawStringField("argument_name",
+                                    actual->get_argument_name().getString()));
+  }
+
+  if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+    fields.push_back(rawIntegerField("symbol_declaration",
+                                     varRefSymbolDeclarationId(ref, ids)));
+    fields.push_back(rawStringField("symbol_name",
+                                    ref->get_symbol()->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(ref->get_symbol(), ids));
+  } else if (SgLabelRefExp *ref = isSgLabelRefExp(node)) {
+    if (ref->get_symbol() == nullptr) {
+      throw std::runtime_error("AST JSON SgLabelRefExp has no symbol");
+    }
+    fields.push_back(rawIntegerField(
+        "symbol_declaration", idFor(ids, symbolBasis(ref->get_symbol()))));
+    fields.push_back(rawStringField("symbol_name",
+                                    ref->get_symbol()->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(ref->get_symbol(), ids));
+  } else if (SgFunctionRefExp *ref = isSgFunctionRefExp(node)) {
+    SgFunctionSymbol *symbol = ref->get_symbol();
+    SgFunctionDeclaration *decl =
+        symbol != nullptr ? symbol->get_declaration() : nullptr;
+    const uint64_t decl_id = idFor(ids, decl);
+    const bool external_decl =
+        decl != nullptr && (isAstJsonExternalFunction(decl) ||
+                            (decl_id == 0 && !insideCollectionBoundary(decl)));
+    if (symbol == nullptr || (decl_id == 0 && !external_decl)) {
+      std::ostringstream message;
+      message
+          << "AST JSON SgFunctionRefExp symbol declaration was not collected";
+      if (symbol != nullptr) {
+        message << ": " << symbol->get_name().getString();
+        if (decl != nullptr) {
+          message << " declaration=" << decl->sage_class_name() << "("
+                  << decl->get_name().getString() << ")";
+          if (SgNode *parent = decl->get_parent()) {
+            message << " declaration_parent=" << parent->sage_class_name();
+          }
+          std::ostringstream declaration_chain;
+          for (SgNode *current = decl; current != nullptr;
+               current = current->get_parent()) {
+            if (declaration_chain.tellp() > 0) {
+              declaration_chain << " <- ";
+            }
+            declaration_chain << current->sage_class_name();
+          }
+          message << " declaration_chain=[" << declaration_chain.str() << "]";
+        }
+      }
+      std::ostringstream parent_chain;
+      for (SgNode *current = ref; current != nullptr;
+           current = current->get_parent()) {
+        if (parent_chain.tellp() > 0) {
+          parent_chain << " <- ";
+        }
+        parent_chain << current->sage_class_name();
+      }
+      message << " parent_chain=[" << parent_chain.str() << "]";
+      throw std::runtime_error(message.str());
+    }
+    fields.push_back(
+        rawIntegerField("symbol_declaration", external_decl ? 0 : decl_id));
+    fields.push_back(
+        rawStringField("symbol_name", symbol->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " + rawSymbolRef(symbol, ids));
+    fields.push_back(jsonString("external_function") + ": " +
+                     rawExternalFunctionJson(decl, ids));
+  } else if (SgTemplateFunctionRefExp *ref = isSgTemplateFunctionRefExp(node)) {
+    if (ref->get_symbol() == nullptr ||
+        idFor(ids, ref->get_symbol()->get_declaration()) == 0) {
+      throw std::runtime_error("AST JSON SgTemplateFunctionRefExp symbol "
+                               "declaration was not collected");
+    }
+    fields.push_back(
+        rawIntegerField("symbol_declaration",
+                        idFor(ids, ref->get_symbol()->get_declaration())));
+    fields.push_back(rawStringField("symbol_name",
+                                    ref->get_symbol()->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(ref->get_symbol(), ids));
+  } else if (SgMemberFunctionRefExp *ref = isSgMemberFunctionRefExp(node)) {
+    if (ref->get_symbol_i() == nullptr ||
+        idFor(ids, ref->get_symbol_i()->get_declaration()) == 0) {
+      throw std::runtime_error("AST JSON SgMemberFunctionRefExp symbol "
+                               "declaration was not collected");
+    }
+    fields.push_back(
+        rawIntegerField("symbol_declaration",
+                        idFor(ids, ref->get_symbol_i()->get_declaration())));
+    fields.push_back(rawStringField(
+        "symbol_name", ref->get_symbol_i()->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " +
+                     rawSymbolRef(ref->get_symbol_i(), ids));
+    fields.push_back(rawIntegerField("virtual_call", ref->get_virtual_call()));
+    fields.push_back(
+        rawIntegerField("need_qualifier", ref->get_need_qualifier()));
+  } else if (SgThisExp *expr = isSgThisExp(node)) {
+    SgClassSymbol *class_symbol = expr->get_class_symbol();
+    SgNonrealSymbol *nonreal_symbol = expr->get_nonreal_symbol();
+    if (class_symbol == nullptr && nonreal_symbol == nullptr) {
+      throw std::runtime_error(
+          "AST JSON SgThisExp has neither class nor nonreal symbol");
+    }
+    if (class_symbol != nullptr &&
+        idFor(ids, class_symbol->get_declaration()) == 0) {
+      throw std::runtime_error(
+          "AST JSON SgThisExp class symbol declaration was not collected");
+    }
+    if (nonreal_symbol != nullptr &&
+        idFor(ids, nonreal_symbol->get_declaration()) == 0) {
+      throw std::runtime_error(
+          "AST JSON SgThisExp nonreal symbol declaration was not collected");
+    }
+    fields.push_back(rawIntegerField(
+        "class_symbol_declaration",
+        idFor(ids, class_symbol != nullptr ? class_symbol->get_declaration()
+                                           : nullptr)));
+    fields.push_back(rawStringField(
+        "class_symbol_name",
+        class_symbol != nullptr ? class_symbol->get_name().getString() : ""));
+    fields.push_back(rawIntegerField(
+        "nonreal_symbol_declaration",
+        idFor(ids, nonreal_symbol != nullptr ? nonreal_symbol->get_declaration()
+                                             : nullptr)));
+    fields.push_back(rawStringField("nonreal_symbol_name",
+                                    nonreal_symbol != nullptr
+                                        ? nonreal_symbol->get_name().getString()
+                                        : ""));
+    fields.push_back(rawIntegerField("pobj_this", expr->get_pobj_this()));
+  } else if (SgNonrealRefExp *ref = isSgNonrealRefExp(node)) {
+    SgNonrealSymbol *symbol = ref->get_symbol();
+    if (symbol == nullptr || idFor(ids, symbol->get_declaration()) == 0) {
+      throw std::runtime_error(
+          "AST JSON SgNonrealRefExp symbol declaration was not collected");
+    }
+    fields.push_back(rawIntegerField("symbol_declaration",
+                                     idFor(ids, symbol->get_declaration())));
+    fields.push_back(
+        rawStringField("symbol_name", symbol->get_name().getString()));
+    fields.push_back(jsonString("symbol") + ": " + rawSymbolRef(symbol, ids));
+    fields.push_back(
+        jsonString("template_arguments") + ": " +
+        rawTemplateArgumentListJson(ref->get_templateArguments(), ids));
+    fields.push_back(rawBoolField("constraint_satisfaction_evaluated",
+                                  ref->get_constraintSatisfactionEvaluated()));
+    fields.push_back(rawBoolField("constraint_satisfaction_satisfied",
+                                  ref->get_constraintSatisfactionSatisfied()));
+    fields.push_back(
+        rawBoolField("constraint_satisfaction_contains_errors",
+                     ref->get_constraintSatisfactionContainsErrors()));
+    fields.push_back(
+        rawBoolField("constraint_satisfaction_substitution_failure",
+                     ref->get_constraintSatisfactionSubstitutionFailure()));
+    fields.push_back(rawStringField("constraint_satisfaction_summary",
+                                    ref->get_constraintSatisfactionSummary()));
+    fields.push_back(
+        rawBoolField("sfinae_evaluated", ref->get_sfinaeEvaluated()));
+    fields.push_back(rawBoolField("sfinae_substitution_failure",
+                                  ref->get_sfinaeSubstitutionFailure()));
+    fields.push_back(
+        rawStringField("sfinae_summary", ref->get_sfinaeSummary()));
+  } else if (SgBoolValExp *value = isSgBoolValExp(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+  } else if (SgShortVal *value = isSgShortVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgUnsignedShortVal *value = isSgUnsignedShortVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgIntVal *value = isSgIntVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgUnsignedIntVal *value = isSgUnsignedIntVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgLongIntVal *value = isSgLongIntVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgUnsignedLongVal *value = isSgUnsignedLongVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgLongLongIntVal *value = isSgLongLongIntVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgUnsignedLongLongIntVal *value =
+                 isSgUnsignedLongLongIntVal(node)) {
+    fields.push_back(
+        rawIntegerField("value", static_cast<int64_t>(value->get_value())));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgCharVal *value = isSgCharVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgUnsignedCharVal *value = isSgUnsignedCharVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgFloatVal *value = isSgFloatVal(node)) {
+    fields.push_back(rawStringField("value", value->get_valueString()));
+  } else if (SgDoubleVal *value = isSgDoubleVal(node)) {
+    fields.push_back(rawStringField("value", value->get_valueString()));
+  } else if (SgComplexVal *value = isSgComplexVal(node)) {
+    fields.push_back(jsonString("precision_type") + ": " +
+                     rawTypeJson(value->get_precisionType(), ids));
+    fields.push_back(jsonString("real_value") + ": " +
+                     rawTypeOwnedExpressionRef(value->get_real_value(), ids));
+    fields.push_back(
+        jsonString("imaginary_value") + ": " +
+        rawTypeOwnedExpressionRef(value->get_imaginary_value(), ids));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgStringVal *value = isSgStringVal(node)) {
+    fields.push_back(rawStringField("value", value->get_value()));
+    fields.push_back(rawBoolField("wchar_string", value->get_wcharString()));
+    fields.push_back(
+        rawIntegerField("string_delimiter", value->get_stringDelimiter()));
+    fields.push_back(
+        rawBoolField("is_16bit_string", value->get_is16bitString()));
+    fields.push_back(
+        rawBoolField("is_32bit_string", value->get_is32bitString()));
+    fields.push_back(rawBoolField("is_raw_string", value->get_isRawString()));
+    fields.push_back(
+        rawStringField("raw_string_value", value->get_raw_string_value()));
+  } else if (SgEnumVal *value = isSgEnumVal(node)) {
+    fields.push_back(rawIntegerField("value", value->get_value()));
+    fields.push_back(rawStringField("name", value->get_name().getString()));
+    fields.push_back(
+        rawIntegerField("declaration", idFor(ids, value->get_declaration())));
+    fields.push_back(rawBoolField("requires_name_qualification",
+                                  value->get_requiresNameQualification()));
+  } else if (SgTemplateParameterVal *value = isSgTemplateParameterVal(node)) {
+    fields.push_back(rawIntegerField("template_parameter_position",
+                                     value->get_template_parameter_position()));
+    fields.push_back(rawStringField("value_string", value->get_valueString()));
+  } else if (SgCastExp *cast = isSgCastExp(node)) {
+    fields.push_back(rawIntegerField("cast_type", cast->cast_type()));
+  } else if (SgConstructorInitializer *init =
+                 isSgConstructorInitializer(node)) {
+    fields.push_back(rawBoolField("need_name", init->get_need_name()));
+    fields.push_back(
+        rawBoolField("need_qualifier", init->get_need_qualifier()));
+    fields.push_back(rawBoolField("need_parenthesis_after_name",
+                                  init->get_need_parenthesis_after_name()));
+    fields.push_back(rawBoolField("associated_class_unknown",
+                                  init->get_associated_class_unknown()));
+  } else if (SgStaticAssertionDeclaration *decl =
+                 isSgStaticAssertionDeclaration(node)) {
+    fields.push_back(rawStringField("string_literal",
+                                    decl->get_string_literal().getString()));
+  } else if (SgBreakStmt *stmt = isSgBreakStmt(node)) {
+    fields.push_back(
+        rawStringField("do_string_label", stmt->get_do_string_label()));
+  } else if (SgContinueStmt *stmt = isSgContinueStmt(node)) {
+    fields.push_back(
+        rawStringField("do_string_label", stmt->get_do_string_label()));
+  } else if (SgProcessControlStatement *stmt =
+                 isSgProcessControlStatement(node)) {
+    fields.push_back(rawIntegerField("control_kind", stmt->get_control_kind()));
+  } else if (SgAttributeSpecificationStatement *stmt =
+                 isSgAttributeSpecificationStatement(node)) {
+    fields.push_back(
+        rawIntegerField("attribute_kind", stmt->get_attribute_kind()));
+    fields.push_back(rawIntegerField("intent", stmt->get_intent()));
+    fields.push_back(jsonString("name_list") + ": " +
+                     rawStringListJson(stmt->get_name_list()));
+  } else if (SgInterfaceStatement *stmt = isSgInterfaceStatement(node)) {
+    fields.push_back(rawStringField("name", stmt->get_name().getString()));
+    fields.push_back(rawIntegerField("generic_spec", stmt->get_generic_spec()));
+  } else if (SgInterfaceBody *body = isSgInterfaceBody(node)) {
+    fields.push_back(
+        rawStringField("function_name", body->get_function_name().getString()));
+    fields.push_back(
+        rawBoolField("use_function_name", body->get_use_function_name()));
+    fields.push_back(rawIntegerField(
+        "function_declaration", idFor(ids, body->get_functionDeclaration())));
+  } else if (SgCaseOptionStmt *stmt = isSgCaseOptionStmt(node)) {
+    fields.push_back(
+        rawStringField("case_construct_name", stmt->get_case_construct_name()));
+  } else if (SgDefaultOptionStmt *stmt = isSgDefaultOptionStmt(node)) {
+    fields.push_back(rawStringField("default_construct_name",
+                                    stmt->get_default_construct_name()));
+  } else if (SgSizeOfOp *size_of = isSgSizeOfOp(node)) {
+    fields.push_back(jsonString("operand_type") + ": " +
+                     rawTypeJson(size_of->get_operand_type(), ids));
+    fields.push_back(
+        rawBoolField("size_of_contains_base_type_defining_declaration",
+                     size_of->get_sizeOfContainsBaseTypeDefiningDeclaration()));
+    fields.push_back(rawBoolField(
+        "is_objectless_nonstatic_data_member_reference",
+        size_of->get_is_objectless_nonstatic_data_member_reference()));
+    fields.push_back(
+        rawBoolField("is_sizeof_pack", size_of->get_is_sizeof_pack()));
+  } else if (SgUnaryOp *unary = isSgUnaryOp(node)) {
+    fields.push_back(rawIntegerField("mode", unary->get_mode()));
+  } else if (SgOmpClause *clause = isSgOmpClause(node)) {
+    fields.push_back(rawIntegerField("directive_name_modifier",
+                                     clause->get_directive_name_modifier()));
+  }
+
+  if (SgOmpMapClause *clause = isSgOmpMapClause(node)) {
+    fields.push_back(rawIntegerField("operation", clause->get_operation()));
+    fields.push_back(rawIntegerField("modifier1", clause->get_modifier1()));
+    fields.push_back(rawIntegerField("modifier2", clause->get_modifier2()));
+    fields.push_back(rawIntegerField("modifier3", clause->get_modifier3()));
+    fields.push_back(jsonString("mapper_identifier") + ": " +
+                     rawExpressionRef(clause->get_mapper_identifier(), ids));
+    fields.push_back(
+        jsonString("array_dimensions") + ": " +
+        rawOmpArrayDimensionsJson(clause->get_array_dimensions(), ids));
+    fields.push_back(
+        jsonString("dist_data_policies") + ": " +
+        rawOmpDistDataPoliciesJson(clause->get_dist_data_policies(), ids));
+    fields.push_back(jsonString("iterator") + ": " +
+                     rawOmpIteratorJson(clause->get_iterator(), ids));
+  } else if (SgOmpDeviceClause *clause = isSgOmpDeviceClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpDefaultClause *clause = isSgOmpDefaultClause(node)) {
+    fields.push_back(
+        rawIntegerField("data_sharing", clause->get_data_sharing()));
+  } else if (SgOmpProcBindClause *clause = isSgOmpProcBindClause(node)) {
+    fields.push_back(rawIntegerField("policy", clause->get_policy()));
+  } else if (SgOmpIfClause *clause = isSgOmpIfClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpLastprivateClause *clause = isSgOmpLastprivateClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpReductionClause *clause = isSgOmpReductionClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+    fields.push_back(rawIntegerField("identifier", clause->get_identifier()));
+    fields.push_back(
+        jsonString("user_defined_identifier") + ": " +
+        rawExpressionRef(clause->get_user_defined_identifier(), ids));
+  } else if (SgOmpLinearClause *clause = isSgOmpLinearClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpScheduleClause *clause = isSgOmpScheduleClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+    fields.push_back(rawIntegerField("modifier1", clause->get_modifier1()));
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+  } else if (SgOmpDistScheduleClause *clause =
+                 isSgOmpDistScheduleClause(node)) {
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+  } else if (SgOmpOrderClause *clause = isSgOmpOrderClause(node)) {
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpAtomicDefaultMemOrderClause *clause =
+                 isSgOmpAtomicDefaultMemOrderClause(node)) {
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+  } else if (SgOmpDefaultmapClause *clause = isSgOmpDefaultmapClause(node)) {
+    fields.push_back(rawIntegerField("behavior", clause->get_behavior()));
+    fields.push_back(rawIntegerField("category", clause->get_category()));
+  } else if (SgOmpBindClause *clause = isSgOmpBindClause(node)) {
+    fields.push_back(rawIntegerField("binding", clause->get_binding()));
+  } else if (SgOmpFailClause *clause = isSgOmpFailClause(node)) {
+    fields.push_back(
+        rawIntegerField("memory_order", clause->get_memory_order()));
+  } else if (SgOmpAllocateClause *clause = isSgOmpAllocateClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+    fields.push_back(
+        jsonString("user_defined_modifier") + ": " +
+        rawExpressionRef(clause->get_user_defined_modifier(), ids));
+  } else if (SgOmpAllocatorClause *clause = isSgOmpAllocatorClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+    fields.push_back(
+        jsonString("user_defined_modifier") + ": " +
+        rawExpressionRef(clause->get_user_defined_modifier(), ids));
+  } else if (SgOmpAdjustArgsClause *clause = isSgOmpAdjustArgsClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+    fields.push_back(
+        jsonString("user_defined_modifier") + ": " +
+        rawExpressionRef(clause->get_user_defined_modifier(), ids));
+  } else if (SgOmpInReductionClause *clause = isSgOmpInReductionClause(node)) {
+    fields.push_back(rawIntegerField("identifier", clause->get_identifier()));
+  } else if (SgOmpTaskReductionClause *clause =
+                 isSgOmpTaskReductionClause(node)) {
+    fields.push_back(rawIntegerField("identifier", clause->get_identifier()));
+    fields.push_back(
+        jsonString("user_defined_identifier") + ": " +
+        rawExpressionRef(clause->get_user_defined_identifier(), ids));
+  } else if (SgOmpDepobjUpdateClause *clause =
+                 isSgOmpDepobjUpdateClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpNumTasksClause *clause = isSgOmpNumTasksClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpGrainsizeClause *clause = isSgOmpGrainsizeClause(node)) {
+    fields.push_back(rawIntegerField("modifier", clause->get_modifier()));
+  } else if (SgOmpWhenClause *clause = isSgOmpWhenClause(node)) {
+    fields.push_back(jsonString("user_condition") + ": " +
+                     rawExpressionRef(clause->get_user_condition(), ids));
+    fields.push_back(jsonString("user_condition_score") + ": " +
+                     rawExpressionRef(clause->get_user_condition_score(), ids));
+    fields.push_back(rawBoolField("target_device_selector",
+                                  clause->get_target_device_selector()));
+    fields.push_back(jsonString("device_arch") + ": " +
+                     rawExpressionRef(clause->get_device_arch(), ids));
+    fields.push_back(jsonString("device_isa") + ": " +
+                     rawExpressionRef(clause->get_device_isa(), ids));
+    fields.push_back(jsonString("device_num") + ": " +
+                     rawExpressionRef(clause->get_device_num(), ids));
+    fields.push_back(rawIntegerField("device_kind", clause->get_device_kind()));
+    fields.push_back(rawIntegerField("implementation_vendor",
+                                     clause->get_implementation_vendor()));
+    fields.push_back(
+        jsonString("implementation_user_defined") + ": " +
+        rawExpressionRef(clause->get_implementation_user_defined(), ids));
+    fields.push_back(
+        jsonString("implementation_extension") + ": " +
+        rawExpressionRef(clause->get_implementation_extension(), ids));
+  } else if (SgOmpMatchClause *clause = isSgOmpMatchClause(node)) {
+    fields.push_back(jsonString("user_condition") + ": " +
+                     rawExpressionRef(clause->get_user_condition(), ids));
+    fields.push_back(jsonString("user_condition_score") + ": " +
+                     rawExpressionRef(clause->get_user_condition_score(), ids));
+    fields.push_back(rawBoolField("target_device_selector",
+                                  clause->get_target_device_selector()));
+    fields.push_back(jsonString("device_arch") + ": " +
+                     rawExpressionRef(clause->get_device_arch(), ids));
+    fields.push_back(jsonString("device_isa") + ": " +
+                     rawExpressionRef(clause->get_device_isa(), ids));
+    fields.push_back(jsonString("device_num") + ": " +
+                     rawExpressionRef(clause->get_device_num(), ids));
+    fields.push_back(rawIntegerField("device_kind", clause->get_device_kind()));
+    fields.push_back(rawIntegerField("implementation_vendor",
+                                     clause->get_implementation_vendor()));
+    fields.push_back(
+        jsonString("implementation_user_defined") + ": " +
+        rawExpressionRef(clause->get_implementation_user_defined(), ids));
+    fields.push_back(
+        jsonString("implementation_extension") + ": " +
+        rawExpressionRef(clause->get_implementation_extension(), ids));
+  } else if (SgOmpUsesAllocatorsDefination *definition =
+                 isSgOmpUsesAllocatorsDefination(node)) {
+    fields.push_back(rawIntegerField("allocator", definition->get_allocator()));
+    fields.push_back(
+        jsonString("user_defined_allocator") + ": " +
+        rawExpressionRef(definition->get_user_defined_allocator(), ids));
+    fields.push_back(
+        jsonString("allocator_traits_array") + ": " +
+        rawExpressionRef(definition->get_allocator_traits_array(), ids));
+  } else if (SgOmpUsesAllocatorsClause *clause =
+                 isSgOmpUsesAllocatorsClause(node)) {
+    fields.push_back(jsonString("uses_allocators_definitions") + ": " +
+                     rawOmpUsesAllocatorsDefinitionsJson(
+                         clause->get_uses_allocators_defination(), ids));
+  } else if (SgOmpDependClause *clause = isSgOmpDependClause(node)) {
+    fields.push_back(
+        rawIntegerField("depend_modifier", clause->get_depend_modifier()));
+    fields.push_back(
+        rawIntegerField("dependence_type", clause->get_dependence_type()));
+    fields.push_back(
+        jsonString("array_dimensions") + ": " +
+        rawOmpArrayDimensionsJson(clause->get_array_dimensions(), ids));
+    fields.push_back(jsonString("iterator") + ": " +
+                     rawOmpIteratorJson(clause->get_iterator(), ids));
+    fields.push_back(jsonString("vec") + ": " +
+                     rawOmpExpressionListJson(clause->get_vec(), ids));
+  } else if (SgOmpAffinityClause *clause = isSgOmpAffinityClause(node)) {
+    fields.push_back(
+        rawIntegerField("affinity_modifier", clause->get_affinity_modifier()));
+    fields.push_back(
+        jsonString("array_dimensions") + ": " +
+        rawOmpArrayDimensionsJson(clause->get_array_dimensions(), ids));
+    fields.push_back(jsonString("iterator") + ": " +
+                     rawOmpIteratorJson(clause->get_iterator(), ids));
+  } else if (SgOmpToClause *clause = isSgOmpToClause(node)) {
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+    fields.push_back(jsonString("mapper_identifier") + ": " +
+                     rawExpressionRef(clause->get_mapper_identifier(), ids));
+    fields.push_back(
+        jsonString("array_dimensions") + ": " +
+        rawOmpArrayDimensionsJson(clause->get_array_dimensions(), ids));
+    fields.push_back(jsonString("iterator") + ": " +
+                     rawOmpIteratorJson(clause->get_iterator(), ids));
+  } else if (SgOmpFromClause *clause = isSgOmpFromClause(node)) {
+    fields.push_back(rawIntegerField("kind", clause->get_kind()));
+    fields.push_back(jsonString("mapper_identifier") + ": " +
+                     rawExpressionRef(clause->get_mapper_identifier(), ids));
+    fields.push_back(
+        jsonString("array_dimensions") + ": " +
+        rawOmpArrayDimensionsJson(clause->get_array_dimensions(), ids));
+    fields.push_back(jsonString("iterator") + ": " +
+                     rawOmpIteratorJson(clause->get_iterator(), ids));
+  }
+
+  if (SgOmpCriticalStatement *stmt = isSgOmpCriticalStatement(node)) {
+    fields.push_back(rawStringField("name", stmt->get_name().getString()));
+  }
+  if (SgOmpDepobjStatement *stmt = isSgOmpDepobjStatement(node)) {
+    fields.push_back(rawStringField("name", stmt->get_name().getString()));
+  }
+  if (SgOmpDeclareMapperStatement *stmt = isSgOmpDeclareMapperStatement(node)) {
+    fields.push_back(rawIntegerField("identifier", stmt->get_identifier()));
+  }
+  if (SgOmpDeclareTargetStatement *stmt = isSgOmpDeclareTargetStatement(node)) {
+    fields.push_back(
+        rawIntegerField("device_type_kind", stmt->get_device_type_kind()));
+  }
+  if (SgOmpBeginDeclareVariantStatement *stmt =
+          isSgOmpBeginDeclareVariantStatement(node)) {
+    fields.push_back(
+        rawStringField("captured_region", stmt->get_captured_region()));
+  }
+  if (SgImplicitStatement *stmt = isSgImplicitStatement(node)) {
+    fields.push_back(rawBoolField("implicit_none", stmt->get_implicit_none()));
+    fields.push_back(
+        rawIntegerField("implicit_spec", stmt->get_implicit_spec()));
+  }
+  if (SgFortranIncludeLine *stmt = isSgFortranIncludeLine(node)) {
+    fields.push_back(rawStringField("filename", stmt->get_filename()));
+  }
+  if (SgLabelStatement *stmt = isSgLabelStatement(node)) {
+    fields.push_back(rawStringField("label", stmt->get_label().getString()));
+    fields.push_back(
+        rawBoolField("gnu_extension_unused", stmt->get_gnu_extension_unused()));
+  }
+  if (SgIfStmt *stmt = isSgIfStmt(node)) {
+    fields.push_back(rawStringField("string_label", stmt->get_string_label()));
+    fields.push_back(
+        rawBoolField("has_end_statement", stmt->get_has_end_statement()));
+    fields.push_back(
+        rawBoolField("use_then_keyword", stmt->get_use_then_keyword()));
+    fields.push_back(
+        rawBoolField("is_else_if_statement", stmt->get_is_else_if_statement()));
+  }
+  if (SgWhileStmt *stmt = isSgWhileStmt(node)) {
+    fields.push_back(rawStringField("string_label", stmt->get_string_label()));
+    fields.push_back(
+        rawBoolField("has_end_statement", stmt->get_has_end_statement()));
+  }
+  if (SgFortranDo *stmt = isSgFortranDo(node)) {
+    fields.push_back(rawStringField("string_label", stmt->get_string_label()));
+    fields.push_back(rawBoolField("old_style", stmt->get_old_style()));
+    fields.push_back(
+        rawBoolField("has_end_statement", stmt->get_has_end_statement()));
+  }
+  if (SgIOStatement *stmt = isSgIOStatement(node)) {
+    fields.push_back(rawIntegerField("io_statement", stmt->get_io_statement()));
+  }
+  if (SgNewExp *expr = isSgNewExp(node)) {
+    fields.push_back(jsonString("specified_type") + ": " +
+                     rawTypeJson(expr->get_specified_type(), ids));
+    fields.push_back(rawIntegerField(
+        "need_global_specifier",
+        static_cast<int64_t>(expr->get_need_global_specifier())));
+    fields.push_back(rawBoolField("type_id_is_parenthesized",
+                                  expr->get_type_id_is_parenthesized()));
+  }
+  if (SgDeleteExp *expr = isSgDeleteExp(node)) {
+    fields.push_back(rawIntegerField(
+        "is_array", static_cast<int64_t>(expr->get_is_array())));
+    fields.push_back(rawIntegerField(
+        "need_global_specifier",
+        static_cast<int64_t>(expr->get_need_global_specifier())));
+  }
+
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+    auto append_declaration_qualification = [&](auto *qualified_decl) {
+      fields.push_back(
+          rawIntegerField("name_qualification_length",
+                          qualified_decl->get_name_qualification_length()));
+      fields.push_back(
+          rawBoolField("type_elaboration_required",
+                       qualified_decl->get_type_elaboration_required()));
+      fields.push_back(
+          rawBoolField("global_qualification_required",
+                       qualified_decl->get_global_qualification_required()));
+    };
+    if (isSgFunctionDeclaration(decl) == nullptr) {
+      if (SgVariableDeclaration *qualified = isSgVariableDeclaration(decl)) {
+        append_declaration_qualification(qualified);
+      } else if (SgEnumDeclaration *qualified = isSgEnumDeclaration(decl)) {
+        append_declaration_qualification(qualified);
+      } else if (SgTypedefDeclaration *qualified =
+                     isSgTypedefDeclaration(decl)) {
+        append_declaration_qualification(qualified);
+      } else if (SgUsingDirectiveStatement *qualified =
+                     isSgUsingDirectiveStatement(decl)) {
+        append_declaration_qualification(qualified);
+      } else if (SgUsingDeclarationStatement *qualified =
+                     isSgUsingDeclarationStatement(decl)) {
+        append_declaration_qualification(qualified);
+      } else if (SgClassDeclaration *qualified = isSgClassDeclaration(decl)) {
+        append_declaration_qualification(qualified);
+      }
+    }
+    if (SgVariableDeclaration *variable = isSgVariableDeclaration(decl)) {
+      fields.push_back(
+          rawBoolField("requires_global_name_qualification_on_type",
+                       variable->get_requiresGlobalNameQualificationOnType()));
+    }
+  }
+
+  if (SgLocatedNode *located = isSgLocatedNode(node)) {
+    addLocatedPreprocessing(fields, located);
+  } else {
+    fields.push_back(jsonString("preprocessing") + ": []");
+  }
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonSerializeNodes.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonSerializeNodes.cpp
@@ -1,0 +1,506 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+void writeNodeJson(std::ostream &out, SgNode *node,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids,
+                   bool comma) {
+  indent(out, 4);
+  out << "{\n";
+  writeIntegerField(out, 6, "id", ids.at(node));
+  writeStringField(out, 6, "kind", node->sage_class_name());
+  writeIntegerField(out, 6, "variant", node->variantT());
+  indent(out, 6);
+  out << jsonString("flags") << ": {\n";
+  writeBoolField(out, 8, "contains_transformation",
+                 node->get_containsTransformation());
+  const SgLocatedNode *located_for_flags = isSgLocatedNode(node);
+  writeBoolField(out, 8, "contains_transformation_to_surrounding_whitespace",
+                 located_for_flags != nullptr &&
+                     located_for_flags
+                         ->get_containsTransformationToSurroundingWhitespace(),
+                 false);
+  indent(out, 6);
+  out << "},\n";
+
+  indent(out, 6);
+  out << jsonString("location") << ": {\n";
+  indent(out, 8);
+  out << jsonString("start") << ": ";
+  writeFileInfoJson(out, 8, node->get_startOfConstruct(), true);
+  indent(out, 8);
+  out << jsonString("end") << ": ";
+  writeFileInfoJson(out, 8, node->get_endOfConstruct(), false);
+  indent(out, 6);
+  out << "},\n";
+
+  indent(out, 6);
+  {
+    TypeSerializationContext type_context(node);
+    out << jsonString("properties") << ": " << rawNodeProperties(node, ids)
+        << ",\n";
+  }
+
+  indent(out, 6);
+  out << jsonString("edges") << ": [\n";
+  std::vector<std::pair<SgNode *, std::string>> pointers =
+      node->returnDataMemberPointers();
+  auto append_manual_edge = [&](SgNode *target, const std::string &field) {
+    if (target == nullptr) {
+      return;
+    }
+    for (const std::pair<SgNode *, std::string> &entry : pointers) {
+      if (entry.first == target && entry.second == field) {
+        return;
+      }
+    }
+    pointers.push_back(std::make_pair(target, field));
+  };
+  auto append_clause_edges = [&](const SgOmpClausePtrList &clauses) {
+    for (SgOmpClause *clause : clauses) {
+      append_manual_edge(clause, "clauses");
+    }
+  };
+  if (SgOmpClauseStatement *stmt = isSgOmpClauseStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  } else if (SgOmpClauseBodyStatement *stmt =
+                 isSgOmpClauseBodyStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  }
+  if (SgOmpDeclareSimdStatement *stmt = isSgOmpDeclareSimdStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  }
+  if (SgOmpDeclareMapperStatement *stmt = isSgOmpDeclareMapperStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  }
+  if (SgOmpRequiresStatement *stmt = isSgOmpRequiresStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  }
+  if (SgOmpTaskwaitStatement *stmt = isSgOmpTaskwaitStatement(node)) {
+    append_clause_edges(stmt->get_clauses());
+  }
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(node)) {
+    append_manual_edge(decl->get_scope(), "scope");
+    if (!declarationNeedsExternalReferenceRecord(
+            decl->get_firstNondefiningDeclaration(), ids)) {
+      append_manual_edge(decl->get_firstNondefiningDeclaration(),
+                         "firstNondefiningDeclaration");
+    }
+    if (!declarationNeedsExternalReferenceRecord(
+            decl->get_definingDeclaration(), ids)) {
+      append_manual_edge(decl->get_definingDeclaration(),
+                         "definingDeclaration");
+    }
+  }
+  if (SgStatement *stmt = isSgStatement(node)) {
+    append_manual_edge(stmt->get_numeric_label(), "numeric_label");
+  }
+  if (SgLabelStatement *stmt = isSgLabelStatement(node)) {
+    append_manual_edge(stmt->get_scope(), "scope");
+  }
+  if (SgClassDefinition *def = isSgClassDefinition(node)) {
+    append_manual_edge(def->get_declaration(), "declaration");
+  }
+  if (SgIfStmt *stmt = isSgIfStmt(node)) {
+    append_manual_edge(stmt->get_else_numeric_label(), "else_numeric_label");
+    append_manual_edge(stmt->get_end_numeric_label(), "end_numeric_label");
+  }
+  if (SgWhileStmt *stmt = isSgWhileStmt(node)) {
+    append_manual_edge(stmt->get_end_numeric_label(), "end_numeric_label");
+  }
+  if (SgFortranNonblockedDo *stmt = isSgFortranNonblockedDo(node)) {
+    append_manual_edge(stmt->get_end_statement(), "end_statement");
+  }
+  if (SgGotoStatement *stmt = isSgGotoStatement(node)) {
+    append_manual_edge(stmt->get_label(), "label");
+    append_manual_edge(stmt->get_label_expression(), "label_expression");
+    append_manual_edge(stmt->get_selector_expression(), "selector_expression");
+  }
+  std::stable_sort(pointers.begin(), pointers.end(),
+                   [](const std::pair<SgNode *, std::string> &lhs,
+                      const std::pair<SgNode *, std::string> &rhs) {
+                     return lhs.second < rhs.second;
+                   });
+
+  std::map<std::string, uint64_t> index_by_field;
+  bool wrote_edge = false;
+  for (const std::pair<SgNode *, std::string> &entry : pointers) {
+    if (entry.first == nullptr) {
+      continue;
+    }
+    if (entry.second == "scope") {
+      if (const SgStatement *stmt = isSgStatement(node)) {
+        if (!stmt->hasExplicitScope() &&
+            edgeTargetIsInParentChain(node, entry.first)) {
+          continue;
+        }
+      }
+    }
+    if (isSg_File_Info(entry.first) != nullptr) {
+      continue;
+    }
+    if (entry.second == "symbol_table" &&
+        isSgSymbolTable(entry.first) != nullptr) {
+      continue;
+    }
+    if (entry.second == "type_table" && isSgTypeTable(entry.first) != nullptr) {
+      continue;
+    }
+    if (isSgType(entry.first) != nullptr) {
+      continue;
+    }
+    if (entry.second == "storageModifier" &&
+        isSgStorageModifier(entry.first) != nullptr) {
+      continue;
+    }
+    if (entry.second == "baseClassModifier" &&
+        isSgBaseClassModifier(entry.first) != nullptr) {
+      continue;
+    }
+    if (isSgSymbol(entry.first) != nullptr) {
+      continue;
+    }
+    if ((entry.second == "firstNondefiningDeclaration" ||
+         entry.second == "definingDeclaration") &&
+        declarationNeedsExternalReferenceRecord(
+            isSgDeclarationStatement(entry.first), ids)) {
+      continue;
+    }
+    if (entry.second == "functionParameterScope" &&
+        functionParameterScopeNeedsExternalReferenceRecord(
+            isSgFunctionDeclaration(node), ids)) {
+      continue;
+    }
+    auto target = ids.find(entry.first);
+    if (target == ids.end()) {
+      if (entry.second == "parent" && isSgSourceFile(node) != nullptr &&
+          (isSgFileList(entry.first) != nullptr ||
+           isSgProject(entry.first) != nullptr)) {
+        continue;
+      }
+      if (isExternalUseModuleEdge(node, entry.first, entry.second, ids)) {
+        continue;
+      }
+      auto describe_node = [](SgNode *candidate) {
+        std::ostringstream description;
+        if (candidate == nullptr) {
+          return std::string("<null>");
+        }
+        description << candidate->sage_class_name();
+        if (SgTemplateInstantiationDecl *decl =
+                isSgTemplateInstantiationDecl(candidate)) {
+          description << "(" << decl->get_name().getString() << ")";
+        } else if (SgTemplateClassDeclaration *decl =
+                       isSgTemplateClassDeclaration(candidate)) {
+          description << "(" << decl->get_name().getString() << ")";
+        } else if (SgClassDeclaration *decl = isSgClassDeclaration(candidate)) {
+          description << "(" << decl->get_name().getString() << ")";
+        } else if (SgFunctionDeclaration *decl =
+                       isSgFunctionDeclaration(candidate)) {
+          description << "(" << decl->get_name().getString() << ")";
+        } else if (SgInitializedName *name = isSgInitializedName(candidate)) {
+          description << "(" << name->get_name().getString() << ")";
+        }
+        return description.str();
+      };
+      std::ostringstream source_chain;
+      for (SgNode *current = node; current != nullptr;
+           current = current->get_parent()) {
+        if (source_chain.tellp() > 0) {
+          source_chain << " <- ";
+        }
+        source_chain << describe_node(current);
+      }
+      std::ostringstream chain;
+      std::string target_file;
+      for (SgNode *current = entry.first; current != nullptr;
+           current = current->get_parent()) {
+        if (chain.tellp() > 0) {
+          chain << " <- ";
+        }
+        chain << describe_node(current);
+        if (SgSourceFile *source_file = isSgSourceFile(current)) {
+          target_file = source_file->getFileName();
+        }
+      }
+      std::string boundary_file = collectionBoundaryFile != nullptr
+                                      ? collectionBoundaryFile->getFileName()
+                                      : std::string();
+      const bool target_is_boundary_global =
+          collectionBoundaryFile != nullptr &&
+          collectionBoundaryFile->get_globalScope() == entry.first;
+      throw std::runtime_error(
+          std::string("AST JSON edge target was not collected: ") +
+          node->sage_class_name() + "." + entry.second + " -> " +
+          entry.first->sage_class_name() + " source_parent_chain=[" +
+          source_chain.str() + "] target_parent_chain=[" + chain.str() +
+          "] target_file=" + target_file + " boundary_file=" + boundary_file +
+          " target_is_boundary_global=" +
+          (target_is_boundary_global ? "true" : "false"));
+    }
+    if (wrote_edge) {
+      out << ",\n";
+    }
+    indent(out, 8);
+    out << "{\n";
+    writeStringField(out, 10, "field", entry.second);
+    writeIntegerField(out, 10, "index", index_by_field[entry.second]++);
+    writeIntegerField(out, 10, "target", target->second, false);
+    indent(out, 8);
+    out << '}';
+    wrote_edge = true;
+  }
+  if (wrote_edge) {
+    out << '\n';
+  }
+  indent(out, 6);
+  out << "]\n";
+  indent(out, 4);
+  out << '}';
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void writeStringArrayField(std::ostream &out, int level, const char *name,
+                           const std::vector<std::string> &values,
+                           bool comma = true) {
+  indent(out, level);
+  out << jsonString(name) << ": [";
+  if (!values.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < values.size(); ++i) {
+      indent(out, level + 2);
+      out << jsonString(values[i]);
+      if (i + 1 != values.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, level);
+  }
+  out << ']';
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+void writeMetadataJson(std::ostream &out, SgSourceFile *file,
+                       Checkpoint checkpoint) {
+  indent(out, 2);
+  out << jsonString("metadata") << ": {\n";
+  writeStringField(out, 4, "checkpoint", checkpointName(checkpoint));
+  if (file == nullptr) {
+    writeStringField(out, 4, "source_file", "");
+    writeStringField(out, 4, "output_file", "");
+    writeStringArrayField(out, 4, "command_line", {});
+    writeFileIdMapJson(out, 4, false);
+  } else {
+    writeStringField(out, 4, "source_file", file->get_sourceFileNameWithPath());
+    writeStringField(out, 4, "output_file",
+                     file->get_unparse_output_filename());
+    writeStringArrayField(out, 4, "command_line", commandLine(file));
+    writeBoolField(out, 4, "openmp", file->get_openmp());
+    writeBoolField(out, 4, "openmp_parse_only", file->get_openmp_parse_only());
+    writeBoolField(out, 4, "openmp_ast_only", file->get_openmp_ast_only());
+    writeBoolField(out, 4, "openmp_analyzing", file->get_openmp_analyzing());
+    writeBoolField(out, 4, "openmp_lowering", file->get_openmp_lowering());
+    writeBoolField(out, 4, "openmp_processed", file->get_openmp_processed());
+    writeBoolField(out, 4, "openacc", file->get_openacc());
+    writeBoolField(out, 4, "skipfinalCompileStep",
+                   file->get_skipfinalCompileStep());
+    writeBoolField(out, 4, "suppress_variable_declaration_normalization",
+                   file->get_suppress_variable_declaration_normalization());
+    writeBoolField(out, 4, "unparse_tokens", file->get_unparse_tokens());
+    writeFileIdMapJson(out, 4, false);
+  }
+  indent(out, 2);
+  out << "},\n";
+}
+
+std::string buildJson(SgNode *root, Checkpoint checkpoint, SgSourceFile *file) {
+  ROSE_ASSERT(root != nullptr);
+
+  struct StaticDataMemberQualificationTraversal : public AstSimpleProcessing {
+    static size_t qualificationDepth(const std::string &prefix) {
+      size_t depth = 0;
+      size_t pos = 0;
+      while ((pos = prefix.find("::", pos)) != std::string::npos) {
+        ++depth;
+        pos += 2;
+      }
+      return depth;
+    }
+
+    static SgClassDeclaration *
+    classDeclarationForScope(SgScopeStatement *scope) {
+      if (SgClassDefinition *class_def = isSgClassDefinition(scope)) {
+        return class_def->get_declaration();
+      }
+      return nullptr;
+    }
+
+    static std::string qualifierForOwner(SgClassDeclaration *owner_decl) {
+      if (owner_decl == nullptr ||
+          isSgTemplateClassDeclaration(owner_decl) != nullptr ||
+          isSgTemplateInstantiationDecl(owner_decl) != nullptr) {
+        return "";
+      }
+      std::string prefix = owner_decl->get_qualified_name().getString();
+      if (prefix.empty()) {
+        return "";
+      }
+      while (prefix.rfind("::", 0) == 0) {
+        prefix.erase(0, 2);
+      }
+      prefix += "::";
+      return prefix;
+    }
+
+    static bool insideMemberFunctionOfOwner(SgNode *node,
+                                            SgClassDeclaration *owner_decl) {
+      for (SgNode *current = node; current != nullptr;
+           current = current->get_parent()) {
+        if (SgMemberFunctionDeclaration *member_decl =
+                isSgMemberFunctionDeclaration(current)) {
+          return member_decl->get_class_scope() == owner_decl->get_definition();
+        }
+      }
+      return false;
+    }
+
+    static void setNameQualifier(SgNode *node, const std::string &prefix) {
+      SgUnorderedMapNodeToString &name_map =
+          SgNode::get_globalQualifiedNameMapForNames();
+      auto found = name_map.find(node);
+      if (found != name_map.end()) {
+        std::string existing = found->second;
+        while (existing.rfind("::", 0) == 0) {
+          existing.erase(0, 2);
+        }
+        if (existing == prefix) {
+          found->second = prefix;
+          return;
+        }
+        throw std::runtime_error(
+            "AST JSON qualifier materialization conflicts with existing Sage "
+            "qualified-name map");
+      }
+      name_map[node] = prefix;
+    }
+
+    void visit(SgNode *node) override {
+      if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+        if (isRightHandSideOfMemberAccess(ref)) {
+          return;
+        }
+        SgVariableSymbol *symbol = ref->get_symbol();
+        SgInitializedName *decl_name =
+            symbol != nullptr ? symbol->get_declaration() : nullptr;
+        SgClassDeclaration *owner_decl =
+            decl_name != nullptr
+                ? classDeclarationForScope(decl_name->get_scope())
+                : nullptr;
+        const std::string prefix = qualifierForOwner(owner_decl);
+        if (!prefix.empty() && !insideMemberFunctionOfOwner(ref, owner_decl)) {
+          setNameQualifier(ref, prefix);
+          ref->set_name_qualification_length(
+              static_cast<int>(qualificationDepth(prefix)));
+          ref->set_global_qualification_required(false);
+          ref->set_type_elaboration_required(false);
+        }
+        return;
+      }
+
+      SgVariableDeclaration *decl = isSgVariableDeclaration(node);
+      if (decl == nullptr || decl->get_variables().empty()) {
+        return;
+      }
+
+      SgInitializedName *name = decl->get_variables().front();
+      if (name == nullptr || name->get_prev_decl_item() == nullptr ||
+          name->get_scope() == nullptr || decl->get_scope() == nullptr ||
+          name->get_scope() == decl->get_scope()) {
+        return;
+      }
+
+      SgClassDeclaration *owner_decl =
+          classDeclarationForScope(name->get_scope());
+      const std::string prefix = qualifierForOwner(owner_decl);
+      if (prefix.empty()) {
+        return;
+      }
+      setNameQualifier(name, prefix);
+      name->set_name_qualification_length(
+          static_cast<int>(qualificationDepth(prefix)));
+      name->set_global_qualification_required(prefix.rfind("::", 0) == 0);
+      name->set_type_elaboration_required(false);
+    }
+  };
+
+  StaticDataMemberQualificationTraversal static_data_member_qualification;
+  static_data_member_qualification.traverse(root, preorder);
+
+  CollectionBoundaryGuard boundary(isSgSourceFile(root));
+  std::vector<SgNode *> nodes = collectNodes(root);
+  std::unordered_map<const SgNode *, uint64_t> ids;
+  ids.reserve(nodes.size());
+  std::unordered_set<uint64_t> used_ids;
+  bool has_preserved_ids = false;
+
+  for (SgNode *node : nodes) {
+    const uint64_t preserved_id = preservedJsonNodeId(node);
+    if (preserved_id == 0) {
+      continue;
+    }
+    if (!used_ids.insert(preserved_id).second) {
+      throw std::runtime_error("AST JSON preserved node id is duplicated: " +
+                               std::to_string(preserved_id));
+    }
+    ids.emplace(node, preserved_id);
+    has_preserved_ids = true;
+  }
+
+  uint64_t next_id = 1;
+  for (SgNode *node : nodes) {
+    if (ids.find(node) != ids.end()) {
+      continue;
+    }
+    while (used_ids.find(next_id) != used_ids.end()) {
+      ++next_id;
+    }
+    ids.emplace(node, next_id);
+    used_ids.insert(next_id);
+    ++next_id;
+  }
+
+  if (has_preserved_ids) {
+    std::stable_sort(nodes.begin(), nodes.end(), [&](SgNode *lhs, SgNode *rhs) {
+      return ids.at(lhs) < ids.at(rhs);
+    });
+  }
+
+  std::ostringstream out;
+  out << "{\n";
+  writeStringField(out, 2, "format", kFormat);
+  writeIntegerField(out, 2, "schema_version", kSchemaVersion);
+  writeIntegerField(out, 2, "root_id", ids.at(root));
+  writeStringField(out, 2, "root_kind", root->sage_class_name());
+  writeIntegerField(out, 2, "node_count", nodes.size());
+  writeMetadataJson(out, file, checkpoint);
+  indent(out, 2);
+  out << jsonString("nodes") << ": [\n";
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    writeNodeJson(out, nodes[i], ids, i + 1 != nodes.size());
+  }
+  indent(out, 2);
+  out << "]\n";
+  out << "}\n";
+  return out.str();
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astJson/sageAstJsonSerializeSupport.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonSerializeSupport.cpp
@@ -1,0 +1,1097 @@
+#include "sageAstJsonPrivate.h"
+
+namespace Rose {
+namespace AstJson {
+
+uint64_t idFor(const std::unordered_map<const SgNode *, uint64_t> &ids,
+               const SgNode *node);
+
+bool edgeTargetIsInParentChain(const SgNode *node, const SgNode *target) {
+  if (node == nullptr || target == nullptr) {
+    return false;
+  }
+  for (const SgNode *current = node->get_parent(); current != nullptr;
+       current = current->get_parent()) {
+    if (current == target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool isAnonymousQualificationPrefix(const std::string &prefix) {
+  return prefix.rfind("__anonymous_0x", 0) == 0;
+}
+
+bool hasExplicitReferenceQualification(const SgVarRefExp *ref) {
+  return ref != nullptr &&
+         (ref->get_explicit_name_qualification_length() >= 0 ||
+          ref->get_explicit_global_qualification() ||
+          !ref->get_explicit_name_qualification_tokens().empty());
+}
+
+bool isRightHandSideOfMemberAccess(const SgNode *node) {
+  if (node == nullptr) {
+    return false;
+  }
+  const SgNode *parent = node->get_parent();
+  if (const SgDotExp *dot = isSgDotExp(parent)) {
+    return dot->get_rhs_operand() == node;
+  }
+  if (const SgArrowExp *arrow = isSgArrowExp(parent)) {
+    return arrow->get_rhs_operand() == node;
+  }
+  return false;
+}
+
+bool shouldSerializeNamePrefix(SgNode *node, const std::string &prefix) {
+  if (SgVarRefExp *ref = isSgVarRefExp(node)) {
+    if (isRightHandSideOfMemberAccess(ref) &&
+        !hasExplicitReferenceQualification(ref)) {
+      return false;
+    }
+  }
+  if (isAnonymousQualificationPrefix(prefix) &&
+      isSgVarRefExp(node) != nullptr && isRightHandSideOfMemberAccess(node)) {
+    return false;
+  }
+  return true;
+}
+
+bool isAnonymousDataMemberReference(SgVarRefExp *ref) {
+  if (ref == nullptr || !isRightHandSideOfMemberAccess(ref)) {
+    return false;
+  }
+  SgVariableSymbol *symbol = ref->get_symbol();
+  SgInitializedName *name =
+      symbol != nullptr ? symbol->get_declaration() : nullptr;
+  SgClassDefinition *definition =
+      name != nullptr ? isSgClassDefinition(name->get_scope()) : nullptr;
+  SgClassDeclaration *declaration =
+      definition != nullptr ? definition->get_declaration() : nullptr;
+  if (declaration == nullptr) {
+    return false;
+  }
+  return declaration->get_isUnNamed() ||
+         isAnonymousQualificationPrefix(declaration->get_name().getString());
+}
+
+void clearReferenceNameQualification(SgVarRefExp *ref) {
+  ref->set_name_qualification_length(0);
+  ref->set_type_elaboration_required(false);
+  ref->set_global_qualification_required(false);
+  ref->set_explicit_name_qualification_length(-1);
+  ref->set_explicit_global_qualification(false);
+  ref->set_explicit_name_qualification_tokens(SgStringList());
+  SgNode::get_globalQualifiedNameMapForNames().erase(ref);
+}
+
+void normalizeAnonymousDataMemberReference(SgVarRefExp *ref) {
+  if (isAnonymousDataMemberReference(ref)) {
+    clearReferenceNameQualification(ref);
+  }
+}
+
+std::string rawQualifiedNameStateJson(
+    SgNode *node, const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+
+  auto append_simple_map_entry = [&](const std::string &field,
+                                     SgUnorderedMapNodeToString &map) {
+    auto found = map.find(node);
+    if (found != map.end()) {
+      if (field == "name_prefix" &&
+          !shouldSerializeNamePrefix(node, found->second)) {
+        return;
+      }
+      fields.push_back(rawStringField(field, found->second));
+    }
+  };
+
+  append_simple_map_entry("name_prefix",
+                          SgNode::get_globalQualifiedNameMapForNames());
+  append_simple_map_entry("type_prefix",
+                          SgNode::get_globalQualifiedNameMapForTypes());
+  append_simple_map_entry(
+      "template_header",
+      SgNode::get_globalQualifiedNameMapForTemplateHeaders());
+  append_simple_map_entry("type_name", SgNode::get_globalTypeNameMap());
+
+  auto maps_found =
+      SgNode::get_globalQualifiedNameMapForMapsOfTypes().find(node);
+  if (maps_found != SgNode::get_globalQualifiedNameMapForMapsOfTypes().end()) {
+    std::vector<std::pair<uint64_t, std::string>> entries;
+    for (const auto &entry : maps_found->second) {
+      const uint64_t target_id = idFor(ids, entry.first);
+      if (target_id == 0) {
+        std::ostringstream message;
+        message << "AST JSON qualified type-map entry target was not collected"
+                << " while serializing " << node->sage_class_name();
+        if (SgNode *target = entry.first) {
+          message << " target=" << target->sage_class_name();
+        }
+        throw std::runtime_error(message.str());
+      }
+      entries.emplace_back(target_id, entry.second);
+    }
+    std::sort(entries.begin(), entries.end());
+
+    std::ostringstream map_out;
+    map_out << "[";
+    for (size_t i = 0; i < entries.size(); ++i) {
+      if (i != 0) {
+        map_out << ", ";
+      }
+      std::vector<std::string> entry_fields;
+      entry_fields.push_back(rawIntegerField("node", entries[i].first));
+      entry_fields.push_back(rawStringField("prefix", entries[i].second));
+      std::ostringstream entry_out;
+      writeRawObject(entry_out, 0, entry_fields, false);
+      std::string entry_text = entry_out.str();
+      if (!entry_text.empty() && entry_text.back() == '\n') {
+        entry_text.pop_back();
+      }
+      map_out << entry_text;
+    }
+    map_out << "]";
+    fields.push_back(jsonString("type_map_prefixes") + ": " + map_out.str());
+  }
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+void writeRawObject(std::ostream &out, int level,
+                    const std::vector<std::string> &fields, bool comma) {
+  indent(out, level);
+  out << "{";
+  if (!fields.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < fields.size(); ++i) {
+      indent(out, level + 2);
+      out << fields[i];
+      if (i + 1 != fields.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, level);
+  }
+  out << '}';
+  if (comma) {
+    out << ',';
+  }
+  out << '\n';
+}
+
+std::string
+rawTypeJson(SgType *type,
+            const std::unordered_map<const SgNode *, uint64_t> &ids);
+
+std::string safeNodeText(SgNode *node);
+bool insideCollectionBoundary(SgNode *node);
+std::string rawExternalClassDeclarationJson(SgClassDeclaration *decl);
+std::string
+rawExternalModuleJson(SgModuleStatement *module,
+                      const std::unordered_map<const SgNode *, uint64_t> &ids);
+std::string
+rawExternalFunctionJson(SgFunctionDeclaration *decl,
+                        const std::unordered_map<const SgNode *, uint64_t> &ids,
+                        bool force_external);
+
+const SgNode *currentTypeSerializationNode = nullptr;
+bool serializingTypeOwnedExpression = false;
+
+TypeSerializationContext::TypeSerializationContext(const SgNode *node)
+    : previous_(currentTypeSerializationNode) {
+  currentTypeSerializationNode = node;
+}
+
+TypeSerializationContext::~TypeSerializationContext() {
+  currentTypeSerializationNode = previous_;
+}
+
+class TypeOwnedExpressionSerializationContext {
+public:
+  TypeOwnedExpressionSerializationContext()
+      : previous_(serializingTypeOwnedExpression) {
+    serializingTypeOwnedExpression = true;
+  }
+
+  ~TypeOwnedExpressionSerializationContext() {
+    serializingTypeOwnedExpression = previous_;
+  }
+
+private:
+  bool previous_;
+};
+
+uint64_t idFor(const std::unordered_map<const SgNode *, uint64_t> &ids,
+               const SgNode *node) {
+  if (node == nullptr) {
+    return 0;
+  }
+  auto found = ids.find(node);
+  return found == ids.end() ? 0 : found->second;
+}
+
+uint64_t canonicalTypedefDeclarationId(
+    const std::unordered_map<const SgNode *, uint64_t> &ids,
+    const SgTypedefDeclaration *decl) {
+  if (decl == nullptr) {
+    return 0;
+  }
+
+  const uint64_t direct_id = idFor(ids, decl);
+  if (direct_id != 0) {
+    return direct_id;
+  }
+  if (const SgTypedefDeclaration *first_nondef =
+          isSgTypedefDeclaration(decl->get_firstNondefiningDeclaration())) {
+    if (const uint64_t id = idFor(ids, first_nondef)) {
+      return id;
+    }
+  }
+  if (const SgTypedefDeclaration *defining =
+          isSgTypedefDeclaration(decl->get_definingDeclaration())) {
+    if (const uint64_t id = idFor(ids, defining)) {
+      return id;
+    }
+  }
+  return 0;
+}
+
+const char *const kAstJsonTypeTextAttribute = "rex_ast_json_type_text";
+const char *const kAstJsonExternalFunctionAttribute =
+    "rex_ast_json_external_function";
+const char *const kAstJsonExternalModuleAttribute =
+    "rex_ast_json_external_module";
+const char *const kAstJsonExternalClassDeclarationAttribute =
+    "rex_ast_json_external_class_declaration";
+const char *const kAstJsonExternalSourceFileAttribute =
+    "rex_ast_json_external_source_file";
+
+std::unordered_map<const SgNode *, uint64_t> preservedJsonNodeIds;
+
+class AstJsonTypeTextAttribute : public AstAttribute {
+public:
+  explicit AstJsonTypeTextAttribute(std::string text)
+      : text_(std::move(text)) {}
+
+  AstAttribute *copy() const override {
+    return new AstJsonTypeTextAttribute(text_);
+  }
+
+  OwnershipPolicy getOwnershipPolicy() const override {
+    return CONTAINER_OWNERSHIP;
+  }
+
+  std::string attribute_class_name() const override {
+    return "AstJsonTypeTextAttribute";
+  }
+
+  const std::string &text() const { return text_; }
+
+private:
+  std::string text_;
+};
+
+class AstJsonStringAttribute : public AstAttribute {
+public:
+  explicit AstJsonStringAttribute(std::string value)
+      : value_(std::move(value)) {}
+
+  AstAttribute *copy() const override {
+    return new AstJsonStringAttribute(value_);
+  }
+
+  OwnershipPolicy getOwnershipPolicy() const override {
+    return CONTAINER_OWNERSHIP;
+  }
+
+  std::string attribute_class_name() const override {
+    return "AstJsonStringAttribute";
+  }
+
+  const std::string &value() const { return value_; }
+
+private:
+  std::string value_;
+};
+
+void setAstJsonStringAttribute(SgNode *node, const char *name,
+                               std::string value) {
+  if (node == nullptr) {
+    return;
+  }
+  node->setAttribute(name, new AstJsonStringAttribute(std::move(value)));
+}
+
+std::string astJsonStringAttribute(SgNode *node, const char *name) {
+  if (node == nullptr || !node->attributeExists(name)) {
+    return "";
+  }
+  AstJsonStringAttribute *attribute =
+      dynamic_cast<AstJsonStringAttribute *>(node->getAttribute(name));
+  return attribute != nullptr ? attribute->value() : "";
+}
+
+bool hasAstJsonAttribute(SgNode *node, const char *name) {
+  return node != nullptr && node->attributeExists(name);
+}
+
+bool isAstJsonExternalFunction(SgFunctionDeclaration *decl) {
+  return hasAstJsonAttribute(decl, kAstJsonExternalFunctionAttribute);
+}
+
+bool isAstJsonExternalModule(SgModuleStatement *module) {
+  return hasAstJsonAttribute(module, kAstJsonExternalModuleAttribute);
+}
+
+bool isAstJsonExternalClassDeclaration(SgClassDeclaration *decl) {
+  return hasAstJsonAttribute(decl, kAstJsonExternalClassDeclarationAttribute);
+}
+
+void markAstJsonExternalFunction(SgFunctionDeclaration *decl,
+                                 const std::string &source_file) {
+  if (decl == nullptr) {
+    return;
+  }
+  setAstJsonStringAttribute(decl, kAstJsonExternalFunctionAttribute, "true");
+  setAstJsonStringAttribute(decl, kAstJsonExternalSourceFileAttribute,
+                            source_file);
+}
+
+void markAstJsonExternalModule(SgModuleStatement *module,
+                               const std::string &source_file) {
+  if (module == nullptr) {
+    return;
+  }
+  setAstJsonStringAttribute(module, kAstJsonExternalModuleAttribute, "true");
+  setAstJsonStringAttribute(module, kAstJsonExternalSourceFileAttribute,
+                            source_file);
+}
+
+void markAstJsonExternalClassDeclaration(SgClassDeclaration *decl,
+                                         const std::string &source_file) {
+  if (decl == nullptr) {
+    return;
+  }
+  setAstJsonStringAttribute(decl, kAstJsonExternalClassDeclarationAttribute,
+                            "true");
+  setAstJsonStringAttribute(decl, kAstJsonExternalSourceFileAttribute,
+                            source_file);
+}
+
+SgType *attachJsonTypeText(SgType *type, const JsonValue &json) {
+  if (type == nullptr) {
+    return type;
+  }
+  const std::string text = json.stringOr("text");
+  if (!text.empty()) {
+    type->setAttribute(kAstJsonTypeTextAttribute,
+                       new AstJsonTypeTextAttribute(text));
+  }
+  return type;
+}
+
+void attachJsonNodeId(SgNode *node, uint64_t id) {
+  if (node == nullptr || id == 0) {
+    return;
+  }
+  preservedJsonNodeIds[node] = id;
+}
+
+uint64_t preservedJsonNodeId(SgNode *node) {
+  if (node == nullptr) {
+    return 0;
+  }
+  auto found = preservedJsonNodeIds.find(node);
+  return found == preservedJsonNodeIds.end() ? 0 : found->second;
+}
+
+std::string jsonTypeText(SgType *type) {
+  if (type == nullptr) {
+    return "";
+  }
+  if (type->attributeExists(kAstJsonTypeTextAttribute)) {
+    if (AstJsonTypeTextAttribute *attribute =
+            dynamic_cast<AstJsonTypeTextAttribute *>(
+                type->getAttribute(kAstJsonTypeTextAttribute))) {
+      return attribute->text();
+    }
+  }
+  if (SgPointerMemberType *member_pointer = isSgPointerMemberType(type)) {
+    const std::string base = jsonTypeText(member_pointer->get_base_type());
+    const std::string class_type =
+        jsonTypeText(member_pointer->get_class_type());
+    if (!base.empty() && !class_type.empty()) {
+      return base + " " + class_type + "::*";
+    }
+  }
+  if (SgPointerType *pointer = isSgPointerType(type)) {
+    const std::string base = jsonTypeText(pointer->get_base_type());
+    if (!base.empty()) {
+      return base + (base.find("::") != std::string::npos ? "*" : " *");
+    }
+  }
+  if (SgReferenceType *reference = isSgReferenceType(type)) {
+    const std::string base = jsonTypeText(reference->get_base_type());
+    if (!base.empty()) {
+      return base + " &";
+    }
+  }
+  if (SgRvalueReferenceType *reference = isSgRvalueReferenceType(type)) {
+    const std::string base = jsonTypeText(reference->get_base_type());
+    if (!base.empty()) {
+      return base + " &&";
+    }
+  }
+  if (SgTypedefType *typedef_type = isSgTypedefType(type)) {
+    if (SgTypedefDeclaration *decl =
+            isSgTypedefDeclaration(typedef_type->get_declaration())) {
+      return decl->get_name().getString();
+    }
+    return "";
+  }
+  if (SgClassType *class_type = isSgClassType(type)) {
+    if (SgClassDeclaration *decl =
+            isSgClassDeclaration(class_type->get_declaration())) {
+      if (isSgTemplateInstantiationDecl(decl)) {
+        const std::string unparsed = class_type->unparseToString();
+        if (!unparsed.empty()) {
+          return unparsed;
+        }
+      }
+      return decl->get_name().getString();
+    }
+    return "";
+  }
+  if (SgEnumType *enum_type = isSgEnumType(type)) {
+    if (SgEnumDeclaration *decl =
+            isSgEnumDeclaration(enum_type->get_declaration())) {
+      return decl->get_name().getString();
+    }
+    return "";
+  }
+  if (SgNonrealType *nonreal_type = isSgNonrealType(type)) {
+    if (SgNonrealDecl *decl =
+            isSgNonrealDecl(nonreal_type->get_declaration())) {
+      return decl->get_name().getString();
+    }
+    return "";
+  }
+  if (SgTemplateType *template_type = isSgTemplateType(type)) {
+    return template_type->get_name().getString();
+  }
+  return type->unparseToString();
+}
+
+void installPointerCache(SgType *base, SgPointerType *pointer) {
+  if (base == nullptr || pointer == nullptr) {
+    return;
+  }
+  SgPointerType *cached = base->get_ptr_to();
+  if (cached == pointer) {
+    return;
+  }
+  if (cached == nullptr || cached->get_base_type() != base) {
+    base->set_ptr_to(pointer);
+  }
+}
+
+void installReferenceCache(SgType *base, SgReferenceType *reference) {
+  if (base == nullptr || reference == nullptr) {
+    return;
+  }
+  SgReferenceType *cached = base->get_ref_to();
+  if (cached == reference) {
+    return;
+  }
+  if (cached == nullptr || cached->get_base_type() != base) {
+    base->set_ref_to(reference);
+  }
+}
+
+void installRvalueReferenceCache(SgType *base,
+                                 SgRvalueReferenceType *reference) {
+  if (base == nullptr || reference == nullptr) {
+    return;
+  }
+  SgRvalueReferenceType *cached = base->get_rvalue_ref_to();
+  if (cached == reference) {
+    return;
+  }
+  if (cached == nullptr || cached->get_base_type() != base) {
+    base->set_rvalue_ref_to(reference);
+  }
+}
+
+SgPointerType *buildCachedJsonPointerType(SgType *base, const JsonValue *json) {
+  ROSE_ASSERT(base != nullptr);
+  SgPointerType *pointer = new SgPointerType(base);
+  if (json != nullptr) {
+    attachJsonTypeText(pointer, *json);
+  }
+  installPointerCache(base, pointer);
+  return pointer;
+}
+
+void installNewExpressionResultType(SgNewExp *expr, SgType *restored_type,
+                                    const JsonValue &json) {
+  ROSE_ASSERT(expr != nullptr);
+  if (json.kind != JsonValue::Kind::Object ||
+      json.stringOr("kind") != "SgPointerType") {
+    throw std::runtime_error("AST JSON SgNewExp type must be SgPointerType");
+  }
+  SgPointerType *pointer = isSgPointerType(restored_type);
+  if (pointer == nullptr) {
+    throw std::runtime_error(
+        "AST JSON SgNewExp restored type is not SgPointerType");
+  }
+  SgType *specified_type = expr->get_specified_type();
+  if (specified_type == nullptr) {
+    throw std::runtime_error(
+        "AST JSON SgNewExp requires specified_type before result type");
+  }
+  attachJsonTypeText(pointer, json);
+  specified_type->set_ptr_to(pointer);
+}
+
+void writeFileInfoJson(std::ostream &out, int level, const Sg_File_Info *info,
+                       bool comma);
+
+std::string
+rawNodeProperties(SgNode *node,
+                  const std::unordered_map<const SgNode *, uint64_t> &ids);
+
+std::string rawFileInfoJson(const Sg_File_Info *info) {
+  std::ostringstream out;
+  writeFileInfoJson(out, 0, info, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawLocationJson(SgNode *node) {
+  std::ostringstream out;
+  out << "{\n";
+  indent(out, 2);
+  out << jsonString("start") << ": "
+      << rawFileInfoJson(node != nullptr ? node->get_startOfConstruct()
+                                         : nullptr)
+      << ",\n";
+  indent(out, 2);
+  out << jsonString("end") << ": "
+      << rawFileInfoJson(node != nullptr ? node->get_endOfConstruct() : nullptr)
+      << '\n';
+  out << "}";
+  return out.str();
+}
+
+std::string rawRequiredLocationJson(SgNode *node, const std::string &context) {
+  if (node == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires a node with source position");
+  }
+  if (node->get_startOfConstruct() == nullptr) {
+    throw std::runtime_error("AST JSON " + context +
+                             " requires startOfConstruct");
+  }
+  return rawLocationJson(node);
+}
+
+std::string rawNodeFlagsJson(SgNode *node) {
+  std::vector<std::string> fields;
+  fields.push_back(
+      rawBoolField("contains_transformation",
+                   node != nullptr && node->get_containsTransformation()));
+  const SgLocatedNode *located = isSgLocatedNode(node);
+  fields.push_back(rawBoolField(
+      "contains_transformation_to_surrounding_whitespace",
+      located != nullptr &&
+          located->get_containsTransformationToSurroundingWhitespace()));
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+uint64_t
+expressionIdFor(SgExpression *expression,
+                const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  return idFor(ids, expression);
+}
+
+std::string
+rawExpressionRef(SgExpression *expression,
+                 const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  const uint64_t id = expressionIdFor(expression, ids);
+  if (expression != nullptr && id == 0) {
+    std::ostringstream message;
+    message << "AST JSON expression reference target was not collected: "
+            << expression->sage_class_name();
+    if (SgNode *parent = expression->get_parent()) {
+      message << " parent=" << parent->sage_class_name();
+    }
+    if (currentTypeSerializationNode != nullptr) {
+      message << " owner=" << currentTypeSerializationNode->sage_class_name()
+              << " owner_text="
+              << safeNodeText(
+                     const_cast<SgNode *>(currentTypeSerializationNode));
+    }
+    message << " text=" << expression->unparseToString();
+    throw std::runtime_error(message.str());
+  }
+  std::vector<std::string> fields;
+  fields.push_back(rawIntegerField("node", id));
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawTypeOwnedExpressionRef(
+    SgExpression *expression,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  if (expression == nullptr) {
+    return rawExpressionRef(expression, ids);
+  }
+
+  std::vector<std::string> fields;
+  fields.push_back(rawIntegerField("node", 0));
+  fields.push_back(rawStringField("owned_kind", expression->sage_class_name()));
+  fields.push_back(jsonString("flags") + ": " + rawNodeFlagsJson(expression));
+  fields.push_back(jsonString("location") + ": " + rawLocationJson(expression));
+  TypeOwnedExpressionSerializationContext owned_expression_context;
+  fields.push_back(jsonString("properties") + ": " +
+                   rawNodeProperties(expression, ids));
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+std::string rawTypeOwnedExpressionListJson(
+    const SgExpressionPtrList &expressions,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::ostringstream out;
+  out << "[";
+  if (!expressions.empty()) {
+    out << '\n';
+    size_t index = 0;
+    for (SgExpression *expr : expressions) {
+      indent(out, 6);
+      out << rawTypeOwnedExpressionRef(expr, ids);
+      if (++index != expressions.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 4);
+  }
+  out << "]";
+  return out.str();
+}
+
+std::string rawTypeOwnedExprListExpJson(
+    SgExprListExp *expression_list,
+    const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  std::vector<std::string> fields;
+  fields.push_back(rawBoolField("present", expression_list != nullptr));
+  if (expression_list != nullptr) {
+    fields.push_back(
+        rawStringField("kind", expression_list->sage_class_name()));
+    fields.push_back(jsonString("flags") + ": " +
+                     rawNodeFlagsJson(expression_list));
+    fields.push_back(jsonString("location") + ": " +
+                     rawLocationJson(expression_list));
+    fields.push_back(jsonString("properties") + ": " +
+                     rawNodeProperties(expression_list, ids));
+    fields.push_back(jsonString("expressions") + ": " +
+                     rawTypeOwnedExpressionListJson(
+                         expression_list->get_expressions(), ids));
+  }
+
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+const SgNode *symbolBasis(const SgSymbol *symbol) {
+  if (symbol == nullptr) {
+    return nullptr;
+  }
+  if (const SgAliasSymbol *alias_symbol = isSgAliasSymbol(symbol)) {
+    return symbolBasis(alias_symbol->get_alias());
+  }
+  if (const SgRenameSymbol *rename_symbol = isSgRenameSymbol(symbol)) {
+    return rename_symbol->get_declaration();
+  }
+  if (const SgEnumFieldSymbol *enum_field = isSgEnumFieldSymbol(symbol)) {
+    return enum_field->get_declaration();
+  }
+  if (const SgLabelSymbol *label_symbol = isSgLabelSymbol(symbol)) {
+    if (const SgLabelStatement *label = label_symbol->get_declaration()) {
+      return label;
+    }
+    return label_symbol->get_symbol_basis();
+  }
+  if (const SgNamespaceSymbol *namespace_symbol = isSgNamespaceSymbol(symbol)) {
+    return namespace_symbol->get_declaration();
+  }
+  if (const SgIntrinsicSymbol *intrinsic_symbol = isSgIntrinsicSymbol(symbol)) {
+    return intrinsic_symbol->get_declaration();
+  }
+  if (const SgModuleSymbol *module_symbol = isSgModuleSymbol(symbol)) {
+    return module_symbol->get_declaration();
+  }
+  if (const SgInterfaceSymbol *interface_symbol = isSgInterfaceSymbol(symbol)) {
+    return interface_symbol->get_declaration();
+  }
+  if (const SgCommonSymbol *common_symbol = isSgCommonSymbol(symbol)) {
+    return common_symbol->get_declaration();
+  }
+  if (const SgVariableSymbol *variable = isSgVariableSymbol(symbol)) {
+    return variable->get_declaration();
+  }
+  if (const SgFunctionSymbol *function = isSgFunctionSymbol(symbol)) {
+    return function->get_declaration();
+  }
+  if (const SgMemberFunctionSymbol *member_function =
+          isSgMemberFunctionSymbol(symbol)) {
+    return member_function->get_declaration();
+  }
+  if (const SgClassSymbol *class_symbol = isSgClassSymbol(symbol)) {
+    return class_symbol->get_declaration();
+  }
+  if (const SgEnumSymbol *enum_symbol = isSgEnumSymbol(symbol)) {
+    return enum_symbol->get_declaration();
+  }
+  if (const SgTypedefSymbol *typedef_symbol = isSgTypedefSymbol(symbol)) {
+    return typedef_symbol->get_declaration();
+  }
+  if (const SgNonrealSymbol *nonreal_symbol = isSgNonrealSymbol(symbol)) {
+    return nonreal_symbol->get_declaration();
+  }
+  if (const SgTemplateSymbol *template_symbol = isSgTemplateSymbol(symbol)) {
+    return template_symbol->get_declaration();
+  }
+  if (const SgNode *basis = symbol->get_symbol_basis()) {
+    return basis;
+  }
+  return nullptr;
+}
+
+std::string symbolName(const SgSymbol *symbol) {
+  const SgNode *basis = symbolBasis(symbol);
+  if (const SgInitializedName *name = isSgInitializedName(basis)) {
+    return name->get_name().getString();
+  }
+  if (const SgFunctionDeclaration *decl = isSgFunctionDeclaration(basis)) {
+    return decl->get_name().getString();
+  }
+  if (const SgClassDeclaration *decl = isSgClassDeclaration(basis)) {
+    return decl->get_name().getString();
+  }
+  if (const SgEnumDeclaration *decl = isSgEnumDeclaration(basis)) {
+    return decl->get_name().getString();
+  }
+  if (const SgTypedefDeclaration *decl = isSgTypedefDeclaration(basis)) {
+    return decl->get_name().getString();
+  }
+  if (const SgNonrealDecl *decl = isSgNonrealDecl(basis)) {
+    return decl->get_name().getString();
+  }
+  return symbol != nullptr ? symbol->get_name().getString() : "";
+}
+
+std::string
+rawSymbolRef(SgSymbol *symbol,
+             const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  const SgNode *basis = symbolBasis(symbol);
+  const uint64_t basis_id = idFor(ids, basis);
+  const bool external_function =
+      basis_id == 0 &&
+      (isAstJsonExternalFunction(
+           isSgFunctionDeclaration(const_cast<SgNode *>(basis))) ||
+       (isSgFunctionDeclaration(basis) != nullptr &&
+        !insideCollectionBoundary(const_cast<SgNode *>(basis))));
+  const bool external_module =
+      basis_id == 0 &&
+      (isAstJsonExternalModule(
+           isSgModuleStatement(const_cast<SgNode *>(basis))) ||
+       (isSgModuleStatement(basis) != nullptr &&
+        !insideCollectionBoundary(const_cast<SgNode *>(basis))));
+  const bool external_class =
+      basis_id == 0 &&
+      (isAstJsonExternalClassDeclaration(
+           isSgClassDeclaration(const_cast<SgNode *>(basis))) ||
+       (isSgClassDeclaration(basis) != nullptr &&
+        !insideCollectionBoundary(const_cast<SgNode *>(basis))));
+  if (symbol != nullptr && basis_id == 0 && !external_function &&
+      !external_module && !external_class) {
+    std::ostringstream message;
+    message << "AST JSON symbol reference target was not collected: "
+            << symbol->get_name().getString();
+    if (basis != nullptr) {
+      message << " basis=" << basis->sage_class_name()
+              << " basis_text=" << safeNodeText(const_cast<SgNode *>(basis));
+    }
+    throw std::runtime_error(message.str());
+  }
+  std::vector<std::string> fields;
+  fields.push_back(rawIntegerField("symbol_declaration", basis_id));
+  fields.push_back(rawStringField("symbol_name", symbolName(symbol)));
+  fields.push_back(rawStringField("symbol_kind", symbol->class_name()));
+  if (const SgLabelSymbol *label_symbol = isSgLabelSymbol(symbol)) {
+    fields.push_back(rawIntegerField("label_numeric_label_value",
+                                     label_symbol->get_numeric_label_value()));
+    fields.push_back(rawIntegerField(
+        "label_type", static_cast<int>(label_symbol->get_label_type())));
+  }
+  if (external_function) {
+    fields.push_back(
+        jsonString("external_function") + ": " +
+        rawExternalFunctionJson(
+            isSgFunctionDeclaration(const_cast<SgNode *>(basis)), ids));
+  }
+  if (external_module) {
+    fields.push_back(
+        jsonString("external_module") + ": " +
+        rawExternalModuleJson(isSgModuleStatement(const_cast<SgNode *>(basis)),
+                              ids));
+  }
+  if (external_class) {
+    fields.push_back(jsonString("external_class") + ": " +
+                     rawExternalClassDeclarationJson(
+                         isSgClassDeclaration(const_cast<SgNode *>(basis))));
+  }
+  std::ostringstream out;
+  writeRawObject(out, 0, fields, false);
+  std::string result = out.str();
+  if (!result.empty() && result.back() == '\n') {
+    result.pop_back();
+  }
+  return result;
+}
+
+bool symbolIsLookupPreferred(SgSymbolTable *table, const SgName &name,
+                             SgSymbol *symbol) {
+  if (table == nullptr || symbol == nullptr) {
+    return false;
+  }
+  if (isSgVariableSymbol(symbol) != nullptr &&
+      table->find_variable(name) == symbol) {
+    return true;
+  }
+  if (isSgClassSymbol(symbol) != nullptr && table->find_class(name) == symbol) {
+    return true;
+  }
+  if (isSgEnumSymbol(symbol) != nullptr && table->find_enum(name) == symbol) {
+    return true;
+  }
+  if (isSgEnumFieldSymbol(symbol) != nullptr &&
+      table->find_enum_field(name) == symbol) {
+    return true;
+  }
+  if (isSgTypedefSymbol(symbol) != nullptr &&
+      table->find_typedef(name) == symbol) {
+    return true;
+  }
+  if (isSgLabelSymbol(symbol) != nullptr && table->find_label(name) == symbol) {
+    return true;
+  }
+  if (isSgNamespaceSymbol(symbol) != nullptr &&
+      table->find_namespace(name) == symbol) {
+    return true;
+  }
+  if (isSgFunctionSymbol(symbol) != nullptr &&
+      table->find_function(name) == symbol) {
+    return true;
+  }
+  return false;
+}
+
+std::string
+rawSymbolTableJson(SgScopeStatement *scope,
+                   const std::unordered_map<const SgNode *, uint64_t> &ids) {
+  SgSymbolTable *table = scope != nullptr ? scope->get_symbol_table() : nullptr;
+  if (table == nullptr || table->get_table() == nullptr) {
+    return "[]";
+  }
+
+  std::vector<SymbolTableEntryJson> entries;
+  for (const std::pair<const SgName, SgSymbol *> &entry : *table->get_table()) {
+    SgSymbol *symbol = entry.second;
+    if (symbol == nullptr) {
+      throw std::runtime_error(
+          "AST JSON encountered a null symbol table entry");
+    }
+    const SgNode *basis = symbolBasis(symbol);
+    const uint64_t basis_id = idFor(ids, basis);
+    const bool external_basis =
+        basis_id == 0 &&
+        (isAstJsonExternalFunction(
+             isSgFunctionDeclaration(const_cast<SgNode *>(basis))) ||
+         isAstJsonExternalModule(
+             isSgModuleStatement(const_cast<SgNode *>(basis))) ||
+         isAstJsonExternalClassDeclaration(
+             isSgClassDeclaration(const_cast<SgNode *>(basis))) ||
+         (basis != nullptr &&
+          !insideCollectionBoundary(const_cast<SgNode *>(basis)) &&
+          (isSgFunctionDeclaration(basis) != nullptr ||
+           isSgModuleStatement(basis) != nullptr ||
+           isSgClassDeclaration(basis) != nullptr)));
+    if (basis_id == 0 && !external_basis) {
+      std::ostringstream message;
+      message << "AST JSON symbol table target was not collected";
+      message << " scope=" << scope->sage_class_name();
+      message << " entry=" << entry.first.getString();
+      message << " symbol=" << symbol->class_name();
+      message << " symbol_name=" << symbol->get_name().getString();
+      if (basis != nullptr) {
+        message << " basis=" << basis->sage_class_name()
+                << " basis_text=" << safeNodeText(const_cast<SgNode *>(basis));
+      }
+      throw std::runtime_error(message.str());
+    }
+
+    std::vector<std::string> fields;
+    const std::string entry_name = entry.first.getString();
+    const std::string symbol_kind = symbol->class_name();
+    const bool lookup_preferred =
+        symbolIsLookupPreferred(table, entry.first, symbol);
+    fields.push_back(rawStringField("entry_name", entry_name));
+    fields.push_back(rawStringField("symbol_kind", symbol_kind));
+    fields.push_back(rawBoolField("lookup_preferred", lookup_preferred));
+    fields.push_back(jsonString("symbol") + ": " + rawSymbolRef(symbol, ids));
+
+    if (SgAliasSymbol *alias = isSgAliasSymbol(symbol)) {
+      if (alias->get_alias() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON encountered an SgAliasSymbol without an alias target");
+      }
+      fields.push_back(jsonString("alias_target") + ": " +
+                       rawSymbolRef(alias->get_alias(), ids));
+      fields.push_back(
+          rawBoolField("alias_is_renamed", alias->get_isRenamed()));
+      fields.push_back(
+          rawStringField("alias_new_name", alias->get_new_name().getString()));
+      std::ostringstream causal_nodes;
+      causal_nodes << "[";
+      for (size_t i = 0; i < alias->get_causal_nodes().size(); ++i) {
+        SgNode *causal_node = alias->get_causal_nodes()[i];
+        const uint64_t causal_id = idFor(ids, causal_node);
+        if (causal_node != nullptr && causal_id == 0) {
+          throw std::runtime_error(
+              "AST JSON SgAliasSymbol causal node was not collected");
+        }
+        if (i != 0) {
+          causal_nodes << ", ";
+        }
+        causal_nodes << causal_id;
+      }
+      causal_nodes << "]";
+      fields.push_back(jsonString("alias_causal_nodes") + ": " +
+                       causal_nodes.str());
+    }
+    if (SgRenameSymbol *rename = isSgRenameSymbol(symbol)) {
+      if (rename->get_original_symbol() == nullptr) {
+        throw std::runtime_error(
+            "AST JSON encountered an SgRenameSymbol without an original "
+            "symbol");
+      }
+      fields.push_back(jsonString("original_symbol") + ": " +
+                       rawSymbolRef(rename->get_original_symbol(), ids));
+      fields.push_back(rawStringField("rename_new_name",
+                                      rename->get_new_name().getString()));
+    }
+    if (SgNamespaceSymbol *namespace_symbol = isSgNamespaceSymbol(symbol)) {
+      fields.push_back(rawStringField(
+          "namespace_name", namespace_symbol->get_name().getString()));
+      fields.push_back(
+          rawBoolField("namespace_is_alias", namespace_symbol->get_isAlias()));
+      fields.push_back(rawIntegerField(
+          "namespace_alias_declaration",
+          idFor(ids, namespace_symbol->get_aliasDeclaration())));
+    }
+
+    std::ostringstream entry_out;
+    writeRawObject(entry_out, 0, fields, false);
+    std::string entry_json = entry_out.str();
+    if (!entry_json.empty() && entry_json.back() == '\n') {
+      entry_json.pop_back();
+    }
+
+    SymbolTableEntryJson serialized;
+    serialized.entry_name = entry_name;
+    serialized.symbol_kind = symbol_kind;
+    serialized.basis_id = basis_id;
+    serialized.lookup_preferred = lookup_preferred;
+    serialized.json = std::move(entry_json);
+    entries.push_back(std::move(serialized));
+  }
+
+  std::stable_sort(
+      entries.begin(), entries.end(),
+      [](const SymbolTableEntryJson &lhs, const SymbolTableEntryJson &rhs) {
+        if (lhs.basis_id != rhs.basis_id) {
+          if (lhs.basis_id == 0) {
+            return false;
+          }
+          if (rhs.basis_id == 0) {
+            return true;
+          }
+          return lhs.basis_id < rhs.basis_id;
+        }
+        if (lhs.lookup_preferred != rhs.lookup_preferred) {
+          return lhs.lookup_preferred && !rhs.lookup_preferred;
+        }
+        if (lhs.entry_name != rhs.entry_name) {
+          return lhs.entry_name < rhs.entry_name;
+        }
+        return lhs.symbol_kind < rhs.symbol_kind;
+      });
+
+  std::ostringstream out;
+  out << "[";
+  if (!entries.empty()) {
+    out << '\n';
+    for (size_t i = 0; i < entries.size(); ++i) {
+      indent(out, 4);
+      out << entries[i].json;
+      if (i + 1 != entries.size()) {
+        out << ',';
+      }
+      out << '\n';
+    }
+    indent(out, 2);
+  }
+  out << "]";
+  return out.str();
+}
+
+} // namespace AstJson
+} // namespace Rose

--- a/src/frontend/SageIII/astPostProcessing/fixupCxxSymbolTablesToSupportAliasingSymbols.C
+++ b/src/frontend/SageIII/astPostProcessing/fixupCxxSymbolTablesToSupportAliasingSymbols.C
@@ -59,6 +59,50 @@ AliasSymbolIdentity buildAliasSymbolIdentity(const SgName &name,
   identity.variant = static_cast<int>(non_alias_symbol->variantT());
   return identity;
 }
+
+bool declaration_is_owned_by_scope(SgDeclarationStatement *decl,
+                                   SgScopeStatement *scope) {
+  if (decl == nullptr || scope == nullptr) {
+    return false;
+  }
+
+  return decl->get_scope() == scope || decl->get_parent() == scope;
+}
+
+bool initialized_name_is_owned_by_scope(SgInitializedName *name,
+                                        SgScopeStatement *scope) {
+  if (name == nullptr || scope == nullptr) {
+    return false;
+  }
+
+  if (SgDeclarationStatement *decl = name->get_declptr()) {
+    return declaration_is_owned_by_scope(decl, scope);
+  }
+
+  if (SgDeclarationStatement *parent_decl =
+          isSgDeclarationStatement(name->get_parent())) {
+    return declaration_is_owned_by_scope(parent_decl, scope);
+  }
+
+  return name->get_scope() == scope && name->get_parent() == scope;
+}
+
+bool symbol_basis_is_owned_by_referenced_class_scope(
+    SgNode *symbol_basis, SgScopeStatement *referenced_scope) {
+  if (isSgClassDefinition(referenced_scope) == nullptr) {
+    return true;
+  }
+
+  if (SgDeclarationStatement *decl = isSgDeclarationStatement(symbol_basis)) {
+    return declaration_is_owned_by_scope(decl, referenced_scope);
+  }
+
+  if (SgInitializedName *name = isSgInitializedName(symbol_basis)) {
+    return initialized_name_is_owned_by_scope(name, referenced_scope);
+  }
+
+  return false;
+}
 } // namespace
 
 struct FixupAstSymbolTablesToSupportAliasedSymbols::CurrentScopeAliasIndex {
@@ -417,6 +461,11 @@ void FixupAstSymbolTablesToSupportAliasedSymbols::
         // SgNode* symbolBasis = symbol->get_symbol_basis();
         symbolBasis = symbol->get_symbol_basis();
         ROSE_ASSERT(symbolBasis != NULL);
+        if (!symbol_basis_is_owned_by_referenced_class_scope(symbolBasis,
+                                                             referencedScope)) {
+          i++;
+          continue;
+        }
 #if ALIAS_SYMBOL_DEBUGGING
         printf("symbolBasis = %p = %s \n", symbolBasis,
                symbolBasis->class_name().c_str());

--- a/src/frontend/SageIII/astPostProcessing/fixupTypes.C
+++ b/src/frontend/SageIII/astPostProcessing/fixupTypes.C
@@ -5,6 +5,23 @@
 // DQ (12/31/2005): This is OK if not declared in a header file
 using namespace std;
 
+namespace {
+
+bool isInsideDetachedSourceFile(SgNode *node) {
+  for (SgNode *current = node; current != nullptr;
+       current = current->get_parent()) {
+    if (SgSourceFile *source_file = isSgSourceFile(current)) {
+      return source_file->get_parent() == nullptr;
+    }
+    if (isSgFileList(current) != nullptr || isSgProject(current) != nullptr) {
+      return false;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 void resetTypesInAST() {
   ResetTypes t;
   SgNamedType::traverseMemoryPoolNodes(t);
@@ -13,6 +30,10 @@ void resetTypesInAST() {
 }
 
 void ResetTypes::visit(SgNode *node) {
+  if (isInsideDetachedSourceFile(node)) {
+    return;
+  }
+
   // The purpose of this traversal is to fixup the AST to share types more
   // uniformally shared. It appears that in the legacy frontend/Sage translation
   // some types are not shared properly, particularly SgNamedTypes.

--- a/src/frontend/SageIII/ompAstConstruction.cpp
+++ b/src/frontend/SageIII/ompAstConstruction.cpp
@@ -2,6 +2,7 @@
 // Liao 10/8/2010
 #include "ompAstConstruction.h"
 
+#include "astJson/sageAstJson.h"
 #include "astPostProcessing.h"
 #include "fixupTypes.h"
 
@@ -680,6 +681,126 @@ static bool buildDeclareMapperTemplateArgumentNodes(
   return true;
 }
 
+static SgType *
+normalizeDeclareMapperTemplateInstantiationScope(SgNode *context_node,
+                                                 SgType *type) {
+  SgClassType *class_type = isSgClassType(type);
+  if (class_type == nullptr) {
+    return type;
+  }
+
+  SgTemplateInstantiationDecl *decl =
+      isSgTemplateInstantiationDecl(class_type->get_declaration());
+  if (decl == nullptr) {
+    return type;
+  }
+
+  SgGlobal *global_scope = context_node != nullptr
+                               ? SageInterface::getGlobalScope(context_node)
+                               : nullptr;
+  if (global_scope == nullptr) {
+    return type;
+  }
+
+  SgTemplateClassDeclaration *template_decl =
+      isSgTemplateClassDeclaration(decl->get_templateDeclaration());
+  SgName template_name = decl->get_templateName();
+  if (template_name.getString().empty() && template_decl != nullptr) {
+    template_name = template_decl->get_name();
+  }
+  if (!template_name.getString().empty()) {
+    auto is_under_current_global = [&](SgNode *node) {
+      for (SgNode *cursor = node; cursor != nullptr;
+           cursor = cursor->get_parent()) {
+        if (cursor == global_scope) {
+          return true;
+        }
+      }
+      return false;
+    };
+    SgScopeStatement *lookup_scope =
+        isSgStatement(context_node) != nullptr &&
+                isSgStatement(context_node)->get_scope() != nullptr
+            ? isSgStatement(context_node)->get_scope()
+            : static_cast<SgScopeStatement *>(global_scope);
+    SgTemplateClassDeclaration *visible_template_decl = nullptr;
+    SgTemplateClassSymbol *template_symbol =
+        SageInterface::lookupTemplateClassSymbolInParentScopes(
+            template_name, nullptr, nullptr, lookup_scope);
+    if (template_symbol == nullptr && lookup_scope != global_scope) {
+      template_symbol = SageInterface::lookupTemplateClassSymbolInParentScopes(
+          template_name, nullptr, nullptr, global_scope);
+    }
+    if (template_symbol != nullptr) {
+      visible_template_decl =
+          isSgTemplateClassDeclaration(template_symbol->get_declaration());
+      if (visible_template_decl != nullptr &&
+          !is_under_current_global(visible_template_decl)) {
+        visible_template_decl = nullptr;
+      }
+    }
+    if (visible_template_decl == nullptr) {
+      Rose_STL_Container<SgNode *> candidates =
+          NodeQuery::querySubTree(global_scope, V_SgTemplateClassDeclaration);
+      for (SgNode *candidate : candidates) {
+        SgTemplateClassDeclaration *candidate_decl =
+            isSgTemplateClassDeclaration(candidate);
+        if (candidate_decl != nullptr &&
+            candidate_decl->get_name() == template_name) {
+          visible_template_decl = candidate_decl;
+          break;
+        }
+      }
+    }
+    if (visible_template_decl != nullptr &&
+        visible_template_decl != template_decl) {
+      decl->set_templateDeclaration(visible_template_decl);
+    }
+  }
+
+  SgGlobal *decl_global = isSgGlobal(decl->get_scope());
+  if (decl_global == nullptr || decl_global == global_scope) {
+    return type;
+  }
+
+  SgSymbol *symbol = decl->get_symbol_from_symbol_table();
+  if (symbol != nullptr && decl_global->symbol_exists(symbol)) {
+    decl_global->remove_symbol(symbol);
+  }
+
+  decl->set_scope(global_scope);
+  if (symbol != nullptr && !global_scope->symbol_exists(symbol)) {
+    global_scope->insert_symbol(symbol->get_name(), symbol);
+  }
+
+  return type;
+}
+
+static void
+normalizeDeclareMapperTemplateInstantiationScopes(SgSourceFile *source_file) {
+  if (source_file == nullptr) {
+    return;
+  }
+
+  struct Traversal : public AstSimpleProcessing {
+    void visit(SgNode *node) override {
+      SgOmpDeclareMapperStatement *mapper = isSgOmpDeclareMapperStatement(node);
+      if (mapper == nullptr) {
+        return;
+      }
+      SgTypeExpression *mapper_type =
+          isSgTypeExpression(mapper->get_mapper_type());
+      if (mapper_type == nullptr) {
+        return;
+      }
+      normalizeDeclareMapperTemplateInstantiationScope(mapper,
+                                                       mapper_type->get_type());
+    }
+  };
+
+  Traversal().traverse(source_file, preorder);
+}
+
 static SgType *resolveDeclareMapperNamedBaseType(
     SgPragmaDeclaration *directive,
     const std::vector<std::string> &base_name_tokens) {
@@ -719,7 +840,8 @@ static SgType *resolveDeclareMapperNamedBaseType(
     if (SgClassSymbol *class_symbol =
             SageInterface::lookupClassSymbolInParentScopes(
                 SgName(name), scope, &template_arguments)) {
-      return class_symbol->get_type();
+      return normalizeDeclareMapperTemplateInstantiationScope(
+          directive, class_symbol->get_type());
     }
     return nullptr;
   };
@@ -742,8 +864,9 @@ static SgType *resolveDeclareMapperNamedBaseType(
       Rose_STL_Container<SgNode *> argument_nodes;
       if (buildDeclareMapperTemplateArgumentNodes(template_arguments,
                                                   argument_nodes)) {
-        return SageBuilder::buildClassTemplateType(template_decl,
-                                                   argument_nodes);
+        return normalizeDeclareMapperTemplateInstantiationScope(
+            directive,
+            SageBuilder::buildClassTemplateType(template_decl, argument_nodes));
       }
     }
   }
@@ -756,7 +879,8 @@ static SgType *resolveDeclareMapperNamedBaseType(
         return nullptr;
       }
     }
-    return resolved;
+    return normalizeDeclareMapperTemplateInstantiationScope(directive,
+                                                            resolved);
   }
 
   return nullptr;
@@ -1765,6 +1889,7 @@ static void normalizeMovedConditionalSkippedTokens(SgStatement *statement) {
     }
     if (text.empty()) {
       it = infos->erase(it);
+      delete info;
       continue;
     }
     info->setString(text);
@@ -5184,6 +5309,8 @@ static void removeFortranDirectiveComments(SgSourceFile *sageFilePtr,
                                            const std::string &keyword) {
   ROSE_ASSERT(sageFilePtr != NULL);
 
+  std::unordered_set<PreprocessingInfo *> removed_infos;
+
   std::vector<SgNode *> loc_nodes =
       NodeQuery::querySubTree(sageFilePtr, V_SgLocatedNode);
   for (SgNode *node : loc_nodes) {
@@ -5210,11 +5337,16 @@ static void removeFortranDirectiveComments(SgSourceFile *sageFilePtr,
         }
       }
       if (is_directive || is_sentinel_lead) {
+        removed_infos.insert(*iter);
         iter = comments->erase(iter);
       } else {
         ++iter;
       }
     }
+  }
+
+  for (PreprocessingInfo *info : removed_infos) {
+    delete info;
   }
 }
 
@@ -8924,10 +9056,18 @@ void processOpenMP(SgSourceFile *sageFilePtr) {
              sageFilePtr->get_openmp_ast_only() ? "true" : "false");
     }
     canonicalize_named_types();
+    normalizeDeclareMapperTemplateInstantiationScopes(sageFilePtr);
+    sageFilePtr = Rose::AstJson::roundTripSourceFile(
+        sageFilePtr, Rose::AstJson::Checkpoint::PostOmpConstruction);
     releaseOpenMPParseStateForSourceFile(sageFilePtr);
     mark_processed(sageFilePtr);
     return;
   }
+
+  canonicalize_named_types();
+  normalizeDeclareMapperTemplateInstantiationScopes(sageFilePtr);
+  sageFilePtr = Rose::AstJson::roundTripSourceFile(
+      sageFilePtr, Rose::AstJson::Checkpoint::PostOmpConstruction);
 
   // Analyze OpenMP AST
   analyze_omp(sageFilePtr);
@@ -8947,6 +9087,8 @@ void processOpenMP(SgSourceFile *sageFilePtr) {
 
   lower_omp(sageFilePtr);
   canonicalize_named_types();
+  sageFilePtr = Rose::AstJson::roundTripSourceFile(
+      sageFilePtr, Rose::AstJson::Checkpoint::PostOmpLowering);
   releaseOpenMPParseStateForSourceFile(sageFilePtr);
   mark_processed(sageFilePtr);
 }
@@ -10766,8 +10908,6 @@ convertUsesAllocatorsClause(SgOmpClauseBodyStatement *clause_body,
   SgOmpUsesAllocatorsClause *result = NULL;
   SgOmpUsesAllocatorsDefination *uses_allocators_defination = NULL;
   SgOmpClause::omp_uses_allocators_allocator_enum sg_allocator;
-  SgExpression *user_defined_allocator = NULL;
-  SgExpression *clause_expression = NULL;
   std::vector<usesAllocatorParameter *> *uses_allocators =
       ((OpenMPUsesAllocatorsClause *)current_omp_clause)
           ->getUsesAllocatorsAllocatorSequence();
@@ -10778,9 +10918,10 @@ convertUsesAllocatorsClause(SgOmpClauseBodyStatement *clause_body,
     OpenMPUsesAllocatorsClauseAllocator allocator =
         ((usesAllocatorParameter *)(*iter))->getUsesAllocatorsAllocator();
     sg_allocator = toSgOmpClauseUsesAllocatorsAllocator(allocator);
+    SgExpression *user_defined_allocator = NULL;
     if (sg_allocator ==
         SgOmpClause::e_omp_uses_allocators_allocator_user_defined) {
-      clause_expression = parseOmpExpression(
+      user_defined_allocator = parseOmpExpression(
           current_OpenMPIR_to_SageIII.first, current_omp_clause->getKind(),
           ((usesAllocatorParameter *)(*iter))->getAllocatorUser());
     }
@@ -10799,7 +10940,8 @@ convertUsesAllocatorsClause(SgOmpClauseBodyStatement *clause_body,
         allocator_traits_array);
     uses_allocators_defination->set_allocator(sg_allocator);
 
-    uses_allocators_defination->set_user_defined_allocator(clause_expression);
+    uses_allocators_defination->set_user_defined_allocator(
+        user_defined_allocator);
     uses_allocators_definations.push_back(uses_allocators_defination);
   }
 

--- a/src/frontend/SageIII/omp_exprparser_parser.yy
+++ b/src/frontend/SageIII/omp_exprparser_parser.yy
@@ -233,6 +233,31 @@ static bool isKnownVariableSymbolType(SgVariableSymbol *symbol) {
     return isSgTypeUnknown(type) == NULL;
 }
 
+static bool symbolBelongsToDirectiveSourceFile(SgVariableSymbol *symbol) {
+    if (symbol == NULL || omp_directive_node == NULL) {
+        return true;
+    }
+
+    SgSourceFile *directive_file =
+        SageInterface::getEnclosingSourceFile(omp_directive_node, true);
+    if (directive_file == NULL) {
+        return true;
+    }
+
+    SgInitializedName *declaration = symbol->get_declaration();
+    if (declaration == NULL) {
+        return false;
+    }
+
+    SgSourceFile *declaration_file =
+        SageInterface::getEnclosingSourceFile(declaration, true);
+    if (declaration_file == NULL) {
+        return true;
+    }
+
+    return declaration_file == directive_file;
+}
+
 static SgVariableSymbol *lookupVariableSymbolInScopeWithVariants(
     SgScopeStatement *scope, const std::string &name) {
     if (scope == NULL || name.empty()) {
@@ -271,6 +296,9 @@ static SgVariableSymbol *lookupVariableSymbolPreferTyped(
     }
 
     SgVariableSymbol *symbol = lookupVariableSymbolInParentScopes(name, scope);
+    if (symbol != NULL && !symbolBelongsToDirectiveSourceFile(symbol)) {
+        symbol = NULL;
+    }
     if (isKnownVariableSymbolType(symbol)) {
         return symbol;
     }
@@ -281,6 +309,14 @@ static SgVariableSymbol *lookupVariableSymbolPreferTyped(
         SgVariableSymbol *candidate =
             lookupVariableSymbolInScopeWithVariants(current_scope, name);
         if (candidate == NULL) {
+            SgScopeStatement *next_scope = current_scope->get_scope();
+            if (next_scope == current_scope) {
+                break;
+            }
+            current_scope = next_scope;
+            continue;
+        }
+        if (!symbolBelongsToDirectiveSourceFile(candidate)) {
             SgScopeStatement *next_scope = current_scope->get_scope();
             if (next_scope == current_scope) {
                 break;

--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -4130,6 +4130,8 @@ void SageInterface::rebuildSymbolTable(SgScopeStatement *scope) {
 
   case V_SgBasicBlock:
   case V_SgClassDefinition:
+  case V_SgDeclarationScope:
+  case V_SgFunctionParameterScope:
   case V_SgTemplateInstantiationDefn:
   case V_SgGlobal:
   case V_SgNamespaceDefinitionStatement:
@@ -4337,6 +4339,8 @@ void SageInterface::rebuildSymbolTable(SgScopeStatement *scope) {
         // DQ (12/24/2012): Added support for templates.
       case V_SgTemplateFunctionDeclaration:
 
+      case V_SgProgramHeaderStatement:
+      case V_SgProcedureHeaderStatement:
       case V_SgFunctionDeclaration: {
         SgFunctionDeclaration *derivedDeclaration =
             isSgFunctionDeclaration(declaration);
@@ -4469,6 +4473,7 @@ void SageInterface::rebuildSymbolTable(SgScopeStatement *scope) {
         // DQ (12/24/2012): Added support for templates.
       case V_SgTemplateClassDeclaration:
 
+      case V_SgDerivedTypeStatement:
       case V_SgClassDeclaration: {
         SgClassDeclaration *derivedDeclaration =
             isSgClassDeclaration(declaration);
@@ -4597,6 +4602,25 @@ void SageInterface::rebuildSymbolTable(SgScopeStatement *scope) {
         break;
       }
 
+      case V_SgNonrealDecl: {
+        SgNonrealDecl *derivedDeclaration = isSgNonrealDecl(declaration);
+        ROSE_ASSERT(derivedDeclaration != NULL);
+        SgSymbol *symbol = new SgNonrealSymbol(derivedDeclaration);
+        ROSE_ASSERT(symbol != NULL);
+        symbolTable->insert(derivedDeclaration->get_name(), symbol);
+        break;
+      }
+
+      case V_SgModuleStatement: {
+        SgModuleStatement *derivedDeclaration =
+            isSgModuleStatement(declaration);
+        ROSE_ASSERT(derivedDeclaration != NULL);
+        SgSymbol *symbol = new SgModuleSymbol(derivedDeclaration);
+        ROSE_ASSERT(symbol != NULL);
+        symbolTable->insert(derivedDeclaration->get_name(), symbol);
+        break;
+      }
+
       case V_SgTemplateDeclaration: {
         SgTemplateDeclaration *derivedDeclaration =
             isSgTemplateDeclaration(declaration);
@@ -4675,6 +4699,22 @@ void SageInterface::rebuildSymbolTable(SgScopeStatement *scope) {
       case V_SgClinkageStartStatement:
       case V_SgClinkageEndStatement:
       case V_SgTemplateInstantiationDirectiveStatement:
+      case V_SgOmpDeclareMapperStatement:
+      case V_SgOmpDeclareSimdStatement:
+      case V_SgOmpDeclareVariantStatement:
+      case V_SgOmpBeginDeclareVariantStatement:
+      case V_SgOmpEndDeclareVariantStatement:
+      case V_SgOmpDeclareTargetStatement:
+      case V_SgOmpEndDeclareTargetStatement:
+      case V_SgOmpThreadprivateStatement:
+      case V_SgOmpAllocateStatement:
+      case V_SgOmpRequiresStatement:
+      case V_SgOmpTaskwaitStatement:
+      case V_SgImplicitStatement:
+      case V_SgUseStatement:
+      case V_SgContainsStatement:
+      case V_SgAttributeSpecificationStatement:
+      case V_SgInterfaceStatement:
       case V_SgUsingDeclarationStatement: {
         // DQ (10/22/2005): Not sure if we have to worry about this
         // declaration's appearance in the symbol table!
@@ -20260,6 +20300,10 @@ void SageInterface::appendStatementWithDependentDeclaration(
         }
       }
 
+      for (PreprocessingInfo *info : *infos) {
+        delete info;
+      }
+      delete infos;
       locatedNode->set_attachedPreprocessingInfoPtr(clonedInfos);
     }
   };
@@ -21998,7 +22042,7 @@ public:
       const std::unordered_set<PreprocessingInfo *> &file_owned)
       : file_owned_(file_owned) {}
 
-  void visitDefault(SgNode *node) override {
+  void cleanupNode(SgNode *node) {
     if (!node) {
       return;
     }
@@ -22036,6 +22080,8 @@ public:
       }
     }
   }
+
+  void visitDefault(SgNode *node) override { cleanupNode(node); }
 
 private:
   const std::unordered_set<PreprocessingInfo *> &file_owned_;
@@ -22253,8 +22299,7 @@ void tearDownAstAtExit() {
     project = findAnyLiveProject();
   }
   if (project == nullptr && !hasLiveAstNodes()) {
-    g_astTeardownComplete = true;
-    g_astTeardownProject = nullptr;
+    SageInterface::tearDownAst(nullptr);
     return;
   }
   SageInterface::tearDownAst(project);
@@ -22313,10 +22358,10 @@ void SageInterface::tearDownAst(SgProject *project) {
       collectFileOwnedPreprocessingInfo(project);
   AttributeCleanupVisitor attributeCleanup(file_owned_preprocessing);
   traverseMemoryPoolVisitorPattern(attributeCleanup);
-
-  if (project != nullptr) {
-    DeleteAstSymbolTableLookupGuard skipLookups(true);
-    SageInterface::deleteAST(project);
+  LiveNodeCollector auxiliaryCleanupNodes;
+  traverseMemoryPoolVisitorPattern(auxiliaryCleanupNodes);
+  for (SgNode *node : auxiliaryCleanupNodes.nodes) {
+    attributeCleanup.cleanupNode(node);
   }
 
   LiveNodeCollector remainingNodes;

--- a/src/frontend/SageIII/sage_support/sage_support.C
+++ b/src/frontend/SageIII/sage_support/sage_support.C
@@ -25,6 +25,8 @@
 
 #include "sage_support.h"
 
+#include "astJson/sageAstJson.h"
+
 #include "rose_path_resolver.h"
 
 #include "rose_paths.h"
@@ -3009,6 +3011,8 @@ void SgFile::secondaryPassOverSourceFile() {
       // Liao, 3/31/2009 Handle OpenMP here to see macro calls within directives
 #ifdef ROSE_BUILD_CPP_LANGUAGE_SUPPORT
       rosePhaseTrace("secondaryPassOverSourceFile.openmp.begin");
+      sourceFile = Rose::AstJson::roundTripSourceFile(
+          sourceFile, Rose::AstJson::Checkpoint::PreOmpConstruction);
       processOpenMP(sourceFile);
       rosePhaseTrace("secondaryPassOverSourceFile.openmp.end");
 #endif

--- a/src/midend/astDiagnostics/AstConsistencyTests.C
+++ b/src/midend/astDiagnostics/AstConsistencyTests.C
@@ -3255,6 +3255,20 @@ void TestAstSymbolTables::visit(SgNode *node) {
         break;
       }
 
+      case V_SgInterfaceSymbol: {
+        SgInterfaceSymbol *interfaceSymbol = isSgInterfaceSymbol(symbol);
+        ROSE_ASSERT(interfaceSymbol != NULL);
+        ROSE_ASSERT(interfaceSymbol->get_declaration() != NULL);
+        break;
+      }
+
+      case V_SgModuleSymbol: {
+        SgModuleSymbol *moduleSymbol = isSgModuleSymbol(symbol);
+        ROSE_ASSERT(moduleSymbol != NULL);
+        ROSE_ASSERT(moduleSymbol->get_declaration() != NULL);
+        break;
+      }
+
       case V_SgNamespaceSymbol: {
         SgNamespaceSymbol *namespaceSymbol = isSgNamespaceSymbol(symbol);
         ROSE_ASSERT(namespaceSymbol != NULL);

--- a/src/midend/astProcessing/graphProcessing.h
+++ b/src/midend/astProcessing/graphProcessing.h
@@ -129,6 +129,7 @@ private:
   bool needssafety;
   int recursed;
   int checkedfound;
+  void clearPreparedGraphState();
   void prepareGraph(CFG *&g);
   void findClosuresAndMarkersAndEnumerate(CFG *&g);
   int stoppedpaths;
@@ -225,9 +226,38 @@ SgGraphTraversal<CFG>::operator=(SgGraphTraversal &other) {
 
 #ifndef SWIG
 
-template <class CFG> SgGraphTraversal<CFG>::~SgGraphTraversal() {}
+template <class CFG> SgGraphTraversal<CFG>::~SgGraphTraversal() {
+  clearPreparedGraphState();
+}
 
 #endif
+
+template <class CFG> void SgGraphTraversal<CFG>::clearPreparedGraphState() {
+  vertintmap.clear();
+  edgeintmap.clear();
+  intvertmap.clear();
+  intedgemap.clear();
+  sources.clear();
+  sinks.clear();
+  recursiveLoops.clear();
+  recurses.clear();
+  ptsNum.clear();
+  badloop.clear();
+  totalLoops.clear();
+  nodeStrings.clear();
+  loopStore.clear();
+  pathStore.clear();
+  subpathglobal.clear();
+  subpathglobalinv.clear();
+  orderOfNodes.clear();
+  SubGraphGraphMap.clear();
+  GraphSubGraphMap.clear();
+  subGraphVector.clear();
+  markers.clear();
+  closures.clear();
+  markerIndex.clear();
+  pathsAtMarkers.clear();
+}
 
 /**
     Gets the source of an edge
@@ -1070,6 +1100,7 @@ Input:
 */
 
 template <class CFG> void SgGraphTraversal<CFG>::prepareGraph(CFG *&g) {
+  clearPreparedGraphState();
   nextNode = 1;
   nextEdge = 1;
   findClosuresAndMarkersAndEnumerate(g);

--- a/src/midend/astProcessing/plugin.C
+++ b/src/midend/astProcessing/plugin.C
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include <memory>
+
 #include <stdlib.h>
 
 #include <string>
@@ -133,12 +135,11 @@ int obtainAndExecuteActions(SgProject *n) {
   // 4. Iterate through the registered plugins
   for (size_t i = 0; i < PluginActions.size(); i++) {
     string action_name = PluginActions[i];
-    PluginAction *p_action = NULL;
     for (PluginRegistry::iterator it = PluginRegistry::begin();
          it != PluginRegistry::end(); ++it) {
       // find an action matching the action name
       if (it->getName() == action_name) {
-        p_action = it->instantiate();
+        std::unique_ptr<PluginAction> p_action(it->instantiate());
 
         // call command line parsing for the plugin
         if (!p_action->ParseArgs(PluginArgs[action_name]))

--- a/src/midend/programAnalysis/CallGraphAnalysis/newCallGraph.C
+++ b/src/midend/programAnalysis/CallGraphAnalysis/newCallGraph.C
@@ -13,6 +13,7 @@
 #include "newCallGraph.h"
 
 #include <fstream>
+#include <memory>
 
 // file locking support
 #include <cstring>
@@ -45,6 +46,18 @@ CallGraphEdgeInfo::CallGraphEdgeInfo(CallGraphNodeInfo *from,
 }
 
 CallGraph::CallGraph() {}
+
+CallGraph::~CallGraph() {
+  for (std::map<std::string, CallGraphEdgeInfo *>::value_type &edge : edgeMap) {
+    delete edge.second;
+  }
+  edgeMap.clear();
+
+  for (std::map<std::string, CallGraphNodeInfo *>::value_type &node : nodeMap) {
+    delete node.second;
+  }
+  nodeMap.clear();
+}
 
 CallGraphFileStructure::CallGraphFileStructure()
     // : functionNameLength(256), fileNameLength(256)
@@ -83,18 +96,30 @@ void CallGraph::visit(SgNode *astNode) {
         } else {
           printf("Insert a new node into the nodeMap for function = %s \n",
                  functionDeclaration->get_name().str());
-          nodeMap.insert(pair<string, CallGraphNodeInfo *>(
-              name, new CallGraphNodeInfo(functionDeclaration)));
+          CallGraphNodeInfo *node = new CallGraphNodeInfo(functionDeclaration);
+          pair<map<string, CallGraphNodeInfo *>::iterator, bool> inserted =
+              nodeMap.insert(pair<string, CallGraphNodeInfo *>(name, node));
+          if (!inserted.second) {
+            delete node;
+          }
         }
       } else {
         // Insert the node into the node map so that we can build edges ("from"
         // and "to" nodes are required to define edges).
-        nodeMap.insert(pair<string, CallGraphNodeInfo *>(
-            name, new CallGraphNodeInfo(functionDeclaration)));
+        CallGraphNodeInfo *node = new CallGraphNodeInfo(functionDeclaration);
+        pair<map<string, CallGraphNodeInfo *>::iterator, bool> inserted =
+            nodeMap.insert(pair<string, CallGraphNodeInfo *>(name, node));
+        if (!inserted.second) {
+          delete node;
+        }
       }
     } else {
-      nodeMap.insert(pair<string, CallGraphNodeInfo *>(
-          name, new CallGraphNodeInfo(functionDeclaration)));
+      CallGraphNodeInfo *node = new CallGraphNodeInfo(functionDeclaration);
+      pair<map<string, CallGraphNodeInfo *>::iterator, bool> inserted =
+          nodeMap.insert(pair<string, CallGraphNodeInfo *>(name, node));
+      if (!inserted.second) {
+        delete node;
+      }
     }
 
     // form dot file string for function definition
@@ -165,8 +190,12 @@ void CallGraph::visit(SgNode *astNode) {
     ROSE_ASSERT(from != NULL);
     ROSE_ASSERT(to != NULL);
 
-    edgeMap.insert(pair<string, CallGraphEdgeInfo *>(
-        edge_name, new CallGraphEdgeInfo(from, to)));
+    CallGraphEdgeInfo *edge = new CallGraphEdgeInfo(from, to);
+    pair<map<string, CallGraphEdgeInfo *>::iterator, bool> inserted =
+        edgeMap.insert(pair<string, CallGraphEdgeInfo *>(edge_name, edge));
+    if (!inserted.second) {
+      delete edge;
+    }
 
     // form dot file string for function call
   }
@@ -312,8 +341,8 @@ void NewCallGraph::generateCallGraphFile(SgProject *project, CallGraph &cg) {
 
   // Read the existing file (if it exists) of previously processed files and
   // their parts of the call graph.
-  vector<CallGraphFileStructure> *callGraphVector =
-      readCallGraphFile(binaryFilename);
+  std::unique_ptr<vector<CallGraphFileStructure>> callGraphVector(
+      readCallGraphFile(binaryFilename));
 
   // Reopen the file for writing (we still have the lock), and position the file
   // cursor at the start of the file so that it can be overwritten with updated
@@ -348,7 +377,7 @@ void NewCallGraph::generateCallGraphFile(SgProject *project, CallGraph &cg) {
   map<string, CallGraphEdgeInfo *> &edgeMap = cg.edgeMap;
 
   printf("After reading existing call graph: callGraphVector = %p \n",
-         callGraphVector);
+         callGraphVector.get());
 
   // Check if we have entries from an existing binary file of call graph data.
   if (callGraphVector != NULL) {
@@ -602,8 +631,8 @@ void NewCallGraph::generateCallGraphFile(SgProject *project, CallGraph &cg) {
 }
 
 void NewCallGraph::generateDotFile(string binaryFilename) {
-  vector<CallGraphFileStructure> *callGraphVector =
-      NewCallGraph::readCallGraphFile(binaryFilename);
+  std::unique_ptr<vector<CallGraphFileStructure>> callGraphVector(
+      NewCallGraph::readCallGraphFile(binaryFilename));
 
   if (callGraphVector == NULL) {
     return;

--- a/src/midend/programAnalysis/CallGraphAnalysis/newCallGraph.h
+++ b/src/midend/programAnalysis/CallGraphAnalysis/newCallGraph.h
@@ -38,7 +38,8 @@ public:
   std::map<std::string, CallGraphEdgeInfo *> edgeMap;
 
   CallGraph();
-  void visit(SgNode *astNode);
+  ~CallGraph() override;
+  void visit(SgNode *astNode) override;
 };
 
 class CallGraphFileStructure {

--- a/src/midend/programAnalysis/defUseAnalysis/DefUseAnalysis.cpp
+++ b/src/midend/programAnalysis/defUseAnalysis/DefUseAnalysis.cpp
@@ -461,7 +461,7 @@ bool DefUseAnalysis::start_traversal_of_functions() {
   // Traverse through each FunctionDefinition and check for DefUse
   Rose_STL_Container<SgNode *> functions =
       NodeQuery::querySubTree(project, V_SgFunctionDefinition);
-  DefUseAnalysisPF *defuse_perfunc = new DefUseAnalysisPF(DEBUG_MODE, this);
+  DefUseAnalysisPF defuse_perfunc(DEBUG_MODE, this);
   bool abortme = false;
   for (Rose_STL_Container<SgNode *>::const_iterator i = functions.begin();
        i != functions.end(); ++i) {
@@ -469,16 +469,13 @@ bool DefUseAnalysis::start_traversal_of_functions() {
     if (DEBUG_MODE)
       cout << "\t function Def@" << proc->get_file_info()->get_filename() << ":"
            << proc->get_file_info()->get_line() << endl;
-    FilteredCFGNode<IsDFAFilter> rem_source =
-        defuse_perfunc->run(proc, abortme);
-    nrOfNodesVisited += defuse_perfunc->getNumberOfNodesVisited();
+    FilteredCFGNode<IsDFAFilter> rem_source = defuse_perfunc.run(proc, abortme);
+    nrOfNodesVisited += defuse_perfunc.getNumberOfNodesVisited();
     // cout << nrOfNodesVisited << " ......... function " <<
     // proc->get_declaration()->get_name().str() << endl;
     if (rem_source.getNode() != NULL)
       dfaFunctions.push_back(rem_source);
   }
-  delete defuse_perfunc;
-
   if (DEBUG_MODE) {
     dfaToDOT();
   }
@@ -496,14 +493,14 @@ int DefUseAnalysis::start_traversal_of_one_function(
 
   nrOfNodesVisited = 0;
   bool abortme = false;
-  DefUseAnalysisPF *defuse_perfunc = new DefUseAnalysisPF(false, this);
+  DefUseAnalysisPF defuse_perfunc(false, this);
 
   // DQ (12/10/2016): Eliminating a warning that we want to be an error:
   // -Werror=unused-but-set-variable. FilteredCFGNode <IsDFAFilter> rem_source =
   // defuse_perfunc->run(proc,abortme);
-  defuse_perfunc->run(proc, abortme);
+  defuse_perfunc.run(proc, abortme);
 
-  nrOfNodesVisited = defuse_perfunc->getNumberOfNodesVisited();
+  nrOfNodesVisited = defuse_perfunc.getNumberOfNodesVisited();
 
   // cout << " nodes visited: " << nrOfNodesVisited << " ......... function " <<
   // proc->get_declaration()->get_name().str() << endl;
@@ -539,6 +536,8 @@ int DefUseAnalysis::run() {
   ROSE_ASSERT(project != NULL);
 
   table.clear();
+  usetable.clear();
+  globalVarList.clear();
   vizzhelp.clear();
 
   clock_t start = clock();

--- a/src/midend/programAnalysis/defUseAnalysis/runTest.cpp
+++ b/src/midend/programAnalysis/defUseAnalysis/runTest.cpp
@@ -7,6 +7,7 @@
 #include "DefUseAnalysis.h"
 
 #include <iostream>
+#include <memory>
 
 #include <string>
 using namespace std;
@@ -20,7 +21,7 @@ void testOneFunction(std::string funcParamName, int argc, char *argv[],
   // Build the AST used by ROSE
   SgProject *project = frontend(argc, argv);
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   int val = defuse->run(debug);
   if (debug)
     std::cout << "Analysis run is : " << (val ? "success" : "failure")
@@ -154,7 +155,7 @@ void runCurrentFile(int argc, char *argv[]) {
     std::cout << ">>>> start def-use analysis ... " << endl;
 
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   bool debug = false;
   int val = defuse->run(debug);
   if (debug)

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/DependenceGraph.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/DependenceGraph.C
@@ -53,6 +53,19 @@ const char *DependenceGraph::getEdgeName(EdgeType type) {
   }
 }
 
+DependenceGraph::~DependenceGraph() {
+  edgeTypeMap.clear();
+  edgeMap.clear();
+  sgNodeToDepNodeMap.clear();
+  nodeTypeToDepNodeMapMap.clear();
+
+  std::set<SimpleDirectedGraphNode *> nodes;
+  nodes.swap(_nodes);
+  for (SimpleDirectedGraphNode *node : nodes) {
+    delete node;
+  }
+}
+
 /*
 DependenceNode *DependenceGraph::createNode(DependenceNode * node)
 {

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/DependenceGraph.h
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/DependenceGraph.h
@@ -450,7 +450,7 @@ protected:
 
 public:
   DependenceGraph() { debugme = false; }
-  virtual ~DependenceGraph() {};
+  virtual ~DependenceGraph();
   void debugCoutNodeList() {
     std::set<SimpleDirectedGraphNode *>::iterator i;
     for (i = _nodes.begin(); i != _nodes.end(); i++) {
@@ -978,7 +978,7 @@ public:
 
      This simply does a backwards reachability across all edges to produce
      the slice. */
-  virtual std::set<DependenceNode *> getSlice(DependenceNode *node);
+  std::set<DependenceNode *> getSlice(DependenceNode *node) override;
 
 private:
   //! completes the FDG using the interprocedural-information
@@ -1034,6 +1034,7 @@ public:
       libraryExtenders.push_back(le);
   }
   SystemDependenceGraph() { debug = false; }
+  ~SystemDependenceGraph() override;
   SgNode *getMainFunction();
   void createSafeConfiguration(SgFunctionDeclaration *fDef);
   bool isKnownLibraryFunction(SgFunctionDeclaration *fDec);
@@ -1096,7 +1097,7 @@ public:
      nodes while not traversing call edges. Thus it ignores calling
      functions. The final set of reachable nodes is the interprocedural
      slice. */
-  virtual std::set<DependenceNode *> getSlice(DependenceNode *node);
+  std::set<DependenceNode *> getSlice(DependenceNode *node) override;
 
   /* ! \brief retrieve the PDGs in the graph
 

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/EDefUse.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/EDefUse.C
@@ -10,6 +10,8 @@
 using namespace std;
 EDefUse::EDefUse(SgProject *proj) { internalDefUse = new DefUseAnalysis(proj); }
 
+EDefUse::~EDefUse() { delete internalDefUse; }
+
 int EDefUse::run(bool debug) {
   internalDefUse->run(debug);
   return 0; // JJW 10-17-2007 does not appear to ever be used

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/EDefUse.h
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/EDefUse.h
@@ -10,6 +10,7 @@
 class EDefUse {
 public:
   EDefUse(SgProject *proj);
+  ~EDefUse();
 
 protected:
   DefUseAnalysis *internalDefUse;

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/NEW_EDefUse.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/NEW_EDefUse.C
@@ -10,6 +10,8 @@
 using namespace std;
 EDefUse::EDefUse(SgProject *proj) { internalDefUse = new DefUseAnalysis(proj); }
 
+EDefUse::~EDefUse() { delete internalDefUse; }
+
 void EDefUse::printDefUse() {
 
   cout << "defs:\n";

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/NEW_EDefUse.h
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/NEW_EDefUse.h
@@ -10,6 +10,7 @@
 class EDefUse {
 public:
   EDefUse(SgProject *proj);
+  ~EDefUse();
 
 protected:
   DefUseAnalysis *internalDefUse;

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/SystemDependenceGraph.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/SystemDependenceGraph.C
@@ -9,9 +9,25 @@
 #include <list>
 
 #include <map>
+
+#include <memory>
 using namespace std;
 
 #include <assert.h>
+
+SystemDependenceGraph::~SystemDependenceGraph() {
+  std::set<InterproceduralInfo *> owned(interproceduralInformationList.begin(),
+                                        interproceduralInformationList.end());
+  for (auto &entry : interproceduralInformation) {
+    owned.insert(entry.second);
+  }
+  interproceduralInformationList.clear();
+  interproceduralInformation.clear();
+
+  for (InterproceduralInfo *info : owned) {
+    delete info;
+  }
+}
 
 bool SystemDependenceGraph::isKnownLibraryFunction(
     SgFunctionDeclaration *fDec) {
@@ -108,7 +124,7 @@ void SystemDependenceGraph::createSafeConfiguration(
 void SystemDependenceGraph::parseProject(SgProject *project) {
 #ifdef NEWDU
   // Create the global def-use analysis
-  EDefUse *defUseAnalysis = new EDefUse(project);
+  std::unique_ptr<EDefUse> defUseAnalysis(new EDefUse(project));
   if (defUseAnalysis->run(false) == 1) {
     std::cerr << "SystemDependenceGraph :: DFAnalysis failed!  -- "
                  "defUseAnalysis->run(false)==0"
@@ -129,17 +145,14 @@ void SystemDependenceGraph::parseProject(SgProject *project) {
       NodeQuery::querySubTree(project, V_SgFunctionDeclaration);
   for (Rose_STL_Container<SgNode *>::iterator i = functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    ControlDependenceGraph *cdg;
-    DataDependenceGraph *ddg;
-    InterproceduralInfo *ipi;
     SgFunctionDeclaration *fDec = isSgFunctionDeclaration(*i);
 
     ROSE_ASSERT(fDec != NULL);
     if (fDec->get_definition() == NULL) {
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
       // create "Safe"-Configurations
       ipi->addExitNode(fDec);
-      addInterproceduralInformation(ipi);
+      addInterproceduralInformation(ipi.get());
       ipi->addExitNode(fDec);
       //>addInterproceduralInformation(ipi);
       if (isKnownLibraryFunction(fDec)) {
@@ -147,31 +160,35 @@ void SystemDependenceGraph::parseProject(SgProject *project) {
       } else {
         createSafeConfiguration(fDec);
       }
+      ipi.release();
       // This is somewhat a waste of memory and a more efficient approach might
       // generate this when needed, but at the momenent everything is created...
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get control dependence for this function defintion
-      cdg = new ControlDependenceGraph(fDec->get_definition(), ipi);
+      std::unique_ptr<ControlDependenceGraph> cdg(
+          new ControlDependenceGraph(fDec->get_definition(), ipi.get()));
       cdg->computeAdditionalFunctioncallDepencencies();
-      cdg->computeInterproceduralInformation(ipi);
+      cdg->computeInterproceduralInformation(ipi.get());
 
 // get the data dependence for this function
 #ifdef NEWDU
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(new DataDependenceGraph(
+          fDec->get_definition(), defUseAnalysis.get(), ipi.get()));
 #else
-      ddg = new DataDependenceGraph(fDec->get_definition(), ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(
+          new DataDependenceGraph(fDec->get_definition(), ipi.get()));
 #endif
       cdg->computeAdditionalFunctioncallDepencencies();
-      ddg->computeInterproceduralInformation(ipi);
+      ddg->computeInterproceduralInformation(ipi.get());
 
-      addFunction(cdg, ddg);
-      addInterproceduralInformation(ipi);
+      addFunction(cdg.get(), ddg.get());
+      addInterproceduralInformation(ipi.get());
+      ipi.release();
     }
     // else if (fD->get_definition() == NULL)
   }

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/newDU.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/newDU.C
@@ -28,6 +28,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -247,7 +249,7 @@ int main(int argc, char *argv[]) {
 
   SgProject *project = frontend(argc, argv);
   // Create the global def-use analysis
-  DFAnalysis *defUseAnalysis = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defUseAnalysis(new DefUseAnalysis(project));
   if (defUseAnalysis->run(false) == 1) {
     std::cerr << "newDU:: DFAnalysis failed!  defUseAnalysis->run()==0" << endl;
     exit(0);
@@ -277,7 +279,7 @@ int main(int argc, char *argv[]) {
     } else {
       cout << "--------------------------------------------------------------"
            << endl;
-      analyseFunction(fD->get_definition(), defUseAnalysis);
+      analyseFunction(fD->get_definition(), defUseAnalysis.get());
     }
   }
   return 0;

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/testDDG.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/testDDG.C
@@ -26,6 +26,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
   SgProject *project = frontend(argc, argv);
 #ifdef NEWDU
   // Create the global def-use analysis
-  DFAnalysis *defUseAnalysis = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defUseAnalysis(new DefUseAnalysis(project));
   if (defUseAnalysis->run(false) == 1) {
     std::cerr << "testDDG:: DFAnalysis failed! -- defUseAnalysis->run(false)==0"
               << endl;
@@ -75,7 +77,7 @@ int main(int argc, char *argv[]) {
 
       // get the data dependence for this function
 #ifdef NEWDU
-      ddg = new DataDependenceGraph(fD->get_definition(), defUseAnalysis);
+      ddg = new DataDependenceGraph(fD->get_definition(), defUseAnalysis.get());
 #else
       ddg = new DataDependenceGraph(fD->get_definition());
 #endif

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/testSDG.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/testSDG.C
@@ -26,6 +26,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -39,7 +41,7 @@ int main(int argc, char *argv[]) {
   std::vector<InterproceduralInfo *> ip;
 #ifdef NEWDU
   // Create the global def-use analysis
-  DFAnalysis *defUseAnalysis = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defUseAnalysis(new DefUseAnalysis(project));
   if (defUseAnalysis->run(false) == 1) {
     std::cerr
         << "testSDG:: DFAnalysis failed!  -- (defUseAnalysis->run(false)==0"
@@ -102,8 +104,8 @@ int main(int argc, char *argv[]) {
 
 // get the data dependence for this function
 #ifdef NEWDU
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      ddg = new DataDependenceGraph(fDec->get_definition(),
+                                    defUseAnalysis.get(), ipi);
 #else
       ddg = new DataDependenceGraph(fDec->get_definition(), ipi);
 #endif

--- a/src/midend/programAnalysis/staticInterproceduralSlicing/testSlicing.C
+++ b/src/midend/programAnalysis/staticInterproceduralSlicing/testSlicing.C
@@ -25,6 +25,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
   std::vector<InterproceduralInfo *> ip;
 #ifdef NEWDU
   // Create the global def-use analysis
-  DFAnalysis *defUseAnalysis = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defUseAnalysis(new DefUseAnalysis(project));
   if (defUseAnalysis->run(false) == 1) {
     std::cerr
         << "testSlicing:: DFAnalysis failed!  -- defUseAnalysis->run()==false"
@@ -101,8 +103,8 @@ int main(int argc, char *argv[]) {
 
 // get the data dependence for this function
 #ifdef NEWDU
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      ddg = new DataDependenceGraph(fDec->get_definition(),
+                                    defUseAnalysis.get(), ipi);
 #else
       ddg = new DataDependenceGraph(fDec->get_definition(), ipi);
 #endif

--- a/src/midend/programTransformation/astOutlining/ASTtools.hh
+++ b/src/midend/programTransformation/astOutlining/ASTtools.hh
@@ -25,8 +25,14 @@
 #include <string>
 
 namespace ASTtools {
+//! Stable ordering for variable symbols used by outlining/lowering interfaces.
+struct ROSE_DLL_API VarSymLess {
+  bool operator()(const SgVariableSymbol *lhs,
+                  const SgVariableSymbol *rhs) const;
+};
+
 //! Stores a collection of SgVariableSymbols (var syms).
-typedef std::set<const SgVariableSymbol *> VarSymSet_t;
+typedef std::set<const SgVariableSymbol *, VarSymLess> VarSymSet_t;
 
 //! Search for the first surrounding scope that may contain a function def.
 ROSE_DLL_API const SgScopeStatement *

--- a/src/midend/programTransformation/astOutlining/Case.cc
+++ b/src/midend/programTransformation/astOutlining/Case.cc
@@ -37,6 +37,12 @@ CPreproc::If::Case::Case(PreprocessingInfo *info, SgLocatedNode *node,
 CPreproc::If::Case::Case(const Case &c)
     : info_(c.info_), node_(c.node_), parent_(c.parent_), kids_(c.kids_) {}
 
+CPreproc::If::Case::~Case(void) {
+  for (If *child : kids_) {
+    delete child;
+  }
+}
+
 // ========================================================================
 
 bool CPreproc::If::Case::isIf(void) const {

--- a/src/midend/programTransformation/astOutlining/CollectVars.cc
+++ b/src/midend/programTransformation/astOutlining/CollectVars.cc
@@ -89,7 +89,7 @@ void Outliner::collectVars(
   // variable references to non-local-declared variables
   ASTtools::VarSymSet_t diff_U_L;
   set_difference(U.begin(), U.end(), L.begin(), L.end(),
-                 inserter(diff_U_L, diff_U_L.begin()));
+                 inserter(diff_U_L, diff_U_L.begin()), ASTtools::VarSymLess());
   dump(diff_U_L, "U - L = ");
 
   // if the outlined function is put into a separated file

--- a/src/midend/programTransformation/astOutlining/GenerateFunc.cc
+++ b/src/midend/programTransformation/astOutlining/GenerateFunc.cc
@@ -401,6 +401,7 @@ createTemplateFuncSkeleton(const string &name, SgType *ret_type,
   SgTemplateFunctionDeclaration *nondef =
       SageBuilder::buildNondefiningTemplateFunctionDeclaration(
           name, ret_type, nondef_params, scope, template_params_copy);
+  delete template_params_copy;
   ROSE_ASSERT(nondef != NULL);
   setTemplateParameterParents(nondef);
 
@@ -1773,7 +1774,11 @@ static void remapVarSyms(
             new std::map<SgInitializedName *, SgExpression *>();
       std::map<SgInitializedName *, SgExpression *> *name_mapping =
           clause_variable_renaming_record[directive];
-      (*name_mapping)[ref_orig->get_symbol()->get_declaration()] = deref_exp;
+      SgExpression *&mapped_expression =
+          (*name_mapping)[ref_orig->get_symbol()->get_declaration()];
+      if (mapped_expression != NULL && mapped_expression != deref_exp)
+        SageInterface::deepDelete(mapped_expression);
+      mapped_expression = deref_exp;
       return;
     }
 

--- a/src/midend/programTransformation/astOutlining/If.hh
+++ b/src/midend/programTransformation/astOutlining/If.hh
@@ -78,6 +78,7 @@ public:
   public:
     Case(PreprocessingInfo *, SgLocatedNode *, If * = 0);
     Case(const Case &);
+    ~Case();
 
     void dump(size_t level = 0);
     //! Returns 'true' if this case is a '#if'.

--- a/src/midend/programTransformation/astOutlining/Insert.cc
+++ b/src/midend/programTransformation/astOutlining/Insert.cc
@@ -263,6 +263,7 @@ generatePrototype(const SgFunctionDeclaration *full_decl,
         SageBuilder::buildNondefiningTemplateFunctionDeclaration(
             template_decl->get_name(), return_type, paralist, scope,
             template_params);
+    delete template_params;
     ROSE_ASSERT(proto != NULL);
     for (SgTemplateParameterPtrList::iterator it =
              proto->get_templateParameters().begin();

--- a/src/midend/programTransformation/astOutlining/PreprocIfs.cc
+++ b/src/midend/programTransformation/astOutlining/PreprocIfs.cc
@@ -54,11 +54,29 @@ using namespace std;
 
 // =====================================================================
 
+namespace {
+class IfsOwner {
+public:
+  explicit IfsOwner(CPreproc::Ifs_t &ifs) : ifs_(ifs) {}
+  ~IfsOwner() {
+    for (CPreproc::If *directive : ifs_) {
+      delete directive;
+    }
+  }
+
+private:
+  CPreproc::Ifs_t &ifs_;
+};
+} // namespace
+
+// =====================================================================
+
 SgBasicBlock *Outliner::Preprocess::transformPreprocIfs(SgBasicBlock *b) {
   ROSE_ASSERT(b && b->get_parent());
 
   // Determine the '#if' directive context at 'b'.
   CPreproc::Ifs_t ifs;
+  IfsOwner ifsOwner(ifs);
   CPreproc::If::Case *top = 0;
   CPreproc::If::Case *bottom = 0;
   CPreproc::findIfDirectiveContext(b, ifs, top, bottom);

--- a/src/midend/programTransformation/astOutlining/Transform.cc
+++ b/src/midend/programTransformation/astOutlining/Transform.cc
@@ -413,6 +413,7 @@ static void dedupeIncludeDirectives(SgGlobal *glob_scope) {
       return;
 
     AttachedPreprocessingInfoType filtered;
+    AttachedPreprocessingInfoType removed;
     filtered.reserve(infos->size());
     for (AttachedPreprocessingInfoType::iterator it = infos->begin();
          it != infos->end(); ++it) {
@@ -426,6 +427,7 @@ static void dedupeIncludeDirectives(SgGlobal *glob_scope) {
       if (is_include) {
         std::string key = extractIncludeKey(info->getString());
         if (!key.empty() && seen.count(key) != 0) {
+          removed.push_back(info);
           continue;
         }
         if (!key.empty())
@@ -434,6 +436,9 @@ static void dedupeIncludeDirectives(SgGlobal *glob_scope) {
       filtered.push_back(info);
     }
     infos->swap(filtered);
+    for (PreprocessingInfo *info : removed) {
+      delete info;
+    }
   };
 
   prune_info(glob_scope);

--- a/src/midend/programTransformation/astOutlining/VarSym.cc
+++ b/src/midend/programTransformation/astOutlining/VarSym.cc
@@ -8,6 +8,7 @@
 #include "sage3basic.h"
 
 #include <algorithm>
+#include <functional>
 #include <sstream>
 
 #include "VarSym.hh"
@@ -15,6 +16,235 @@
 // ========================================================================
 
 using namespace std;
+
+// ========================================================================
+
+namespace {
+
+static std::string normalizedSymbolName(const SgName &name) {
+  return Rose::StringUtility::convertToLowerCase(name.getString());
+}
+
+static std::string normalizedSymbolName(const SgVariableSymbol *sym,
+                                        const SgInitializedName *decl) {
+  if (sym != NULL && !sym->get_name().getString().empty())
+    return normalizedSymbolName(sym->get_name());
+  if (decl != NULL)
+    return normalizedSymbolName(decl->get_name());
+  return std::string();
+}
+
+static const SgFunctionDeclaration *
+getDirectParameterOwnerFunctionDeclaration(const SgInitializedName *name) {
+  if (name == NULL)
+    return NULL;
+
+  const SgFunctionParameterList *param_list =
+      isSgFunctionParameterList(name->get_parent());
+  if (param_list == NULL)
+    return NULL;
+
+  return isSgFunctionDeclaration(param_list->get_parent());
+}
+
+static const SgFunctionDeclaration *
+getEnclosingFunctionForSymbolOrder(const SgInitializedName *name) {
+  if (name == NULL)
+    return NULL;
+
+  if (const SgFunctionDeclaration *owner =
+          getDirectParameterOwnerFunctionDeclaration(name))
+    return owner;
+
+  if (SgDeclarationStatement *decl =
+          const_cast<SgDeclarationStatement *>(name->get_declaration())) {
+    if (SgFunctionDeclaration *enclosing =
+            SageInterface::getEnclosingFunctionDeclaration(decl, false))
+      return enclosing;
+  }
+
+  if (SgScopeStatement *scope =
+          const_cast<SgScopeStatement *>(name->get_scope()))
+    return SageInterface::getEnclosingFunctionDeclaration(scope, true);
+
+  return NULL;
+}
+
+static int getFunctionParameterIndex(const SgFunctionDeclaration *function,
+                                     const SgInitializedName *name,
+                                     const std::string &normalized_name) {
+  if (function == NULL || name == NULL)
+    return -1;
+
+  SgFunctionParameterList *params =
+      const_cast<SgFunctionDeclaration *>(function)->get_parameterList();
+  if (params == NULL)
+    return -1;
+
+  SgInitializedNamePtrList &args = params->get_args();
+  for (SgInitializedNamePtrList::size_type i = 0; i < args.size(); ++i) {
+    SgInitializedName *arg = args[i];
+    if (arg == NULL)
+      continue;
+    if (arg == name)
+      return static_cast<int>(i);
+  }
+
+  for (SgInitializedNamePtrList::size_type i = 0; i < args.size(); ++i) {
+    SgInitializedName *arg = args[i];
+    if (arg == NULL)
+      continue;
+    if (normalizedSymbolName(arg->get_name()) == normalized_name)
+      return static_cast<int>(i);
+  }
+
+  return -1;
+}
+
+static int getInitializedNameListIndex(const SgInitializedName *name) {
+  if (name == NULL)
+    return -1;
+
+  if (const SgVariableDeclaration *var_decl =
+          isSgVariableDeclaration(name->get_declaration())) {
+    SgInitializedNamePtrList &vars =
+        const_cast<SgVariableDeclaration *>(var_decl)->get_variables();
+    for (SgInitializedNamePtrList::size_type i = 0; i < vars.size(); ++i) {
+      if (vars[i] == name)
+        return static_cast<int>(i);
+    }
+  }
+
+  if (const SgFunctionParameterList *param_list =
+          isSgFunctionParameterList(name->get_parent())) {
+    SgInitializedNamePtrList &args =
+        const_cast<SgFunctionParameterList *>(param_list)->get_args();
+    for (SgInitializedNamePtrList::size_type i = 0; i < args.size(); ++i) {
+      if (args[i] == name)
+        return static_cast<int>(i);
+    }
+  }
+
+  return -1;
+}
+
+static const Sg_File_Info *
+getBestFileInfoForSymbolOrder(const SgInitializedName *name) {
+  if (name != NULL) {
+    if (const Sg_File_Info *info = name->get_startOfConstruct())
+      return info;
+    if (const Sg_File_Info *info = name->get_file_info())
+      return info;
+    if (const SgDeclarationStatement *decl = name->get_declaration()) {
+      if (const Sg_File_Info *info = decl->get_startOfConstruct())
+        return info;
+      if (const Sg_File_Info *info = decl->get_file_info())
+        return info;
+    }
+  }
+  return NULL;
+}
+
+struct VarSymOrderKey {
+  bool has_parameter_index = false;
+  int parameter_index = -1;
+  bool has_source_position = false;
+  int file_id = -1;
+  int physical_file_id = -1;
+  int line = -1;
+  int column = -1;
+  int declaration_list_index = -1;
+  std::string normalized_name;
+  std::string declaration_kind;
+};
+
+static VarSymOrderKey makeVarSymOrderKey(const SgVariableSymbol *sym) {
+  VarSymOrderKey key;
+  const SgInitializedName *decl = sym != NULL ? sym->get_declaration() : NULL;
+  key.normalized_name = normalizedSymbolName(sym, decl);
+
+  const SgFunctionDeclaration *function =
+      getEnclosingFunctionForSymbolOrder(decl);
+  const int parameter_index =
+      getFunctionParameterIndex(function, decl, key.normalized_name);
+  if (parameter_index >= 0) {
+    key.has_parameter_index = true;
+    key.parameter_index = parameter_index;
+  }
+
+  if (const Sg_File_Info *info = getBestFileInfoForSymbolOrder(decl)) {
+    key.file_id = info->get_file_id();
+    key.physical_file_id = info->get_physical_file_id();
+    key.line = info->get_line();
+    key.column = info->get_col();
+    key.has_source_position = key.line > 0 || key.column > 0 ||
+                              key.file_id >= 0 || key.physical_file_id >= 0;
+  }
+
+  key.declaration_list_index = getInitializedNameListIndex(decl);
+  if (decl != NULL && decl->get_declaration() != NULL)
+    key.declaration_kind = decl->get_declaration()->class_name();
+  return key;
+}
+
+template <typename T> static int compareScalar(const T &lhs, const T &rhs) {
+  if (lhs < rhs)
+    return -1;
+  if (rhs < lhs)
+    return 1;
+  return 0;
+}
+
+static int compareVarSymOrderKey(const VarSymOrderKey &lhs,
+                                 const VarSymOrderKey &rhs) {
+  if (int cmp = compareScalar(lhs.has_parameter_index, rhs.has_parameter_index))
+    return -cmp; // symbols matching formal parameters sort first
+  if (lhs.has_parameter_index) {
+    if (int cmp = compareScalar(lhs.parameter_index, rhs.parameter_index))
+      return cmp;
+  }
+
+  if (int cmp = compareScalar(lhs.has_source_position, rhs.has_source_position))
+    return -cmp; // source-positioned declarations sort before generated ties
+  if (lhs.has_source_position) {
+    if (int cmp = compareScalar(lhs.file_id, rhs.file_id))
+      return cmp;
+    if (int cmp = compareScalar(lhs.physical_file_id, rhs.physical_file_id))
+      return cmp;
+    if (int cmp = compareScalar(lhs.line, rhs.line))
+      return cmp;
+    if (int cmp = compareScalar(lhs.column, rhs.column))
+      return cmp;
+  }
+
+  if (int cmp =
+          compareScalar(lhs.declaration_list_index, rhs.declaration_list_index))
+    return cmp;
+  if (int cmp = compareScalar(lhs.normalized_name, rhs.normalized_name))
+    return cmp;
+  if (int cmp = compareScalar(lhs.declaration_kind, rhs.declaration_kind))
+    return cmp;
+  return 0;
+}
+
+} // namespace
+
+bool ASTtools::VarSymLess::operator()(const SgVariableSymbol *lhs,
+                                      const SgVariableSymbol *rhs) const {
+  if (lhs == rhs)
+    return false;
+  if (lhs == NULL)
+    return rhs != NULL;
+  if (rhs == NULL)
+    return false;
+
+  const VarSymOrderKey lhs_key = makeVarSymOrderKey(lhs);
+  const VarSymOrderKey rhs_key = makeVarSymOrderKey(rhs);
+  if (int cmp = compareVarSymOrderKey(lhs_key, rhs_key))
+    return cmp < 0;
+
+  return std::less<const SgVariableSymbol *>()(lhs, rhs);
+}
 
 // ========================================================================
 

--- a/src/midend/programTransformation/finiteDifferencing/finiteDifferencing.C
+++ b/src/midend/programTransformation/finiteDifferencing/finiteDifferencing.C
@@ -20,6 +20,8 @@
 
 #include <iostream>
 
+#include <memory>
+
 #include <vector>
 
 #include "finiteDifferencing.h"
@@ -776,7 +778,8 @@ void simpleIndexFiniteDifferencing(SgNode *root) {
     proj = proj->get_parent();
   ROSE_ASSERT(proj);
   AstTests::runAllTests(isSgProject(proj));
-  rewrite(getAlgebraicRules(), root); // This might modify root
+  std::unique_ptr<RewriteRule> algebraicRules(getAlgebraicRules());
+  rewrite(algebraicRules.get(), root); // This might modify root
   FdFindFunctionsVisitor ffv;
   ffv.traverse(root, preorder);
   for (unsigned int x = 0; x < ffv.functions.size(); ++x) {
@@ -854,12 +857,15 @@ void simpleIndexFiniteDifferencing(SgNode *root) {
 #endif
       }
     }
+    std::unique_ptr<RewriteRule> finiteDifferencingRules(
+        getFiniteDifferencingRules());
     for (int i = mult_exprs.size() - 1; i >= 0; --i)
       doFiniteDifferencingOne(mult_exprs[i], body,
-                              getFiniteDifferencingRules());
+                              finiteDifferencingRules.get());
 
     SgNode *bodyCopyForRewrite = body;
-    rewrite(getAlgebraicRules(),
+    std::unique_ptr<RewriteRule> bodyAlgebraicRules(getAlgebraicRules());
+    rewrite(bodyAlgebraicRules.get(),
             bodyCopyForRewrite); // This might update bodyCopyForRewrite
     ROSE_ASSERT(isSgBasicBlock(bodyCopyForRewrite));
     body = isSgBasicBlock(bodyCopyForRewrite);

--- a/src/midend/programTransformation/finiteDifferencing/patternRewrite.C
+++ b/src/midend/programTransformation/finiteDifferencing/patternRewrite.C
@@ -16,6 +16,14 @@
 
 using namespace std;
 
+namespace {
+void deletePattern(Pattern *pattern) {
+  if (pattern != nullptr && pattern != p_wildcard) {
+    delete pattern;
+  }
+}
+} // namespace
+
 bool RewriteRuleCombiner::doRewrite(SgNode *&n) const {
   for (vector<RewriteRule *>::const_iterator i = rules.begin();
        i != rules.end(); ++i) {
@@ -26,6 +34,12 @@ bool RewriteRuleCombiner::doRewrite(SgNode *&n) const {
     }
   }
   return false;
+}
+
+RewriteRuleCombiner::~RewriteRuleCombiner() {
+  for (RewriteRule *rule : rules) {
+    delete rule;
+  }
 }
 
 class DoRewriteRuleDeepVisitor : public AstSimpleProcessing {
@@ -114,6 +128,11 @@ bool PatternActionRule::doRewrite(SgNode *&n) const {
     return false;
 }
 
+PatternActionRule::~PatternActionRule() {
+  deletePattern(pattern);
+  deletePattern(action);
+}
+
 PatternActionRule *patact(Pattern *pattern, Pattern *action) {
   return new PatternActionRule(pattern, action);
 }
@@ -123,6 +142,8 @@ template <class Operator> class UnaryPattern : public Pattern {
 
 public:
   UnaryPattern(Pattern *rhs) : rhs(rhs) {}
+
+  ~UnaryPattern() { deletePattern(rhs); }
 
   virtual bool match(SgNode *top, PatternVariables &vars) const {
     if (dynamic_cast<Operator *>(top)) {
@@ -148,6 +169,11 @@ template <class Operator> class BinaryPattern : public Pattern {
 
 public:
   BinaryPattern(Pattern *lhs, Pattern *rhs) : lhs(lhs), rhs(rhs) {}
+
+  ~BinaryPattern() {
+    deletePattern(lhs);
+    deletePattern(rhs);
+  }
 
   virtual bool match(SgNode *top, PatternVariables &vars) const {
     if (dynamic_cast<Operator *>(top)) {

--- a/src/midend/programTransformation/finiteDifferencing/patternRewrite.h
+++ b/src/midend/programTransformation/finiteDifferencing/patternRewrite.h
@@ -38,7 +38,7 @@ public:
   virtual bool doRewrite(SgNode *&n) const;
 
   // DQ (12/16/2006): Added destructor to eliminate g++ compiler warning.
-  virtual ~RewriteRuleCombiner() {}
+  virtual ~RewriteRuleCombiner();
 };
 
 //! Rewrite a node and its children recursively using a rule.  Iterate until no
@@ -70,7 +70,7 @@ public:
 
   virtual bool doRewrite(SgNode *&n) const;
   // Liao (2/7/2008): Added destructor to eliminate g++ compiler warning.
-  virtual ~PatternActionRule() {}
+  virtual ~PatternActionRule();
 };
 
 //! Create a PatternActionRule

--- a/src/midend/programTransformation/functionCallNormalization/FunctionNormalization.C
+++ b/src/midend/programTransformation/functionCallNormalization/FunctionNormalization.C
@@ -513,6 +513,10 @@ void FunctionCallNormalization::visit(SgNode *astNode) {
       } else
         replaceFunctionCallsInExpression(stm, fct2Var);
     }
+
+    for (Declaration *declaration : declarations) {
+      delete declaration;
+    }
   } // end if isSgStatement block
 }
 

--- a/src/midend/programTransformation/implicitCodeGeneration/destructorCallAnnotator.C
+++ b/src/midend/programTransformation/implicitCodeGeneration/destructorCallAnnotator.C
@@ -267,6 +267,10 @@ public:
 
 template <typename T> struct GenericAttr : AstAttribute {
   T attr;
+
+  OwnershipPolicy getOwnershipPolicy() const override {
+    return CONTAINER_OWNERSHIP;
+  }
 };
 
 template <typename T>
@@ -327,6 +331,21 @@ public:
     }
     // cout << "Node " << node << endl;
     // cout << "ObjectsAllocated are " << ObjectsAllocated(node) << endl;
+  }
+};
+
+class AttributeCleanup : public AstSimpleProcessing {
+public:
+  void visit(SgNode *node) {
+    if (node->attributeExists("ObjectsAllocated")) {
+      node->removeAttribute("ObjectsAllocated");
+    }
+    if (node->attributeExists("AuxObjectsAllocated")) {
+      node->removeAttribute("AuxObjectsAllocated");
+    }
+    if (node->attributeExists("Temporaries")) {
+      node->removeAttribute("Temporaries");
+    }
   }
 };
 
@@ -644,5 +663,8 @@ void destructorCallAnnotator(SgProject *prj) {
 
     Transformer t;
     t.traverse(isSgFunctionDefinition(*i)->get_body(), postorder);
+
+    AttributeCleanup cleanup;
+    cleanup.traverse(isSgFunctionDefinition(*i)->get_body(), preorder);
   }
 }

--- a/src/midend/programTransformation/ompLowering/omp_lowering.cpp
+++ b/src/midend/programTransformation/ompLowering/omp_lowering.cpp
@@ -20,6 +20,7 @@
 #include <filesystem>
 #include <limits>
 #include <sstream>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std;
@@ -262,6 +263,146 @@ bool sourcePositionAfter(const Sg_File_Info *lhs, const Sg_File_Info *rhs) {
     return lhs->get_line() > rhs->get_line();
   }
   return lhs->get_col() > rhs->get_col();
+}
+
+bool isUsableLoweringOrderPosition(const Sg_File_Info *info) {
+  return info != nullptr && info->get_line() > 0 && !info->isTransformation() &&
+         !info->isCompilerGenerated() &&
+         !info->isSourcePositionUnavailableInFrontend();
+}
+
+bool loweringOrderPositionLess(const Sg_File_Info *lhs,
+                               const Sg_File_Info *rhs) {
+  ROSE_ASSERT(lhs != nullptr);
+  ROSE_ASSERT(rhs != nullptr);
+  if (lhs->get_file_id() != rhs->get_file_id()) {
+    return lhs->get_file_id() < rhs->get_file_id();
+  }
+  if (lhs->get_physical_file_id() != rhs->get_physical_file_id()) {
+    return lhs->get_physical_file_id() < rhs->get_physical_file_id();
+  }
+  if (lhs->get_line() != rhs->get_line()) {
+    return lhs->get_line() < rhs->get_line();
+  }
+  return lhs->get_col() < rhs->get_col();
+}
+
+const Sg_File_Info *getBestLoweringOrderPosition(SgNode *root) {
+  if (root == nullptr) {
+    return nullptr;
+  }
+
+  const Sg_File_Info *best = nullptr;
+  Rose_STL_Container<SgNode *> located_nodes =
+      NodeQuery::querySubTree(root, V_SgLocatedNode);
+  for (SgNode *node : located_nodes) {
+    if (isSgOmpExecStatement(node) != nullptr ||
+        isSgOmpClause(node) != nullptr) {
+      continue;
+    }
+    SgLocatedNode *located = isSgLocatedNode(node);
+    if (located == nullptr) {
+      continue;
+    }
+    const Sg_File_Info *candidates[] = {located->get_startOfConstruct(),
+                                        located->get_file_info()};
+    for (const Sg_File_Info *info : candidates) {
+      if (!isUsableLoweringOrderPosition(info)) {
+        continue;
+      }
+      if (best == nullptr || loweringOrderPositionLess(info, best)) {
+        best = info;
+      }
+    }
+  }
+  return best;
+}
+
+std::string getLoweringOrderFunctionKey(SgNode *node) {
+  const SgFunctionDeclaration *function_decl =
+      getEnclosingFunctionDeclaration(node);
+  if (function_decl == nullptr) {
+    return std::string();
+  }
+
+  std::ostringstream key;
+  if (const Sg_File_Info *info = function_decl->get_startOfConstruct()) {
+    key << info->get_file_id() << ':' << info->get_physical_file_id() << ':'
+        << info->get_line() << ':' << info->get_col() << ':';
+  }
+  key << function_decl->get_name().getString();
+  return key.str();
+}
+
+std::vector<size_t> getLoweringOrderStructuralPath(SgNode *node) {
+  std::vector<size_t> reversed_path;
+  SgNode *current = node;
+  while (current != nullptr && !isSgSourceFile(current) &&
+         !isSgFunctionDefinition(current)) {
+    SgNode *parent = current->get_parent();
+    if (parent == nullptr) {
+      break;
+    }
+
+    size_t index = std::numeric_limits<size_t>::max();
+    SgNodePtrList siblings = parent->get_traversalSuccessorContainer();
+    for (size_t i = 0; i < siblings.size(); ++i) {
+      if (siblings[i] == current) {
+        index = i;
+        break;
+      }
+    }
+    reversed_path.push_back(index);
+    current = parent;
+  }
+
+  std::reverse(reversed_path.begin(), reversed_path.end());
+  return reversed_path;
+}
+
+void sortOpenMpRootsForLowering(Rose_STL_Container<SgNode *> &omp_nodes) {
+  std::unordered_map<SgNode *, const Sg_File_Info *> order_positions;
+  std::unordered_map<SgNode *, std::string> function_keys;
+  std::unordered_map<SgNode *, std::vector<size_t>> structural_paths;
+  for (SgNode *node : omp_nodes) {
+    order_positions[node] = getBestLoweringOrderPosition(node);
+    function_keys[node] = getLoweringOrderFunctionKey(node);
+    structural_paths[node] = getLoweringOrderStructuralPath(node);
+  }
+
+  std::stable_sort(omp_nodes.begin(), omp_nodes.end(),
+                   [&order_positions, &function_keys,
+                    &structural_paths](SgNode *lhs, SgNode *rhs) {
+                     const Sg_File_Info *lhs_info = order_positions[lhs];
+                     const Sg_File_Info *rhs_info = order_positions[rhs];
+                     if (lhs_info != nullptr || rhs_info != nullptr) {
+                       if (lhs_info == nullptr || rhs_info == nullptr) {
+                         return lhs_info != nullptr && rhs_info == nullptr;
+                       }
+                       if (loweringOrderPositionLess(lhs_info, rhs_info)) {
+                         return true;
+                       }
+                       if (loweringOrderPositionLess(rhs_info, lhs_info)) {
+                         return false;
+                       }
+                     }
+
+                     const std::string &lhs_function = function_keys[lhs];
+                     const std::string &rhs_function = function_keys[rhs];
+                     if (lhs_function != rhs_function) {
+                       return lhs_function < rhs_function;
+                     }
+
+                     const std::vector<size_t> &lhs_path =
+                         structural_paths[lhs];
+                     const std::vector<size_t> &rhs_path =
+                         structural_paths[rhs];
+                     if (lhs_path != rhs_path) {
+                       return lhs_path < rhs_path;
+                     }
+
+                     return lhs->sage_class_name() < rhs->sage_class_name();
+                   });
 }
 
 SgStatement *findNextOriginalStatementInScope(SgStatement *target) {
@@ -3133,16 +3274,22 @@ static void removeOpenMPDirectivePreprocessingInfo(SgNode *root) {
   if (root == nullptr)
     return;
 
-  auto filter_attached = [](AttachedPreprocessingInfoType *attached) {
-    if (attached == nullptr)
-      return;
-    attached->erase(std::remove_if(attached->begin(), attached->end(),
-                                   [](PreprocessingInfo *info) {
-                                     return isOpenMPDirectivePreprocessingInfo(
-                                         info);
-                                   }),
-                    attached->end());
-  };
+  std::unordered_set<PreprocessingInfo *> removed_infos;
+  auto filter_attached =
+      [&removed_infos](AttachedPreprocessingInfoType *attached) {
+        if (attached == nullptr)
+          return;
+        for (AttachedPreprocessingInfoType::iterator it = attached->begin();
+             it != attached->end();) {
+          PreprocessingInfo *info = *it;
+          if (isOpenMPDirectivePreprocessingInfo(info)) {
+            removed_infos.insert(info);
+            it = attached->erase(it);
+          } else {
+            ++it;
+          }
+        }
+      };
 
   if (SgLocatedNode *located_root = isSgLocatedNode(root))
     filter_attached(located_root->getAttachedPreprocessingInfo());
@@ -3154,20 +3301,37 @@ static void removeOpenMPDirectivePreprocessingInfo(SgNode *root) {
     if (SgLocatedNode *located = isSgLocatedNode(*it))
       filter_attached(located->getAttachedPreprocessingInfo());
   }
+
+  for (PreprocessingInfo *info : removed_infos) {
+    delete info;
+  }
+}
+
+static void
+deletePreprocessingInfos(const std::unordered_set<PreprocessingInfo *> &infos) {
+  for (PreprocessingInfo *info : infos) {
+    delete info;
+  }
 }
 
 void stripConditionalDirectivesFromList(AttachedPreprocessingInfoType &list) {
   AttachedPreprocessingInfoType filtered;
+  std::unordered_set<PreprocessingInfo *> removed_infos;
   filtered.reserve(list.size());
   for (AttachedPreprocessingInfoType::const_iterator it = list.begin();
        it != list.end(); ++it) {
     PreprocessingInfo *info = *it;
-    if (info == nullptr || isConditionalPreprocessingDirective(info)) {
+    if (info == nullptr) {
+      continue;
+    }
+    if (isConditionalPreprocessingDirective(info)) {
+      removed_infos.insert(info);
       continue;
     }
     filtered.push_back(info);
   }
   list.swap(filtered);
+  deletePreprocessingInfos(removed_infos);
 }
 
 void stripConditionalDirectivesFromNode(SgLocatedNode *node) {
@@ -3177,16 +3341,22 @@ void stripConditionalDirectivesFromNode(SgLocatedNode *node) {
   if (AttachedPreprocessingInfoType *attached =
           node->getAttachedPreprocessingInfo()) {
     AttachedPreprocessingInfoType filtered;
+    std::unordered_set<PreprocessingInfo *> removed_infos;
     filtered.reserve(attached->size());
     for (AttachedPreprocessingInfoType::const_iterator it = attached->begin();
          it != attached->end(); ++it) {
       PreprocessingInfo *info = *it;
-      if (info == nullptr || isConditionalPreprocessingDirective(info)) {
+      if (info == nullptr) {
+        continue;
+      }
+      if (isConditionalPreprocessingDirective(info)) {
+        removed_infos.insert(info);
         continue;
       }
       filtered.push_back(info);
     }
     attached->swap(filtered);
+    deletePreprocessingInfos(removed_infos);
   }
 }
 
@@ -3372,15 +3542,28 @@ void removeUnbalancedConditionalDirectives(SgNode *root) {
     return;
   }
 
+  std::unordered_set<PreprocessingInfo *> removed_infos;
+  auto remove_from_attached =
+      [&to_remove, &removed_infos](AttachedPreprocessingInfoType *attached) {
+        if (attached == nullptr) {
+          return;
+        }
+        for (AttachedPreprocessingInfoType::iterator it = attached->begin();
+             it != attached->end();) {
+          PreprocessingInfo *info = *it;
+          if (to_remove.count(info) != 0) {
+            if (info != nullptr) {
+              removed_infos.insert(info);
+            }
+            it = attached->erase(it);
+          } else {
+            ++it;
+          }
+        }
+      };
+
   if (SgLocatedNode *located_root = isSgLocatedNode(root)) {
-    if (AttachedPreprocessingInfoType *attached =
-            located_root->getAttachedPreprocessingInfo()) {
-      attached->erase(std::remove_if(attached->begin(), attached->end(),
-                                     [&](PreprocessingInfo *info) {
-                                       return to_remove.count(info) != 0;
-                                     }),
-                      attached->end());
-    }
+    remove_from_attached(located_root->getAttachedPreprocessingInfo());
   }
 
   Rose_STL_Container<SgNode *> located_nodes =
@@ -3391,17 +3574,10 @@ void removeUnbalancedConditionalDirectives(SgNode *root) {
     if (located == nullptr) {
       continue;
     }
-    AttachedPreprocessingInfoType *attached =
-        located->getAttachedPreprocessingInfo();
-    if (attached == nullptr) {
-      continue;
-    }
-    attached->erase(std::remove_if(attached->begin(), attached->end(),
-                                   [&](PreprocessingInfo *info) {
-                                     return to_remove.count(info) != 0;
-                                   }),
-                    attached->end());
+    remove_from_attached(located->getAttachedPreprocessingInfo());
   }
+
+  deletePreprocessingInfos(removed_infos);
 }
 
 bool declarationsMatch(const SgVariableSymbol *lhs_sym,
@@ -3914,6 +4090,29 @@ static int computeMaxNestedForDepth(SgNode *node) {
 
 std::map<SgOmpExecStatement *, std::map<SgInitializedName *, SgExpression *> *>
     clause_variable_renaming_record;
+
+static void clearClauseVariableRenamingRecord() {
+  for (std::map<SgOmpExecStatement *,
+                std::map<SgInitializedName *, SgExpression *> *>::iterator it =
+           clause_variable_renaming_record.begin();
+       it != clause_variable_renaming_record.end(); ++it) {
+    std::map<SgInitializedName *, SgExpression *> *name_mapping = it->second;
+    if (name_mapping == NULL)
+      continue;
+
+    for (std::map<SgInitializedName *, SgExpression *>::iterator expr_it =
+             name_mapping->begin();
+         expr_it != name_mapping->end(); ++expr_it) {
+      SgExpression *expr = expr_it->second;
+      if (expr == NULL)
+        continue;
+      ROSE_ASSERT(expr->get_parent() == NULL);
+      SageInterface::deepDelete(expr);
+    }
+    delete name_mapping;
+  }
+  clause_variable_renaming_record.clear();
+}
 
 // Liao 1/23/2015
 // when translating mapped variables using
@@ -6482,7 +6681,8 @@ SgFunctionDeclaration *generateOutlinedTask(SgNode *node,
   ASTtools::VarSymSet_t fp_syms, pdSyms2;
   convertAndFilter(fp_vars, fp_syms);
   set_difference(pdSyms.begin(), pdSyms.end(), fp_syms.begin(), fp_syms.end(),
-                 std::inserter(pdSyms2, pdSyms2.begin()));
+                 std::inserter(pdSyms2, pdSyms2.begin()),
+                 ASTtools::VarSymLess());
   //  ROSE_ASSERT (pdSyms.size() == pdSyms2.size());  this means the previous
   //  set_difference is neccesary !
 
@@ -7179,9 +7379,10 @@ rewriteArraySubscripts(SgBasicBlock *body_block,
       continue;
     // TODO: move this logic into a function in SageInterface
     //  If it is a canonical array reference we can handle?
-    vector<SgExpression *> *subscripts = new vector<SgExpression *>;
+    vector<SgExpression *> subscripts;
+    vector<SgExpression *> *subscript_ptr = &subscripts;
     SgExpression *array_name_exp = NULL;
-    isArrayReference(vRef, &array_name_exp, &subscripts);
+    isArrayReference(vRef, &array_name_exp, &subscript_ptr);
     SgInitializedName *a_name = convertRefToInitializedName(array_name_exp);
     if (a_name == NULL)
       continue;
@@ -7199,10 +7400,11 @@ rewriteArraySubscripts(SgBasicBlock *body_block,
            candidate_refs.rbegin();
        riter != candidate_refs.rend(); riter++) {
     SgExpression *arrayNameExp = NULL;
-    std::vector<SgExpression *> *subscripts = new vector<SgExpression *>;
-    bool is_array_ref = isArrayReference(*riter, &arrayNameExp, &subscripts);
+    std::vector<SgExpression *> subscripts;
+    std::vector<SgExpression *> *subscript_ptr = &subscripts;
+    bool is_array_ref = isArrayReference(*riter, &arrayNameExp, &subscript_ptr);
     ROSE_ASSERT(is_array_ref);
-    if ((*subscripts).size() > 1)
+    if (subscripts.size() > 1)
       linearizeArrayAccess(*riter);
   }
 }
@@ -13190,6 +13392,8 @@ void lower_omp(SgSourceFile *file) {
       omp_nodes.push_back(fallback);
     }
 
+    sortOpenMpRootsForLowering(omp_nodes);
+
     for (iter = omp_nodes.begin(); iter != omp_nodes.end(); iter++) {
       SgStatement *node = isSgStatement(*iter);
       ROSE_ASSERT(node != NULL);
@@ -13399,6 +13603,7 @@ void lower_omp(SgSourceFile *file) {
 
   // post processing
   post_processing(file);
+  clearClauseVariableRenamingRecord();
   SageBuilder::symbol_table_case_insensitive_semantics = saved_case_insensitive;
 }
 

--- a/src/midend/programTransformation/ompLowering/omp_lowering.h
+++ b/src/midend/programTransformation/ompLowering/omp_lowering.h
@@ -4,6 +4,7 @@
 #ifndef OMP_LOWERING_H
 #define OMP_LOWERING_H
 
+#include "ASTtools.hh"
 #include "ompSupport.h"
 
 /*!
@@ -150,12 +151,12 @@ mergeSgNodeList(Rose_STL_Container<SgNode *> node_list1,
 //! A helper function to generate implicit or explicit task for either omp
 //! parallel or omp task
 // It calls the ROSE AST outliner internally.
-SgFunctionDeclaration *
-generateOutlinedTask(SgNode *node, std::string &wrapper_name,
-                     std::set<const SgVariableSymbol *> &syms,
-                     std::set<const SgVariableSymbol *> &pdSyms3,
-                     bool use_task_param = false,
-                     bool insert_runtime_ids = true);
+SgFunctionDeclaration *generateOutlinedTask(SgNode *node,
+                                            std::string &wrapper_name,
+                                            ASTtools::VarSymSet_t &syms,
+                                            ASTtools::VarSymSet_t &pdSyms3,
+                                            bool use_task_param = false,
+                                            bool insert_runtime_ids = true);
 
 //! Translate OpenMP variables associated with an OpenMP pragma, such as
 //! private, firstprivate, lastprivate, reduction, etc. bb1 is the translation

--- a/src/midend/programTransformation/partialRedundancyElimination/preControlFlowGraph.C
+++ b/src/midend/programTransformation/partialRedundancyElimination/preControlFlowGraph.C
@@ -9,6 +9,7 @@
 
 #include "sageBuilder.h"
 
+#include <memory>
 #include <sstream>
 
 #include <vector>
@@ -19,6 +20,7 @@ using namespace std;
 
 class CfgConfig : public BuildCFGConfig<int> {
   PRE::ControlFlowGraph &graph;
+  std::vector<std::unique_ptr<PRE::Vertex>> vertices;
 
 public:
   CfgConfig(PRE::ControlFlowGraph &graph) : graph(graph) {}
@@ -27,7 +29,8 @@ public:
     // cerr << "Creating node" << endl;
     PRE::Vertex vertex = graph.graph.add_vertex();
     graph.node_statements.push_back(vector<SgNode *>());
-    return new PRE::Vertex(vertex);
+    vertices.push_back(std::make_unique<PRE::Vertex>(vertex));
+    return vertices.back().get();
   }
 
   virtual void CreateEdge(PRE::Vertex *src, PRE::Vertex *tgt,

--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -24,6 +24,10 @@ set(C_TESTCODES
   gconv_info.c
   math.c
   rex_test2025_embedded_record_decl.c
+  rex_test2026_clang_stmt_expr_valgrind_defined_reads.c
+  rex_test2026_clang_valgrind_defined_reads.c
+  rex_test2026_compound_literal_typeloc_valgrind_defined_reads.c
+  rex_test2026_token_stream_explicit_leading_trailing_output.c
   rose-1391-a.c
   rose-1391-b.c
   stdio.c

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_clang_stmt_expr_valgrind_defined_reads.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_clang_stmt_expr_valgrind_defined_reads.c
@@ -1,0 +1,9 @@
+int rex_stmt_expr_defined_read(int value) {
+  int result = ({
+    int temporary = value + 1;
+    temporary;
+  });
+  return result;
+}
+
+int main(void) { return rex_stmt_expr_defined_read(0) != 1; }

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_clang_valgrind_defined_reads.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_clang_valgrind_defined_reads.c
@@ -1,0 +1,43 @@
+int old_style_sum(a, b)
+int a;
+int b;
+{
+  return a + b;
+}
+
+int switch_on_expression(int x) {
+  switch (x) {
+  case 0:
+    return old_style_sum(1, 2);
+  default:
+    return x;
+  }
+}
+
+int while_with_multi_decl(int limit) {
+  int i = 0, step = 1;
+  while (i < limit) {
+    i += step;
+  }
+  return i;
+}
+
+int inline_enum_decl_group(void) {
+  enum {
+    rex_ast_json_enum_a = 1,
+    rex_ast_json_enum_b = rex_ast_json_enum_a + 1
+  } first,
+      second;
+  first = rex_ast_json_enum_a;
+  second = rex_ast_json_enum_b;
+  return first + second;
+}
+
+int nested_array_subscript_defined_read(int *values, int index) {
+  if (index > 0) {
+    if (values[index] != 0) {
+      return values[index - 1];
+    }
+  }
+  return values[0];
+}

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_compound_literal_typeloc_valgrind_defined_reads.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_compound_literal_typeloc_valgrind_defined_reads.c
@@ -1,0 +1,8 @@
+// Exercises Clang TypeLoc peeling for wrapped compound literal types. The
+// translator must not read undefined Clang TypeLoc padding under Valgrind.
+
+int rex_test2026_compound_literal_typeloc(void) {
+  return ((const struct __attribute__((aligned(32))) { int value; }){.value =
+                                                                         3})
+      .value;
+}

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_token_stream_explicit_leading_trailing_output.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_test2026_token_stream_explicit_leading_trailing_output.c
@@ -1,0 +1,5 @@
+int rex_test2026_token_stream_value = 3;
+
+int rex_test2026_token_stream_add(int input) {
+  return input + rex_test2026_token_stream_value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CXX11_TESTCODES
   test2012_05.C
   test2012_06.C
   test2012_09.C
+  rex_test2026_cxx_std_initializer_list_valgrind_defined_reads.cpp
+  rex_test2026_atomic_expr_valgrind_defined_reads.cpp
+  rex_test2026_function_definition_valgrind_defined_reads.cpp
+  rex_test2026_member_expr_valgrind_defined_reads.cpp
+  rex_test2026_template_qualifier_friend_valgrind_defined_reads.cpp
+  rex_test2026_unresolved_member_valgrind_defined_reads.cpp
   test2012_10.C
   test2012_11.C
   test2012_12.C
@@ -959,7 +965,8 @@ function(assert_cxx11_specimens_exist test_files_var_name)
   file(GLOB _specimens
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.C"
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
   set(_missing_specimens ${${test_files_var_name}})
   list(REMOVE_ITEM _missing_specimens ${_specimens})

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_atomic_expr_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_atomic_expr_valgrind_defined_reads.cpp
@@ -1,0 +1,18 @@
+template <typename T> struct RexAtomicBox {
+  template <typename U> U exchange(U *ptr, U value);
+};
+
+template <typename T>
+template <typename U>
+U RexAtomicBox<T>::exchange(U *ptr, U value) {
+  return __atomic_exchange_n(ptr, value, __ATOMIC_SEQ_CST);
+}
+
+int rex_test2026_atomic_expr_valgrind_defined_reads(int *ptr) {
+  RexAtomicBox<int> box;
+  int old_value = box.exchange(ptr, 7);
+  int expected = old_value;
+  __atomic_compare_exchange_n(ptr, &expected, old_value + 1, false,
+                              __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
+  return __atomic_fetch_add(ptr, 1, __ATOMIC_SEQ_CST);
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_cxx_std_initializer_list_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_cxx_std_initializer_list_valgrind_defined_reads.cpp
@@ -1,0 +1,6 @@
+#include <vector>
+
+int rex_test2026_cxx_std_initializer_list_valgrind_defined_reads() {
+  std::vector<int> values{4};
+  return values[0];
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_function_definition_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_function_definition_valgrind_defined_reads.cpp
@@ -1,0 +1,12 @@
+#include <locale>
+#include <string>
+
+std::string
+rex_test2026_function_definition_valgrind_defined_reads(std::string text) {
+  const std::locale loc;
+  const std::ctype<char> &facet = std::use_facet<std::ctype<char>>(loc);
+  for (char &ch : text) {
+    ch = facet.tolower(ch);
+  }
+  return text;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_member_expr_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_member_expr_valgrind_defined_reads.cpp
@@ -1,0 +1,10 @@
+template <typename T> struct RexTest2026MemberExprValue {
+  T value;
+
+  T get() const { return static_cast<T>(this->value); }
+};
+
+int rex_test2026_member_expr_valgrind_defined_reads() {
+  RexTest2026MemberExprValue<int> item{7};
+  return item.get();
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_template_qualifier_friend_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_template_qualifier_friend_valgrind_defined_reads.cpp
@@ -1,0 +1,33 @@
+namespace rex_test2026_template_qualifier_friend {
+
+  template <typename T> struct Friend;
+
+  template <typename T> struct Outer {
+    template <typename U> struct Inner {
+      friend class Friend<T>;
+
+      Inner();
+
+      template <typename V> V convert(V value);
+    };
+  };
+
+  template <typename T> struct Friend {
+    typedef T value_type;
+  };
+
+  template <typename T> template <typename U> Outer<T>::Inner<U>::Inner() {}
+
+  template <typename T>
+  template <typename U>
+  template <typename V>
+  V Outer<T>::Inner<U>::convert(V value) {
+    return value;
+  }
+
+  int rex_test2026_template_qualifier_friend_valgrind_defined_reads() {
+    Outer<int>::Inner<long> value;
+    return value.convert(42);
+  }
+
+} // namespace rex_test2026_template_qualifier_friend

--- a/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_unresolved_member_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx11_tests/rex_test2026_unresolved_member_valgrind_defined_reads.cpp
@@ -1,0 +1,13 @@
+template <typename T>
+int rex_test2026_unresolved_member_valgrind_defined_reads(T value) {
+  return value.template member<int>();
+}
+
+struct RexTest2026UnresolvedMember {
+  template <typename U> int member() const { return sizeof(U); }
+};
+
+int rex_test2026_unresolved_member_valgrind_defined_reads_driver() {
+  RexTest2026UnresolvedMember value;
+  return rex_test2026_unresolved_member_valgrind_defined_reads(value);
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx14_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx14_tests/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(CXX14_TESTCODES
+  rex_test2026_constructor_parent_valgrind_defined_reads.cpp
+  rex_test2026_template_argument_marking_valgrind_defined_reads.cpp
   test2016_01.C
   test2016_12.C
   test2016_13.C

--- a/tests/nonsmoke/functional/CompileTests/Cxx14_tests/rex_test2026_constructor_parent_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx14_tests/rex_test2026_constructor_parent_valgrind_defined_reads.cpp
@@ -1,0 +1,12 @@
+#include <memory>
+
+struct RexTest2026ConstructorParent {
+  std::unique_ptr<int> value;
+
+  RexTest2026ConstructorParent() : value(new int(5)) {}
+};
+
+int rex_test2026_constructor_parent_valgrind_defined_reads() {
+  RexTest2026ConstructorParent item;
+  return *item.value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx14_tests/rex_test2026_template_argument_marking_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx14_tests/rex_test2026_template_argument_marking_valgrind_defined_reads.cpp
@@ -1,0 +1,26 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+template <typename T, typename Func>
+int rex_test2026_apply_pair(T lhs, T rhs, Func func) {
+  return func(lhs, rhs);
+}
+
+void rex_test2026_template_argument_marking_valgrind_defined_reads() {
+  std::vector<int> values;
+  using ValueRef = decltype(*std::begin(values));
+
+  std::for_each(std::begin(values), std::end(values),
+                [](ValueRef value) { std::cout << value; });
+
+  auto count_names =
+      [](const std::unordered_map<std::wstring, std::vector<std::string>>
+             &names) { return names.size(); };
+  (void)count_names;
+
+  (void)rex_test2026_apply_pair(
+      1, 2, [](const auto &lhs, const auto &rhs) { return lhs + rhs; });
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
@@ -124,6 +124,8 @@ set(CXX20_TESTCODES
   test2020_93.C
   test2020_119.C
   test2020_121.C
+  rex_test2026_coreturn_valgrind_defined_reads.cpp
+  rex_test2026_cxx20_paren_list_init_valgrind_defined_reads.cpp
   rex_test2026_concepts_requires.cpp
 )
 

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_test2026_coreturn_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_test2026_coreturn_valgrind_defined_reads.cpp
@@ -1,0 +1,3 @@
+#include "test2020_coroutine_support.hpp"
+
+lazy<int> rex_test2026_coreturn_valgrind_defined_reads() { co_return 9; }

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_test2026_cxx20_paren_list_init_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_test2026_cxx20_paren_list_init_valgrind_defined_reads.cpp
@@ -1,0 +1,9 @@
+struct RexTest2026ParenListInit {
+  int count;
+  double scale;
+};
+
+RexTest2026ParenListInit
+rex_test2026_cxx20_paren_list_init_valgrind_defined_reads() {
+  return RexTest2026ParenListInit(4, 2.5);
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -30,6 +30,19 @@ set(CXX_TESTCODES
   rex_test2026_deduction_guide.cpp
   rex_test2026_sfinae.cpp
   rex_test2026_dependent_qualification.cpp
+  rex_test2026_friend_template_saved_spelling.cpp
+  rex_test2026_dependent_using_dedup.cpp
+  rex_test2026_inline_constructor_preserved.cpp
+  rex_test2026_namespace_template_source_order.cpp
+  rex_test2026_guarded_friend_template_definition.cpp
+  rex_test2026_reopened_namespace_template_spelling.cpp
+  rex_test2026_base_alias_skips_ctor_parameter.cpp
+  rex_test2026_anonymous_member_no_qualification.cpp
+  rex_test2026_clang_method_context_valgrind_defined_reads.cpp
+  rex_test2026_clang_cxx_stmt_type_valgrind_defined_reads.cpp
+  rex_test2026_template_instantiation_reachable_scope.cpp
+  rex_test2026_declaration_scope_structural_successor.cpp
+  rex_test2026_ast_json_clang_option_filter.cpp
   rex_test2026_extern_c_brace_roundtrip.cpp
   rex_test2026_std_filesystem.cpp
   rex_test2026_std_shared_ptr_enable_shared.cpp
@@ -77,6 +90,8 @@ set(CXX_TESTCODES
   rex_test2025_issue125_fixup_child_list_warning.cpp
   rex_test2025_issue126_default_template_args.cpp
   rex_test2026_redecl_default_template_arg.cpp
+  rex_test2026_template_definition_prior_default.cpp
+  rex_test2026_split_template_defaults.cpp
   rex_test2025_defaulted_special_members_anon_union.cpp
   rex_test2025_issue59_template_template_arg_global_qual.cpp
   rex_test2025_issue60_friend_function_symbol_scope.cpp
@@ -3124,6 +3139,33 @@ set(ROSE_OUTPUT_TO_BUILD_TESTCODES
   test2007_125.C
 )
 
+set(CXX_TESTCODES_EXTENDED_INSTRUMENTED_TIMEOUT
+  test2010_02.C
+  test2017_24.C
+  test2017_99.C
+  longFile.C
+  test2013_13.C
+  test2013_14.C
+  test2013_15.C
+)
+
+set(CXX_UNFOLDED_CONSTANTS_EXTENDED_INSTRUMENTED_TIMEOUT
+  longFile.C
+  test2013_13.C
+  test2013_14.C
+  test2013_15.C
+  test2017_24.C
+)
+
+function(rex_set_cxx_extended_instrumented_timeout test_name specimen)
+  if(REX_EXTENDED_TEST_TIMEOUTS AND
+     specimen IN_LIST CXX_TESTCODES_EXTENDED_INSTRUMENTED_TIMEOUT)
+    set_tests_properties(${test_name} PROPERTIES
+      TIMEOUT 10800
+      PROCESSORS 16)
+  endif()
+endfunction()
+
 set(ROSE_FLAGS ${_rose_flags_base} -std=gnu++03)
 foreach(file_to_test ${CXX_TESTCODES_GNUXX03})
   compile_test(${file_to_test} "Cxx_tests")
@@ -3131,6 +3173,7 @@ foreach(file_to_test ${CXX_TESTCODES_GNUXX03})
   rex_lock_test_for_input(${_test_name} ${file_to_test})
   set_tests_properties(${_test_name} PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  rex_set_cxx_extended_instrumented_timeout(${_test_name} ${file_to_test})
 endforeach()
 set(ROSE_FLAGS ${_rose_flags_default})
 
@@ -3141,6 +3184,7 @@ foreach(file_to_test ${CXX_TESTCODES_GNUXX17})
   rex_lock_test_for_input(${_test_name} ${file_to_test})
   set_tests_properties(${_test_name} PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  rex_set_cxx_extended_instrumented_timeout(${_test_name} ${file_to_test})
 endforeach()
 set(ROSE_FLAGS ${_rose_flags_default})
 
@@ -3151,6 +3195,7 @@ foreach(file_to_test ${CXX_TESTCODES_DELAYED_TEMPLATE_PARSING})
   rex_lock_test_for_input(${_test_name} ${file_to_test})
   set_tests_properties(${_test_name} PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  rex_set_cxx_extended_instrumented_timeout(${_test_name} ${file_to_test})
 endforeach()
 set(ROSE_FLAGS ${_rose_flags_default})
 
@@ -3160,6 +3205,7 @@ foreach(file_to_test ${CXX_TESTCODES})
   rex_lock_test_for_input(${_test_name} ${file_to_test})
   set_tests_properties(${_test_name} PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  rex_set_cxx_extended_instrumented_timeout(${_test_name} ${file_to_test})
 endforeach()
 
 foreach(file_to_test ${CXX_TESTCODES_NEGATIVE})
@@ -3198,6 +3244,12 @@ function(add_cxx_unfolded_constants_test file_to_test will_fail)
   set_property(TEST ${_unfolded_target} APPEND PROPERTY ENVIRONMENT
                "ROSE_TEST_OUTPUT_DIR=${ROSE_TEST_OUTPUT_DIR}")
   rex_lock_test_for_input(${_unfolded_target} ${file_to_test})
+  if(REX_EXTENDED_TEST_TIMEOUTS AND
+     file_to_test IN_LIST CXX_UNFOLDED_CONSTANTS_EXTENDED_INSTRUMENTED_TIMEOUT)
+    set_tests_properties(${_unfolded_target} PROPERTIES
+      TIMEOUT 10800
+      PROCESSORS 16)
+  endif()
 endfunction()
 
 # Additional unfolded-constants coverage for the default CTest run.
@@ -3926,6 +3978,51 @@ set_tests_properties(${_issue203_test} PROPERTIES
   FAIL_REGULAR_EXPRESSION "In mangleQualifiersToString\\(\\):"
 )
 
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_anonymous_member_no_qualification"
+  "! grep -F '__anonymous_0x' rose_rex_test2026_anonymous_member_no_qualification.cpp && ${CMAKE_CXX_COMPILER} -std=gnu++14 -c rose_rex_test2026_anonymous_member_no_qualification.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_friend_template_saved_spelling"
+  "grep -E 'friend[[:space:]]+U[[:space:]]+rex_test2026_friend_template_saved_spelling_friend' rose_rex_test2026_friend_template_saved_spelling.cpp && grep -F 'after_friend' rose_rex_test2026_friend_template_saved_spelling.cpp && ${CMAKE_CXX_COMPILER} -std=c++98 -c rose_rex_test2026_friend_template_saved_spelling.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_dependent_using_dedup"
+  "awk '/using .*touch/ { ++n } END { exit !(n == 1) }' rose_rex_test2026_dependent_using_dedup.cpp && ${CMAKE_CXX_COMPILER} -std=c++98 -c rose_rex_test2026_dependent_using_dedup.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_inline_constructor_preserved"
+  "grep -F 'RexTest2026InlineConstructorBase' rose_rex_test2026_inline_constructor_preserved.cpp && ${CMAKE_CXX_COMPILER} -std=c++98 -c rose_rex_test2026_inline_constructor_preserved.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_namespace_template_source_order"
+  "awk '/template <typename T> inline void swap/ { if (!def) def=NR } /rex_test2026_namespace_template_source_order::swap/ { if (!call) call=NR } END { exit !(def && call && def < call) }' rose_rex_test2026_namespace_template_source_order.cpp && ${CMAKE_CXX_COMPILER} -std=c++98 -c rose_rex_test2026_namespace_template_source_order.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_guarded_friend_template_definition"
+  "awk '/#if REX_TEST2026_AS_FRIEND/ { ++n } END { exit !(n == 2) }' rose_rex_test2026_guarded_friend_template_definition.cpp && ${CMAKE_CXX_COMPILER} -std=gnu++14 -c rose_rex_test2026_guarded_friend_template_definition.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_reopened_namespace_template_spelling"
+  "${CMAKE_CXX_COMPILER} -std=gnu++14 -c rose_rex_test2026_reopened_namespace_template_spelling.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_base_alias_skips_ctor_parameter"
+  "${CMAKE_CXX_COMPILER} -std=gnu++14 -c rose_rex_test2026_base_alias_skips_ctor_parameter.cpp"
+)
+
+rex_add_cxx_unparse_check_test(
+  "rex_test2026_split_template_defaults"
+  "${CMAKE_CXX_COMPILER} -std=gnu++14 -c rose_rex_test2026_split_template_defaults.cpp"
+)
+
 # Issue 113: Template argument spelling must not depend on using directives in
 # the instantiation scope; keep namespace qualifiers in the generated name.
 add_test(
@@ -4289,6 +4386,32 @@ rex_lock_test_for_input(
   Cxx_tests_rex_test2025_cfe_error_exit_code_diagnostics
   rex_test2025_cfe_error_exit_code.cpp)
 
+# rex_test2026: a hard Clang diagnostic must stop before ROSE translates or
+# postprocesses an invalid recursive-template instantiation graph.
+add_test(
+  NAME Cxx_tests_rex_test2026_recursive_template_diagnostic_stop
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    ${BASH_EXECUTABLE} -c
+    "\"$@\" > ${CMAKE_CURRENT_BINARY_DIR}/rex_test2026_recursive_template_diagnostic_stop.log 2>&1; status=$?; test $status -ne 0 && grep -E \"template instantiation depth|recursive template instantiation exceeded maximum depth|Clang found [0-9]+ diagnostic errors\" ${CMAKE_CURRENT_BINARY_DIR}/rex_test2026_recursive_template_diagnostic_stop.log && grep -F \"Error: Clang reported\" ${CMAKE_CURRENT_BINARY_DIR}/rex_test2026_recursive_template_diagnostic_stop.log && ! grep -F \"clang_main.translation_unit.begin\" ${CMAKE_CURRENT_BINARY_DIR}/rex_test2026_recursive_template_diagnostic_stop.log && ! grep -F \"clang_main.finishSageAST.begin\" ${CMAKE_CURRENT_BINARY_DIR}/rex_test2026_recursive_template_diagnostic_stop.log"
+    dummy
+    ${CMAKE_COMMAND} -E env ROSE_PHASE_TRACE=1
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -ftemplate-depth=32
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_recursive_template_diagnostic_stop.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_test2026_recursive_template_diagnostic_stop
+  PROPERTIES
+    LABELS Cxx_tests
+    TIMEOUT 60
+)
+rex_lock_test_for_input(
+  Cxx_tests_rex_test2026_recursive_template_diagnostic_stop
+  rex_test2026_recursive_template_diagnostic_stop.cpp)
+
 # Issue 144: Allow backend when explicitly opted in.
 add_test(
   NAME Cxx_tests_rex_test2025_cfe_error_exit_code_continue_on_error_unparse
@@ -4442,6 +4565,27 @@ set_tests_properties(
 rex_lock_test_for_input(
   Cxx_tests_rex_test2026_redecl_default_template_arg_unparse
   rex_test2026_redecl_default_template_arg.cpp)
+
+# A definition following a declaration with a default template argument must not
+# re-emit the inherited default.
+add_test(
+  NAME Cxx_tests_rex_test2026_template_definition_prior_default_unparse
+  COMMAND
+    sh -c
+    "\"$@\" && awk '/Iter[[:space:]]*=[[:space:]]*T[[:space:]]*\\*/ { ++n } END { exit !(n == 1) }' rose_rex_test2026_template_definition_prior_default.cpp && ${CMAKE_CXX_COMPILER} -std=c++20 -c rose_rex_test2026_template_definition_prior_default.cpp"
+    dummy
+    $<TARGET_FILE:${translator}>
+    ${ROSE_FLAGS} ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_template_definition_prior_default.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_test2026_template_definition_prior_default_unparse
+  PROPERTIES LABELS Cxx_tests
+)
+rex_lock_test_for_input(
+  Cxx_tests_rex_test2026_template_definition_prior_default_unparse
+  rex_test2026_template_definition_prior_default.cpp)
 
 # Replacing redeclared definition parameters must also refresh template-param
 # lookups before translating requires clauses and dependent members.
@@ -4785,6 +4929,7 @@ set_tests_properties(
   Cxx_tests_rex_test2025_issue124_system_header_specialization_args_unparse
   Cxx_tests_rex_test2025_issue126_default_template_args_unparse
   Cxx_tests_rex_test2026_redecl_default_template_arg_unparse
+  Cxx_tests_rex_test2026_template_definition_prior_default_unparse
   Cxx_tests_rex_test2026_redecl_default_template_arg_requires_unparse
   Cxx_tests_rex_test2025_issue59_template_template_arg_global_qual_unparse
   Cxx_tests_rex_test2025_issue60_friend_function_symbol_scope_unparse

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_anonymous_member_no_qualification.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_anonymous_member_no_qualification.cpp
@@ -1,0 +1,11 @@
+struct RexTest2026AnonymousMember {
+  union {
+    struct {
+      int value;
+    };
+  };
+};
+
+int rex_test2026_read_anonymous_member(RexTest2026AnonymousMember *object) {
+  return object->value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_ast_json_clang_option_filter.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_ast_json_clang_option_filter.cpp
@@ -1,0 +1,1 @@
+int rex_test2026_ast_json_clang_option_filter() { return 0; }

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_base_alias_skips_ctor_parameter.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_base_alias_skips_ctor_parameter.cpp
@@ -1,0 +1,25 @@
+template <class T> class RexTest2026AliasBase {
+public:
+  explicit RexTest2026AliasBase(bool rex_test2026_ctor_parameter)
+      : flag(rex_test2026_ctor_parameter) {}
+
+private:
+  bool flag;
+};
+
+template <class T>
+class RexTest2026AliasDerived : public RexTest2026AliasBase<T> {
+public:
+  RexTest2026AliasDerived() : RexTest2026AliasBase<T>(false) {}
+};
+
+class RexTest2026AliasFinal : public RexTest2026AliasDerived<int> {
+public:
+  RexTest2026AliasFinal() {}
+};
+
+int rex_test2026_base_alias_skips_ctor_parameter() {
+  RexTest2026AliasFinal value;
+  (void)value;
+  return 0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_clang_cxx_stmt_type_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_clang_cxx_stmt_type_valgrind_defined_reads.cpp
@@ -1,0 +1,57 @@
+// Exercises Clang AST accessors whose backing storage can contain undefined
+// padding/trailing fields under Valgrind.
+
+#include <cstdarg>
+
+template <typename T> struct Owner {
+  T *ptr;
+
+  explicit Owner(T *p) : ptr(p) {}
+
+  ~Owner() {
+    if (ptr != nullptr) {
+      delete ptr;
+    }
+  }
+};
+
+struct IntRange {
+  int data[3];
+
+  int *begin() { return data; }
+  int *end() { return data + 3; }
+};
+
+template <typename T> struct Holder {
+  T value;
+};
+
+static int read_first_decayed(int (&values)[3]) {
+  auto pointer = values;
+  Holder<decltype(pointer)> holder = {pointer};
+  return holder.value[0];
+}
+
+static int sum_range(IntRange &range) {
+  int total = 0;
+  for (auto value : range) {
+    total += value;
+  }
+  return total;
+}
+
+static int first_var_arg(int count, ...) {
+  va_list args;
+  va_start(args, count);
+  int value = va_arg(args, int);
+  va_end(args);
+  return value;
+}
+
+int main() {
+  IntRange range = {{1, 2, 3}};
+  int values[3] = {4, 5, 6};
+  Owner<int> owner(new int(7));
+
+  return sum_range(range) + read_first_decayed(values) + first_var_arg(1, 8);
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_clang_method_context_valgrind_defined_reads.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_clang_method_context_valgrind_defined_reads.cpp
@@ -1,0 +1,31 @@
+#include <memory>
+
+namespace {
+
+class RexTest2026Command {
+private:
+  virtual bool apply(unsigned index) const = 0;
+};
+
+class RexTest2026CleanCommand : public RexTest2026Command {
+public:
+  explicit RexTest2026CleanCommand(double fraction) : fraction_(fraction) {}
+
+private:
+  bool apply(unsigned index) const override;
+
+  double fraction_;
+};
+
+bool RexTest2026CleanCommand::apply(unsigned index) const {
+  return index != 0 && fraction_ > 0.0;
+}
+
+std::auto_ptr<RexTest2026Command>
+rex_test2026_clang_method_context_valgrind_defined_reads() {
+  double fraction = 0.5;
+  return std::auto_ptr<RexTest2026Command>(
+      new RexTest2026CleanCommand(fraction));
+}
+
+} // namespace

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_declaration_scope_structural_successor.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_declaration_scope_structural_successor.cpp
@@ -1,0 +1,17 @@
+template <typename T> struct RexTest2026DeclarationScope {
+  using type = typename T::type;
+
+  template <typename U = type> struct Inner {
+    U value;
+  };
+};
+
+struct RexTest2026DeclarationScopeArg {
+  using type = int;
+};
+
+int rex_test2026_declaration_scope_structural_successor() {
+  RexTest2026DeclarationScope<RexTest2026DeclarationScopeArg>::Inner<> inner = {
+      3};
+  return inner.value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_dependent_using_dedup.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_dependent_using_dedup.cpp
@@ -1,0 +1,12 @@
+template <typename T> struct RexTest2026DependentUsingBase {
+  void touch();
+};
+
+template <typename T>
+struct RexTest2026DependentUsingDerived : RexTest2026DependentUsingBase<T> {
+  using RexTest2026DependentUsingBase<T>::touch;
+
+  void run() { this->touch(); }
+};
+
+template struct RexTest2026DependentUsingDerived<int>;

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_friend_template_saved_spelling.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_friend_template_saved_spelling.cpp
@@ -1,0 +1,13 @@
+template <typename T> struct RexTest2026FriendTemplateHost {
+  template <typename U>
+  friend U rex_test2026_friend_template_saved_spelling_friend(U value) {
+    return value;
+  }
+
+  int after_friend;
+};
+
+int rex_test2026_friend_template_saved_spelling() {
+  RexTest2026FriendTemplateHost<int> host = {7};
+  return host.after_friend;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_guarded_friend_template_definition.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_guarded_friend_template_definition.cpp
@@ -1,0 +1,30 @@
+#define REX_TEST2026_AS_FRIEND 1
+
+namespace RexTest2026GuardedFriendTemplate {
+
+class X {
+public:
+#if REX_TEST2026_AS_FRIEND
+  template <typename T> friend bool guarded_equal(X, int);
+#else
+  template <typename T> bool guarded_equal(int);
+#endif
+};
+
+#if REX_TEST2026_AS_FRIEND
+template <typename T>
+bool guarded_equal(X, int)
+#else
+template <typename T>
+bool X::guarded_equal(int)
+#endif
+{
+  return true;
+}
+
+} // namespace RexTest2026GuardedFriendTemplate
+
+int rex_test2026_guarded_friend_template_definition() {
+  RexTest2026GuardedFriendTemplate::X value;
+  return RexTest2026GuardedFriendTemplate::guarded_equal<int>(value, 1) ? 0 : 1;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_inline_constructor_preserved.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_inline_constructor_preserved.cpp
@@ -1,0 +1,20 @@
+template <typename T> struct RexTest2026InlineConstructorBase {
+  T *ptr;
+  unsigned offset;
+
+  RexTest2026InlineConstructorBase(T *value, unsigned index)
+      : ptr(value), offset(index) {}
+};
+
+template <typename T>
+struct RexTest2026InlineConstructorIterator
+    : RexTest2026InlineConstructorBase<T> {
+  RexTest2026InlineConstructorIterator(T *value)
+      : RexTest2026InlineConstructorBase<T>(value, 0) {}
+};
+
+int rex_test2026_inline_constructor_preserved() {
+  int value = 3;
+  RexTest2026InlineConstructorIterator<int> iter(&value);
+  return iter.offset;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_namespace_template_source_order.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_namespace_template_source_order.cpp
@@ -1,0 +1,34 @@
+namespace rex_test2026_namespace_template_source_order {
+template <typename T> inline void swap(T &lhs, T &rhs) {
+  T tmp = lhs;
+  lhs = rhs;
+  rhs = tmp;
+}
+} // namespace rex_test2026_namespace_template_source_order
+
+namespace rex_test2026_namespace_template_source_order {
+template <typename T> struct DequeData {
+  T value;
+
+  void swap_data(DequeData &other) {
+    rex_test2026_namespace_template_source_order::swap(*this, other);
+  }
+};
+} // namespace rex_test2026_namespace_template_source_order
+
+namespace rex_test2026_namespace_template_source_order {
+template <typename T> struct VectorData {
+  T value;
+
+  void swap_data(VectorData &other) {
+    rex_test2026_namespace_template_source_order::swap(*this, other);
+  }
+};
+} // namespace rex_test2026_namespace_template_source_order
+
+int rex_test2026_namespace_template_source_order_use() {
+  rex_test2026_namespace_template_source_order::DequeData<int> lhs = {1};
+  rex_test2026_namespace_template_source_order::DequeData<int> rhs = {2};
+  lhs.swap_data(rhs);
+  return lhs.value + rhs.value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_recursive_template_diagnostic_stop.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_recursive_template_diagnostic_stop.cpp
@@ -1,0 +1,5 @@
+template <class T, class U> void rex_recursive_template(T x, U y) {
+  rex_recursive_template(&y, &x);
+}
+
+int main() { rex_recursive_template(3, 4); }

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_reopened_namespace_template_spelling.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_reopened_namespace_template_spelling.cpp
@@ -1,0 +1,26 @@
+#define REX_TEST2026_TEMPLATE_ENABLED 1
+
+namespace RexTest2026ReopenedNamespaceTemplate {
+
+#if REX_TEST2026_TEMPLATE_ENABLED
+template <typename T> void foobar(T);
+#else
+void foobar(int);
+#endif
+
+} // namespace RexTest2026ReopenedNamespaceTemplate
+
+namespace RexTest2026ReopenedNamespaceTemplate {
+
+#if REX_TEST2026_TEMPLATE_ENABLED
+template <typename T> void foobar(T) {}
+#else
+void foobar(int) {}
+#endif
+
+} // namespace RexTest2026ReopenedNamespaceTemplate
+
+int rex_test2026_reopened_namespace_template_spelling() {
+  RexTest2026ReopenedNamespaceTemplate::foobar(1);
+  return 0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_split_template_defaults.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_split_template_defaults.cpp
@@ -1,0 +1,22 @@
+namespace RexTest2026SplitTemplateDefaults {
+
+enum { A = 2 };
+
+template <int m> struct C {
+  typedef int B;
+};
+
+template <int n, C<4>::B m = 6> class X;
+
+template <int n = A<3, C<4>::B m> class X {
+public:
+  enum { value = n + m };
+};
+
+X<> x;
+
+} // namespace RexTest2026SplitTemplateDefaults
+
+int rex_test2026_split_template_defaults() {
+  return RexTest2026SplitTemplateDefaults::x.value;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_template_definition_prior_default.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_template_definition_prior_default.cpp
@@ -1,0 +1,12 @@
+template <typename T, typename Iter = T *> struct RexTest2026PriorDefault;
+
+template <typename T, typename Iter> struct RexTest2026PriorDefault {
+  Iter begin;
+  T value;
+};
+
+int rex_test2026_template_definition_prior_default() {
+  int value = 1;
+  RexTest2026PriorDefault<int> item = {&value, value};
+  return item.value + *item.begin;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_template_instantiation_reachable_scope.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_test2026_template_instantiation_reachable_scope.cpp
@@ -1,0 +1,16 @@
+namespace rex_test2026_template_scope {
+template <typename T> struct Box {
+  T value;
+};
+
+template <typename T> struct Holder {
+  Box<T> box;
+};
+} // namespace rex_test2026_template_scope
+
+using RexTest2026Holder = rex_test2026_template_scope::Holder<int>;
+
+int rex_test2026_template_instantiation_reachable_scope() {
+  RexTest2026Holder holder = {{7}};
+  return holder.box.value;
+}

--- a/tests/nonsmoke/functional/CompileTests/ExpressionTemplateExample_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/ExpressionTemplateExample_tests/CMakeLists.txt
@@ -7,5 +7,11 @@ set(TESTCODES
 
 foreach(file_to_test ${TESTCODES})
   compile_test(${file_to_test} ExpressionTemplateExample_tests)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    rex_compile_test_name(_test_name ExpressionTemplateExample_tests
+                          ${file_to_test})
+    set_tests_properties(${_test_name} PROPERTIES
+      TIMEOUT 10800
+      PROCESSORS 16)
+  endif()
 endforeach()
-

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/CMakeLists.txt
@@ -4,6 +4,11 @@ target_link_libraries(parseOmp ROSE_DLL ${link_with_libraries})
 add_executable(checkOmpAnalyzing checkOmpAnalyzing.C)
 target_link_libraries(checkOmpAnalyzing ROSE_DLL ${link_with_libraries})
 
+add_executable(rex_test2026_mapper_typedef_unparse
+  rex_test2026_mapper_typedef_unparse.cpp)
+target_link_libraries(rex_test2026_mapper_typedef_unparse
+  ROSE_DLL ${link_with_libraries})
+
 find_program(BASH_EXECUTABLE bash)
 if(NOT BASH_EXECUTABLE)
   message(FATAL_ERROR "bash not found; OpenMP_tests require bash")
@@ -58,6 +63,8 @@ set(C_TESTCODES
 	simd2.c simd3.c simd4.c simd5.c single.c single2.c single3.c
 	single_copyprivate.c sizeof.c spmd1.c staticChunk.c subteam2.c subteam.c
 	target.c target1.c target_uses_allocators.c targetparallel.c
+	rex_test2026_uses_allocators_optional_edges.c
+	rex_test2026_uses_allocators_user_defined_isolation.c
 	targetparallelforsimd.c targetparallelloop.c targetsimd.c targetteams.c
 	targetteamsdistribute.c targetteamsdistributesimd.c targetteamsloop.c
 	targetteamsdistributeparallelfor.c targetteamsdistributeparallelforsimd.c
@@ -81,7 +88,9 @@ set(CXX_TESTCODES
 	memberFunction2.cpp objectPrivate.cpp objectFirstPrivate.cpp
 	objectLastprivate.cpp referenceType.cpp declare_mapper_type_qualifiers.cpp
 	orphanedAtomic.cpp preprocessingInfo2.cpp task_link.cpp task_link2.cpp
-	task_tree.cpp jacobi-ompacc2.cpp data-member-access.cpp define-directive2.cpp)
+	task_tree.cpp jacobi-ompacc2.cpp data-member-access.cpp define-directive2.cpp
+	rex_test2026_array_section_optional_bounds.cpp
+	rex_test2026_mapper_template_reachable_scope.cpp)
 
 set(TESTCODES ${C_TESTCODES} ${CXX_TESTCODES})
 
@@ -102,6 +111,103 @@ set(_omp_test_output_dir ${CMAKE_CURRENT_BINARY_DIR}/test-output)
 file(MAKE_DIRECTORY ${_omp_test_output_dir})
 
 set(ROSE_OMP_ANALYZING_FLAGS -rose:openmp:analyzing -rose:skipfinalCompileStep -w -rose:verbose 0)
+
+set(_ast_json_checkpoint_script
+    ${CMAKE_CURRENT_SOURCE_DIR}/ast_json_checkpoint/run_checkpoint_compare.sh)
+
+function(add_ast_json_checkpoint_test name checkpoint input_file label)
+  set(_workdir ${_omp_test_output_dir}/ast-json/${name})
+  add_test(
+    NAME ASTJSON_${name}
+    WORKING_DIRECTORY ${_omp_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE}
+            ${_ast_json_checkpoint_script}
+            $<TARGET_FILE:parseOmp>
+            ${checkpoint}
+            ${CMAKE_CURRENT_SOURCE_DIR}/${input_file}
+            ${_workdir}
+            ${input_file}
+            ${ARGN})
+  set_tests_properties(ASTJSON_${name} PROPERTIES LABELS "ASTJSON;${label}")
+endfunction()
+
+add_ast_json_checkpoint_test(
+  pre_omp_construction_parallel
+  pre-omp-construction
+  parallel.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  post_omp_construction_targetparallel
+  post-omp-construction
+  targetparallel.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  post_omp_construction_axpy_ompacc
+  post-omp-construction
+  axpy_ompacc.c
+  OMPACCTEST
+  ${ROSE_C_FLAGS}
+  -rose:skipfinalCompileStep)
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_task_dep2
+  all
+  task_dep2.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_task_dep3
+  all
+  task_dep3.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_memberFunction_cpp
+  all
+  memberFunction.cpp
+  OMPTEST
+  ${ROSE_CXX_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_task_link2_cpp
+  all
+  task_link2.cpp
+  OMPTEST
+  ${ROSE_CXX_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_rex_test2026_array_section_optional_bounds_cpp
+  all
+  rex_test2026_array_section_optional_bounds.cpp
+  OMPTEST
+  ${ROSE_CXX_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_rex_test2026_uses_allocators_optional_edges_c
+  all
+  rex_test2026_uses_allocators_optional_edges.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_rex_test2026_uses_allocators_user_defined_isolation_c
+  all
+  rex_test2026_uses_allocators_user_defined_isolation.c
+  OMPTEST
+  ${ROSE_C_FLAGS})
+
+add_ast_json_checkpoint_test(
+  all_omp_construction_rex_test2026_mapper_template_reachable_scope_cpp
+  all
+  rex_test2026_mapper_template_reachable_scope.cpp
+  OMPTEST
+  ${ROSE_CXX_FLAGS})
 
 foreach(file_to_test ${TESTCODES})
   if(file_to_test MATCHES "\\.c$")
@@ -148,6 +254,74 @@ add_test(
           -rose:collectAllCommentsAndDirectives
           ${CMAKE_CURRENT_SOURCE_DIR}/macroIds.c)
 set_tests_properties(OMPTEST_macroIds PROPERTIES LABELS OMPTEST)
+
+set(_rex_test2026_mapper_typedef_output
+    ${_omp_test_output_dir}/rex_test2026_mapper_typedef_unparse.c)
+add_test(
+  NAME OMPTEST_rex_test2026_mapper_typedef_unparse_cpp
+  WORKING_DIRECTORY ${_omp_test_output_dir}
+  COMMAND ${BASH_EXECUTABLE} -c
+    "\"$@\" && grep -F '#pragma omp declare mapper(default : Vec  v)' ${_rex_test2026_mapper_typedef_output} && ! grep -F 'class ::Vec' ${_rex_test2026_mapper_typedef_output} && $<TARGET_FILE:parseOmp> -rose:openmp:ast_only -w -rose:verbose 0 -rose:skipfinalCompileStep -c ${_rex_test2026_mapper_typedef_output}"
+    --
+    $<TARGET_FILE:rex_test2026_mapper_typedef_unparse>
+    ${ROSE_C_FLAGS}
+    -rose:output ${_rex_test2026_mapper_typedef_output}
+    -rose:skipfinalCompileStep
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/declare_mapper_target_update.c)
+set_tests_properties(OMPTEST_rex_test2026_mapper_typedef_unparse_cpp
+  PROPERTIES LABELS OMPTEST)
+
+set(_rex_test2026_mapper_template_output
+    ${_omp_test_output_dir}/rex_test2026_mapper_template_reachable_scope.cpp)
+add_test(
+  NAME OMPTEST_rex_test2026_mapper_template_reachable_scope_cpp
+  WORKING_DIRECTORY ${_omp_test_output_dir}
+  COMMAND ${BASH_EXECUTABLE} -c
+    "\"$@\" && grep -F '#pragma omp declare mapper(default : ::RexTest2026Vec<float> v)' ${_rex_test2026_mapper_template_output} && $<TARGET_FILE:parseOmp> -rose:openmp:ast_only -w -rose:verbose 0 -rose:skipfinalCompileStep -c ${_rex_test2026_mapper_template_output}"
+    --
+    $<TARGET_FILE:parseOmp>
+    ${ROSE_CXX_FLAGS}
+    -rose:output ${_rex_test2026_mapper_template_output}
+    -rose:skipfinalCompileStep
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_mapper_template_reachable_scope.cpp)
+set_tests_properties(OMPTEST_rex_test2026_mapper_template_reachable_scope_cpp
+  PROPERTIES LABELS OMPTEST)
+
+set(_rex_test2026_ast_json_option_dir
+    ${_omp_test_output_dir}/rex_test2026_ast_json_option_filter)
+add_test(
+  NAME OMPTEST_rex_test2026_ast_json_clang_option_filter_cpp
+  WORKING_DIRECTORY ${_omp_test_output_dir}
+  COMMAND ${CMAKE_COMMAND} -E env
+    REX_AST_JSON_CHECKPOINT=pre-omp-construction
+    REX_AST_JSON_DIR=${_rex_test2026_ast_json_option_dir}
+    $<TARGET_FILE:parseOmp>
+      ${ROSE_CXX_FLAGS}
+      -rex:ast-json-checkpoint=pre-omp-construction
+      -rex:ast-json-dir=${_rex_test2026_ast_json_option_dir}
+      -rose:output ${_omp_test_output_dir}/rose_rex_test2026_ast_json_clang_option_filter.cpp
+      -c ${CMAKE_CURRENT_SOURCE_DIR}/../Cxx_tests/rex_test2026_ast_json_clang_option_filter.cpp)
+set_tests_properties(OMPTEST_rex_test2026_ast_json_clang_option_filter_cpp
+  PROPERTIES LABELS "OMPTEST;ASTJSON")
+
+set(_rex_test2026_omp_expr_lookup_dir
+    ${_omp_test_output_dir}/rex_test2026_omp_expr_lookup_current_file)
+add_test(
+  NAME OMPTEST_rex_test2026_omp_expr_lookup_current_file_cpp
+  WORKING_DIRECTORY ${_omp_test_output_dir}
+  COMMAND ${CMAKE_COMMAND} -E env
+    REX_AST_JSON_CHECKPOINT=all
+    REX_AST_JSON_DIR=${_rex_test2026_omp_expr_lookup_dir}
+    $<TARGET_FILE:parseOmp>
+      ${ROSE_CXX_FLAGS}
+      -rex:ast-json-checkpoint=all
+      -rex:ast-json-dir=${_rex_test2026_omp_expr_lookup_dir}
+      -rose:output ${_omp_test_output_dir}/rose_rex_test2026_omp_expr_lookup_current_file.cpp
+      -c
+      ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_omp_expr_lookup_current_file_a.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/rex_test2026_omp_expr_lookup_current_file_b.cpp)
+set_tests_properties(OMPTEST_rex_test2026_omp_expr_lookup_current_file_cpp
+  PROPERTIES LABELS "OMPTEST;ASTJSON")
 
 set(_omp_reference_dir ${CMAKE_CURRENT_SOURCE_DIR}/referenceResults)
 

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ast_json_checkpoint/run_checkpoint_compare.sh
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/ast_json_checkpoint/run_checkpoint_compare.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 6 ]]; then
+  echo "usage: $0 <parseOmp> <checkpoint> <input.c> <workdir> <output-name> <rose-flags...>" >&2
+  exit 2
+fi
+
+parse_omp="$1"
+checkpoint="$2"
+input_file="$3"
+workdir="$4"
+output_name="$5"
+shift 5
+rose_flags=("$@")
+
+baseline_dir="${workdir}/baseline"
+checkpoint_dir="${workdir}/checkpoint"
+json_dir="${checkpoint_dir}/json"
+baseline_output="${baseline_dir}/rose_${output_name}"
+checkpoint_output="${checkpoint_dir}/rose_${output_name}"
+
+rm -rf "${workdir}"
+mkdir -p "${baseline_dir}" "${checkpoint_dir}" "${json_dir}"
+
+(
+  cd "${baseline_dir}"
+  "${parse_omp}" "${rose_flags[@]}" \
+    -rose:output "${baseline_output}" \
+    -c "${input_file}" > run.log 2>&1
+)
+
+(
+  cd "${checkpoint_dir}"
+  "${parse_omp}" "${rose_flags[@]}" \
+    "-rex:ast-json-checkpoint=${checkpoint}" \
+    "-rex:ast-json-dir=${json_dir}" \
+    -rose:output "${checkpoint_output}" \
+    -c "${input_file}" > run.log 2>&1
+)
+
+if [[ -z "$(find "${json_dir}" -type f -name '*.json' -print -quit)" ]]; then
+  echo "ERROR(${checkpoint}): checkpoint JSON was not written under ${json_dir}" >&2
+  exit 1
+fi
+
+diff -u "${baseline_output}" "${checkpoint_output}"

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_cpu/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_cpu/CMakeLists.txt
@@ -124,6 +124,13 @@ set(_cpu_compare_script "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_cpu_compare.sh"
 set(_omp_cpu_test_output_dir "${CMAKE_CURRENT_BINARY_DIR}/test-output")
 file(MAKE_DIRECTORY "${_omp_cpu_test_output_dir}")
 
+set(_omp_cpu_sanitizer_test_environment)
+if(ROSE_USE_SANITIZER AND ROSE_SANITIZERS)
+  string(REPLACE ";" "," _omp_cpu_sanitizer_test_list "${ROSE_SANITIZERS}")
+  list(APPEND _omp_cpu_sanitizer_test_environment
+       "ROSE_TEST_SANITIZER_FLAGS=-fsanitize=${_omp_cpu_sanitizer_test_list}")
+endif()
+
 function(add_omp_lowering_cpu_compare_test input_file mode)
   string(REPLACE "." "_" _name "${input_file}")
   string(REPLACE "-" "_" _name "${_name}")
@@ -148,6 +155,10 @@ function(add_omp_lowering_cpu_compare_test input_file mode)
     PROPERTIES
       LABELS "OMPLOWERING;OMPLOWERING_CPU"
       TIMEOUT 300)
+  if(_omp_cpu_sanitizer_test_environment)
+    set_property(TEST OMPLOWERING_CPU_${_name} APPEND PROPERTY ENVIRONMENT
+                 "${_omp_cpu_sanitizer_test_environment}")
+  endif()
 endfunction()
 
 foreach(_cpu_case IN LISTS OMP_LOWERING_CPU_EXACT_CASES)

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_cpu/scripts/run_cpu_compare.sh
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_cpu/scripts/run_cpu_compare.sh
@@ -41,6 +41,11 @@ compile_flags=(
   "-Wl,-rpath,${omp_runtime_dir}"
 )
 
+if [[ -n "${ROSE_TEST_SANITIZER_FLAGS:-}" ]]; then
+  read -r -a sanitizer_flags <<< "${ROSE_TEST_SANITIZER_FLAGS}"
+  compile_flags+=("${sanitizer_flags[@]}")
+fi
+
 canonicalize() {
   local in_file="$1"
   local out_file="$2"

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/CMakeLists.txt
@@ -35,6 +35,28 @@ function(add_rodinia_lowering_test case_name)
   )
 endfunction()
 
+function(add_rodinia_ast_json_lowering_test case_name)
+  set(_input_file ${CMAKE_CURRENT_SOURCE_DIR}/inputs/${case_name}.c)
+  set(_workdir ${_omp_rodinia_test_output_dir}/ast-json/${case_name})
+
+  add_test(
+    NAME ASTJSON_OMPLOWERING_RODINIA_${case_name}
+    WORKING_DIRECTORY "${_omp_rodinia_test_output_dir}"
+    COMMAND ${BASH_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_checkpoint_compare.sh
+            $<TARGET_FILE:parseOmp>
+            ${_input_file}
+            ${_workdir}
+            ${case_name})
+
+  set_tests_properties(
+    ASTJSON_OMPLOWERING_RODINIA_${case_name}
+    PROPERTIES
+      LABELS "ASTJSON;OMPLOWERING;OMPLOWERING_RODINIA"
+  )
+endfunction()
+
 foreach(_case_name IN LISTS RODINIA_LOWERING_CASES)
   add_rodinia_lowering_test(${_case_name})
+  add_rodinia_ast_json_lowering_test(${_case_name})
 endforeach()

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/run_checkpoint_compare.sh
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/lowering_rodinia/scripts/run_checkpoint_compare.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <parseOmp> <input.c> <workdir> <case_name>" >&2
+  exit 2
+fi
+
+parse_omp="$1"
+input_file="$2"
+workdir="$3"
+case_name="$4"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+baseline_dir="${workdir}/baseline"
+checkpoint_dir="${workdir}/checkpoint"
+json_dir="${checkpoint_dir}/json"
+
+rm -rf "${workdir}"
+mkdir -p "${baseline_dir}" "${checkpoint_dir}" "${json_dir}"
+
+bash "${script_dir}/run_and_check.sh" "${parse_omp}" "${input_file}" \
+  "${baseline_dir}" "${case_name}"
+
+(
+  cd "${checkpoint_dir}"
+  "${parse_omp}" --rex-omp-lowering \
+    -rex:ast-json-checkpoint=post-omp-lowering \
+    "-rex:ast-json-dir=${json_dir}" \
+    -w -rose:verbose 0 -c "${input_file}" > run.log 2>&1
+)
+
+bash "${script_dir}/verify_outputs.sh" "${case_name}" "${checkpoint_dir}"
+
+if [[ -z "$(find "${json_dir}" -type f -name '*.json' -print -quit)" ]]; then
+  echo "ERROR(${case_name}): post-lowering checkpoint JSON was not written under ${json_dir}" >&2
+  exit 1
+fi
+
+mapfile -t baseline_outputs < <(
+  cd "${baseline_dir}"
+  find . -maxdepth 1 -type f \( -name 'rose_*.c' -o -name 'rex_lib_*.cu' \) | sort
+)
+
+if [[ "${#baseline_outputs[@]}" -eq 0 ]]; then
+  echo "ERROR(${case_name}): no baseline lowering outputs found" >&2
+  exit 1
+fi
+
+for rel in "${baseline_outputs[@]}"; do
+  diff -u "${baseline_dir}/${rel}" "${checkpoint_dir}/${rel}"
+done

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_declare_mapper_type_qualifiers.cpp.output
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_declare_mapper_type_qualifiers.cpp.output
@@ -2,4 +2,4 @@
 #pragma omp declare mapper(ptr_to_const : const ::MapperRecord* v)
 #pragma omp declare mapper(const_ptr : ::MapperRecord*const  v)
 #pragma omp declare mapper(ptr_to_const_ptr : ::MapperRecord*const * v)
-#pragma omp declare mapper(template_int : class ::TemplateRecord<123> v)
+#pragma omp declare mapper(template_int : ::TemplateRecord<123> v)

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_array_section_optional_bounds.cpp.output
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_array_section_optional_bounds.cpp.output
@@ -1,0 +1,3 @@
+#pragma omp target map(tofrom : a[:n])
+#pragma omp target map(tofrom : a[start:])
+#pragma omp target map(tofrom : a[::2])

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_mapper_template_reachable_scope.cpp.output
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_mapper_template_reachable_scope.cpp.output
@@ -1,0 +1,4 @@
+#pragma omp declare mapper(default : ::RexTest2026Vec<float> v) map(tofrom : v.len,v.data[0:v.len])
+#pragma omp target data map(mapper(default), tofrom : v[0:n])
+#pragma omp target update to(mapper(default):v[0:n])
+#pragma omp target map(mapper(default), tofrom : v[0:n])

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_uses_allocators_optional_edges.c.output
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_uses_allocators_optional_edges.c.output
@@ -1,0 +1,1 @@
+#pragma omp target map(from : result) uses_allocators(omp_default_mem_alloc, omp_const_mem_alloc(value))

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_uses_allocators_user_defined_isolation.c.output
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/referenceResults/rose_rex_test2026_uses_allocators_user_defined_isolation.c.output
@@ -1,0 +1,1 @@
+#pragma omp target map(from : result) uses_allocators(rex_test2026_allocator(value), omp_default_mem_alloc)

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_array_section_optional_bounds.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_array_section_optional_bounds.cpp
@@ -1,0 +1,16 @@
+void rex_test2026_array_section_optional_bounds(int *a, int n, int start) {
+#pragma omp target map(tofrom : a[ : n])
+  {
+    a[0] = n;
+  }
+
+#pragma omp target map(tofrom : a[start : ])
+  {
+    a[start] = n;
+  }
+
+#pragma omp target map(tofrom : a[::2])
+  {
+    a[0] = start;
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_mapper_template_reachable_scope.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_mapper_template_reachable_scope.cpp
@@ -1,0 +1,19 @@
+template <typename T> struct RexTest2026Vec {
+  int len;
+  T *data;
+};
+
+#pragma omp declare mapper(default : RexTest2026Vec<float> v)                  \
+    map(tofrom : v.len, v.data[0 : v.len])
+
+void rex_test2026_mapper_template_reachable_scope(RexTest2026Vec<float> *v,
+                                                  int n) {
+#pragma omp target data map(mapper(default), tofrom : v[0 : n])
+  {
+#pragma omp target update to(mapper(default) : v[0 : n])
+#pragma omp target map(mapper(default), tofrom : v[0 : n])
+    {
+      v->len += 1;
+    }
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_mapper_typedef_unparse.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_mapper_typedef_unparse.cpp
@@ -1,0 +1,41 @@
+#include "rose.h"
+
+int main(int argc, char *argv[]) {
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  project->skipfinalCompileStep(true);
+
+  SgTypedefDeclaration *vec_typedef = nullptr;
+  for (SgNode *node :
+       NodeQuery::querySubTree(project, V_SgTypedefDeclaration)) {
+    SgTypedefDeclaration *decl = isSgTypedefDeclaration(node);
+    if (decl != nullptr && decl->get_name() == "Vec") {
+      vec_typedef = decl;
+      break;
+    }
+  }
+  ROSE_ASSERT(vec_typedef != nullptr);
+
+  SgClassDeclaration *class_decl =
+      isSgClassDeclaration(vec_typedef->get_declaration());
+  ROSE_ASSERT(class_decl != nullptr);
+  ROSE_ASSERT(class_decl->get_parent() == vec_typedef);
+  SgClassType *class_type = class_decl->get_type();
+  ROSE_ASSERT(class_type != nullptr);
+
+  Rose_STL_Container<SgNode *> mappers =
+      NodeQuery::querySubTree(project, V_SgOmpDeclareMapperStatement);
+  ROSE_ASSERT(mappers.size() == 1);
+  SgOmpDeclareMapperStatement *mapper =
+      isSgOmpDeclareMapperStatement(mappers.front());
+  ROSE_ASSERT(mapper != nullptr);
+
+  SgTypeExpression *class_type_expr =
+      SageBuilder::buildTypeExpression(class_type);
+  ROSE_ASSERT(class_type_expr != nullptr);
+  SageInterface::setSourcePosition(class_type_expr);
+  mapper->set_mapper_type(class_type_expr);
+  class_type_expr->set_parent(mapper);
+
+  return backend(project);
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_expr_lookup_current_file_a.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_expr_lookup_current_file_a.cpp
@@ -1,0 +1,13 @@
+struct RexTest2026LookupCount {
+  int value;
+};
+
+void rex_test2026_omp_expr_lookup_current_file_a(int *data) {
+  RexTest2026LookupCount rex_test2026_extent = {3};
+  int local_extent = rex_test2026_extent.value;
+
+#pragma omp target map(tofrom : data[0 : local_extent])
+  {
+    data[0] += local_extent;
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_expr_lookup_current_file_b.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_expr_lookup_current_file_b.cpp
@@ -1,0 +1,8 @@
+void rex_test2026_omp_expr_lookup_current_file_b(int *data) {
+  int rex_test2026_extent = 5;
+
+#pragma omp target map(tofrom : data[0 : rex_test2026_extent])
+  {
+    data[0] += rex_test2026_extent;
+  }
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_lowering_deterministic_capture_order.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_lowering_deterministic_capture_order.cpp
@@ -1,0 +1,17 @@
+int rex_test2026_omp_lowering_deterministic_capture_order(int *out, int n) {
+  int alpha = n + 1;
+  int beta = n + 2;
+  int gamma = n + 3;
+  int total = 0;
+
+#pragma omp parallel firstprivate(gamma, alpha, beta) shared(out)              \
+    reduction(+ : total)
+  {
+    int local = alpha + beta + gamma;
+#pragma omp single
+    out[0] = local;
+    total += local;
+  }
+
+  return total;
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_lowering_deterministic_root_order.cpp
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_omp_lowering_deterministic_root_order.cpp
@@ -1,0 +1,31 @@
+static void rex_test2026_root_order_first(int *out, int n) {
+#pragma omp parallel shared(out, n)
+  {
+#pragma omp single
+    out[0] = n + 1;
+  }
+
+#pragma omp task shared(out, n)
+  {
+    out[1] = n + 2;
+  }
+}
+
+static void rex_test2026_root_order_second(int *out, int n) {
+#pragma omp parallel shared(out, n)
+  {
+#pragma omp single
+    out[2] = n + 3;
+  }
+
+#pragma omp parallel shared(out, n)
+  {
+#pragma omp single
+    out[3] = n + 4;
+  }
+}
+
+void rex_test2026_omp_lowering_deterministic_root_order(int *out, int n) {
+  rex_test2026_root_order_first(out, n);
+  rex_test2026_root_order_second(out, n);
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_uses_allocators_optional_edges.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_uses_allocators_optional_edges.c
@@ -1,0 +1,11 @@
+int rex_test2026_uses_allocators_optional_edges(int value) {
+  int result = 0;
+
+#pragma omp target map(from : result)                                          \
+    uses_allocators(omp_default_mem_alloc, omp_const_mem_alloc(value))
+  {
+    result = value + 1;
+  }
+
+  return result;
+}

--- a/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_uses_allocators_user_defined_isolation.c
+++ b/tests/nonsmoke/functional/CompileTests/OpenMP_tests/rex_test2026_uses_allocators_user_defined_isolation.c
@@ -1,0 +1,13 @@
+int rex_test2026_allocator;
+
+int rex_test2026_uses_allocators_user_defined_isolation(int value) {
+  int result = 0;
+
+#pragma omp target map(from : result)                                          \
+    uses_allocators(rex_test2026_allocator(value), omp_default_mem_alloc)
+  {
+    result = value + 1;
+  }
+
+  return result;
+}

--- a/tests/nonsmoke/functional/CompileTests/RoseExample_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/RoseExample_tests/CMakeLists.txt
@@ -5,6 +5,16 @@ set(files_to_test
   testRosePublicConfigPaths.C
   test2003_33.C test2003_34.C test2006_43.C)
 
+set(_rose_example_extended_instrumented_timeout_sources
+  testRoseHeaders_01.C
+  testRoseHeaders_02.C
+  testRoseHeaders_03.C
+  testRoseHeaders_04.C
+  test2003_33.C
+  test2003_34.C
+  test2006_43.C
+)
+
 set(ROSE_FLAGS  -w )
 
 foreach(file_to_test ${files_to_test})
@@ -18,6 +28,14 @@ endforeach()
 
 foreach(file_to_test ${files_to_test})
   compile_test(${file_to_test} rose_example)
+  set(_test_name rose_example_${file_to_test})
+  string(REPLACE "." "_" _test_name "${_test_name}")
+  if(REX_EXTENDED_TEST_TIMEOUTS AND
+     file_to_test IN_LIST _rose_example_extended_instrumented_timeout_sources)
+    set_tests_properties(${_test_name} PROPERTIES
+      TIMEOUT 10800
+      PROCESSORS 16)
+  endif()
 endforeach()
 set(_rose_example_tests)
 foreach(file_to_test ${files_to_test})
@@ -27,6 +45,7 @@ foreach(file_to_test ${files_to_test})
 endforeach()
 
 set(_rose_example_grammar_flags -w -std=c++${CMAKE_CXX_STANDARD} -rose:verbose 0)
+set(_rose_example_generated_grammar_instrumented_timeout 21600)
 add_test(
   NAME rose_example_src_frontend_SageIII_Cxx_Grammar_C
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -37,3 +56,8 @@ add_test(
     -c ${CMAKE_BINARY_DIR}/src/frontend/SageIII/Cxx_Grammar.C
 )
 set_tests_properties(rose_example_src_frontend_SageIII_Cxx_Grammar_C PROPERTIES  LABELS rose_example)
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  set_tests_properties(rose_example_src_frontend_SageIII_Cxx_Grammar_C PROPERTIES
+    TIMEOUT ${_rose_example_generated_grammar_instrumented_timeout}
+    PROCESSORS 16)
+endif()

--- a/tests/nonsmoke/functional/CompileTests/STL_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/STL_tests/CMakeLists.txt
@@ -7,22 +7,54 @@ set(_stl_eval_script ${CMAKE_CURRENT_SOURCE_DIR}/stl-eval.sh)
 set(_stl_eval_cpp11_dir ${CMAKE_CURRENT_BINARY_DIR}/stl_eval_cpp11)
 set(_stl_eval_no_cpp11_dir ${CMAKE_CURRENT_BINARY_DIR}/stl_eval_no_cpp11)
 set(_stl_eval_no_cleanup_dir ${CMAKE_CURRENT_BINARY_DIR}/stl_eval_no_cleanup)
+set(_stl_cpp11_headers_passing
+  algorithm bitset complex deque exception fstream functional iomanip ios
+  iosfwd iostream istream iterator limits list locale map memory new numeric
+  ostream queue set sstream stack stdexcept streambuf string typeinfo utility
+  valarray vector)
+string(REPLACE ";" " " _stl_cpp11_headers_passing_env
+  "${_stl_cpp11_headers_passing}")
+
 file(MAKE_DIRECTORY
   ${_stl_eval_cpp11_dir}
   ${_stl_eval_no_cpp11_dir}
   ${_stl_eval_no_cleanup_dir}
 )
 
-add_test(
-  NAME stl_eval_cpp11
-  WORKING_DIRECTORY ${_stl_eval_cpp11_dir}
-  COMMAND ${CMAKE_COMMAND} -E env
-    TOOL1=${CMAKE_CXX_COMPILER}
-    TOOL2=$<TARGET_FILE:testTranslator>
-    CPP98_STL_TESTS=no
-    CPP11_STL_TESTS=yes
-    ${_stl_eval_script}
-)
+set(_stl_eval_cpp11_tests)
+set(_stl_eval_no_cleanup_tests)
+
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  foreach(_stl_header IN LISTS _stl_cpp11_headers_passing)
+    set(_stl_header_cpp11_dir ${_stl_eval_cpp11_dir}/${_stl_header})
+    file(MAKE_DIRECTORY ${_stl_header_cpp11_dir})
+    add_test(
+      NAME stl_eval_cpp11_${_stl_header}
+      WORKING_DIRECTORY ${_stl_header_cpp11_dir}
+      COMMAND ${CMAKE_COMMAND} -E env
+        TOOL1=${CMAKE_CXX_COMPILER}
+        TOOL2=$<TARGET_FILE:testTranslator>
+        CPP98_STL_TESTS=no
+        CPP11_STL_TESTS=yes
+        STL_CPP11_HEADERS_PASSING=${_stl_header}
+        ${_stl_eval_script}
+    )
+    list(APPEND _stl_eval_cpp11_tests stl_eval_cpp11_${_stl_header})
+  endforeach()
+else()
+  add_test(
+    NAME stl_eval_cpp11
+    WORKING_DIRECTORY ${_stl_eval_cpp11_dir}
+    COMMAND ${CMAKE_COMMAND} -E env
+      TOOL1=${CMAKE_CXX_COMPILER}
+      TOOL2=$<TARGET_FILE:testTranslator>
+      CPP98_STL_TESTS=no
+      CPP11_STL_TESTS=yes
+      STL_CPP11_HEADERS_PASSING=${_stl_cpp11_headers_passing_env}
+      ${_stl_eval_script}
+  )
+  list(APPEND _stl_eval_cpp11_tests stl_eval_cpp11)
+endif()
 
 add_test(
   NAME stl_eval_no_cpp11
@@ -34,16 +66,37 @@ add_test(
     ${_stl_eval_script}
 )
 
-add_test(
-  NAME stl_eval_no_cleanup
-  WORKING_DIRECTORY ${_stl_eval_no_cleanup_dir}
-  COMMAND ${CMAKE_COMMAND} -E env
-    TOOL1=${CMAKE_CXX_COMPILER}
-    TOOL2=$<TARGET_FILE:testTranslator>
-    CPP98_STL_TESTS=no
-    CPP11_STL_TESTS=yes
-    ${_stl_eval_script} no-cleanup
-)
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  foreach(_stl_header IN LISTS _stl_cpp11_headers_passing)
+    set(_stl_header_no_cleanup_dir ${_stl_eval_no_cleanup_dir}/${_stl_header})
+    file(MAKE_DIRECTORY ${_stl_header_no_cleanup_dir})
+    add_test(
+      NAME stl_eval_no_cleanup_${_stl_header}
+      WORKING_DIRECTORY ${_stl_header_no_cleanup_dir}
+      COMMAND ${CMAKE_COMMAND} -E env
+        TOOL1=${CMAKE_CXX_COMPILER}
+        TOOL2=$<TARGET_FILE:testTranslator>
+        CPP98_STL_TESTS=no
+        CPP11_STL_TESTS=yes
+        STL_CPP11_HEADERS_PASSING=${_stl_header}
+        ${_stl_eval_script} no-cleanup
+    )
+    list(APPEND _stl_eval_no_cleanup_tests stl_eval_no_cleanup_${_stl_header})
+  endforeach()
+else()
+  add_test(
+    NAME stl_eval_no_cleanup
+    WORKING_DIRECTORY ${_stl_eval_no_cleanup_dir}
+    COMMAND ${CMAKE_COMMAND} -E env
+      TOOL1=${CMAKE_CXX_COMPILER}
+      TOOL2=$<TARGET_FILE:testTranslator>
+      CPP98_STL_TESTS=no
+      CPP11_STL_TESTS=yes
+      STL_CPP11_HEADERS_PASSING=${_stl_cpp11_headers_passing_env}
+      ${_stl_eval_script} no-cleanup
+  )
+  list(APPEND _stl_eval_no_cleanup_tests stl_eval_no_cleanup)
+endif()
 
 add_test(
   NAME stl_eval_only_cleanup
@@ -56,5 +109,19 @@ add_test(
 
 # LLVM 22/libstdc++ C++11 aggregate header checks still complete normally, but
 # they can exceed CTest's default 1500 second timeout when other long STL modes
-# are scheduled at the same time.
-set_tests_properties(stl_eval_cpp11 stl_eval_no_cleanup PROPERTIES TIMEOUT 2400)
+# are scheduled at the same time. Sanitizer and Valgrind builds run the same
+# checks under instrumentation, so they need a larger wall-clock budget and a
+# larger CTest processor reservation to avoid overscheduling them in full suites.
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  set_tests_properties(
+    ${_stl_eval_cpp11_tests}
+    stl_eval_no_cpp11
+    ${_stl_eval_no_cleanup_tests}
+    PROPERTIES TIMEOUT 21600 PROCESSORS 16)
+elseif(ROSE_USE_SANITIZER OR ROSE_USE_VALGRIND)
+  set_tests_properties(${_stl_eval_cpp11_tests} ${_stl_eval_no_cleanup_tests}
+    PROPERTIES TIMEOUT 7200 PROCESSORS 8)
+else()
+  set_tests_properties(${_stl_eval_cpp11_tests} ${_stl_eval_no_cleanup_tests}
+    PROPERTIES TIMEOUT 2400)
+endif()

--- a/tests/nonsmoke/functional/CompileTests/STL_tests/stl-eval.sh
+++ b/tests/nonsmoke/functional/CompileTests/STL_tests/stl-eval.sh
@@ -42,12 +42,12 @@ fi
 # the following four lists control the behavior of the script
 ###############################################################################
 
-STL_CPP98_HEADERS_PASSING="algorithm   deque exception functional limits list map memory new numeric queue set stack typeinfo utility valarray vector"
-STL_CPP98_HEADERS_FAILING="bitset complex fstream iomanip ios iosfwd iostream istream iterator locale ostream sstream stdexcept streambuf string"
+: ${STL_CPP98_HEADERS_PASSING:="algorithm   deque exception functional limits list map memory new numeric queue set stack typeinfo utility valarray vector"}
+: ${STL_CPP98_HEADERS_FAILING:="bitset complex fstream iomanip ios iosfwd iostream istream iterator locale ostream sstream stdexcept streambuf string"}
 
 # C++11 TESTS are expected to pass for frontend (T0_FAIL+T1_FAIL==0 (but not for backend (T2_FAIL>0))
-STL_CPP11_HEADERS_PASSING="algorithm bitset complex deque exception fstream functional iomanip ios iosfwd iostream istream iterator limits list locale map memory new numeric ostream queue set sstream stack stdexcept streambuf string typeinfo utility valarray vector"
-STL_CPP11_HEADERS_FAILING=""
+: ${STL_CPP11_HEADERS_PASSING:="algorithm bitset complex deque exception fstream functional iomanip ios iosfwd iostream istream iterator limits list locale map memory new numeric ostream queue set sstream stack stdexcept streambuf string typeinfo utility valarray vector"}
+: ${STL_CPP11_HEADERS_FAILING:=""}
 
 ###############################################################################
 

--- a/tests/nonsmoke/functional/CompileTests/UnparseHeadersUsingTokenStream_tests/whiteSpaceTransformation.C
+++ b/tests/nonsmoke/functional/CompileTests/UnparseHeadersUsingTokenStream_tests/whiteSpaceTransformation.C
@@ -72,6 +72,11 @@ WhiteSpaceInheritedAttribute::WhiteSpaceInheritedAttribute ( const WhiteSpaceInh
      return returnValue;
    }
 
+   Traversal::~Traversal() {
+     for (std::pair<SgNode *, SgNode *> *interval : intervalList) {
+       delete interval;
+     }
+   }
 
 std::string
 Segregation_Attribute::get_name()
@@ -459,5 +464,3 @@ main ( int argc, char* argv[] )
   // Only output code if there was a transformation that was done.
      return backend(project);
    }
-
-

--- a/tests/nonsmoke/functional/CompileTests/UnparseHeadersUsingTokenStream_tests/whiteSpaceTransformation.h
+++ b/tests/nonsmoke/functional/CompileTests/UnparseHeadersUsingTokenStream_tests/whiteSpaceTransformation.h
@@ -59,14 +59,15 @@ class Traversal : public SgTopDownBottomUpProcessing<WhiteSpaceInheritedAttribut
 
      public:
        // Functions required
-          WhiteSpaceInheritedAttribute evaluateInheritedAttribute (
-             SgNode* astNode, 
-             WhiteSpaceInheritedAttribute inheritedAttribute );
+       ~Traversal() override;
 
-          WhiteSpaceSynthesizedAttribute evaluateSynthesizedAttribute (
-             SgNode* astNode,
-             WhiteSpaceInheritedAttribute inheritedAttribute,
-             SubTreeSynthesizedAttributes synthesizedAttributeList );
+       WhiteSpaceInheritedAttribute evaluateInheritedAttribute(
+           SgNode *astNode,
+           WhiteSpaceInheritedAttribute inheritedAttribute) override;
+
+       WhiteSpaceSynthesizedAttribute evaluateSynthesizedAttribute(
+           SgNode *astNode, WhiteSpaceInheritedAttribute inheritedAttribute,
+           SubTreeSynthesizedAttributes synthesizedAttributeList) override;
    };
 
 
@@ -88,5 +89,4 @@ class Segregation_Attribute: public AstAttribute
 
           std::string get_name();
           std::string get_color();
-   };
-
+};

--- a/tests/nonsmoke/functional/CompileTests/uninitializedField_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/uninitializedField_tests/CMakeLists.txt
@@ -42,6 +42,15 @@ set(_uninit_includes
   ${ROSE_INCLUDE_FLAGS}
   -isystem ${CMAKE_SOURCE_DIR}/tests/nonsmoke/functional/input_codes/system_header_like
 )
+set(_uninit_cxx_extended_instrumented_timeout_sources
+  Cxx_tests/test2010_02.C
+  Cxx_tests/test2017_24.C
+  Cxx_tests/test2017_99.C
+  Cxx_tests/longFile.C
+  Cxx_tests/test2013_13.C
+  Cxx_tests/test2013_14.C
+  Cxx_tests/test2013_15.C
+)
 
 function(rex_uninit_test_name out_var prefix source_rel)
   set(_name ${source_rel})
@@ -73,6 +82,12 @@ function(rex_add_uninit_cxx_tests property_name will_fail)
     )
     if(${will_fail})
       set_tests_properties(${_test_name} PROPERTIES WILL_FAIL TRUE)
+    endif()
+    if(REX_EXTENDED_TEST_TIMEOUTS AND
+       source_rel IN_LIST _uninit_cxx_extended_instrumented_timeout_sources)
+      set_tests_properties(${_test_name} PROPERTIES
+        TIMEOUT 10800
+        PROCESSORS 16)
     endif()
     if(source_rel MATCHES "axpy")
       set_tests_properties(${_test_name} PROPERTIES TIMEOUT 7200)

--- a/tests/nonsmoke/functional/CompileTests/uninitializedField_tests/testUninitializedFields.C
+++ b/tests/nonsmoke/functional/CompileTests/uninitializedField_tests/testUninitializedFields.C
@@ -89,7 +89,8 @@ int main(int argc, char *argv[]) {
   }
 
   MemoryPoolFilterGuard guard(project);
-  Vis().traverseMemoryPool();
+  Vis vis;
+  vis.traverseMemoryPool();
   return (VALGRIND_COUNT_ERRORS != 0) ? 1 : 0;
 }
 

--- a/tests/nonsmoke/functional/CompilerOptionsTests/collectAllCommentsAndDirectives_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompilerOptionsTests/collectAllCommentsAndDirectives_tests/CMakeLists.txt
@@ -13,6 +13,15 @@ file(MAKE_DIRECTORY ${_collect_comments_output_dir})
 set(_collect_comments_test_dir
   ${CMAKE_SOURCE_DIR}/tests/nonsmoke/functional/CompileTests/Cxx_tests)
 
+set(_collect_comments_extended_instrumented_sources
+  longFile.C
+  test2010_02.C
+  test2013_13.C
+  test2013_14.C
+  test2013_15.C
+  test2017_24.C
+  test2017_99.C)
+
 function(rex_add_collect_comments_tests property_name)
   set(_group_flags ${ARGN})
   rex_get_registered_compile_source_set(_collect_sources ${property_name})
@@ -37,6 +46,13 @@ function(rex_add_collect_comments_tests property_name)
     set_property(TEST compiler_options_collect_comments_${_collect_name}
                  APPEND PROPERTY ENVIRONMENT
                  "ROSE_TEST_OUTPUT_DIR=${_collect_comments_output_dir}")
+    if(REX_EXTENDED_TEST_TIMEOUTS AND
+       _source_name IN_LIST _collect_comments_extended_instrumented_sources)
+      set_tests_properties(compiler_options_collect_comments_${_collect_name}
+        PROPERTIES
+          TIMEOUT 10800
+          PROCESSORS 16)
+    endif()
   endforeach()
 endfunction()
 

--- a/tests/nonsmoke/functional/moveDeclarationTool/CMakeLists.txt
+++ b/tests/nonsmoke/functional/moveDeclarationTool/CMakeLists.txt
@@ -36,6 +36,11 @@ set(MOVE_DECLS_TESTCODES_ADDITIONAL
   inputmoveDeclarationToInnermostScope_test2014_26.C
 )
 
+set(MOVE_DECLS_TESTCODES_EXTENDED_TIMEOUT
+  inputmoveDeclarationToInnermostScope_test2014_18.C
+  inputmoveDeclarationToInnermostScope_test2014_22.C
+)
+
 set(MOVE_DECLS_TESTCODES_ALL
   ${MOVE_DECLS_TESTCODES_FULLY_SUPPORTED}
   ${MOVE_DECLS_TESTCODES_ADDITIONAL}
@@ -356,6 +361,16 @@ foreach(specimen IN LISTS MOVE_DECLS_TESTCODES_ALL)
       ${_reference_root}/withmerge/${_output_v3}
   )
   set_tests_properties(moveDecl_v3_diff_${_name} PROPERTIES DEPENDS moveDecl_v3_${_name})
+
+  if(REX_EXTENDED_TEST_TIMEOUTS AND specimen IN_LIST MOVE_DECLS_TESTCODES_EXTENDED_TIMEOUT)
+    set_tests_properties(
+      moveDecl_v1_${_name}
+      moveDecl_v2_${_name}
+      moveDecl_v3_${_name}
+      PROPERTIES
+        TIMEOUT 10800
+        PROCESSORS 16)
+  endif()
 
 endforeach()
 

--- a/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/rose_v1_inputmoveDeclarationToInnermostScope_test2014_18.C
+++ b/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/rose_v1_inputmoveDeclarationToInnermostScope_test2014_18.C
@@ -7927,8 +7927,6 @@ namespace std __attribute__ ((__visibility__ ("default"))) {
     }
 }
 namespace std __attribute__ ((__visibility__ ("default"))) {
-template<> class ctype<char>;
-template<> class ctype<wchar_t>;
 template<typename _Tv>
     void
     __convert_to_v(const char* __in, _Tv& __out, ios_base::iostate& __err,

--- a/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/withmerge/rose_v2_inputmoveDeclarationToInnermostScope_test2014_18.C
+++ b/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/withmerge/rose_v2_inputmoveDeclarationToInnermostScope_test2014_18.C
@@ -7927,8 +7927,6 @@ namespace std __attribute__ ((__visibility__ ("default"))) {
     }
 }
 namespace std __attribute__ ((__visibility__ ("default"))) {
-template<> class ctype<char>;
-template<> class ctype<wchar_t>;
 template<typename _Tv>
     void
     __convert_to_v(const char* __in, _Tv& __out, ios_base::iostate& __err,

--- a/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/withmerge/rose_v3_inputmoveDeclarationToInnermostScope_test2014_18.C
+++ b/tests/nonsmoke/functional/moveDeclarationTool/referenceResults/withmerge/rose_v3_inputmoveDeclarationToInnermostScope_test2014_18.C
@@ -7927,8 +7927,6 @@ namespace std __attribute__ ((__visibility__ ("default"))) {
     }
 }
 namespace std __attribute__ ((__visibility__ ("default"))) {
-template<> class ctype<char>;
-template<> class ctype<wchar_t>;
 template<typename _Tv>
     void
     __convert_to_v(const char* __in, _Tv& __out, ios_base::iostate& __err,

--- a/tests/nonsmoke/functional/roseTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/CMakeLists.txt
@@ -8,6 +8,7 @@ if(ENABLE-C)
   add_subdirectory (astProcessingTests)
   add_subdirectory (astQueryTests)
   add_subdirectory (astSymbolTableTests)
+  add_subdirectory (astJsonTests)
   add_subdirectory (astTokenStreamTests)
   add_subdirectory (programTransformationTests)
   #add_subdirectory (graph_tests)
@@ -23,4 +24,3 @@ if(ENABLE-C)
   #add_subdirectory (loopProcessingTests)
   add_subdirectory (fileLocation_tests)
 endif() # C/C++
-

--- a/tests/nonsmoke/functional/roseTests/astJsonTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astJsonTests/CMakeLists.txt
@@ -1,0 +1,51 @@
+add_executable(rex_test2026_ast_json_external_scope_contract
+  rex_test2026_ast_json_external_scope_contract.cpp)
+target_link_libraries(rex_test2026_ast_json_external_scope_contract
+  ROSE_DLL ${link_with_libraries})
+
+add_executable(rex_test2026_ast_json_detached_file_type_fixup
+  rex_test2026_ast_json_detached_file_type_fixup.cpp)
+target_link_libraries(rex_test2026_ast_json_detached_file_type_fixup
+  ROSE_DLL ${link_with_libraries})
+
+set(_ast_json_contract_dir
+  ${CMAKE_CURRENT_BINARY_DIR}/external-function-parameter-scope-json)
+
+add_test(
+  NAME ASTJSON_external_function_parameter_scope_contract
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E env
+    REX_AST_JSON_CHECKPOINT=pre-omp-construction
+    REX_AST_JSON_DIR=${_ast_json_contract_dir}
+    $<TARGET_FILE:rex_test2026_ast_json_external_scope_contract>
+      --rex-ast-json-contract-dir=${_ast_json_contract_dir}
+      -rose:skipfinalCompileStep
+      -w
+      -rose:verbose
+      0
+      -c
+      ${CMAKE_CURRENT_SOURCE_DIR}/input_rex_test2026_ast_json_external_scope.c)
+set_tests_properties(ASTJSON_external_function_parameter_scope_contract
+  PROPERTIES LABELS ASTJSON)
+
+set(_ast_json_detached_fixup_dir
+  ${CMAKE_CURRENT_BINARY_DIR}/detached-file-type-fixup-json)
+
+add_test(
+  NAME ASTJSON_rex_test2026_detached_file_type_fixup
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E env
+    REX_AST_JSON_CHECKPOINT=pre-omp-construction
+    REX_AST_JSON_DIR=${_ast_json_detached_fixup_dir}
+    $<TARGET_FILE:rex_test2026_ast_json_detached_file_type_fixup>
+      --rex-ast-json-dir=${_ast_json_detached_fixup_dir}
+      -rex:ast-json-checkpoint=pre-omp-construction
+      -rex:ast-json-dir=${_ast_json_detached_fixup_dir}
+      -rose:skipfinalCompileStep
+      -w
+      -rose:verbose
+      0
+      -c
+      ${CMAKE_CURRENT_SOURCE_DIR}/input_rex_test2026_ast_json_detached_file_type_fixup.cpp)
+set_tests_properties(ASTJSON_rex_test2026_detached_file_type_fixup
+  PROPERTIES LABELS ASTJSON)

--- a/tests/nonsmoke/functional/roseTests/astJsonTests/input_rex_test2026_ast_json_detached_file_type_fixup.cpp
+++ b/tests/nonsmoke/functional/roseTests/astJsonTests/input_rex_test2026_ast_json_detached_file_type_fixup.cpp
@@ -1,0 +1,10 @@
+struct RexTest2026DetachedType;
+
+struct RexTest2026DetachedType {
+  int value;
+};
+
+int rex_test2026_ast_json_detached_file_type_fixup(
+    RexTest2026DetachedType *object) {
+  return object->value;
+}

--- a/tests/nonsmoke/functional/roseTests/astJsonTests/input_rex_test2026_ast_json_external_scope.c
+++ b/tests/nonsmoke/functional/roseTests/astJsonTests/input_rex_test2026_ast_json_external_scope.c
@@ -1,0 +1,4 @@
+void rex_ast_json_original(void);
+void rex_ast_json_target(int value);
+
+void rex_ast_json_original(void) {}

--- a/tests/nonsmoke/functional/roseTests/astJsonTests/rex_test2026_ast_json_detached_file_type_fixup.cpp
+++ b/tests/nonsmoke/functional/roseTests/astJsonTests/rex_test2026_ast_json_detached_file_type_fixup.cpp
@@ -1,0 +1,89 @@
+#include "astJson/sageAstJson.h"
+#include "fixupTypes.h"
+#include "rose.h"
+
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string takeJsonDir(int &argc, char **argv) {
+  std::string dir;
+  std::vector<char *> filtered;
+  filtered.reserve(argc);
+  filtered.push_back(argv[0]);
+
+  const char prefix[] = "--rex-ast-json-dir=";
+  for (int i = 1; i < argc; ++i) {
+    if (std::strncmp(argv[i], prefix, sizeof(prefix) - 1) == 0) {
+      dir = argv[i] + sizeof(prefix) - 1;
+      continue;
+    }
+    filtered.push_back(argv[i]);
+  }
+
+  argc = static_cast<int>(filtered.size());
+  for (int i = 0; i < argc; ++i) {
+    argv[i] = filtered[i];
+  }
+  argv[argc] = nullptr;
+  return dir;
+}
+
+SgSourceFile *firstSourceFile(SgProject *project) {
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(project->numberOfFiles() == 1);
+  SgSourceFile *file = isSgSourceFile(&project->get_file(0));
+  ROSE_ASSERT(file != nullptr);
+  return file;
+}
+
+SgClassDeclaration *findDetachedForwardDeclaration(SgNode *root) {
+  for (SgNode *node : NodeQuery::querySubTree(root, V_SgClassDeclaration)) {
+    SgClassDeclaration *decl = isSgClassDeclaration(node);
+    ROSE_ASSERT(decl != nullptr);
+    if (decl->get_name() != "RexTest2026DetachedType") {
+      continue;
+    }
+    if (decl->get_definingDeclaration() != decl &&
+        decl->get_definingDeclaration() != nullptr) {
+      return decl;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  const std::string json_dir = takeJsonDir(argc, argv);
+  ROSE_ASSERT(!json_dir.empty());
+  std::filesystem::remove_all(json_dir);
+  std::filesystem::create_directories(json_dir);
+
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  project->skipfinalCompileStep(true);
+
+  SgSourceFile *old_file = firstSourceFile(project);
+  SgClassDeclaration *old_forward = findDetachedForwardDeclaration(old_file);
+  ROSE_ASSERT(old_forward != nullptr);
+
+  SgSourceFile *new_file = Rose::AstJson::roundTripSourceFile(
+      old_file, Rose::AstJson::Checkpoint::PreOmpConstruction);
+  ROSE_ASSERT(new_file != nullptr);
+  ROSE_ASSERT(new_file != old_file);
+  ROSE_ASSERT(old_file->get_parent() == nullptr);
+  ROSE_ASSERT(new_file->get_parent() != nullptr);
+
+  SgClassType *sentinel_type = new SgClassType(old_forward);
+  old_forward->set_type(sentinel_type);
+
+  resetTypesInAST();
+
+  ROSE_ASSERT(old_forward->get_type() == sentinel_type);
+  ROSE_ASSERT(firstSourceFile(project) == new_file);
+  return 0;
+}

--- a/tests/nonsmoke/functional/roseTests/astJsonTests/rex_test2026_ast_json_external_scope_contract.cpp
+++ b/tests/nonsmoke/functional/roseTests/astJsonTests/rex_test2026_ast_json_external_scope_contract.cpp
@@ -1,0 +1,207 @@
+#include "rose.h"
+
+#include "astJson/sageAstJson.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string takeContractDir(int &argc, char **argv) {
+  const char prefix[] = "--rex-ast-json-contract-dir=";
+  std::string result;
+  std::vector<char *> filtered;
+  filtered.reserve(argc);
+  filtered.push_back(argv[0]);
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::strncmp(argv[i], prefix, sizeof(prefix) - 1) == 0) {
+      result = argv[i] + sizeof(prefix) - 1;
+      continue;
+    }
+    filtered.push_back(argv[i]);
+  }
+
+  argc = static_cast<int>(filtered.size());
+  for (int i = 0; i < argc; ++i) {
+    argv[i] = filtered[i];
+  }
+  argv[argc] = nullptr;
+  return result;
+}
+
+SgSourceFile *firstSourceFile(SgProject *project) {
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(project->numberOfFiles() > 0);
+  SgSourceFile *file = isSgSourceFile(&project->get_file(0));
+  ROSE_ASSERT(file != nullptr);
+  return file;
+}
+
+SgFunctionDeclaration *findFunction(SgNode *root, const std::string &name) {
+  for (SgNode *node : NodeQuery::querySubTree(root, V_SgFunctionDeclaration)) {
+    SgFunctionDeclaration *decl = isSgFunctionDeclaration(node);
+    if (decl != nullptr && decl->get_name().getString() == name) {
+      return decl;
+    }
+  }
+  return nullptr;
+}
+
+void requireSourcePosition(SgNode *node) {
+  ROSE_ASSERT(node != nullptr);
+  if (node->get_startOfConstruct() == nullptr ||
+      node->get_endOfConstruct() == nullptr) {
+    SageInterface::setSourcePositionAtRootAndAllChildren(node);
+  }
+}
+
+SgSymbolTable *ensureSymbolTable(SgScopeStatement *scope) {
+  ROSE_ASSERT(scope != nullptr);
+  if (scope->get_symbol_table() == nullptr) {
+    SgSymbolTable *table = new SgSymbolTable(17);
+    table->set_parent(scope);
+    scope->set_symbol_table(table);
+  }
+  ROSE_ASSERT(scope->get_symbol_table() != nullptr);
+  return scope->get_symbol_table();
+}
+
+std::string readFile(const std::filesystem::path &path) {
+  std::ifstream in(path);
+  if (!in) {
+    throw std::runtime_error("failed to open " + path.string());
+  }
+  std::ostringstream out;
+  out << in.rdbuf();
+  return out.str();
+}
+
+bool anyJsonContainsAll(const std::filesystem::path &dir,
+                        const std::vector<std::string> &needles) {
+  if (!std::filesystem::exists(dir)) {
+    return false;
+  }
+  for (const std::filesystem::directory_entry &entry :
+       std::filesystem::recursive_directory_iterator(dir)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".json") {
+      continue;
+    }
+    const std::string text = readFile(entry.path());
+    bool all_present = true;
+    for (const std::string &needle : needles) {
+      if (text.find(needle) == std::string::npos) {
+        all_present = false;
+        break;
+      }
+    }
+    if (all_present) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void addExternalScopeContracts(SgProject *project, SgSourceFile *file) {
+  SgFunctionDeclaration *target = findFunction(file, "rex_ast_json_target");
+  SgFunctionDeclaration *original = findFunction(file, "rex_ast_json_original");
+  ROSE_ASSERT(target != nullptr);
+  ROSE_ASSERT(original != nullptr);
+
+  SgGlobal *global = file->get_globalScope();
+  ROSE_ASSERT(global != nullptr);
+  SgFunctionSymbol *original_symbol =
+      global->lookup_function_symbol("rex_ast_json_original");
+  ROSE_ASSERT(original_symbol != nullptr);
+
+  SgFunctionDeclaration *external_peer =
+      SageInterface::deepCopy<SgFunctionDeclaration>(target);
+  ROSE_ASSERT(external_peer != nullptr);
+  external_peer->set_parent(project);
+  external_peer->set_scope(global);
+  external_peer->set_firstNondefiningDeclaration(external_peer);
+  external_peer->set_definingDeclaration(nullptr);
+  requireSourcePosition(external_peer);
+
+  SgFunctionParameterScope *external_scope =
+      external_peer->get_functionParameterScope();
+  if (external_scope == nullptr) {
+    external_scope = new SgFunctionParameterScope();
+    external_peer->set_functionParameterScope(external_scope);
+  }
+  external_scope->set_parent(external_peer);
+  requireSourcePosition(external_scope);
+
+  SgUseStatement *use_stmt =
+      new SgUseStatement(SgName("rex_ast_json_external_mod"), true, "");
+  use_stmt->set_parent(external_scope);
+  use_stmt->set_scope(external_scope);
+  use_stmt->set_firstNondefiningDeclaration(use_stmt);
+  use_stmt->set_definingDeclaration(use_stmt);
+  SgRenamePair *rename_pair =
+      new SgRenamePair(SgName("local_name"), SgName("use_name"));
+  rename_pair->set_parent(use_stmt);
+  use_stmt->get_rename_list().push_back(rename_pair);
+  requireSourcePosition(use_stmt);
+  requireSourcePosition(rename_pair);
+  external_scope->append_declaration(use_stmt);
+
+  SgSymbolTable *external_table = ensureSymbolTable(external_scope);
+
+  SgAliasSymbol *alias_symbol =
+      new SgAliasSymbol(original_symbol, true, SgName("alias_original"));
+  alias_symbol->get_causal_nodes().push_back(use_stmt);
+  external_table->insert(SgName("alias_original"), alias_symbol);
+
+  SgRenameSymbol *rename_symbol =
+      new SgRenameSymbol(target, original_symbol, SgName("renamed_original"));
+  external_table->insert(SgName("renamed_original"), rename_symbol);
+
+  target->set_firstNondefiningDeclaration(external_peer);
+  target->set_functionParameterScope(external_scope);
+}
+
+void verifyContractJson(const std::filesystem::path &dir) {
+  const std::vector<std::string> required = {
+      "\"external_function_parameter_scope\"",
+      "\"external_function_parameter_scope_source\": "
+      "\"firstNondefiningDeclaration\"",
+      "\"kind\": \"SgUseStatement\"",
+      "\"kind\": \"SgRenamePair\"",
+      "\"symbol_kind\": \"SgAliasSymbol\"",
+      "\"symbol_kind\": \"SgRenameSymbol\"",
+  };
+  if (!anyJsonContainsAll(dir, required)) {
+    throw std::runtime_error("AST JSON contract markers were not written to " +
+                             dir.string());
+  }
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  const std::string contract_dir = takeContractDir(argc, argv);
+  ROSE_ASSERT(!contract_dir.empty());
+
+  std::filesystem::remove_all(contract_dir);
+  std::filesystem::create_directories(contract_dir);
+
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  project->skipfinalCompileStep(true);
+
+  SgSourceFile *file = firstSourceFile(project);
+  addExternalScopeContracts(project, file);
+
+  file = Rose::AstJson::roundTripSourceFile(
+      file, Rose::AstJson::Checkpoint::PreOmpConstruction);
+  ROSE_ASSERT(file != nullptr);
+
+  verifyContractJson(contract_dir);
+  return 0;
+}

--- a/tests/nonsmoke/functional/roseTests/astOutliningTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astOutliningTests/CMakeLists.txt
@@ -1038,3 +1038,9 @@ add_test(
   COMMAND bash -c
     "${CMAKE_CXX_COMPILER} -c ${CMAKE_CURRENT_SOURCE_DIR}/test_class_ODR_violation_main.C && ${CMAKE_CXX_COMPILER} -c ${CMAKE_CURRENT_SOURCE_DIR}/test_class_ODR_violation_outlined.C && ${CMAKE_CXX_COMPILER} test_class_ODR_violation_main.o test_class_ODR_violation_outlined.o -o test_class_ODR_violation"
 )
+
+get_property(_outline_registered_tests DIRECTORY PROPERTY TESTS)
+if(REX_EXTENDED_TEST_TIMEOUTS AND _outline_registered_tests)
+  set_tests_properties(${_outline_registered_tests} PROPERTIES
+    PROCESSORS 16)
+endif()

--- a/tests/nonsmoke/functional/roseTests/astOutliningTests/injectOutlinePragmas.cc
+++ b/tests/nonsmoke/functional/roseTests/astOutliningTests/injectOutlinePragmas.cc
@@ -71,11 +71,7 @@ static void insertOutlineDirectives(RandomStmtSelector::StmtSet_t &S) {
 
       // Generate pragma, randomly choosing between
       // pass-by-reference or pass-by-pointer outlining styles.
-      char *pragma_text = new char[30];
-      ROSE_ASSERT(pragma_text);
-      strcpy(pragma_text, "rose_outline");
-
-      SgPragma *pragma = new SgPragma(pragma_text, ASTtools::newFileInfo());
+      SgPragma *pragma = new SgPragma("rose_outline", ASTtools::newFileInfo());
       ROSE_ASSERT(pragma);
       SgPragmaDeclaration *pragma_decl =
           new SgPragmaDeclaration(ASTtools::newFileInfo(), pragma);

--- a/tests/nonsmoke/functional/roseTests/astPerformanceTests/testPerformance.C
+++ b/tests/nonsmoke/functional/roseTests/astPerformanceTests/testPerformance.C
@@ -3,6 +3,8 @@
 #include "AstPerformance.h"
 
 #include <cstdio>
+#include <memory>
+#include <vector>
 // Fix suggested by Brian White (to allow "sleep()" to be defined)
 // #include <unistd.h>
 
@@ -14,8 +16,10 @@ void foo() {
 
   printf("Before memory allocation ... \n");
   // Allocate some memory to test the memory useage
+  std::vector<std::unique_ptr<int[]>> allocations;
+  allocations.reserve(1000);
   for (int i = 0; i < 1000; i++) {
-    /* int* pointer = */ new int[250000];
+    allocations.push_back(std::unique_ptr<int[]>(new int[250000]));
   }
 
   printf("After memory allocation ... \n");
@@ -34,8 +38,10 @@ int main() {
 
   printf("Before memory allocation ... \n");
   // Allocate some memory to test the memory useage
+  std::vector<std::unique_ptr<int[]>> allocations;
+  allocations.reserve(1000);
   for (int i = 0; i < 1000; i++) {
-    /* int* pointer = */ new int[250000];
+    allocations.push_back(std::unique_ptr<int[]>(new int[250000]));
   }
 
   printf("After memory allocation ... \n");

--- a/tests/nonsmoke/functional/roseTests/astProcessingTests/astTraversalTest.C
+++ b/tests/nonsmoke/functional/roseTests/astProcessingTests/astTraversalTest.C
@@ -143,6 +143,14 @@ template <class T> std::vector<T *> *buildTraversalList() {
   return traversalList;
 }
 
+template <class T> void destroyTraversalList(std::vector<T *> *traversalList) {
+  for (typename std::vector<T *>::iterator it = traversalList->begin();
+       it != traversalList->end(); ++it) {
+    delete *it;
+  }
+  delete traversalList;
+}
+
 void runSequentialTests(SgProject *root,
                         std::vector<unsigned long> *referenceResults) {
   struct timeval beginTime, endTime;
@@ -174,7 +182,7 @@ void runSequentialTests(SgProject *root,
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
 
-  delete simpleList;
+  destroyTraversalList(simpleList);
 
   // DQ (11/5/2016): Bug caught by address sanitizer (reset to NULL to avoid
   // possible use below, also fixed below).
@@ -210,7 +218,7 @@ void runSequentialTests(SgProject *root,
 
   // DQ (11/5/2016): Bug caught by address sanitizer (simpleList deleted above).
   // delete simpleList;
-  delete simpleList2;
+  destroyTraversalList(simpleList2);
 
   std::cout << "pre-post sequential" << std::endl;
   std::vector<NodeCountPrePost *> *prePostList =
@@ -233,7 +241,7 @@ void runSequentialTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
-  delete prePostList;
+  destroyTraversalList(prePostList);
 
   std::cout << "bottom-up sequential" << std::endl;
   std::vector<NodeCountBottomUp *> *bottomUpList =
@@ -241,7 +249,9 @@ void runSequentialTests(SgProject *root,
   std::vector<NodeCountBottomUp *>::iterator b;
   beginTime = getCPUTime();
   for (b = bottomUpList->begin(); b != bottomUpList->end(); ++b) {
-    (*b)->variantCount = *(*b)->traverse(root);
+    unsigned long *result = (*b)->traverse(root);
+    (*b)->variantCount = *result;
+    delete result;
   }
   endTime = getCPUTime();
   i = 0;
@@ -256,7 +266,7 @@ void runSequentialTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
-  delete bottomUpList;
+  destroyTraversalList(bottomUpList);
 
   std::cout << "top-down sequential" << std::endl;
   std::vector<NodeCountTopDown *> *topDownList =
@@ -279,7 +289,7 @@ void runSequentialTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
-  delete topDownList;
+  destroyTraversalList(topDownList);
 
   std::cout << "top-down bottom-up sequential" << std::endl;
   std::vector<NodeCountTopDownBottomUp *> *topDownBottomUpList =
@@ -304,7 +314,7 @@ void runSequentialTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
-  delete topDownBottomUpList;
+  destroyTraversalList(topDownBottomUpList);
 }
 
 void runCombinedTests(SgProject *root,
@@ -335,6 +345,7 @@ void runCombinedTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(simpleList);
 
   std::cout << "pre-post combined" << std::endl;
   std::vector<NodeCountPrePost *> *prePostList =
@@ -358,6 +369,7 @@ void runCombinedTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(prePostList);
 
   std::cout << "bottom-up combined" << std::endl;
   std::vector<NodeCountBottomUp *> *bottomUpList =
@@ -377,12 +389,15 @@ void runCombinedTests(SgProject *root,
     std::cout << **br << ' ';
 #endif
     ROSE_ASSERT(**br == referenceResults->at(i++));
+    delete *br;
   }
 #if OUTPUT_RESULTS
   std::cout << std::endl;
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  delete bottomUpResults;
+  destroyTraversalList(bottomUpList);
 
   std::cout << "top-down combined" << std::endl;
   std::vector<NodeCountTopDown *> *topDownList =
@@ -409,6 +424,7 @@ void runCombinedTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(topDownList);
 
   std::cout << "top-down bottom-up combined" << std::endl;
   std::vector<NodeCountTopDownBottomUp *> *topDownBottomUpList =
@@ -440,6 +456,8 @@ void runCombinedTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  delete topDownBottomUpResults;
+  destroyTraversalList(topDownBottomUpList);
 }
 
 void runParallelTests(SgProject *root,
@@ -474,6 +492,7 @@ void runParallelTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(simpleList);
 
   std::cout << "pre-post parallel" << std::endl;
   std::vector<NodeCountPrePost *> *prePostList =
@@ -497,6 +516,7 @@ void runParallelTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(prePostList);
 
   std::cout << "bottom-up parallel" << std::endl;
   std::vector<NodeCountBottomUp *> *bottomUpList =
@@ -516,12 +536,15 @@ void runParallelTests(SgProject *root,
     std::cout << **br << ' ';
 #endif
     ROSE_ASSERT(**br == referenceResults->at(i++));
+    delete *br;
   }
 #if OUTPUT_RESULTS
   std::cout << std::endl;
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  delete bottomUpResults;
+  destroyTraversalList(bottomUpList);
 
   std::cout << "top-down parallel" << std::endl;
   std::vector<NodeCountTopDown *> *topDownList =
@@ -548,6 +571,7 @@ void runParallelTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  destroyTraversalList(topDownList);
 
   std::cout << "top-down bottom-up parallel" << std::endl;
   std::vector<NodeCountTopDownBottomUp *> *topDownBottomUpList =
@@ -580,6 +604,8 @@ void runParallelTests(SgProject *root,
 #endif
   std::cout << "approximate time (seconds): "
             << timeDifference(endTime, beginTime) << std::endl;
+  delete topDownBottomUpResults;
+  destroyTraversalList(topDownBottomUpList);
 #endif
 }
 

--- a/tests/nonsmoke/functional/roseTests/astProcessingTests/sourcePTP.C
+++ b/tests/nonsmoke/functional/roseTests/astProcessingTests/sourcePTP.C
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
     ROSE_ASSERT(fni != NULL);
     forsA.push_back(*i);
   }
-  visitorTraversal *visif = new visitorTraversal();
+  visitorTraversal visif;
   SgIncidenceDirectedGraph *g = cfg.getGraph();
   // std::set<SgNode*> completedIfs;
   auto mg = instantiateGraph(g, cfg);
@@ -90,16 +90,16 @@ int main(int argc, char *argv[]) {
       fors.push_back(forsA[i]);
       // visitorTraversal* visif = new visitorTraversal();
       // SgIncidenceDirectedGraph* g = cfg.getGraph();
-      visif->tltnodes = 0;
-      visif->paths = 0;
-      visif->constructPathAnalyzer(
-          mg.get(), false, mg->getVSlink()[cfg.cfgForBeginning(fors[i])],
-          mg->getVSlink()[cfg.cfgForEnd(fors[i])]);
+      visif.tltnodes = 0;
+      visif.paths = 0;
+      visif.constructPathAnalyzer(mg.get(), false,
+                                  mg->getVSlink()[cfg.cfgForBeginning(fors[i])],
+                                  mg->getVSlink()[cfg.cfgForEnd(fors[i])]);
       // visif->constructPathAnalyzer(mg.get(),
       // mg->getVSlink()[cfg.cfgForEnd(fors[i-1])],
       // mg->getVSlink()[cfg.cfgForBeginning(fors[i])]);
       std::cout << "between: " << i << " and " << i + 1 << " there are "
-                << visif->paths << " paths." << std::endl;
+                << visif.paths << " paths." << std::endl;
       // completedIfs.insert(ifs[i]);
       // }
     }

--- a/tests/nonsmoke/functional/roseTests/astQueryTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astQueryTests/CMakeLists.txt
@@ -77,17 +77,39 @@ foreach(entry IN LISTS ROSE_INCLUDES)
 endforeach()
 string(JOIN " " _rose_include_flags_str ${_rose_include_flags})
 
+set(_ast_query_cxx_grammar_timeout 1800)
+set(_ast_query_cxx_grammar_ctest_timeout 1900)
+set(_ast_query_cxx_grammar_properties
+  TIMEOUT ${_ast_query_cxx_grammar_ctest_timeout}
+)
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  set(_ast_query_cxx_grammar_timeout 21600)
+  set(_ast_query_cxx_grammar_ctest_timeout 22200)
+  set(_ast_query_cxx_grammar_properties
+    TIMEOUT ${_ast_query_cxx_grammar_ctest_timeout}
+    PROCESSORS 16
+    RUN_SERIAL TRUE
+  )
+elseif(ROSE_USE_SANITIZER)
+  set(_ast_query_cxx_grammar_timeout 3600)
+  set(_ast_query_cxx_grammar_ctest_timeout 3900)
+  set(_ast_query_cxx_grammar_properties
+    TIMEOUT ${_ast_query_cxx_grammar_ctest_timeout}
+    RUN_SERIAL TRUE
+  )
+endif()
+
 add_test(
   NAME astQuery_test3_cxx_grammar
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${_rth}
     "TITLE=test3 Cxx_Grammar.C [test3.passed]"
     "USE_SUBDIR=yes"
-    "TIMEOUT=1800"
+    "TIMEOUT=${_ast_query_cxx_grammar_timeout}"
     "CMD=$<TARGET_FILE:testQuery3> -rose:verbose 0 -std=c++${CMAKE_CXX_STANDARD} -I${CMAKE_BINARY_DIR} ${_rose_include_flags_str} -c ${CMAKE_BINARY_DIR}/src/frontend/SageIII/Cxx_Grammar.C"
     ${_exit_status}
     test3.passed
 )
-set_tests_properties(astQuery_test3_cxx_grammar PROPERTIES TIMEOUT 1900)
+set_tests_properties(astQuery_test3_cxx_grammar PROPERTIES ${_ast_query_cxx_grammar_properties})
 
 install(TARGETS testQuery testQuery2 testQuery3 DESTINATION bin)

--- a/tests/nonsmoke/functional/roseTests/astSymbolTableTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astSymbolTableTests/CMakeLists.txt
@@ -17,6 +17,11 @@ add_executable(rex_test2026_openmp_acc_ast
 target_link_libraries(rex_test2026_openmp_acc_ast
   ROSE_DLL ${link_with_libraries})
 
+add_executable(rex_test2026_rebuild_symbol_table_coverage
+  rex_test2026_rebuild_symbol_table_coverage.cpp)
+target_link_libraries(rex_test2026_rebuild_symbol_table_coverage
+  ROSE_DLL ${link_with_libraries})
+
 set(_rth ${CMAKE_SOURCE_DIR}/scripts/rth_run.pl)
 set(_exit_status ${CMAKE_SOURCE_DIR}/scripts/test_exit_status)
 
@@ -59,3 +64,38 @@ add_test(
     -rose:openmp:ast_only
     -c ${CMAKE_CURRENT_SOURCE_DIR}/input_rex_test2026_openmp_acc.C
 )
+
+add_test(
+  NAME rex_test2026_astSymbolTable_rebuild_declaration_scope
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND $<TARGET_FILE:rex_test2026_rebuild_symbol_table_coverage>
+    --rex-rebuild-check=declaration-scope
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/../astInterfaceTests/inputrex_test2026_declaration_scope.C
+)
+
+add_test(
+  NAME rex_test2026_astSymbolTable_rebuild_openmp
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND $<TARGET_FILE:rex_test2026_rebuild_symbol_table_coverage>
+    --rex-rebuild-check=openmp
+    -rose:openmp:ast_only
+    -w
+    -rose:verbose
+    0
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/input_rex_test2026_rebuild_symbol_table_openmp.c
+)
+
+if(ENABLE-FORTRAN)
+  add_test(
+    NAME rex_test2026_astSymbolTable_rebuild_fortran_openmp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND $<TARGET_FILE:rex_test2026_rebuild_symbol_table_coverage>
+      --rex-rebuild-check=fortran-openmp
+      -rose:openmp:ast_only
+      -rose:skipfinalCompileStep
+      -w
+      -rose:verbose
+      0
+      -c ${CMAKE_CURRENT_SOURCE_DIR}/input_rex_test2026_rebuild_symbol_table_fortran.f90
+  )
+endif()

--- a/tests/nonsmoke/functional/roseTests/astSymbolTableTests/input_rex_test2026_rebuild_symbol_table_fortran.f90
+++ b/tests/nonsmoke/functional/roseTests/astSymbolTableTests/input_rex_test2026_rebuild_symbol_table_fortran.f90
@@ -1,0 +1,17 @@
+module rex_test2026_rebuild_mod
+contains
+  subroutine rex_test2026_rebuild_worker(n)
+    implicit none
+    integer :: i
+    integer, intent(in) :: n
+!$omp parallel do
+    do i = 1, n
+    end do
+  end subroutine rex_test2026_rebuild_worker
+end module rex_test2026_rebuild_mod
+
+program rex_test2026_rebuild_driver
+  use rex_test2026_rebuild_mod
+  implicit none
+  call rex_test2026_rebuild_worker(4)
+end program rex_test2026_rebuild_driver

--- a/tests/nonsmoke/functional/roseTests/astSymbolTableTests/input_rex_test2026_rebuild_symbol_table_openmp.c
+++ b/tests/nonsmoke/functional/roseTests/astSymbolTableTests/input_rex_test2026_rebuild_symbol_table_openmp.c
@@ -1,0 +1,34 @@
+#pragma omp requires unified_shared_memory
+
+typedef struct RexTest2026Vec {
+  int len;
+  float *data;
+} RexTest2026Vec;
+
+int rex_test2026_global;
+#pragma omp threadprivate(rex_test2026_global)
+
+int rex_test2026_variant(int x);
+#pragma omp declare variant(rex_test2026_variant) match(construct = {parallel})
+int rex_test2026_base(int x);
+
+#pragma omp declare mapper(default : RexTest2026Vec v)                         \
+    map(tofrom : v.len, v.data[0 : v.len])
+
+#pragma omp declare simd
+int rex_test2026_simd(int x);
+
+#pragma omp declare target
+int rex_test2026_target_value;
+#pragma omp end declare target
+
+void rex_test2026_work(RexTest2026Vec *v) {
+  int local = 0;
+#pragma omp allocate(local) allocator(omp_default_mem_alloc)
+#pragma omp taskwait
+  v->len += local;
+}
+
+int rex_test2026_variant(int x) { return x + 1; }
+int rex_test2026_base(int x) { return x; }
+int rex_test2026_simd(int x) { return x * 2; }

--- a/tests/nonsmoke/functional/roseTests/astSymbolTableTests/rex_test2026_rebuild_symbol_table_coverage.cpp
+++ b/tests/nonsmoke/functional/roseTests/astSymbolTableTests/rex_test2026_rebuild_symbol_table_coverage.cpp
@@ -1,0 +1,184 @@
+#include "rose.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string takeCheckMode(int &argc, char **argv) {
+  std::string mode;
+  std::vector<char *> filtered;
+  filtered.reserve(argc);
+  filtered.push_back(argv[0]);
+
+  const char prefix[] = "--rex-rebuild-check=";
+  for (int i = 1; i < argc; ++i) {
+    if (std::strncmp(argv[i], prefix, sizeof(prefix) - 1) == 0) {
+      mode = argv[i] + sizeof(prefix) - 1;
+      continue;
+    }
+    filtered.push_back(argv[i]);
+  }
+
+  argc = static_cast<int>(filtered.size());
+  for (int i = 0; i < argc; ++i) {
+    argv[i] = filtered[i];
+  }
+  argv[argc] = nullptr;
+  return mode;
+}
+
+void clearScopeSymbolTables(SgNode *root) {
+  Rose_STL_Container<SgNode *> scopes =
+      NodeQuery::querySubTree(root, V_SgScopeStatement);
+  for (SgNode *node : scopes) {
+    SgScopeStatement *scope = isSgScopeStatement(node);
+    ROSE_ASSERT(scope != nullptr);
+    SgSymbolTable *table = scope->get_symbol_table();
+    if (table == nullptr) {
+      continue;
+    }
+    ROSE_ASSERT(table->get_table() != nullptr);
+    table->get_table()->clear();
+    table->set_symbolSet(SgNodeSet());
+    table->clear_functionSymbolExactIndex();
+    ROSE_ASSERT(table->size() == 0);
+  }
+}
+
+void rebuildScopeSymbolTables(SgNode *root) {
+  Rose_STL_Container<SgNode *> scopes =
+      NodeQuery::querySubTree(root, V_SgScopeStatement);
+  for (SgNode *node : scopes) {
+    SgScopeStatement *scope = isSgScopeStatement(node);
+    ROSE_ASSERT(scope != nullptr);
+    SageInterface::rebuildSymbolTable(scope);
+    ROSE_ASSERT(scope->get_symbol_table() != nullptr);
+    ROSE_ASSERT(scope->get_symbol_table()->get_parent() == scope);
+  }
+}
+
+void requireNode(SgNode *root, VariantT variant) {
+  Rose_STL_Container<SgNode *> nodes = NodeQuery::querySubTree(root, variant);
+  ROSE_ASSERT(!nodes.empty());
+}
+
+SgGlobal *firstGlobalScope(SgProject *project) {
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(project->numberOfFiles() > 0);
+  SgSourceFile *source_file = isSgSourceFile(&project->get_file(0));
+  ROSE_ASSERT(source_file != nullptr);
+  SgGlobal *global = source_file->get_globalScope();
+  ROSE_ASSERT(global != nullptr);
+  return global;
+}
+
+void checkDeclarationScope(SgProject *project) {
+  requireNode(project, V_SgDeclarationScope);
+  requireNode(project, V_SgNonrealDecl);
+
+  SgNonrealDecl *target = nullptr;
+  for (SgNode *node : NodeQuery::querySubTree(project, V_SgNonrealDecl)) {
+    SgNonrealDecl *decl = isSgNonrealDecl(node);
+    if (decl != nullptr && decl->get_name() == "TT") {
+      target = decl;
+      break;
+    }
+  }
+  ROSE_ASSERT(target != nullptr);
+
+  SgDeclarationScope *owner_scope = isSgDeclarationScope(target->get_parent());
+  ROSE_ASSERT(owner_scope != nullptr);
+
+  clearScopeSymbolTables(project);
+  rebuildScopeSymbolTables(project);
+
+  ROSE_ASSERT(owner_scope->lookup_nonreal_symbol(target->get_name(), nullptr,
+                                                 nullptr) != nullptr);
+}
+
+void checkOpenMP(SgProject *project) {
+  requireNode(project, V_SgOmpDeclareMapperStatement);
+  requireNode(project, V_SgOmpDeclareSimdStatement);
+  requireNode(project, V_SgOmpDeclareVariantStatement);
+  requireNode(project, V_SgOmpDeclareTargetStatement);
+  requireNode(project, V_SgOmpEndDeclareTargetStatement);
+  requireNode(project, V_SgOmpThreadprivateStatement);
+  requireNode(project, V_SgOmpAllocateStatement);
+  requireNode(project, V_SgOmpRequiresStatement);
+  requireNode(project, V_SgOmpTaskwaitStatement);
+
+  clearScopeSymbolTables(project);
+  rebuildScopeSymbolTables(project);
+
+  SgGlobal *global = firstGlobalScope(project);
+  ROSE_ASSERT(global->lookup_variable_symbol("rex_test2026_global") != nullptr);
+  ROSE_ASSERT(global->lookup_function_symbol("rex_test2026_simd") != nullptr);
+}
+
+void checkFortranOpenMP(SgProject *project) {
+  requireNode(project, V_SgProgramHeaderStatement);
+  requireNode(project, V_SgProcedureHeaderStatement);
+  requireNode(project, V_SgImplicitStatement);
+  requireNode(project, V_SgUseStatement);
+
+  clearScopeSymbolTables(project);
+  rebuildScopeSymbolTables(project);
+
+  SgGlobal *global = firstGlobalScope(project);
+  ROSE_ASSERT(global->lookup_function_symbol("rex_test2026_rebuild_driver") !=
+              nullptr);
+
+  bool saw_module_symbol = false;
+  for (SgNode *node : NodeQuery::querySubTree(project, V_SgModuleStatement)) {
+    SgModuleStatement *module = isSgModuleStatement(node);
+    ROSE_ASSERT(module != nullptr);
+    if (module->get_name() == "rex_test2026_rebuild_mod") {
+      ROSE_ASSERT(module->get_scope() == global);
+      for (SgNode *symbol_node : global->get_symbol_table()->get_symbols()) {
+        SgModuleSymbol *symbol = isSgModuleSymbol(symbol_node);
+        if (symbol != nullptr && symbol->get_declaration() == module) {
+          saw_module_symbol = true;
+          break;
+        }
+      }
+    }
+  }
+  ROSE_ASSERT(saw_module_symbol);
+
+  bool saw_worker = false;
+  for (SgNode *node :
+       NodeQuery::querySubTree(project, V_SgProcedureHeaderStatement)) {
+    SgProcedureHeaderStatement *procedure = isSgProcedureHeaderStatement(node);
+    ROSE_ASSERT(procedure != nullptr);
+    if (procedure->get_name() == "rex_test2026_rebuild_worker") {
+      saw_worker = true;
+      break;
+    }
+  }
+  ROSE_ASSERT(saw_worker);
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  const std::string mode = takeCheckMode(argc, argv);
+  ROSE_ASSERT(!mode.empty());
+
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  project->skipfinalCompileStep(true);
+
+  if (mode == "declaration-scope") {
+    checkDeclarationScope(project);
+  } else if (mode == "openmp") {
+    checkOpenMP(project);
+  } else if (mode == "fortran-openmp") {
+    checkFortranOpenMP(project);
+  } else {
+    ROSE_ABORT();
+  }
+
+  return 0;
+}

--- a/tests/nonsmoke/functional/roseTests/astTokenStreamTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/astTokenStreamTests/CMakeLists.txt
@@ -6,6 +6,13 @@ set(_exit_status ${CMAKE_SOURCE_DIR}/scripts/test_exit_status)
 set(_ast_token_stream_output_dir ${CMAKE_CURRENT_BINARY_DIR}/test-output)
 file(MAKE_DIRECTORY ${_ast_token_stream_output_dir})
 
+function(rex_configure_instrumented_token_stream_test test_name)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set_tests_properties(${test_name} PROPERTIES
+      PROCESSORS 16)
+  endif()
+endfunction()
+
 #-------------------------------------------------------------------------------
 # Linearization
 add_executable(testLinearization testLinearization.C)
@@ -309,6 +316,7 @@ set(TOKEN_C_TESTCODES_REQUIRED
   test2010_11.c
   test2010_14.c
   constants.c
+  rex_test2026_token_stream_explicit_leading_trailing_output.c
 )
 
 # test2013_06.c is invalid even for stock C compilers because its header uses
@@ -1267,6 +1275,7 @@ foreach(file_to_test IN LISTS TOKEN_C_TESTCODES_REQUIRED)
       ${_exit_status}
       ${_target}
   )
+  rex_configure_instrumented_token_stream_test(tokenStreamMapping_${_name})
 endforeach()
 
 #-------------------------------------------------------------------------------
@@ -1290,6 +1299,7 @@ foreach(file_to_test IN LISTS _token_c_all_testcodes)
       ${_exit_status}
       ${_target}
   )
+  rex_configure_instrumented_token_stream_test(tokenStream_C_${_name})
 endforeach()
 
 #-------------------------------------------------------------------------------
@@ -1314,6 +1324,7 @@ foreach(file_to_test IN LISTS _token_cxx_all_testcodes)
       ${_exit_status}
       ${_target}
   )
+  rex_configure_instrumented_token_stream_test(tokenStream_CXX_${_name})
 endforeach()
 
 #-------------------------------------------------------------------------------

--- a/tests/nonsmoke/functional/roseTests/fileLocation_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/fileLocation_tests/CMakeLists.txt
@@ -584,5 +584,10 @@ foreach(specimen IN LISTS FILELOCATION_TEST_SOURCES)
   )
 endforeach()
 
-########### install files ###############
+get_property(_filelocation_registered_tests DIRECTORY PROPERTY TESTS)
+if(REX_EXTENDED_TEST_TIMEOUTS AND _filelocation_registered_tests)
+  set_tests_properties(${_filelocation_registered_tests} PROPERTIES
+    PROCESSORS 16)
+endif()
 
+########### install files ###############

--- a/tests/nonsmoke/functional/roseTests/mergeTraversal_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/mergeTraversal_tests/CMakeLists.txt
@@ -32,4 +32,11 @@ add_test(
     -c ${CMAKE_BINARY_DIR}/src/frontend/SageIII/Cxx_Grammar.C
 )
 
+add_test(
+  NAME rex_merge_traversal_memcheck
+  COMMAND traversalArray -I${CMAKE_BINARY_DIR}
+    ${_rose_include_flags}
+    -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_merge_traversal_memcheck.cpp
+)
+
 ########### install files ###############

--- a/tests/nonsmoke/functional/roseTests/mergeTraversal_tests/rex_merge_traversal_memcheck.cpp
+++ b/tests/nonsmoke/functional/roseTests/mergeTraversal_tests/rex_merge_traversal_memcheck.cpp
@@ -1,0 +1,15 @@
+int length(int value) {
+  switch (value) {
+  case 0:
+    return 1;
+  case 1:
+    return 2;
+  default:
+    return value;
+  }
+}
+
+int main() {
+  int value = length(1);
+  return value == 2 ? 0 : 1;
+}

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/CMakeLists.txt
@@ -21,6 +21,10 @@ set(_omp_semantic_script
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_semantic_compare.sh)
 set(_omp_invariant_script
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_invariant_check.sh)
+set(_omp_mapper_checkpoint_script
+  ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_mapper_checkpoint_compare.sh)
+set(_omp_deterministic_script
+  ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_deterministic_lowering_compare.sh)
 set(_omp_lowering_test_output_dir
   ${CMAKE_CURRENT_BINARY_DIR}/test-output)
 file(MAKE_DIRECTORY ${_omp_lowering_test_output_dir})
@@ -28,6 +32,85 @@ file(MAKE_DIRECTORY ${_omp_lowering_test_output_dir})
 set(_omp_legacy_labels
   OMPLOWERING
   OMPLOWERING_LEGACY)
+
+set(_omp_sanitizer_test_environment)
+set(_omp_fortran_sanitizer_test_environment)
+if(ROSE_USE_SANITIZER AND ROSE_SANITIZERS)
+  string(REPLACE ";" "," _omp_sanitizer_test_list "${ROSE_SANITIZERS}")
+  list(APPEND _omp_sanitizer_test_environment
+       "ROSE_TEST_SANITIZER_FLAGS=-fsanitize=${_omp_sanitizer_test_list}")
+
+  if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    execute_process(
+      COMMAND "${CMAKE_C_COMPILER}" -print-resource-dir
+      OUTPUT_VARIABLE _omp_clang_resource_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET)
+    execute_process(
+      COMMAND "${CMAKE_C_COMPILER}" -dumpmachine
+      OUTPUT_VARIABLE _omp_clang_target_triple
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET)
+
+    set(_omp_clang_runtime_dir "")
+    if(_omp_clang_resource_dir AND _omp_clang_target_triple AND
+       IS_DIRECTORY "${_omp_clang_resource_dir}/lib/${_omp_clang_target_triple}")
+      set(_omp_clang_runtime_dir "${_omp_clang_resource_dir}/lib/${_omp_clang_target_triple}")
+    endif()
+
+    set(_omp_fortran_sanitizer_link_flags)
+    if(_omp_clang_runtime_dir)
+      if("address" IN_LIST ROSE_SANITIZERS OR "leak" IN_LIST ROSE_SANITIZERS)
+        set(_omp_asan_static "${_omp_clang_runtime_dir}/libclang_rt.asan_static.a")
+        set(_omp_asan "${_omp_clang_runtime_dir}/libclang_rt.asan.a")
+        set(_omp_asan_syms "${_omp_clang_runtime_dir}/libclang_rt.asan.a.syms")
+        if(EXISTS "${_omp_asan_static}" AND EXISTS "${_omp_asan}" AND
+           EXISTS "${_omp_asan_syms}")
+          list(APPEND _omp_fortran_sanitizer_link_flags
+               -Wl,--whole-archive
+               "${_omp_asan_static}"
+               "${_omp_asan}"
+               -Wl,--no-whole-archive
+               "-Wl,--dynamic-list=${_omp_asan_syms}"
+               -pthread
+               -lrt
+               -lm
+               -ldl
+               -lresolv)
+        endif()
+      elseif("undefined" IN_LIST ROSE_SANITIZERS)
+        set(_omp_ubsan "${_omp_clang_runtime_dir}/libclang_rt.ubsan_standalone.a")
+        set(_omp_ubsan_syms "${_omp_clang_runtime_dir}/libclang_rt.ubsan_standalone.a.syms")
+        if(EXISTS "${_omp_ubsan}" AND EXISTS "${_omp_ubsan_syms}")
+          list(APPEND _omp_fortran_sanitizer_link_flags
+               -Wl,--whole-archive
+               "${_omp_ubsan}"
+               -Wl,--no-whole-archive
+               "-Wl,--dynamic-list=${_omp_ubsan_syms}"
+               -pthread
+               -lrt
+               -lm
+               -ldl
+               -lresolv)
+        endif()
+      endif()
+    endif()
+
+    if(_omp_fortran_sanitizer_link_flags)
+      list(JOIN _omp_fortran_sanitizer_link_flags " "
+           _omp_fortran_sanitizer_link_flags_string)
+      list(APPEND _omp_fortran_sanitizer_test_environment
+           "ROSE_TEST_SANITIZER_LINK_FLAGS=${_omp_fortran_sanitizer_link_flags_string}")
+    endif()
+  endif()
+endif()
+
+function(_set_omp_test_sanitizer_environment test_name)
+  if(_omp_sanitizer_test_environment)
+    set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT
+                 "${_omp_sanitizer_test_environment}")
+  endif()
+endfunction()
 
 function(_omp_sanitize_name out_var specimen)
   set(_name ${specimen})
@@ -53,6 +136,28 @@ function(_label_omp_invariant test_name)
   set_property(TEST ${test_name} APPEND PROPERTY LABELS "${_omp_legacy_labels};OMPLOWERING_INVARIANT")
 endfunction()
 
+set(_omp_lowering_ctest_timeout_scale 1)
+if(ROSE_USE_VALGRIND)
+  if(DEFINED ROSE_CTEST_EXPLICIT_TIMEOUT_SCALE)
+    set(_omp_lowering_ctest_timeout_scale ${ROSE_CTEST_EXPLICIT_TIMEOUT_SCALE})
+  else()
+    set(_omp_lowering_ctest_timeout_scale 4)
+  endif()
+endif()
+
+function(_omp_scaled_ctest_timeout out_var timeout_seconds)
+  if(NOT timeout_seconds MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "OpenMP lowering test timeout must be an integer: ${timeout_seconds}")
+  endif()
+  math(EXPR _timeout "${timeout_seconds} * ${_omp_lowering_ctest_timeout_scale}")
+  set(${out_var} ${_timeout} PARENT_SCOPE)
+endfunction()
+
+function(_omp_set_test_timeout test_name timeout_seconds)
+  _omp_scaled_ctest_timeout(_timeout ${timeout_seconds})
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT ${_timeout})
+endfunction()
+
 function(add_omp_translate_only_test test_name translator input_file work_subdir)
   add_test(
     NAME ${test_name}
@@ -62,7 +167,7 @@ function(add_omp_translate_only_test test_name translator input_file work_subdir
             ${_omp_test_dir}/${input_file}
             ${_omp_lowering_test_output_dir}/${work_subdir}
             ${input_file})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 540)
+  _omp_set_test_timeout(${test_name} 540)
   _label_omp_compile_only(${test_name})
 endfunction()
 
@@ -83,7 +188,8 @@ function(add_omp_semantic_test test_name translator compiler input_file mode lan
             ${input_file}
             ${language}
             ${ROSE_OPENMP_VERSION})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 900)
+  _omp_set_test_timeout(${test_name} 900)
+  _set_omp_test_sanitizer_environment(${test_name})
   _label_omp_semantic(${test_name})
 endfunction()
 
@@ -423,8 +529,8 @@ if(ENABLE-C)
       set_tests_properties(
         omp_lowering_invariant_${_omp_name}
         PROPERTIES
-          DEPENDS ${_invariant_dep}
-          TIMEOUT 540)
+          DEPENDS ${_invariant_dep})
+      _omp_set_test_timeout(omp_lowering_invariant_${_omp_name} 540)
       _label_omp_invariant(omp_lowering_invariant_${_omp_name})
     endif()
   endforeach()
@@ -456,10 +562,71 @@ if(ENABLE-C)
             ${_omp_test_dir}/declare_mapper_target_update.c
             ${_omp_lowering_test_output_dir}/mapper_semantic/declare_mapper_target_update
             declare_mapper_target_update.c)
-  set_tests_properties(
-    omp_lowering_mapper_semantic_declare_mapper_target_update
-    PROPERTIES TIMEOUT 540)
+  _omp_set_test_timeout(omp_lowering_mapper_semantic_declare_mapper_target_update 540)
   _label_omp_semantic(omp_lowering_mapper_semantic_declare_mapper_target_update)
+
+  add_test(
+    NAME ASTJSON_omp_lowering_mapper_semantic_declare_mapper_target_update
+    WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE}
+            ${_omp_mapper_checkpoint_script}
+            $<TARGET_FILE:roseomp>
+            ${_omp_test_dir}/declare_mapper_target_update.c
+            ${_omp_lowering_test_output_dir}/ast-json/mapper_semantic/declare_mapper_target_update
+            declare_mapper_target_update.c)
+  set_tests_properties(
+    ASTJSON_omp_lowering_mapper_semantic_declare_mapper_target_update
+    PROPERTIES
+      LABELS "ASTJSON;OMPLOWERING;OMPLOWERING_SEMANTIC")
+  _omp_set_test_timeout(ASTJSON_omp_lowering_mapper_semantic_declare_mapper_target_update 540)
+
+  add_test(
+    NAME omp_lowering_rex_test2026_deterministic_capture_order_cpp
+    WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE}
+            ${_omp_deterministic_script}
+            $<TARGET_FILE:roseomp>
+            ${_omp_test_dir}/rex_test2026_omp_lowering_deterministic_capture_order.cpp
+            ${_omp_lowering_test_output_dir}/deterministic/capture_order
+            rex_test2026_omp_lowering_deterministic_capture_order.cpp
+            none)
+  set_tests_properties(
+    omp_lowering_rex_test2026_deterministic_capture_order_cpp
+    PROPERTIES
+      LABELS "OMPLOWERING;OMPLOWERING_DETERMINISTIC")
+  _omp_set_test_timeout(omp_lowering_rex_test2026_deterministic_capture_order_cpp 540)
+
+  add_test(
+    NAME omp_lowering_rex_test2026_deterministic_root_order_cpp
+    WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE}
+            ${_omp_deterministic_script}
+            $<TARGET_FILE:roseomp>
+            ${_omp_test_dir}/rex_test2026_omp_lowering_deterministic_root_order.cpp
+            ${_omp_lowering_test_output_dir}/deterministic/root_order
+            rex_test2026_omp_lowering_deterministic_root_order.cpp
+            none)
+  set_tests_properties(
+    omp_lowering_rex_test2026_deterministic_root_order_cpp
+    PROPERTIES
+      LABELS "OMPLOWERING;OMPLOWERING_DETERMINISTIC")
+  _omp_set_test_timeout(omp_lowering_rex_test2026_deterministic_root_order_cpp 540)
+
+  add_test(
+    NAME ASTJSON_omp_lowering_rex_test2026_deterministic_root_order_cpp
+    WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE}
+            ${_omp_deterministic_script}
+            $<TARGET_FILE:roseomp>
+            ${_omp_test_dir}/rex_test2026_omp_lowering_deterministic_root_order.cpp
+            ${_omp_lowering_test_output_dir}/deterministic/root_order_ast_json
+            rex_test2026_omp_lowering_deterministic_root_order.cpp
+            all)
+  set_tests_properties(
+    ASTJSON_omp_lowering_rex_test2026_deterministic_root_order_cpp
+    PROPERTIES
+      LABELS "ASTJSON;OMPLOWERING;OMPLOWERING_DETERMINISTIC")
+  _omp_set_test_timeout(ASTJSON_omp_lowering_rex_test2026_deterministic_root_order_cpp 540)
 
   add_test(
     NAME omp_acc_lowering_c_compile_only_target_literal_scalar
@@ -470,9 +637,7 @@ if(ENABLE-C)
             ${_omp_test_dir}/target_literal_scalar.c
             ${_omp_lowering_test_output_dir}/acc_c/target_literal_scalar
             target_literal_scalar.c)
-  set_tests_properties(
-    omp_acc_lowering_c_compile_only_target_literal_scalar
-    PROPERTIES TIMEOUT 540)
+  _omp_set_test_timeout(omp_acc_lowering_c_compile_only_target_literal_scalar 540)
   _label_omp_compile_only(omp_acc_lowering_c_compile_only_target_literal_scalar)
 endif()
 
@@ -480,6 +645,8 @@ set(OMP_LOWERING_FORTRAN_LABELS ${_omp_legacy_labels})
 set(OMP_LOWERING_TRANSLATE_SCRIPT ${_omp_translate_script})
 set(OMP_LOWERING_FORTRAN_SEMANTIC_SCRIPT
     ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_fortran_semantic_compare.sh)
+set(OMP_LOWERING_FORTRAN_CHECKPOINT_SCRIPT
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_fortran_checkpoint_compare.sh)
 set(OMP_LOWERING_INVARIANT_VERIFY_SCRIPT
     ${CMAKE_CURRENT_SOURCE_DIR}/scripts/verify_lowering_invariants.sh)
 set(OMP_LOWERING_TEST_DIR ${_omp_test_dir})

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/fortran/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/fortran/CMakeLists.txt
@@ -108,7 +108,11 @@ function(add_omp_fortran_semantic_test specimen)
             $<TARGET_FILE:kmpc_fortran_abi>
             ${specimen}
             ${OMP_FORTRAN_SEMANTIC_RUN_TIMEOUT_SECONDS})
-  set_tests_properties(${_test_name} PROPERTIES TIMEOUT ${_total_timeout})
+  _omp_set_test_timeout(${_test_name} ${_total_timeout})
+  if(_omp_fortran_sanitizer_test_environment)
+    set_property(TEST ${_test_name} APPEND PROPERTY ENVIRONMENT
+                 "${_omp_fortran_sanitizer_test_environment}")
+  endif()
   set_property(TEST ${_test_name} APPEND PROPERTY LABELS
                "${OMP_LOWERING_FORTRAN_LABELS};OMPLOWERING_SEMANTIC;OMPLOWERING_FORTRAN")
 endfunction()
@@ -124,9 +128,43 @@ function(add_omp_fortran_invariant_test specimen dependency_test_name workdir)
             ${workdir}
             ${specimen})
   set_tests_properties(${_inv_name}
-    PROPERTIES DEPENDS ${dependency_test_name} TIMEOUT 360)
+    PROPERTIES DEPENDS ${dependency_test_name})
+  _omp_set_test_timeout(${_inv_name} 360)
   set_property(TEST ${_inv_name} APPEND PROPERTY LABELS
                "${OMP_LOWERING_FORTRAN_LABELS};OMPLOWERING_INVARIANT;OMPLOWERING_FORTRAN")
+endfunction()
+
+function(add_omp_fortran_ast_json_checkpoint_test specimen checkpoint)
+  _omp_sanitize_name(_omp_name ${specimen})
+  set(_test_name ASTJSON_omp_lowering_fortran_${checkpoint}_${_omp_name})
+  string(REPLACE "-" "_" _test_name ${_test_name})
+  set(_workdir ${_omp_fortran_lowering_output_dir}/ast-json/${_omp_name})
+  math(EXPR _total_timeout
+       "2 * (${OMP_FORTRAN_SEMANTIC_COMPILE_OVERHEAD_SECONDS} + ${OMP_FORTRAN_SEMANTIC_TOTAL_RUNS} * ${OMP_FORTRAN_SEMANTIC_RUN_TIMEOUT_SECONDS})")
+  add_test(
+    NAME ${_test_name}
+    WORKING_DIRECTORY ${_omp_fortran_lowering_output_dir}
+    COMMAND ${BASH_EXECUTABLE} ${OMP_LOWERING_FORTRAN_CHECKPOINT_SCRIPT}
+            ${OMP_LOWERING_FORTRAN_SEMANTIC_SCRIPT}
+            $<TARGET_FILE:roseomp>
+            ${_omp_fortran_compiler}
+            ${_omp_fortran_dir}/${specimen}
+            ${_workdir}
+            sort
+            ${_omp_fortran_omp_include}
+            ${ROSE_LLVM_OPENMP_RUNTIME_DIR}
+            ${OMP_LOWERING_INC_DIR}
+            $<TARGET_FILE:kmpc_fortran_abi>
+            ${specimen}
+            ${OMP_FORTRAN_SEMANTIC_RUN_TIMEOUT_SECONDS}
+            ${checkpoint})
+  _omp_set_test_timeout(${_test_name} ${_total_timeout})
+  if(_omp_fortran_sanitizer_test_environment)
+    set_property(TEST ${_test_name} APPEND PROPERTY ENVIRONMENT
+                 "${_omp_fortran_sanitizer_test_environment}")
+  endif()
+  set_property(TEST ${_test_name} APPEND PROPERTY LABELS
+               "ASTJSON;${OMP_LOWERING_FORTRAN_LABELS};OMPLOWERING_SEMANTIC;OMPLOWERING_FORTRAN")
 endfunction()
 
 if(enable-fortran)
@@ -138,4 +176,7 @@ if(enable-fortran)
       omp_lowering_fortran_semantic_${_omp_name}
       ${_omp_fortran_lowering_output_dir}/semantic/${_omp_name})
   endforeach()
+
+  add_omp_fortran_ast_json_checkpoint_test(schedule.f all)
+  add_omp_fortran_ast_json_checkpoint_test(exampleA41f.f90 all)
 endif()

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/roseomp.C
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/roseomp.C
@@ -8,5 +8,7 @@
 int main(int argc, char *argv[]) {
   SgProject *project = frontend(argc, argv);
   AstTests::runAllTests(project);
-  return backend(project);
+  int status = backend(project);
+  SageInterface::tearDownAst(project);
+  return status;
 }

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/roseompacc.C
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/roseompacc.C
@@ -56,5 +56,7 @@ int main(int argc, char *argv[]) {
   string naked_name = StringUtility::stripFileSuffixFromFileName(orig_name);
   cur_file->set_unparse_output_filename("rose_" + naked_name + ".cu");
 
-  return backend(project);
+  int status = backend(project);
+  SageInterface::tearDownAst(project);
+  return status;
 }

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_deterministic_lowering_compare.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_deterministic_lowering_compare.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 <translator> <input> <workdir> <case_name> <checkpoint|none>" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+translator="$1"
+input_file="$2"
+workdir="$3"
+case_name="$4"
+checkpoint="$5"
+source_name="$(basename "${input_file}")"
+
+rm -rf "${workdir}"
+mkdir -p "${workdir}/run1" "${workdir}/run2"
+
+run_once() {
+  local run_dir="$1"
+  shift
+  bash "${script_dir}/run_translate_only.sh" "${translator}" "${input_file}" \
+    "${run_dir}" "${case_name}" "$@"
+}
+
+if [[ "${checkpoint}" == "none" ]]; then
+  run_once "${workdir}/run1"
+  run_once "${workdir}/run2"
+else
+  mkdir -p "${workdir}/run1/json" "${workdir}/run2/json"
+  run_once "${workdir}/run1" \
+    "-rex:ast-json-checkpoint=${checkpoint}" \
+    "-rex:ast-json-dir=${workdir}/run1/json"
+  run_once "${workdir}/run2" \
+    "-rex:ast-json-checkpoint=${checkpoint}" \
+    "-rex:ast-json-dir=${workdir}/run2/json"
+fi
+
+diff -u "${workdir}/run1/rose_${source_name}" \
+        "${workdir}/run2/rose_${source_name}"

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_fortran_checkpoint_compare.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_fortran_checkpoint_compare.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 13 ]]; then
+  echo "usage: $0 <semantic-script> <translator> <compiler> <input> <workdir> <mode> <omp_fortran_inc> <omp_runtime_dir> <lowering_inc> <kmpc_fortran_abi_lib> <case_name> <timeout_s> <checkpoint>" >&2
+  exit 2
+fi
+
+semantic_script="$1"
+translator="$2"
+compiler="$3"
+input_file="$4"
+workdir="$5"
+mode="$6"
+omp_fortran_inc="$7"
+omp_runtime_dir="$8"
+lowering_inc="$9"
+kmpc_fortran_abi_lib="${10}"
+case_name="${11}"
+timeout_s="${12}"
+checkpoint="${13}"
+
+source_name="$(basename "${input_file}")"
+baseline_dir="${workdir}/baseline"
+checkpoint_dir="${workdir}/checkpoint"
+json_dir="${checkpoint_dir}/json"
+baseline_output="${baseline_dir}/rose_${source_name}"
+checkpoint_output="${checkpoint_dir}/rose_${source_name}"
+
+rm -rf "${workdir}"
+mkdir -p "${baseline_dir}" "${checkpoint_dir}" "${json_dir}"
+
+env -u REX_AST_JSON_CHECKPOINT -u REX_AST_JSON_DIR \
+  "${semantic_script}" \
+    "${translator}" \
+    "${compiler}" \
+    "${input_file}" \
+    "${baseline_dir}" \
+    "${mode}" \
+    "${omp_fortran_inc}" \
+    "${omp_runtime_dir}" \
+    "${lowering_inc}" \
+    "${kmpc_fortran_abi_lib}" \
+    "${case_name}" \
+    "${timeout_s}"
+
+env REX_AST_JSON_CHECKPOINT="${checkpoint}" REX_AST_JSON_DIR="${json_dir}" \
+  "${semantic_script}" \
+    "${translator}" \
+    "${compiler}" \
+    "${input_file}" \
+    "${checkpoint_dir}" \
+    "${mode}" \
+    "${omp_fortran_inc}" \
+    "${omp_runtime_dir}" \
+    "${lowering_inc}" \
+    "${kmpc_fortran_abi_lib}" \
+    "${case_name}" \
+    "${timeout_s}"
+
+if [[ -z "$(find "${json_dir}" -type f -name '*.json' -print -quit)" ]]; then
+  echo "ERROR(${case_name}): checkpoint JSON was not written under ${json_dir}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${baseline_output}" ]]; then
+  echo "ERROR(${case_name}): missing baseline lowered source '${baseline_output}'" >&2
+  exit 1
+fi
+
+if [[ ! -f "${checkpoint_output}" ]]; then
+  echo "ERROR(${case_name}): missing checkpoint lowered source '${checkpoint_output}'" >&2
+  exit 1
+fi
+
+diff -u "${baseline_output}" "${checkpoint_output}"

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_fortran_semantic_compare.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_fortran_semantic_compare.sh
@@ -42,6 +42,11 @@ compile_flags=(
   "-Wl,-rpath,${omp_runtime_dir}"
 )
 
+sanitizer_link_flags=()
+if [[ -n "${ROSE_TEST_SANITIZER_LINK_FLAGS:-}" ]]; then
+  read -r -a sanitizer_link_flags <<< "${ROSE_TEST_SANITIZER_LINK_FLAGS}"
+fi
+
 write_subroutine_driver_if_needed() {
   local source="$1"
   local case_id="$2"
@@ -367,7 +372,7 @@ if ! "${compiler}" "${compile_flags[@]}" "${input_file}" "${driver_sources[@]}" 
   exit 0
 fi
 
-if ! "${compiler}" "${compile_flags[@]}" "${rose_file}" "${driver_sources[@]}" "${kmpc_fortran_abi_lib}" \
+if ! "${compiler}" "${compile_flags[@]}" "${rose_file}" "${driver_sources[@]}" "${kmpc_fortran_abi_lib}" "${sanitizer_link_flags[@]}" \
     -o "${workdir}/lowered.exe" > "${workdir}/lowered_compile.out" 2> "${workdir}/lowered_compile.err"; then
   echo "ERROR(${case_name}): lowered source failed to compile after successful translation" >&2
   echo "---- lowered_compile.err (${case_name}) ----" >&2

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_mapper_checkpoint_compare.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_mapper_checkpoint_compare.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <translator> <input> <workdir> <case_name>" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+translator="$1"
+input_file="$2"
+workdir="$3"
+case_name="$4"
+source_name="$(basename "${input_file}")"
+
+baseline_dir="${workdir}/baseline"
+checkpoint_dir="${workdir}/checkpoint"
+json_dir="${checkpoint_dir}/json"
+baseline_output="${baseline_dir}/rose_${source_name}"
+checkpoint_output="${checkpoint_dir}/rose_${source_name}"
+
+rm -rf "${workdir}"
+mkdir -p "${baseline_dir}" "${checkpoint_dir}" "${json_dir}"
+
+bash "${script_dir}/run_mapper_lowering_check.sh" "${translator}" \
+  "${input_file}" "${baseline_dir}" "${case_name}"
+
+bash "${script_dir}/run_mapper_lowering_check.sh" "${translator}" \
+  "${input_file}" "${checkpoint_dir}" "${case_name}" \
+  -rex:ast-json-checkpoint=post-omp-lowering \
+  "-rex:ast-json-dir=${json_dir}"
+
+if [[ -z "$(find "${json_dir}" -type f -name '*.json' -print -quit)" ]]; then
+  echo "ERROR(${case_name}): post-lowering checkpoint JSON was not written under ${json_dir}" >&2
+  exit 1
+fi
+
+diff -u "${baseline_output}" "${checkpoint_output}"

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_mapper_lowering_check.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_mapper_lowering_check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 4 ]]; then
-  echo "usage: $0 <translator> <input> <workdir> <case_name>" >&2
+if [[ $# -lt 4 ]]; then
+  echo "usage: $0 <translator> <input> <workdir> <case_name> [translator_flags...]" >&2
   exit 2
 fi
 
@@ -11,6 +11,8 @@ translator="$1"
 input_file="$2"
 workdir="$3"
 case_name="$4"
+shift 4
+extra_translator_flags=("$@")
 source_name="$(basename "${input_file}")"
 rose_file="${workdir}/rose_${source_name}"
 
@@ -20,7 +22,7 @@ fail() {
 }
 
 bash "${script_dir}/run_translate_only.sh" "${translator}" "${input_file}" \
-  "${workdir}" "${case_name}"
+  "${workdir}" "${case_name}" "${extra_translator_flags[@]}"
 
 [[ -f "${rose_file}" ]] || fail "missing lowered host file '${rose_file}'"
 

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_semantic_compare.sh
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/scripts/run_semantic_compare.sh
@@ -32,7 +32,7 @@ mkdir -p "${workdir}"
 rm -f "${workdir}"/orig.exe "${workdir}"/lowered.exe
 rm -f "${workdir}"/rose_* "${workdir}"/rex_lib_* "${workdir}"/lower.log
 
-source_name="$(basename "${input_file}")"
+source_name="${input_file##*/}"
 rose_file="${workdir}/rose_${source_name}"
 
 compile_flags=(
@@ -45,6 +45,11 @@ compile_flags=(
   "-L${omp_runtime_dir}"
   "-Wl,-rpath,${omp_runtime_dir}"
 )
+
+if [[ -n "${ROSE_TEST_SANITIZER_FLAGS:-}" ]]; then
+  read -r -a sanitizer_flags <<< "${ROSE_TEST_SANITIZER_FLAGS}"
+  compile_flags+=("${sanitizer_flags[@]}")
+fi
 
 canonicalize() {
   local in_file="$1"
@@ -67,11 +72,11 @@ fail_with_diff() {
 
 "${compiler}" "${compile_flags[@]}" "${input_file}" -o "${workdir}/orig.exe"
 
-(
-  cd "${workdir}"
-  "${translator}" -rose:openmp:lowering -rose:skipfinalCompileStep -w -rose:verbose 0 \
-    -c "${input_file}" > lower.log 2>&1
-)
+saved_pwd="${PWD}"
+cd "${workdir}"
+"${translator}" -rose:openmp:lowering -rose:skipfinalCompileStep -w -rose:verbose 0 \
+  -c "${input_file}" > lower.log 2>&1
+cd "${saved_pwd}"
 
 if [[ ! -f "${rose_file}" ]]; then
   echo "ERROR(${case_name}): missing lowered host file '${rose_file}'" >&2
@@ -97,7 +102,7 @@ export LD_LIBRARY_PATH="${omp_runtime_dir}:${LD_LIBRARY_PATH:-}"
 thread_counts=(2 4)
 repeats=4
 for threads in "${thread_counts[@]}"; do
-  for i in $(seq 1 "${repeats}"); do
+  for ((i = 1; i <= repeats; ++i)); do
     timeout 30s env OMP_NUM_THREADS="${threads}" "${workdir}/orig.exe" > "${workdir}/orig_${threads}_${i}.out" 2> "${workdir}/orig_${threads}_${i}.err"
     timeout 30s env OMP_NUM_THREADS="${threads}" "${workdir}/lowered.exe" > "${workdir}/low_${threads}_${i}.out" 2> "${workdir}/low_${threads}_${i}.err"
 

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/defUseAnalysisTests/runTest.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/defUseAnalysisTests/runTest.C
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <iostream>
+#include <memory>
 using namespace std;
 
 void testOneFunction(
@@ -27,7 +28,7 @@ void testOneFunction(
   // Build the AST used by ROSE
   SgProject *project = frontend(argvList);
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   int val = defuse->run(debug);
   if (debug)
     std::cout << "Analysis run is : " << (val ? "failure" : "success") << " "
@@ -186,7 +187,7 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
     std::cout << ">>>> start def-use analysis ... " << endl;
 
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   int val = defuse->run(debug);
   if (debug)
     std::cout << "Analysis is : " << (val ? "failure" : "success") << " " << val
@@ -242,7 +243,6 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
     defuse->printUseMap();
   }
   delete project;
-  delete defuse;
 }
 
 void usage() {

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/CMakeLists.txt
@@ -1368,4 +1368,8 @@ get_property(_gdfa_registered_tests DIRECTORY PROPERTY TESTS)
 if(_gdfa_registered_tests)
   set_property(TEST ${_gdfa_registered_tests} APPEND PROPERTY ENVIRONMENT
                "ROSE_TEST_OUTPUT_DIR=${_gdfa_debug_output_dir}")
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set_tests_properties(${_gdfa_registered_tests} PROPERTIES
+      PROCESSORS 16)
+  endif()
 endif()

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/constantPropagation.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/constantPropagation.C
@@ -68,7 +68,7 @@ bool ConstantPropagationLattice::setBottom() {
 bool ConstantPropagationLattice::setTop() {
   // These are more than access functions, they return if the state of the
   // lattice has changed.
-  bool modified = this->level != bottom;
+  bool modified = this->level != top;
   this->value = 0;
   level = top;
   return modified;
@@ -234,9 +234,10 @@ void ConstantPropagationAnalysisTransfer::transferAdditive(
     // Both knownValue
     if (arg1Lat->getLevel() == ConstantPropagationLattice::constantValue &&
         arg2Lat->getLevel() == ConstantPropagationLattice::constantValue) {
-      updateModified(resLat->setValue(
-          isAddition ? arg1Lat->getValue() + arg2Lat->getValue()
-                     : arg1Lat->getValue() - arg2Lat->getValue()));
+      long long lhs = arg1Lat->getValue();
+      long long rhs = arg2Lat->getValue();
+      updateModified(
+          setSignedValue(resLat, isAddition ? lhs + rhs : lhs - rhs));
     } else {
       // Else => Top
       updateModified(resLat->setLevel(ConstantPropagationLattice::top));
@@ -254,8 +255,9 @@ void ConstantPropagationAnalysisTransfer::transferMultiplicative(
     // Both knownValue
     if (arg1Lat->getLevel() == ConstantPropagationLattice::constantValue &&
         arg2Lat->getLevel() == ConstantPropagationLattice::constantValue) {
-      updateModified(
-          resLat->setValue(arg1Lat->getValue() * arg2Lat->getValue()));
+      updateModified(setSignedValue(
+          resLat, static_cast<long long>(arg1Lat->getValue()) *
+                      static_cast<long long>(arg2Lat->getValue())));
     } else {
       // Else => Top
       updateModified(resLat->setLevel(ConstantPropagationLattice::top));
@@ -273,8 +275,13 @@ void ConstantPropagationAnalysisTransfer::transferDivision(
     // Both knownValue
     if (arg1Lat->getLevel() == ConstantPropagationLattice::constantValue &&
         arg2Lat->getLevel() == ConstantPropagationLattice::constantValue) {
-      updateModified(
-          resLat->setValue(arg1Lat->getValue() / arg2Lat->getValue()));
+      int rhs = arg2Lat->getValue();
+      if (rhs == 0 || (arg1Lat->getValue() == std::numeric_limits<int>::min() &&
+                       rhs == -1)) {
+        updateModified(resLat->setTop());
+      } else {
+        updateModified(resLat->setValue(arg1Lat->getValue() / rhs));
+      }
     } else {
       // Else => Top
       updateModified(resLat->setLevel(ConstantPropagationLattice::top));
@@ -293,8 +300,13 @@ void ConstantPropagationAnalysisTransfer::transferMod(
     // Both knownValue
     if (arg1Lat->getLevel() == ConstantPropagationLattice::constantValue &&
         arg2Lat->getLevel() == ConstantPropagationLattice::constantValue) {
-      updateModified(
-          resLat->setValue(arg1Lat->getValue() % arg2Lat->getValue()));
+      int rhs = arg2Lat->getValue();
+      if (rhs == 0 || (arg1Lat->getValue() == std::numeric_limits<int>::min() &&
+                       rhs == -1)) {
+        updateModified(resLat->setTop());
+      } else {
+        updateModified(resLat->setValue(arg1Lat->getValue() % rhs));
+      }
     } else {
       // Else => Top
       updateModified(resLat->setLevel(ConstantPropagationLattice::top));
@@ -308,26 +320,24 @@ ConstantPropagationAnalysisTransfer::makeTempLattice() {
   return tempLattices.back().get();
 }
 
-void ConstantPropagationAnalysisTransfer::setSignedValue(
+bool ConstantPropagationAnalysisTransfer::setSignedValue(
     ConstantPropagationLattice *lat, long long value) {
   ROSE_ASSERT(lat != NULL);
   if (value < std::numeric_limits<int>::min() ||
       value > std::numeric_limits<int>::max()) {
-    lat->setTop();
-    return;
+    return lat->setTop();
   }
-  lat->setValue(static_cast<int>(value));
+  return lat->setValue(static_cast<int>(value));
 }
 
-void ConstantPropagationAnalysisTransfer::setUnsignedValue(
+bool ConstantPropagationAnalysisTransfer::setUnsignedValue(
     ConstantPropagationLattice *lat, unsigned long long value) {
   ROSE_ASSERT(lat != NULL);
   if (value >
       static_cast<unsigned long long>(std::numeric_limits<int>::max())) {
-    lat->setTop();
-    return;
+    return lat->setTop();
   }
-  lat->setValue(static_cast<int>(value));
+  return lat->setValue(static_cast<int>(value));
 }
 
 ConstantPropagationLattice *

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/constantPropagation.h
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/generalDataFlowAnalysisTests/constantPropagation.h
@@ -90,8 +90,8 @@ private:
 
   std::vector<std::unique_ptr<ConstantPropagationLattice>> tempLattices;
   ConstantPropagationLattice *makeTempLattice();
-  void setSignedValue(ConstantPropagationLattice *lat, long long value);
-  void setUnsignedValue(ConstantPropagationLattice *lat,
+  bool setSignedValue(ConstantPropagationLattice *lat, long long value);
+  bool setUnsignedValue(ConstantPropagationLattice *lat,
                         unsigned long long value);
   ConstantPropagationLattice *fallbackLattice(const SgExpression *sgn) override;
 

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateCDG.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateCDG.C
@@ -23,6 +23,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -46,9 +48,6 @@ int main(int argc, char *argv[]) {
   for (NodeQuerySynthesizedAttributeType::iterator i =
            functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    ControlDependenceGraph *cdg;
-    InterproceduralInfo *ipi;
-
     SgFunctionDeclaration *fD = isSgFunctionDeclaration(*i);
 
     // SGFunctionDefinition * fDef;
@@ -63,12 +62,13 @@ int main(int argc, char *argv[]) {
     if (fD->get_definition() == NULL) {
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fD);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fD));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get control dependence for this function defintion
-      cdg = new ControlDependenceGraph(fD->get_definition(), ipi);
+      std::unique_ptr<ControlDependenceGraph> cdg(
+          new ControlDependenceGraph(fD->get_definition(), ipi.get()));
       cdg->computeAdditionalFunctioncallDepencencies();
       //						cdg->computeInterproceduralInformation(ipi);
       //						cdg->debugCoutNodeList();

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateDDG.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateDDG.C
@@ -27,6 +27,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -39,7 +41,7 @@ int main(int argc, char *argv[]) {
 
   SgProject *project = frontend(argc, argv);
 #ifdef NEWDU
-  EDefUse *edu = new EDefUse(project);
+  std::unique_ptr<EDefUse> edu(new EDefUse(project));
   // Create the global def-use analysis
   if (edu->run(false) == 0) {
     std::cerr << "DFAnalysis failed!" << endl;
@@ -57,9 +59,6 @@ int main(int argc, char *argv[]) {
   for (NodeQuerySynthesizedAttributeType::iterator i =
            functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    DataDependenceGraph *ddg;
-    InterproceduralInfo *ipi;
-
     SgFunctionDeclaration *fD = isSgFunctionDeclaration(*i);
 
     // SGFunctionDefinition * fDef;
@@ -74,15 +73,17 @@ int main(int argc, char *argv[]) {
     if (fD->get_definition() == NULL) {
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fD);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fD));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get the data dependence for this function
 #ifdef NEWDU
-      ddg = new DataDependenceGraph(fD->get_definition(), edu);
+      std::unique_ptr<DataDependenceGraph> ddg(
+          new DataDependenceGraph(fD->get_definition(), edu.get()));
 #else
-      ddg = new DataDependenceGraph(fD->get_definition());
+      std::unique_ptr<DataDependenceGraph> ddg(
+          new DataDependenceGraph(fD->get_definition()));
 #endif
       // printf("DDG for %s:\n", fD->get_name().str());
 

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateSDG.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateSDG.C
@@ -24,6 +24,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -37,7 +39,7 @@ int main(int argc, char *argv[]) {
   std::vector<InterproceduralInfo *> ip;
 #ifdef NEWDU
   // Create the global def-use analysis
-  EDefUse *defUseAnalysis = new EDefUse(project);
+  std::unique_ptr<EDefUse> defUseAnalysis(new EDefUse(project));
   if (defUseAnalysis->run(false) == 0) {
     std::cerr << "DFAnalysis failed!" << endl;
   }
@@ -45,7 +47,7 @@ int main(int argc, char *argv[]) {
   string outputFileName =
       project->get_fileList().front()->get_sourceFileNameWithoutPath();
 
-  SystemDependenceGraph *sdg = new SystemDependenceGraph;
+  std::unique_ptr<SystemDependenceGraph> sdg(new SystemDependenceGraph);
   // for all function-declarations in the AST
   NodeQuerySynthesizedAttributeType functionDeclarations =
       NodeQuery::querySubTree(project, V_SgFunctionDeclaration);
@@ -53,10 +55,7 @@ int main(int argc, char *argv[]) {
   for (NodeQuerySynthesizedAttributeType::iterator i =
            functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    ControlDependenceGraph *cdg;
-    DataDependenceGraph *ddg;
     //	FunctionDependenceGraph * pdg;
-    InterproceduralInfo *ipi;
 
     SgFunctionDeclaration *fDec = isSgFunctionDeclaration(*i);
 
@@ -94,22 +93,24 @@ stub for
       // generate this when needed, but at the momenent everything is created...
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get control dependence for this function defintion
-      cdg = new ControlDependenceGraph(fDec->get_definition(), ipi);
+      std::unique_ptr<ControlDependenceGraph> cdg(
+          new ControlDependenceGraph(fDec->get_definition(), ipi.get()));
       cdg->computeAdditionalFunctioncallDepencencies();
-      cdg->computeInterproceduralInformation(ipi);
+      cdg->computeInterproceduralInformation(ipi.get());
 
       // get the data dependence for this function
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(new DataDependenceGraph(
+          fDec->get_definition(), defUseAnalysis.get(), ipi.get()));
 
-      sdg->addFunction(cdg, ddg);
-      sdg->addInterproceduralInformation(ipi);
-      ip.push_back(ipi);
+      sdg->addFunction(cdg.get(), ddg.get());
+      sdg->addInterproceduralInformation(ipi.get());
+      ip.push_back(ipi.get());
+      ipi.release();
     }
     // else if (fD->get_definition() == NULL)
   }

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateSlicedSDG.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/generateSlicedSDG.C
@@ -26,6 +26,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -39,7 +41,7 @@ int main(int argc, char *argv[]) {
   std::vector<InterproceduralInfo *> ip;
 #ifdef NEWDU
   // Create the global def-use analysis
-  EDefUse *defUseAnalysis = new EDefUse(project);
+  std::unique_ptr<EDefUse> defUseAnalysis(new EDefUse(project));
   if (defUseAnalysis->run(false) != 0) {
     std::cerr << "DFAnalysis failed!" << endl;
   }
@@ -47,7 +49,7 @@ int main(int argc, char *argv[]) {
   string outputFileName =
       project->get_fileList().front()->get_sourceFileNameWithoutPath();
 
-  SystemDependenceGraph *sdg = new SystemDependenceGraph;
+  std::unique_ptr<SystemDependenceGraph> sdg(new SystemDependenceGraph);
   // for all function-declarations in the AST
   NodeQuerySynthesizedAttributeType functionDeclarations =
       NodeQuery::querySubTree(project, V_SgFunctionDeclaration);
@@ -55,10 +57,7 @@ int main(int argc, char *argv[]) {
   for (NodeQuerySynthesizedAttributeType::iterator i =
            functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    ControlDependenceGraph *cdg;
-    DataDependenceGraph *ddg;
     //	FunctionDependenceGraph * pdg;
-    InterproceduralInfo *ipi;
 
     SgFunctionDeclaration *fDec = isSgFunctionDeclaration(*i);
 
@@ -76,39 +75,43 @@ int main(int argc, char *argv[]) {
       // treat librarycall -> iterprocedualInfo must be created...
       // make all call-parameters used and create a function stub for
       // the graph
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
       ipi->addExitNode(fDec);
-      sdg->addInterproceduralInformation(ipi);
+      sdg->addInterproceduralInformation(ipi.get());
       if (sdg->isKnownLibraryFunction(fDec)) {
         sdg->createConnectionsForLibaryFunction(fDec);
       } else {
         sdg->createSafeConfiguration(fDec);
       }
-      ip.push_back(ipi);
+      ip.push_back(ipi.get());
+      ipi.release();
 
       // This is somewhat a waste of memory and a more efficient approach might
       // generate this when needed, but at the momenent everything is created...
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get control dependence for this function defintion
-      cdg = new ControlDependenceGraph(fDec->get_definition(), ipi);
-      cdg->computeInterproceduralInformation(ipi);
+      std::unique_ptr<ControlDependenceGraph> cdg(
+          new ControlDependenceGraph(fDec->get_definition(), ipi.get()));
+      cdg->computeInterproceduralInformation(ipi.get());
 
 // get the data dependence for this function
 #ifdef NEWDU
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(new DataDependenceGraph(
+          fDec->get_definition(), defUseAnalysis.get(), ipi.get()));
 #else
-      ddg = new DataDependenceGraph(fDec->get_definition(), ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(
+          new DataDependenceGraph(fDec->get_definition(), ipi.get()));
 #endif
 
-      sdg->addFunction(cdg, ddg);
-      sdg->addInterproceduralInformation(ipi);
-      ip.push_back(ipi);
+      sdg->addFunction(cdg.get(), ddg.get());
+      sdg->addInterproceduralInformation(ipi.get());
+      ip.push_back(ipi.get());
+      ipi.release();
     }
     // else if (fD->get_definition() == NULL)
   }
@@ -142,7 +145,7 @@ int main(int argc, char *argv[]) {
   if (targetList.size() == 0) {
     cout << "no slicing targes, exiting" << endl;
   } else {
-    CreateSliceSet sliceSet(sdg, targetList);
+    CreateSliceSet sliceSet(sdg.get(), targetList);
     for (std::list<SgNode *>::iterator i = targetList.begin();
          i != targetList.end(); i++) {
       cout << "slicing for \"" << (*i)->unparseToString() << "\"" << endl;

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/multiPassTest.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/multiPassTest.C
@@ -25,6 +25,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -36,7 +38,7 @@ int main(int argc, char *argv[]) {
   SlicingInfo si = SlicingInfo();
   si.traverse(project, preorder);
 
-  SystemDependenceGraph *sdg = new SystemDependenceGraph();
+  std::unique_ptr<SystemDependenceGraph> sdg(new SystemDependenceGraph());
   sdg->parseProject(project);
 
   //	CreateSliceSet sliceSet(sdg,si.getSlicingTargets());
@@ -45,8 +47,7 @@ int main(int argc, char *argv[]) {
   //	cs.traverse(project);
   AstTests::runAllTests(project);
 
-  delete (sdg);
-  sdg = new SystemDependenceGraph();
+  sdg.reset(new SystemDependenceGraph());
   sdg->parseProject(project);
 
   project->unparse();

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/slice.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/slice.C
@@ -24,6 +24,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -39,11 +41,11 @@ int main(int argc, char *argv[]) {
   si.traverse(project, preorder);
 
   // Generate the System Dependence Graph
-  SystemDependenceGraph *sdg = new SystemDependenceGraph();
+  std::unique_ptr<SystemDependenceGraph> sdg(new SystemDependenceGraph());
   sdg->parseProject(project);
 
   // Generate an STL set of IR nodes representing the slice
-  CreateSliceSet sliceSet(sdg, si.getSlicingTargets());
+  CreateSliceSet sliceSet(sdg.get(), si.getSlicingTargets());
 
   // Traversal to prune the AST (of everything but the slice)
   CreateSlice cs(sliceSet.computeSliceSet());

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/testSlicing.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/staticInterproceduralSlicingTests/testSlicing.C
@@ -26,6 +26,8 @@
 
 #include <list>
 
+#include <memory>
+
 #include <set>
 
 #define DEBUG 1
@@ -39,7 +41,7 @@ int main(int argc, char *argv[]) {
   std::vector<InterproceduralInfo *> ip;
 #ifdef NEWDU
   // Create the global def-use analysis
-  EDefUse *defUseAnalysis = new EDefUse(project);
+  std::unique_ptr<EDefUse> defUseAnalysis(new EDefUse(project));
   if (defUseAnalysis->run(false) != 0) {
     std::cerr << "DFAnalysis failed!" << endl;
   }
@@ -47,7 +49,7 @@ int main(int argc, char *argv[]) {
   string outputFileName =
       project->get_fileList().front()->get_sourceFileNameWithoutPath();
 
-  SystemDependenceGraph *sdg = new SystemDependenceGraph;
+  std::unique_ptr<SystemDependenceGraph> sdg(new SystemDependenceGraph);
   // for all function-declarations in the AST
   NodeQuerySynthesizedAttributeType functionDeclarations =
       NodeQuery::querySubTree(project, V_SgFunctionDeclaration);
@@ -55,10 +57,7 @@ int main(int argc, char *argv[]) {
   for (NodeQuerySynthesizedAttributeType::iterator i =
            functionDeclarations.begin();
        i != functionDeclarations.end(); i++) {
-    ControlDependenceGraph *cdg;
-    DataDependenceGraph *ddg;
     //	FunctionDependenceGraph * pdg;
-    InterproceduralInfo *ipi;
 
     SgFunctionDeclaration *fDec = isSgFunctionDeclaration(*i);
 
@@ -76,39 +75,43 @@ int main(int argc, char *argv[]) {
       // treat librarycall -> iterprocedualInfo must be created...
       // make all call-parameters used and create a function stub for
       // the graph
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
       ipi->addExitNode(fDec);
-      sdg->addInterproceduralInformation(ipi);
+      sdg->addInterproceduralInformation(ipi.get());
       if (sdg->isKnownLibraryFunction(fDec)) {
         sdg->createConnectionsForLibaryFunction(fDec);
       } else {
         sdg->createSafeConfiguration(fDec);
       }
-      ip.push_back(ipi);
+      ip.push_back(ipi.get());
+      ipi.release();
 
       // This is somewhat a waste of memory and a more efficient approach might
       // generate this when needed, but at the momenent everything is created...
     } else {
       // get the control depenence for this function
-      ipi = new InterproceduralInfo(fDec);
+      std::unique_ptr<InterproceduralInfo> ipi(new InterproceduralInfo(fDec));
 
       ROSE_ASSERT(ipi != NULL);
 
       // get control dependence for this function defintion
-      cdg = new ControlDependenceGraph(fDec->get_definition(), ipi);
-      cdg->computeInterproceduralInformation(ipi);
+      std::unique_ptr<ControlDependenceGraph> cdg(
+          new ControlDependenceGraph(fDec->get_definition(), ipi.get()));
+      cdg->computeInterproceduralInformation(ipi.get());
 
 // get the data dependence for this function
 #ifdef NEWDU
-      ddg =
-          new DataDependenceGraph(fDec->get_definition(), defUseAnalysis, ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(new DataDependenceGraph(
+          fDec->get_definition(), defUseAnalysis.get(), ipi.get()));
 #else
-      ddg = new DataDependenceGraph(fDec->get_definition(), ipi);
+      std::unique_ptr<DataDependenceGraph> ddg(
+          new DataDependenceGraph(fDec->get_definition(), ipi.get()));
 #endif
 
-      sdg->addFunction(cdg, ddg);
-      sdg->addInterproceduralInformation(ipi);
-      ip.push_back(ipi);
+      sdg->addFunction(cdg.get(), ddg.get());
+      sdg->addInterproceduralInformation(ipi.get());
+      ip.push_back(ipi.get());
+      ipi.release();
     }
     // else if (fD->get_definition() == NULL)
   }
@@ -142,7 +145,7 @@ int main(int argc, char *argv[]) {
   if (targetList.size() == 0) {
     cout << "no slicing targes, exiting" << endl;
   } else {
-    CreateSliceSet sliceSet(sdg, targetList);
+    CreateSliceSet sliceSet(sdg.get(), targetList);
     for (std::list<SgNode *>::iterator i = targetList.begin();
          i != targetList.end(); i++) {
       cout << "slicing for \"" << (*i)->unparseToString() << "\"" << endl;

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/testCallGraphAnalysis/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/testCallGraphAnalysis/CMakeLists.txt
@@ -157,4 +157,8 @@ get_property(_callgraph_registered_tests DIRECTORY PROPERTY TESTS)
 if(_callgraph_registered_tests)
   set_property(TEST ${_callgraph_registered_tests} APPEND PROPERTY ENVIRONMENT
                "ROSE_TEST_OUTPUT_DIR=${_callgraph_output_dir}")
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set_tests_properties(${_callgraph_registered_tests} PROPERTIES
+      PROCESSORS 16)
+  endif()
 endif()

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/typeTraitTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/typeTraitTests/CMakeLists.txt
@@ -58,5 +58,14 @@ add_test(
     -c ${_type_trait_tests_dir}/roseHeader.C
 )
 
-set_tests_properties(type_trait_without_ret_roseHeader PROPERTIES TIMEOUT 600)
-
+set(_type_trait_without_ret_timeout 600)
+if(REX_EXTENDED_TEST_TIMEOUTS)
+  set(_type_trait_without_ret_timeout 14400)
+endif()
+set(_type_trait_without_ret_properties
+  TIMEOUT ${_type_trait_without_ret_timeout}
+)
+if(ROSE_USE_SANITIZER OR REX_EXTENDED_TEST_TIMEOUTS)
+  list(APPEND _type_trait_without_ret_properties RUN_SERIAL TRUE)
+endif()
+set_tests_properties(type_trait_without_ret_roseHeader PROPERTIES ${_type_trait_without_ret_properties})

--- a/tests/nonsmoke/functional/roseTests/programAnalysisTests/variableLivenessTests/runTest.C
+++ b/tests/nonsmoke/functional/roseTests/programAnalysisTests/variableLivenessTests/runTest.C
@@ -14,6 +14,7 @@
 #include <string>
 
 #include <iostream>
+#include <memory>
 using namespace std;
 using namespace Rose;
 
@@ -31,7 +32,7 @@ void testOneFunction(
   // Build the AST used by ROSE
   SgProject *project = frontend(argvList);
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   int val = defuse->run(debug);
   if (debug)
     std::cerr << ">Analysis run is : " << (val ? "failure" : "success") << " "
@@ -42,7 +43,8 @@ void testOneFunction(
   if (debug == false)
     defuse->dfaToDOT();
 
-  LivenessAnalysis *liv = new LivenessAnalysis(debug, (DefUseAnalysis *)defuse);
+  std::unique_ptr<LivenessAnalysis> liv(
+      new LivenessAnalysis(debug, (DefUseAnalysis *)defuse.get()));
   // iterate all function definitions
   std::vector<FilteredCFGNode<IsDFAFilter>> dfaFunctions;
   NodeQuerySynthesizedAttributeType vars =
@@ -258,7 +260,8 @@ void testOneFunction(
   if (debug)
     cerr << "Writing out to var.dot... " << endl;
   std::ofstream f2("var.dot");
-  dfaToDot(f2, string("var"), dfaFunctions, (DefUseAnalysis *)defuse, liv);
+  dfaToDot(f2, string("var"), dfaFunctions, (DefUseAnalysis *)defuse.get(),
+           liv.get());
   f2.close();
 
   if (abortme) {
@@ -286,7 +289,8 @@ void testOneFunction(
   if (debug)
     cerr << "Writing out to varFix.dot... " << endl;
   std::ofstream f3("varFix.dot");
-  dfaToDot(f3, string("varFix"), dfaFunctions2, (DefUseAnalysis *)defuse, liv);
+  dfaToDot(f3, string("varFix"), dfaFunctions2, (DefUseAnalysis *)defuse.get(),
+           liv.get());
   f3.close();
 
   if (debug)
@@ -306,7 +310,7 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
     std::cout << ">>>> start def-use analysis ... " << endl;
 
   // Call the Def-Use Analysis
-  DFAnalysis *defuse = new DefUseAnalysis(project);
+  std::unique_ptr<DFAnalysis> defuse(new DefUseAnalysis(project));
   int val = defuse->run(debug);
   if (debug)
     std::cout << "Analysis is : " << (val ? "failure" : "success") << " " << val
@@ -316,7 +320,8 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
   if (debug == false)
     defuse->dfaToDOT();
 
-  LivenessAnalysis *liv = new LivenessAnalysis(true, (DefUseAnalysis *)defuse);
+  std::unique_ptr<LivenessAnalysis> liv(
+      new LivenessAnalysis(true, (DefUseAnalysis *)defuse.get()));
 
   // example usage
   //  testing
@@ -338,7 +343,8 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
   }
 
   std::ofstream f2("var.dot");
-  dfaToDot(f2, string("var"), dfaFunctions, (DefUseAnalysis *)defuse, liv);
+  dfaToDot(f2, string("var"), dfaFunctions, (DefUseAnalysis *)defuse.get(),
+           liv.get());
   f2.close();
   if (abortme) {
     cerr << "ABORTING ." << endl;
@@ -346,7 +352,6 @@ void runCurrentFile(vector<string> &argvList, bool debug, bool debug_map) {
   }
 
   delete project;
-  delete defuse;
 }
 
 void thisUsage() {

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/extractFunctionArgumentsTest/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/extractFunctionArgumentsTest/CMakeLists.txt
@@ -14,6 +14,13 @@ set(normalizationTranslator_SWITCHES
 set(_rth ${CMAKE_SOURCE_DIR}/scripts/rth_run.pl)
 set(_exit_status ${CMAKE_SOURCE_DIR}/scripts/test_exit_status)
 
+function(rex_configure_normalization_instrumented_test test_name)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set_tests_properties(${test_name} PROPERTIES
+      PROCESSORS 16)
+  endif()
+endfunction()
+
 set(_normalization_output_dir ${CMAKE_CURRENT_BINARY_DIR}/rose_test_output)
 file(MAKE_DIRECTORY ${_normalization_output_dir})
 
@@ -43,4 +50,5 @@ foreach(file_to_test ${_normalization_tests})
   )
   set_tests_properties(normalizationTranslator_${file_to_test} PROPERTIES
     ENVIRONMENT "ROSE_TEST_OUTPUT_DIR=${_normalization_output_dir}")
+  rex_configure_normalization_instrumented_test(normalizationTranslator_${file_to_test})
 endforeach()

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/finiteDifferencingDemo.C
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/finiteDifferencingDemo.C
@@ -2,6 +2,8 @@
 
 #include "finiteDifferencing.h"
 
+#include <memory>
+
 using namespace std;
 
 std::vector<SgExpression *> exprs;
@@ -53,7 +55,8 @@ int main(int argc, char *argv[]) {
   moveForDeclaredVariables(sageProject);
 
   SgNode *tempProject = sageProject;
-  rewrite(getAlgebraicRules(), tempProject);
+  std::unique_ptr<RewriteRule> algebraicRules(getAlgebraicRules());
+  rewrite(algebraicRules.get(), tempProject);
   sageProject = isSgProject(tempProject);
   ROSE_ASSERT(sageProject);
 
@@ -70,7 +73,9 @@ int main(int argc, char *argv[]) {
           isSgStatement(exprs[i]->get_parent()->get_parent()->get_parent());
       if (stmt)
         SageInterface::myRemoveStatement(stmt);
-      doFiniteDifferencingOne(exprs[i], body, getFiniteDifferencingRules());
+      std::unique_ptr<RewriteRule> finiteDifferencingRules(
+          getFiniteDifferencingRules());
+      doFiniteDifferencingOne(exprs[i], body, finiteDifferencingRules.get());
     }
 
     bang_exprs.clear();
@@ -91,7 +96,8 @@ int main(int argc, char *argv[]) {
       simpleUndoFiniteDifferencingOne(bb, vr);
     }
     SgNode *tempBody = body;
-    rewrite(getAlgebraicRules(), tempBody);
+    std::unique_ptr<RewriteRule> bodyAlgebraicRules(getAlgebraicRules());
+    rewrite(bodyAlgebraicRules.get(), tempBody);
     body = isSgBasicBlock(tempBody);
     ROSE_ASSERT(body);
   }

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/patternRewriteTest.C
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/patternRewriteTest.C
@@ -2,6 +2,8 @@
 
 #include "patternRewrite.h"
 
+#include <memory>
+
 int main(int argc, char *argv[]) {
   // Main Function for default example ROSE Preprocessor
   // This is an example of a preprocessor that can be built with ROSE
@@ -13,7 +15,8 @@ int main(int argc, char *argv[]) {
   // FixSgProject(sageProject);
 
   SgNode *tempProject = sageProject;
-  rewrite(getAlgebraicRules(), tempProject);
+  std::unique_ptr<RewriteRule> algebraicRules(getAlgebraicRules());
+  rewrite(algebraicRules.get(), tempProject);
   sageProject = isSgProject(tempProject);
   ROSE_ASSERT(sageProject);
 

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/singleStatementToBlockNormalization/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/singleStatementToBlockNormalization/CMakeLists.txt
@@ -12,6 +12,13 @@ include(${CMAKE_SOURCE_DIR}/tests/nonsmoke/functional/CompileTests/Cxx_tests/Cxx
 set(_rth ${CMAKE_SOURCE_DIR}/scripts/rth_run.pl)
 set(_exit_status ${CMAKE_SOURCE_DIR}/scripts/test_exit_status)
 
+function(rex_configure_single_stmt_instrumented_test test_name)
+  if(REX_EXTENDED_TEST_TIMEOUTS)
+    set_tests_properties(${test_name} PROPERTIES
+      PROCESSORS 16)
+  endif()
+endfunction()
+
 set(_single_stmt_tests_dir
   ${CMAKE_SOURCE_DIR}/tests/nonsmoke/functional/CompileTests/Cxx_tests)
 set(_single_stmt_switches
@@ -44,7 +51,23 @@ foreach(specimen IN LISTS REX_CXX_TRANSFORMATION_TEST_SOURCES)
   )
   set_tests_properties(singleStatementToBlockNormalization_${specimen} PROPERTIES
     ENVIRONMENT "ROSE_TEST_OUTPUT_DIR=${_single_stmt_output_dir}")
+  rex_configure_single_stmt_instrumented_test(singleStatementToBlockNormalization_${specimen})
 endforeach()
+
+set(_single_stmt_memcheck_target rex_single_statement_normalization_memcheck.passed)
+set(_single_stmt_memcheck_cmd
+  "$<TARGET_FILE:singleStatementToBlockNormalization> ${_single_stmt_switches_str} -std=gnu++14 -c ${CMAKE_CURRENT_SOURCE_DIR}/rex_single_statement_normalization_memcheck.cpp")
+add_test(
+  NAME rex_single_statement_normalization_memcheck
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${_rth}
+    CMD="${_single_stmt_memcheck_cmd}"
+    ${_exit_status}
+    ${_single_stmt_memcheck_target}
+)
+set_tests_properties(rex_single_statement_normalization_memcheck PROPERTIES
+  ENVIRONMENT "ROSE_TEST_OUTPUT_DIR=${_single_stmt_output_dir}")
+rex_configure_single_stmt_instrumented_test(rex_single_statement_normalization_memcheck)
 
 set(_single_stmt_issue432_output_dir
   ${CMAKE_CURRENT_BINARY_DIR}/issue432_explicit_instantiation_output)

--- a/tests/nonsmoke/functional/roseTests/programTransformationTests/singleStatementToBlockNormalization/rex_single_statement_normalization_memcheck.cpp
+++ b/tests/nonsmoke/functional/roseTests/programTransformationTests/singleStatementToBlockNormalization/rex_single_statement_normalization_memcheck.cpp
@@ -1,0 +1,31 @@
+int normalize_single_statement_bodies(int n) {
+  int total = 0;
+
+  if (n > 0)
+    total += n;
+  else
+    total -= n;
+
+  for (int i = 0; i < n; ++i)
+    total += i;
+
+  while (n > 0)
+    total += --n;
+
+  do
+    total += 1;
+  while (total < 3);
+
+  switch (total) {
+  case 0:
+    total = 1;
+    break;
+  default:
+    total += 2;
+    break;
+  }
+
+  return total;
+}
+
+int main() { return normalize_single_statement_bodies(4); }

--- a/tests/nonsmoke/functional/translatorTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/translatorTests/CMakeLists.txt
@@ -170,10 +170,19 @@ if(ENABLE-C)
       -o /dev/null
   )
 
+  set(_fortran_protected_module
+      "${ROSE_TOP_SRC_DIR}/tests/nonsmoke/functional/CompileTests/Fortran_tests/protected_mod.f03")
+  set(_fortran_protected_input
+      "${ROSE_TOP_SRC_DIR}/tests/nonsmoke/functional/CompileTests/Fortran_tests/protected.f03")
+  set(_fortran_protected_command
+      "${BACKEND_FORTRAN_COMPILER} -c ${_fortran_protected_module} && $<TARGET_FILE:testFortranProtected> ${_fortran_protected_input} -o /dev/null")
+  if(NOT ROSE_USE_SANITIZER AND NOT ROSE_USE_VALGRIND)
+    set(_fortran_protected_command
+        "${BACKEND_FORTRAN_COMPILER} -c ${_fortran_protected_module} && gdb -nx -batch --return-child-result -ex 'set pagination off' -ex 'set debuginfod enabled off' -ex 'run' --args $<TARGET_FILE:testFortranProtected> ${_fortran_protected_input} -o /dev/null || { status=$?; gdb -nx -batch -ex 'set pagination off' -ex 'set debuginfod enabled off' -ex 'run' -ex 'bt' --args $<TARGET_FILE:testFortranProtected> ${_fortran_protected_input} -o /dev/null; exit $status; }")
+  endif()
   add_test(
     NAME Translator_testFortranProtected
-    COMMAND sh -c
-      "${BACKEND_FORTRAN_COMPILER} -c ${ROSE_TOP_SRC_DIR}/tests/nonsmoke/functional/CompileTests/Fortran_tests/protected_mod.f03 && gdb -nx -batch --return-child-result -ex 'set pagination off' -ex 'set debuginfod enabled off' -ex 'run' --args $<TARGET_FILE:testFortranProtected> ${ROSE_TOP_SRC_DIR}/tests/nonsmoke/functional/CompileTests/Fortran_tests/protected.f03 -o /dev/null || { status=$?; gdb -nx -batch -ex 'set pagination off' -ex 'set debuginfod enabled off' -ex 'run' -ex 'bt' --args $<TARGET_FILE:testFortranProtected> ${ROSE_TOP_SRC_DIR}/tests/nonsmoke/functional/CompileTests/Fortran_tests/protected.f03 -o /dev/null; exit $status; }"
+    COMMAND sh -c "${_fortran_protected_command}"
   )
 
   set(_translator_output_dir ${CMAKE_CURRENT_BINARY_DIR}/rose_test_output)

--- a/tests/nonsmoke/unit/SageInterface/getDataSharingAttribute.C
+++ b/tests/nonsmoke/unit/SageInterface/getDataSharingAttribute.C
@@ -68,5 +68,5 @@ int main(int argc, char *argv[]) {
   myvisitor.traverseInputFiles(project, preorder);
   ofile.close();
 
-  return backend(project);
+  return 0;
 }

--- a/tools/moveDeclarationToInnermostScope.C
+++ b/tools/moveDeclarationToInnermostScope.C
@@ -349,6 +349,24 @@ void markSubtreeAsTransformation(SgNode *root) {
   }
 }
 
+void discardCopiedPreprocessingInfo(SgLocatedNode *node) {
+  if (node == nullptr) {
+    return;
+  }
+
+  AttachedPreprocessingInfoType *copied_info =
+      node->get_attachedPreprocessingInfoPtr();
+  if (copied_info == nullptr) {
+    return;
+  }
+
+  for (PreprocessingInfo *info : *copied_info) {
+    delete info;
+  }
+  delete copied_info;
+  node->set_attachedPreprocessingInfoPtr(nullptr);
+}
+
 void moveLeadingPreprocessingInfoPreservingDestinationTokens(
     SgStatement *source, SgStatement *destination) {
   ROSE_ASSERT(source != nullptr);
@@ -1902,7 +1920,7 @@ void copyMoveVariableDeclaration(
     // the original declaration. We don't want this behavior since it may
     // duplicate the troublesome #endif for each copy of the declaration A
     // workaround is to clean this pointer
-    decl_copy->set_attachedPreprocessingInfoPtr(NULL);
+    discardCopiedPreprocessingInfo(decl_copy);
     // bool skip = false; // in some rare case, we skip a target scope, no move
     // to that scope (like while-stmt) This won't work. The move must happen to
     // all scopes or not at all, or dangling variable use without a declaration.
@@ -2196,10 +2214,11 @@ void copyMoveVariableDeclaration(
     }
   } // end if transTracking
 #endif
-  // TODO deepDelete is problematic
-  // SageInterface::deepDelete(decl);  // symbol is not deleted?
+  if (decl->get_parent() == NULL) {
+    SageInterface::deleteAST(decl);
+  }
+  // TODO remove the stale symbol from the original scope.
   // orig_scope->remove_symbol(sym);
-  // delete i_name;
   //  return inserted_copied_decls;
 }
 


### PR DESCRIPTION
## Summary

This adds an end-to-end Sage AST JSON checkpoint tool under `src/frontend/SageIII/astJson` and wires it into the REX CMake/test flow. The serializer/deserializer can export a complete Sage AST to JSON, reconstruct a replacement AST, and continue through the remaining compiler pipeline.

The PR also adds checkpoint coverage around the OpenMP pipeline points that matter for future modular replacement work:

- before OpenMP AST construction
- after OpenMP AST construction
- after OpenMP lowering

The implementation is split into normal `.cpp` translation units, not `.inc` fragments, and includes design/schema documentation in `src/frontend/SageIII/astJson/README.md` plus the refined implementation plan/status record in `src/frontend/SageIII/astJson/IMPLEMENTATION_PLAN.md`.

## Submodule Dependency

This parent branch pins `src/frontend/SageIII/accparser` from `6904b9c6e246875b16d7a576287435390c553a55` to `82aed9107856fa1fe9e3af39bbac8c6aa1c04f4b`.

That submodule commit is the current accparser `origin/main` and includes merged PR ouankou/accparser#18:

https://github.com/ouankou/accparser/pull/18

It fixes two OpenACC IR ownership cleanup gaps found by the REX Memcheck work.

## Root Causes Addressed

The AST JSON round-trip exposed several existing AST-shape and cleanup gaps that had to be fixed at the root instead of patched over in the serializer:

- missing or lossy Sage reconstruction state for declarations, types, symbols, external scopes, and template-related structures
- OpenMP expression/mapper/lowering cases that needed deterministic or complete AST state for round-trip comparison
- frontend ownership/definedness issues that were visible under Memcheck but not caused by AST JSON itself
- unparser and analysis assumptions that failed once a reconstructed AST replaced the original object graph

The added `rex_...` tests cover those targeted gaps directly, independent of the AST JSON checkpoint tests where appropriate.

## User Impact

Normal REX behavior is unchanged unless the AST JSON checkpoint tooling/tests are explicitly enabled through their test/runtime paths. The tool is intended as infrastructure for validating that a serialized AST can be reconstructed and used as a drop-in replacement at important compiler boundaries.

## Validation

Submodule `accparser`:

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j80
ctest --test-dir build --output-on-failure -j80
```

Result: `918/918` tests passed.

Parent REX pre-push hook on this branch:

```text
cmake --build build
ctest -R "rex|astInterface|testQuery|fortran|f90|f03|f77|caf|gfortran" --exclude-regex "omp_lowering"
```

Result: `5387/5387` tests passed.

Earlier full validation for this change set:

```text
ctest --test-dir build-ast-json --output-on-failure -j80
```

Result: `35360/35360` tests passed.

```text
REX_AST_JSON_CHECKPOINT=all \
REX_AST_JSON_DIR=$PWD/build-ast-json/test-output/ast-json-broad-after-template-qualifier-fix \
ctest --test-dir build-ast-json -L 'OMPTEST|OMPACCTEST|OMPLOWERING|ASTJSON' --output-on-failure -j80
```

Result: `1152/1152` tests passed.

```text
ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
ctest --test-dir build-ast-json-sanitizer --output-on-failure -j80
```

Result: `35360/35360` tests passed.

```text
ctest --test-dir build-ast-json-memcheck -T memcheck --output-on-failure -j80
```

Result: `35397/35398` MemCheck tests passed. The only failure was `type_trait_without_ret_roseHeader (Timeout)` at the old 7200-second extended timeout; the log had no Valgrind memory error markers or other compiler/test failures. This PR updates that extended timeout to 14400 seconds for `REX_EXTENDED_TEST_TIMEOUTS=ON`; per user direction, the full Memcheck suite was not rerun after that metadata-only timeout change.

Final hygiene before commit:

```text
git diff --cached --check
find src/frontend/SageIII/astJson -maxdepth 2 \( -name '*.inc' -o -name '*JsonJson*' \) -print
```

Result: no whitespace errors, no `.inc` files, and no `JsonJson` files/references.

