### PR TITLE
Fix Clang attr memcheck boundary

### DIFF
--- a/src/frontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/Clang/clang-frontend-decl.cpp
@@ -21016,84 +21016,90 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
   if (decl != nullptr) {
     int max_alignment = -1;
     bool has_aligned_attr = false;
+    const bool has_attrs =
+        readClangApiValueDefined([&]() { return decl->hasAttrs(); });
+    if (has_attrs) {
 #if ROSE_USE_VALGRIND
-    markClangDeclAttrsDefined(decl);
-    VALGRIND_DISABLE_ERROR_REPORTING;
+      markClangDeclAttrsDefined(decl);
+      VALGRIND_DISABLE_ERROR_REPORTING;
 #endif
-    const clang::AttrVec &attrs = decl->getAttrs();
+      const clang::AttrVec &attrs = decl->getAttrs();
 #if ROSE_USE_VALGRIND
-    VALGRIND_ENABLE_ERROR_REPORTING;
+      VALGRIND_ENABLE_ERROR_REPORTING;
 #endif
-    for (size_t attr_index = 0; attr_index < attrs.size(); ++attr_index) {
-      const clang::Attr *attr = markClangAstObjectDefined(
-          readClangApiValueDefined([&]() { return attrs[attr_index]; }));
-      const clang::AlignedAttr *aligned_attr =
-          llvm::dyn_cast_or_null<clang::AlignedAttr>(attr);
-      aligned_attr = markClangAstObjectDefined(aligned_attr);
-      if (aligned_attr == nullptr) {
-        continue;
-      }
-      has_aligned_attr = true;
-      if (aligned_attr == nullptr || p_compiler_instance == nullptr) {
-        continue;
-      }
-      clang::ASTContext &ast_context = p_compiler_instance->getASTContext();
+      const size_t attr_count =
+          readClangApiValueDefined([&]() { return attrs.size(); });
+      for (size_t attr_index = 0; attr_index < attr_count; ++attr_index) {
+        const clang::Attr *attr = markClangAstObjectDefined(
+            readClangApiValueDefined([&]() { return attrs[attr_index]; }));
+        const clang::AlignedAttr *aligned_attr =
+            llvm::dyn_cast_or_null<clang::AlignedAttr>(attr);
+        aligned_attr = markClangAstObjectDefined(aligned_attr);
+        if (aligned_attr == nullptr) {
+          continue;
+        }
+        has_aligned_attr = true;
+        if (aligned_attr == nullptr || p_compiler_instance == nullptr) {
+          continue;
+        }
+        clang::ASTContext &ast_context = p_compiler_instance->getASTContext();
 
-      int alignment_candidate = -1;
-      if (readClangApiValueDefined(
-              [&]() { return aligned_attr->isAlignmentDependent(); }) ||
-          readClangApiValueDefined(
-              [&]() { return aligned_attr->isAlignmentErrorDependent(); })) {
-        continue;
-      }
+        int alignment_candidate = -1;
+        if (readClangApiValueDefined(
+                [&]() { return aligned_attr->isAlignmentDependent(); }) ||
+            readClangApiValueDefined(
+                [&]() { return aligned_attr->isAlignmentErrorDependent(); })) {
+          continue;
+        }
 
-      if (readClangApiValueDefined(
-              [&]() { return aligned_attr->isAlignmentExpr(); })) {
-        const clang::Expr *alignment_expr =
-            markClangAstObjectDefined(readClangApiValueDefined(
-                [&]() { return aligned_attr->getAlignmentExpr(); }));
-        if (alignment_expr != nullptr) {
-          alignment_expr = markClangAstObjectDefined(readClangApiValueDefined(
-              [&]() { return alignment_expr->IgnoreParenImpCasts(); }));
-          if (readClangApiValueDefined([&]() {
-                return alignment_expr->isEvaluatable(ast_context);
-              })) {
-            const llvm::APSInt value = readClangApiValueDefined([&]() {
-              return alignment_expr->EvaluateKnownConstInt(ast_context);
-            });
-            if (value.isNonNegative()) {
-              const int64_t alignment_value_64 = value.getSExtValue();
-              if (alignment_value_64 <= std::numeric_limits<int>::max()) {
-                alignment_candidate = static_cast<int>(alignment_value_64);
+        if (readClangApiValueDefined(
+                [&]() { return aligned_attr->isAlignmentExpr(); })) {
+          const clang::Expr *alignment_expr =
+              markClangAstObjectDefined(readClangApiValueDefined(
+                  [&]() { return aligned_attr->getAlignmentExpr(); }));
+          if (alignment_expr != nullptr) {
+            alignment_expr = markClangAstObjectDefined(readClangApiValueDefined(
+                [&]() { return alignment_expr->IgnoreParenImpCasts(); }));
+            if (readClangApiValueDefined([&]() {
+                  return alignment_expr->isEvaluatable(ast_context);
+                })) {
+              const llvm::APSInt value = readClangApiValueDefined([&]() {
+                return alignment_expr->EvaluateKnownConstInt(ast_context);
+              });
+              if (value.isNonNegative()) {
+                const int64_t alignment_value_64 = value.getSExtValue();
+                if (alignment_value_64 <= std::numeric_limits<int>::max()) {
+                  alignment_candidate = static_cast<int>(alignment_value_64);
+                }
+              }
+            }
+          }
+        } else {
+          clang::TypeSourceInfo *alignment_type =
+              markClangAstObjectDefined(aligned_attr->getAlignmentType());
+          if (alignment_type != nullptr) {
+            const clang::QualType qual_type = alignment_type->getType();
+            markClangValueDefined(qual_type);
+            markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
+            if (!qual_type.isNull() && !qual_type->isDependentType() &&
+                !qual_type->isInstantiationDependentType()) {
+              const clang::CharUnits align_chars =
+                  ast_context.getTypeAlignInChars(qual_type);
+              if (!align_chars.isZero()) {
+                const auto quantity = align_chars.getQuantity();
+                if (quantity > 0 &&
+                    quantity <= static_cast<decltype(quantity)>(
+                                    std::numeric_limits<int>::max())) {
+                  alignment_candidate = static_cast<int>(quantity);
+                }
               }
             }
           }
         }
-      } else {
-        clang::TypeSourceInfo *alignment_type =
-            markClangAstObjectDefined(aligned_attr->getAlignmentType());
-        if (alignment_type != nullptr) {
-          const clang::QualType qual_type = alignment_type->getType();
-          markClangValueDefined(qual_type);
-          markClangTypeObjectDefinedByClass(qual_type.getTypePtrOrNull());
-          if (!qual_type.isNull() && !qual_type->isDependentType() &&
-              !qual_type->isInstantiationDependentType()) {
-            const clang::CharUnits align_chars =
-                ast_context.getTypeAlignInChars(qual_type);
-            if (!align_chars.isZero()) {
-              const auto quantity = align_chars.getQuantity();
-              if (quantity > 0 &&
-                  quantity <= static_cast<decltype(quantity)>(
-                                  std::numeric_limits<int>::max())) {
-                alignment_candidate = static_cast<int>(quantity);
-              }
-            }
-          }
-        }
-      }
 
-      if (alignment_candidate > max_alignment) {
-        max_alignment = alignment_candidate;
+        if (alignment_candidate > max_alignment) {
+          max_alignment = alignment_candidate;
+        }
       }
     }
     int alignment_value = max_alignment;


### PR DESCRIPTION
## Summary

Fixes the Weekly Memory CI memcheck failure from https://github.com/ouankou/rex/actions/runs/28630764864.

The memcheck job was reporting many `Use of uninitialised value of size 8` failures from `llvm::SmallVectorBase<unsigned int>::size()` through `ClangToSageTranslator::VisitDecl`. The frontend always called `Decl::getAttrs()` and then read the returned `AttrVec::size()` even when Clang reported that the declaration had no attributes. That exposed Clang-owned empty attribute vector storage to Valgrind.

This changes the Clang frontend boundary so `VisitDecl` first reads `decl->hasAttrs()` through the existing defined-read helper, and only touches `getAttrs()`, `attrs.size()`, and the alignment-attribute scan when attributes actually exist. The Valgrind marking/error-suppression path remains scoped to the real attr-vector access.

The failed workflow also had a `check_policies` failure on the older scheduled SHA; current `main` already contains the policy fix, and this branch verifies that test passes from the updated base.

## Validation

- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -R '^check_policies$' --output-on-failure -j32`
- `ctest --test-dir build -T MemCheck -R '^C_tests_rex_test2026_compound_literal_typeloc_valgrind_defined_reads_c$' --output-on-failure -j1`
- `ctest --test-dir build -T MemCheck -R 'astInterface|testQuery|rex' -LE death -j"$(nproc)" --timeout 5400 --output-on-failure`
  - 649/649 passed; empty memory-checking results
- `ctest --test-dir build --output-on-failure -j"$(nproc)"`
  - 35,360/35,360 passed
- pre-push hook validation
  - 6,940/6,940 passed