### PR TITLE
[codex] Fix LLVM runtime deps in base images

### DIFF
--- a/.github/workflows/weekly-base-images.yml
+++ b/.github/workflows/weekly-base-images.yml
@@ -194,6 +194,16 @@ jobs:
             bash -lc '
               set -euo pipefail
               javac -version
-              dpkg-query -W openjdk-25-jdk-headless antlr4 clang-${LLVM_VERSION} lld-${LLVM_VERSION} mold gdb
+              dpkg-query -W \
+                openjdk-25-jdk-headless \
+                antlr4 \
+                clang-${LLVM_VERSION} \
+                flang-${LLVM_VERSION} \
+                lld-${LLVM_VERSION} \
+                libclang-rt-${LLVM_VERSION}-dev \
+                mold \
+                gdb
+              printf "      end\n" >/tmp/rex_fortran_smoke.f
+              flang-${LLVM_VERSION} -fuse-ld=lld /tmp/rex_fortran_smoke.f -o /tmp/rex_fortran_smoke
             '
         done

--- a/ci/docker/rex-amd64.Dockerfile
+++ b/ci/docker/rex-amd64.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       libantlr4-runtime-dev \
       libclang-${LLVM_VERSION}-dev \
       libclang-cpp${LLVM_VERSION}-dev \
+      libclang-rt-${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
       libomp-${LLVM_VERSION}-dev \

--- a/ci/docker/rex-arm64.Dockerfile
+++ b/ci/docker/rex-arm64.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       libantlr4-runtime-dev \
       libclang-${LLVM_VERSION}-dev \
       libclang-cpp${LLVM_VERSION}-dev \
+      libclang-rt-${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
       libomp-${LLVM_VERSION}-dev \

--- a/ci/docker/rex-loongarch64.Dockerfile
+++ b/ci/docker/rex-loongarch64.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       libantlr4-runtime-dev \
       libclang-${LLVM_VERSION}-dev \
       libclang-cpp${LLVM_VERSION}-dev \
+      libclang-rt-${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
       libomp-${LLVM_VERSION}-dev \

--- a/ci/docker/rex-riscv64.Dockerfile
+++ b/ci/docker/rex-riscv64.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       libantlr4-runtime-dev \
       libclang-${LLVM_VERSION}-dev \
       libclang-cpp${LLVM_VERSION}-dev \
+      libclang-rt-${LLVM_VERSION}-dev \
       libflang-${LLVM_VERSION}-dev \
       libhpdf-dev \
       libomp-${LLVM_VERSION}-dev \


### PR DESCRIPTION
## Summary

Adds the LLVM compiler runtime development package to every Debian-based REX base image variant:

- `ci/docker/rex-amd64.Dockerfile`
- `ci/docker/rex-arm64.Dockerfile`
- `ci/docker/rex-riscv64.Dockerfile`
- `ci/docker/rex-loongarch64.Dockerfile`

The weekly base-image local verification now also checks that `flang-${LLVM_VERSION}` and `libclang-rt-${LLVM_VERSION}-dev` are installed, then links a minimal Fortran program with `flang-${LLVM_VERSION} -fuse-ld=lld`.

## Root Cause

The recent arm64 nightly image build failed during CMake's Fortran compiler sanity check. The published `ghcr.io/ouankou/rex:base` arm64 image had `flang-22` and `lld-22`, but it did not include `libclang-rt-22-dev`. On arm64, Debian's `flang-22` driver injects the LLVM compiler-rt builtins archive into the link command, so CMake failed before the REX build started.

The other published base-image variants were missing the same explicit package, but their sampled `flang-22` link lines used GCC runtime libraries instead, so the dependency gap stayed latent there. This PR fixes all variants to keep the package set consistent and avoid target-specific surprises.

## Validation

- Reproduced the CI failure locally with the published arm64 base image: a trivial `flang-22 -fuse-ld=lld` link failed due to missing compiler-rt builtins.
- Built the patched arm64 base image locally with Docker Buildx under QEMU.
- Verified the rebuilt arm64 image installs `libclang-rt-22-dev` and links the same minimal Fortran program successfully.
- Ran the updated local weekly-base-image verification shell body against the rebuilt arm64 image.
- `git diff --check`
- Pre-push hook: filtered CTest suite passed, `6940/6940` tests passed.

## Follow-up

After this merges, run the weekly base-image workflow to republish `ghcr.io/ouankou/rex:base`. The nightly image workflow consumes that published `base` tag, so rerunning nightly before refreshing the base tag would still use the old arm64 image.