### PR TITLE
[codex] Build fresh base images in nightly

### DIFF
--- a/.github/workflows/nightly-rex-images.yml
+++ b/.github/workflows/nightly-rex-images.yml
@@ -26,6 +26,8 @@ jobs:
 
     env:
       IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/rex
+      LLVM_VERSION: 22
+      BASE_DOCKERFILE: ci/docker/rex-amd64.Dockerfile
       LOCAL_IMAGE_REPO: rex-local
       REX_RUNTIME_TAG: latest
       REX_DEV_TAG: dev
@@ -50,6 +52,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Build and push fresh base image (${{ env.TARGET_ARCH }})
+      if: ${{ !env.ACT }}
+      id: build-base
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ${{ env.BASE_DOCKERFILE }}
+        platforms: ${{ env.TARGET_PLATFORM }}
+        build-args: |
+          LLVM_VERSION=${{ env.LLVM_VERSION }}
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+
     - name: Build and push REX runtime image (${{ env.TARGET_ARCH }})
       if: ${{ !env.ACT }}
       id: build-runtime
@@ -62,7 +78,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -95,7 +111,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -147,6 +163,8 @@ jobs:
 
     env:
       IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/rex
+      LLVM_VERSION: 22
+      BASE_DOCKERFILE: ci/docker/rex-arm64.Dockerfile
       LOCAL_IMAGE_REPO: rex-local
       REX_RUNTIME_TAG: latest
       REX_DEV_TAG: dev
@@ -176,6 +194,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Build and push fresh base image (${{ env.TARGET_ARCH }})
+      if: ${{ !env.ACT }}
+      id: build-base
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ${{ env.BASE_DOCKERFILE }}
+        platforms: ${{ env.TARGET_PLATFORM }}
+        build-args: |
+          LLVM_VERSION=${{ env.LLVM_VERSION }}
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+
     - name: Build and push REX runtime image (${{ env.TARGET_ARCH }})
       if: ${{ !env.ACT }}
       id: build-runtime
@@ -188,7 +220,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -221,7 +253,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -273,6 +305,8 @@ jobs:
 
     env:
       IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/rex
+      LLVM_VERSION: 22
+      BASE_DOCKERFILE: ci/docker/rex-riscv64.Dockerfile
       LOCAL_IMAGE_REPO: rex-local
       REX_RUNTIME_TAG: latest
       REX_DEV_TAG: dev
@@ -302,6 +336,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Build and push fresh base image (${{ env.TARGET_ARCH }})
+      if: ${{ !env.ACT }}
+      id: build-base
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ${{ env.BASE_DOCKERFILE }}
+        platforms: ${{ env.TARGET_PLATFORM }}
+        build-args: |
+          LLVM_VERSION=${{ env.LLVM_VERSION }}
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+
     - name: Build and push REX runtime image (${{ env.TARGET_ARCH }})
       if: ${{ !env.ACT }}
       id: build-runtime
@@ -314,7 +362,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -347,7 +395,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -399,6 +447,8 @@ jobs:
 
     env:
       IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/rex
+      LLVM_VERSION: 22
+      BASE_DOCKERFILE: ci/docker/rex-loongarch64.Dockerfile
       LOCAL_IMAGE_REPO: rex-local
       REX_RUNTIME_TAG: latest
       REX_DEV_TAG: dev
@@ -428,6 +478,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Build and push fresh base image (${{ env.TARGET_ARCH }})
+      if: ${{ !env.ACT }}
+      id: build-base
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ${{ env.BASE_DOCKERFILE }}
+        platforms: ${{ env.TARGET_PLATFORM }}
+        build-args: |
+          LLVM_VERSION=${{ env.LLVM_VERSION }}
+        pull: true
+        provenance: false
+        outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
+
     - name: Build and push REX runtime image (${{ env.TARGET_ARCH }})
       if: ${{ !env.ACT }}
       id: build-runtime
@@ -440,7 +504,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 
@@ -473,7 +537,7 @@ jobs:
         pull: true
         provenance: false
         build-args: |
-          BASE_IMAGE=${{ env.IMAGE_REPO }}:base
+          BASE_IMAGE=${{ env.IMAGE_REPO }}@${{ steps.build-base.outputs.digest }}
           REX_BUILD_NUM_JOBS=${{ env.REX_IMAGE_BUILD_JOBS }}
         outputs: type=registry,name=${{ env.IMAGE_REPO }},push-by-digest=true
 


### PR DESCRIPTION
## Summary

Updates the nightly image workflow so each architecture job builds and pushes a fresh same-commit base image by digest before building the runtime and dev images.

Runtime/dev image builds now use:

```text
BASE_IMAGE=${IMAGE_REPO}@${{ steps.build-base.outputs.digest }}
```

instead of the mutable public `ghcr.io/ouankou/rex:base` tag.

## Root Cause

The previous PR fixed the base Dockerfiles, but the failing nightly run still pulled the old published base manifest:

```text
FROM ghcr.io/ouankou/rex:base@sha256:d7a67609c050227d5c9ba19e658b85779f95cbfd7a116e1ed26b70abdd7393db
```

That stale arm64 base image did not contain `libclang-rt-22-dev`, so CMake's Fortran compiler check failed again when `flang-22` tried to link compiler-rt builtins:

```text
ld.lld: error: cannot open /usr/lib/llvm-22/lib/clang/22/lib/aarch64-unknown-linux-gnu/libclang_rt.builtins.a
```

The real workflow bug was that nightly depended on a mutable, separately refreshed `:base` tag. A source fix to the base Dockerfiles does not affect nightly until that public tag is rebuilt. This PR removes that race/staleness path for nightly by building the base image from the same checkout used for the runtime/dev image build.

The weekly base-image workflow still owns the public `:base` manifest for users who want the reusable base image.

## Validation

- Inspected failed job `85087150001` from run `28689164593` and confirmed it used stale `ghcr.io/ouankou/rex:base@sha256:d7a676...`.
- Confirmed the updated nightly workflow no longer uses `BASE_IMAGE=${IMAGE_REPO}:base` in GitHub-hosted runtime/dev image build paths.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-rex-images.yml")'`
- `act -W .github/workflows/nightly-rex-images.yml --list`
- Rebuilt the current arm64 base Dockerfile locally with Buildx/QEMU.
- Verified the rebuilt arm64 base image has `libclang-rt-22-dev`, `flang-22`, and `lld-22`, and that `flang-22 -fuse-ld=lld` links a minimal Fortran program.
- `git diff --check`
- Pre-push hook: filtered CTest suite passed, `6940/6940` tests passed.