### PR TITLE
Fix docs publish and WASM cache flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,16 +126,16 @@ jobs:
       run: scripts/ci-pages-assemble-site
 
     - name: Configure GitHub Pages
-      if: steps.docs-artifact.outputs.found == 'true'
+      if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}
       uses: actions/configure-pages@v6
 
     - name: Upload GitHub Pages artifact
-      if: steps.docs-artifact.outputs.found == 'true'
+      if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}
       uses: actions/upload-pages-artifact@v5
       with:
         path: ${{ env.PAGES_SITE_DIR }}
 
     - name: Deploy to GitHub Pages
-      if: steps.docs-artifact.outputs.found == 'true'
+      if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}
       id: deployment
       uses: actions/deploy-pages@v5

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -118,13 +118,16 @@ jobs:
         run: scripts/ci-pages-assemble-site
 
       - name: Configure GitHub Pages
+        if: ${{ !env.ACT }}
         uses: actions/configure-pages@v6
 
       - name: Upload GitHub Pages Artifact
+        if: ${{ !env.ACT }}
         uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ env.PAGES_SITE_DIR }}
 
       - name: Deploy to GitHub Pages
+        if: ${{ !env.ACT }}
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/rex-wasm-build.yml
+++ b/.github/workflows/rex-wasm-build.yml
@@ -70,15 +70,16 @@ jobs:
           persist-credentials: false
 
       - name: Restore wasm LLVM cache
-        id: cache-llvm-wasm
-        uses: actions/cache@v4
+        id: restore-llvm-wasm
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.LLVM_WASM_CACHE_DIR }}
           key: rex-wasm-llvm-${{ runner.os }}-emsdk-${{ env.EMSDK_VERSION }}-${{ env.LLVM_PROJECT_REF }}-${{ env.REX_WASM_BUILD_TYPE }}
 
       - name: Report wasm LLVM cache hit
         run: |
-          cache_hit="${{ steps.cache-llvm-wasm.outputs.cache-hit }}"
+          cache_hit="${{ steps.restore-llvm-wasm.outputs.cache-hit }}"
+          matched_key="${{ steps.restore-llvm-wasm.outputs.cache-matched-key }}"
           if [[ "${cache_hit}" == "true" ]]; then
             echo "wasm LLVM cache: exact hit"
           else
@@ -88,7 +89,9 @@ jobs:
             echo "### REX WASM cache"
             echo "- actions/cache cache-hit: ${cache_hit:-false}"
             echo "- cache key: rex-wasm-llvm-${{ runner.os }}-emsdk-${EMSDK_VERSION}-${LLVM_PROJECT_REF}-${REX_WASM_BUILD_TYPE}"
+            echo "- matched key: ${matched_key:-none}"
             echo "- cache path: ${LLVM_WASM_CACHE_DIR}"
+            echo "- cache save enabled: $([[ '${{ github.event_name }}' != 'pull_request' ]] && echo yes || echo no)"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Checkout LLVM project
@@ -136,6 +139,13 @@ jobs:
         run: |
           source scripts/ci-llvm-env "${LLVM_VERSION}"
           scripts/ci-rex-wasm-build-dist dist
+
+      - name: Save wasm LLVM cache
+        if: ${{ steps.restore-llvm-wasm.outputs.cache-hit != 'true' && github.event_name != 'pull_request' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.LLVM_WASM_CACHE_DIR }}
+          key: ${{ steps.restore-llvm-wasm.outputs.cache-primary-key }}
 
       - name: Upload REX WASM dist
         if: ${{ inputs.upload-artifact }}

--- a/docs/mrdocs.yml
+++ b/docs/mrdocs.yml
@@ -31,7 +31,9 @@ multipage: true
 inherit-base-members: never
 auto-function-metadata: true
 extract-private: true
-# Use system libc and C++ standard library headers to match the toolchain.
+# Use the runner toolchain's C and C++ headers. The generated include overlay
+# strips known unsupported HTML doc-comment tags without crossing line
+# boundaries, so system declarations are not rewritten.
 use-system-libc: true
 use-system-stdlib: true
 warnings: true

--- a/scripts/ci-pages-assemble-site
+++ b/scripts/ci-pages-assemble-site
@@ -31,6 +31,11 @@ dir_has_files() {
   find "$path" -mindepth 1 -print -quit | grep -q .
 }
 
+require_file() {
+  local path="$1"
+  [ -f "$path" ] || die "missing expected assembled site file: $path"
+}
+
 copy_tree() {
   local src="$1"
   local dst="$2"
@@ -65,5 +70,18 @@ fi
 
 printf '%s\n' "$pages_domain" > "$site_dir/CNAME"
 touch "$site_dir/.nojekyll"
+
+if [ "$require_wasm" = "1" ]; then
+  require_file "$site_dir/index.html"
+  require_file "$site_dir/rex_wasm.js"
+  require_file "$site_dir/rex_wasm.wasm"
+fi
+
+if [ "$require_docs" = "1" ]; then
+  require_file "$site_dir/docs/index.html"
+fi
+
+require_file "$site_dir/CNAME"
+require_file "$site_dir/.nojekyll"
 
 echo "GitHub Pages site assembled in $site_dir"

--- a/scripts/generate-api-documentation
+++ b/scripts/generate-api-documentation
@@ -641,6 +641,40 @@ def strip_cmake_pch_args(argv: list[str]) -> list[str]:
         i += 1
     return cleaned
 
+def is_stdlib_include_path(value: str) -> bool:
+    return "/include/c++/" in value or "/c++/" in value
+
+def strip_stdlib_include_args(argv: list[str]) -> list[str]:
+    cleaned = []
+    i = 0
+    include_prefixes = ("-I", "-isystem", "-iquote", "-idirafter")
+    while i < len(argv):
+        arg = argv[i]
+
+        if (
+            arg in include_prefixes
+            and i + 1 < len(argv)
+            and is_stdlib_include_path(argv[i + 1])
+        ):
+            i += 2
+            continue
+
+        removed = False
+        for prefix in include_prefixes:
+            if arg.startswith(prefix) and arg != prefix:
+                path = arg[len(prefix):]
+                if is_stdlib_include_path(path):
+                    removed = True
+                break
+        if removed:
+            i += 1
+            continue
+
+        cleaned.append(arg)
+        i += 1
+
+    return cleaned
+
 data = json.loads(compile_db_path.read_text(encoding="utf-8"))
 if not isinstance(data, list):
     raise SystemExit("compile_commands.json is not a list")
@@ -699,6 +733,8 @@ for entry in data:
             return False
 
         if is_cpp_source(file_path, args):
+            if not use_system_stdlib:
+                args = strip_stdlib_include_args(args)
             if not use_system_stdlib and "-nostdinc++" not in args:
                 args.insert(1, "-nostdinc++")
             if overlay_path and overlay_path.is_dir():
@@ -802,18 +838,25 @@ build-include-overlay() {
     local compiler="$1"
     local out_dir="$2"
     local compile_db="${3-}"
+    local use_system_stdlib="${4:-true}"
     local overlay_dir="$out_dir/include-overlay"
     local include_paths=()
 
     while IFS=: read -r kind path; do
         if [ -n "$path" ]; then
+            if [ "$use_system_stdlib" != "true" ] && [ "$kind" = "stdlib" ]; then
+                continue
+            fi
             include_paths+=("$path")
         fi
     done < <(collect-include-paths "$compiler")
 
     if [ -n "$compile_db" ] && [ -f "$compile_db" ]; then
-        while IFS= read -r path; do
+        while IFS=: read -r kind path; do
             if [ -n "$path" ]; then
+                if [ "$use_system_stdlib" != "true" ] && [ "$kind" = "stdlib" ]; then
+                    continue
+                fi
                 include_paths+=("$path")
             fi
         done < <("$PYTHON_BIN" - "$compile_db" <<'PY'
@@ -843,6 +886,8 @@ for entry in data:
         if arg == "-isystem" and next_val:
             paths.append(next_val)
             i += 1
+        elif arg.startswith("-isystem") and arg != "-isystem":
+            paths.append(arg[len("-isystem"):])
         i += 1
 
 seen = set()
@@ -851,7 +896,14 @@ for raw in paths:
     if path in seen:
         continue
     seen.add(path)
-    print(path)
+    path_text = str(path)
+    if "/include/c++/" in path_text or "/c++/" in path_text:
+        kind = "stdlib"
+    elif "/lib/clang/" in path_text or "/llvm" in path_text:
+        kind = "system"
+    else:
+        kind = "libc"
+    print(f"{kind}:{path}")
 PY
 )
     fi
@@ -879,7 +931,9 @@ for raw in sys.argv[2:]:
         continue
     seen.add(resolved)
     bases.append(path)
-pattern_tags = re.compile(r"</?\s*(tt|summary|p|strong|pre|ul|li|code|em)\b[^>]*>", re.IGNORECASE)
+# Keep tag stripping line-bounded. Malformed system-header doc comments can
+# otherwise make the match cross into real declarations before the next ">".
+pattern_tags = re.compile(r"</?\s*(tt|summary|p|strong|pre|ul|li|code|em)\b[^>\n]*>", re.IGNORECASE)
 written = 0
 
 for base in bases:
@@ -999,7 +1053,7 @@ fi
 
 compiler="$(resolve-compiler "$(compiler-from-db "$compilation_db")")"
 docs_dir="$(mktemp -d)"
-include_overlay="$(build-include-overlay "$compiler" "$docs_dir" "$compilation_db")"
+include_overlay="$(build-include-overlay "$compiler" "$docs_dir" "$compilation_db" "$use_system_stdlib")"
 docs_db="$(filter-compilation-db "$CONFIG" "$compilation_db" "$docs_dir" "$include_overlay")"
 
 output_args=()


### PR DESCRIPTION
## Summary

This fixes the post-merge docs publish failure and makes the WASM build/cache path easier to inspect in CI.

Changes:
- Fix `scripts/generate-api-documentation` so the include overlay keeps system stdlib headers sanitized when `use-system-stdlib: true`.
- Make the unsupported HTML-tag stripping line-bounded with `[^>\n]*`, preventing malformed system-header comments from consuming declarations across newlines.
- Split the reusable WASM workflow into explicit restore/cache-status, LLVM build-or-reuse, REX configure, REX build, smoke test, and static-site assembly steps.
- Move the WASM LLVM cache to `actions/cache/restore@v6` + `actions/cache/save@v6`, and only save on non-PR events so PR-created caches do not pretend to seed the default branch.
- Validate assembled Pages output before deploy: required REX WASM root files, docs index, `CNAME`, and `.nojekyll`.
- Skip only the live GitHub Pages API/upload/deploy steps under local `act`; hosted Pages deploy behavior is unchanged.

## Root Cause

The docs failure was not a generic MrDocs problem. The generated include overlay was stripping unsupported HTML-like doc tags with a pattern that could cross newlines. In malformed system-header comments this could corrupt later declarations. Disabling stdlib in the overlay avoided that corruption but let raw libstdc++ HTML tags reach MrDocs, which still fails.

The fix is to keep stdlib headers in the overlay when the config asks for the runner system stdlib, but make the sanitizer line-bounded so it only removes the unsupported tags themselves.

For the cache complaint: PR caches do not seed the main/default branch cache. The workflow now restores the shared key for all events, reports exact hit/miss visibly, and saves the LLVM WASM cache only from non-PR runs after a miss.

## Validation

Static/local checks run:
- `bash -n scripts/generate-api-documentation scripts/ci-docs-build scripts/ci-rex-wasm-build-dist scripts/ci-pages-assemble-site scripts/ci-download-latest-artifact`
- Ruby YAML parse for every `.github/workflows/*.{yml,yaml}`
- `git diff --check`
- `actionlint` was not installed locally, so it was not run.

Full local workflow validation run with `act`:

```bash
act workflow_dispatch -W .github/workflows/docs-publish.yml \
  -P ubuntu-26.04=ompparser-act-ubuntu:26.04 \
  --container-architecture linux/amd64 \
  --artifact-server-path /tmp/rex-act-docs-artifacts \
  --cache-server-path /tmp/rex-act-docs-cache \
  --concurrent-jobs 1 \
  --pull=false
```

Observed from the passing `act` run:
- WASM LLVM cache restored with an exact hit for `rex-wasm-llvm-linux-emsdk-4.0.22-llvmorg-22.1.8-minsizerel`.
- LLVM WASM step reused the cached toolchain instead of rebuilding it.
- REX WASM configure/build/smoke tests passed.
- WASM artifact uploaded locally: `13228800` bytes.
- MrDocs extracted `100959 declarations` and generated `18402 pages`.
- Docs artifact uploaded locally: `81942362` bytes.
- Final `pages-site` assembly completed and validated.

Native pre-push hook also passed:
- Rebuilt native targets.
- Ran the selected CTest sweep: `100% tests passed, 0 tests failed out of 6987`.

## Action Versions

Updated cache usage to the current `actions/cache` v6 split restore/save actions.

I checked the relevant action major versions. Checkout/setup-python/Pages actions are already on current majors. `actions/upload-artifact@v4` and `actions/download-artifact@v4` are intentionally retained for ordinary artifacts because v7/v8 currently fail under local `act` with an artifact protocol `mime_type` error; keeping v4 lets `act` validate the real artifact handoff and site assembly path.
