### PR TITLE
Make Pages deploy reruns use unique artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,12 @@ jobs:
       if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}
       uses: actions/upload-pages-artifact@v5
       with:
+        name: github-pages-${{ github.run_attempt }}
         path: ${{ env.PAGES_SITE_DIR }}
 
     - name: Deploy to GitHub Pages
       if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}
       id: deployment
       uses: actions/deploy-pages@v5
+      with:
+        artifact_name: github-pages-${{ github.run_attempt }}

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -125,9 +125,12 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/upload-pages-artifact@v5
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: ${{ env.PAGES_SITE_DIR }}
 
       - name: Deploy to GitHub Pages
         if: ${{ !env.ACT }}
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

Fixes the docs publish rerun failure caused by duplicate `github-pages` artifacts in the same workflow run.

Changes:
- `docs-publish.yml` now uploads the Pages artifact as `github-pages-${{ github.run_attempt }}`.
- `docs-publish.yml` passes the same attempt-scoped artifact name to `actions/deploy-pages@v5`.
- `ci.yml` uses the same attempt-scoped Pages artifact naming for the main-push WASM/docs deploy path.

## Root Cause From Failed Run

Failed run: https://github.com/ouankou/rex/actions/runs/28753088269/job/85258828080

The docs and WASM jobs both succeeded. The failing job was `Deploy Full Static Site`.

Attempt 1 uploaded `github-pages` artifact `8095596988`, then `deploy-pages@v5` created a Pages deployment and failed while polling GitHub Pages status:

```text
Current status: syncing_files
Deployment failed, try again later.
```

That looks like a GitHub Pages deployment-side failure after a valid artifact upload.

Attempt 2 then uploaded another artifact with the same default name, `github-pages` artifact `8095619915`. `deploy-pages@v5` failed before deployment because it found two artifacts with that name in the same workflow run:

```text
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

The durable repo-side fix is to stop using the default shared `github-pages` name across run attempts. With `github-pages-${{ github.run_attempt }}`, a rerun deploys only the artifact produced by that attempt.

## Validation

Local static checks:
- Ruby parsed every `.github/workflows/*.{yml,yaml}` successfully.
- `bash -n scripts/ci-pages-assemble-site scripts/ci-docs-build scripts/ci-rex-wasm-build-dist scripts/ci-download-latest-artifact`
- `git diff --check`
- `actionlint` is not installed locally, so it was not run.

Full local `act` run:

```bash
act workflow_dispatch -W .github/workflows/docs-publish.yml \
  -P ubuntu-26.04=ompparser-act-ubuntu:26.04 \
  --container-architecture linux/amd64 \
  --artifact-server-path /tmp/rex-act-docs-artifacts \
  --cache-server-path /tmp/rex-act-docs-cache \
  --concurrent-jobs 1 \
  --pull=false
```

Observed from the passing `act` run:
- WASM LLVM cache exact hit.
- Reused existing WASM LLVM/Clang toolchain.
- REX WASM build and smoke tests passed.
- REX WASM artifact uploaded locally: `13228798` bytes.
- MrDocs extracted `100959 declarations`.
- MrDocs generated `18402 pages`.
- Docs built in `_site`.
- Docs artifact uploaded locally: `81942011` bytes.
- Final `pages-site` assembly passed after downloading both artifacts.

Pre-push hook also passed:
- `100% tests passed, 0 tests failed out of 6987`.
