### PR TITLE
Fix Pages WASM packaging for docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         persist-credentials: false
 
     - name: Download REX WASM dist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ env.REX_WASM_ARTIFACT }}
         path: ${{ env.REX_WASM_ARTIFACT }}
@@ -135,6 +135,7 @@ jobs:
       with:
         name: github-pages-${{ github.run_attempt }}
         path: ${{ env.PAGES_SITE_DIR }}
+        include-hidden-files: true
 
     - name: Deploy to GitHub Pages
       if: ${{ steps.docs-artifact.outputs.found == 'true' && !env.ACT }}

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -61,7 +61,7 @@ jobs:
           bash scripts/ci-docs-build
 
       - name: Upload docs site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.DOCS_SITE_ARTIFACT }}
           path: ${{ env.DOCS_BUILD_OUTPUT_DIR }}
@@ -97,13 +97,13 @@ jobs:
           persist-credentials: false
 
       - name: Download docs site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.DOCS_SITE_ARTIFACT }}
           path: ${{ env.DOCS_SITE_ARTIFACT }}
 
       - name: Download REX WASM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.REX_WASM_ARTIFACT }}
           path: ${{ env.REX_WASM_ARTIFACT }}
@@ -127,6 +127,7 @@ jobs:
         with:
           name: github-pages-${{ github.run_attempt }}
           path: ${{ env.PAGES_SITE_DIR }}
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         if: ${{ !env.ACT }}

--- a/.github/workflows/rex-wasm-build.yml
+++ b/.github/workflows/rex-wasm-build.yml
@@ -19,6 +19,10 @@ on:
       build-type:
         type: string
         default: MinSizeRel
+      package-sysroot:
+        description: Package Emscripten sysroot headers into the browser demo.
+        type: boolean
+        default: false
       llvm-project-checkout-dir:
         type: string
         default: llvm-project
@@ -52,6 +56,7 @@ jobs:
       LLVM_PROJECT_REF: ${{ inputs.llvm-project-ref }}
       EMSDK_VERSION: ${{ inputs.emsdk-version }}
       REX_WASM_BUILD_TYPE: ${{ inputs.build-type }}
+      REX_WASM_PACKAGE_SYSROOT: ${{ inputs.package-sysroot }}
       LLVM_PROJECT_CHECKOUT_DIR: ${{ inputs.llvm-project-checkout-dir }}
       LLVM_WASM_CACHE_DIR: ${{ inputs.llvm-wasm-cache-dir }}
       REX_WASM_CMAKE_BUILD_DIR: ${{ inputs.rex-wasm-cmake-build-dir }}
@@ -149,7 +154,7 @@ jobs:
 
       - name: Upload REX WASM dist
         if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.REX_WASM_ARTIFACT }}
           path: ${{ env.REX_WASM_ARTIFACT }}

--- a/scripts/ci-rex-wasm-build-dist
+++ b/scripts/ci-rex-wasm-build-dist
@@ -10,7 +10,7 @@ rex_wasm_build_dir="${REX_WASM_BUILD_DIR:-${build_root}/rex}"
 dist_dir="${REX_WASM_DIST_DIR:-${repo_root}/rex-wasm-dist}"
 jobs="${REX_WASM_JOBS:-$(nproc)}"
 build_type="${REX_WASM_BUILD_TYPE:-MinSizeRel}"
-package_sysroot="${REX_WASM_PACKAGE_SYSROOT:-ON}"
+package_sysroot="${REX_WASM_PACKAGE_SYSROOT:-OFF}"
 phase="${1:-all}"
 
 find_existing_dir() {

--- a/src/wasm/tests/run_rex_wasm_tests.js
+++ b/src/wasm/tests/run_rex_wasm_tests.js
@@ -20,19 +20,6 @@ int main(void) {
     expectedFiles : [ "rose_plain_round_trip.c" ],
   },
   {
-    name : "plain-c-stdio",
-    mode : "plain",
-    filename : "plain_stdio.c",
-    source : `#include <stdio.h>
-
-int main(void) {
-  printf("rex wasm\\n");
-  return 0;
-}
-`,
-    expectedFiles : [ "rose_plain_stdio.c" ],
-  },
-  {
     name : "plain-cxx-round-trip",
     mode : "plain",
     filename : "plain_class.cpp",
@@ -71,9 +58,7 @@ int main() {
     name : "openmp-ast",
     mode : "omp_ast",
     filename : "omp_parallel.c",
-    source : `#include <omp.h>
-
-int main(void) {
+    source : `int main(void) {
   int sum = 0;
 #pragma omp parallel reduction(+:sum)
   {

--- a/web/rex-wasm/README.md
+++ b/web/rex-wasm/README.md
@@ -20,3 +20,7 @@ OpenMP GPU offloading example. It exposes three modes:
 
 All modes route through REX with `-rose:skipfinalCompileStep`; the browser app
 only displays generated source files and the REX log.
+
+The published browser package intentionally omits the Emscripten sysroot to keep
+the static site small. Use self-contained C/C++ examples; OpenMP pragma parsing
+and the bundled `omp.h` resource are still available.


### PR DESCRIPTION
## Summary

Fixes the static Pages deploy path after the merged WASM/docs workflow started failing during the GitHub Pages sync stage.

Changes in this PR:
- stop packaging the Emscripten sysroot into the default browser demo, reducing `rex_wasm.data` from the previously inspected ~26.4 MB to ~7.7 MB
- add a reusable workflow input for opting sysroot packaging back in if needed
- keep `.nojekyll` in uploaded Pages artifacts by enabling hidden file upload for `upload-pages-artifact`
- update artifact actions used by the touched workflows to current majors
- adjust WASM smoke tests to match the published static demo scope without the full Emscripten sysroot

## Validation

Local checks run:
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/docs-publish.yml .github/workflows/rex-wasm-build.yml`
- `git diff --check`
- `node src/wasm/tests/run_rex_wasm_tests.js /tmp/rex-act-wasm-dist/rex_wasm.js`
- OpenMP header probe against the same `act`-built package: `#include <omp.h>` in AST-only mode passed
- `scripts/ci-pages-assemble-site` using the docs and WASM outputs copied from the `act` job containers
- pre-push hook CTest selection: `100% tests passed, 0 tests failed out of 6987`

Local `act` run:
- command used: `act workflow_dispatch -W .github/workflows/docs-publish.yml --pull=false -P ubuntu-26.04=rex-act-ubuntu:26.04 --artifact-server-path /tmp/rex-act-artifacts`
- WASM build/test completed successfully inside `act`
- docs build completed successfully inside `act`
- full local `act` workflow stopped at `actions/upload-artifact@v7` because latest `act` v0.2.89 rejects the v7 artifact request field `mime_type`; this is an `act` artifact-server compatibility failure, not a REX build/test/docs failure

Assembled site inspection from the `act` outputs:
- WASM dist: `41M`
- docs site: `482M`
- combined Pages site: `522M`
- local Pages tar: `435M`
- `.nojekyll` present
- `rex_wasm.data`: `7,719,074` bytes, gzip-9 `650,393` bytes
- `rex_wasm.wasm`: `34,207,564` bytes, gzip-9 `9,921,189` bytes

Action version check:
- checked touched workflow `uses:` tags against remote tags; the used major versions match the current latest majors for `actions/checkout`, `actions/cache`, `actions/upload-artifact`, `actions/download-artifact`, `actions/setup-python`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `mymindstorm/setup-emsdk`, and `StoneMoe/setup-antlr4`

Not claimed:
- I am not claiming the live GitHub Pages deploy has passed. The live deploy path only proves itself in hosted GitHub Actions with Pages deployment enabled.
