### PR TITLE
Fix scheduled cross-architecture CI regressions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
-.github
 .cache
 .act
 **/.DS_Store

--- a/ci/docker/rex-nightly.Dockerfile
+++ b/ci/docker/rex-nightly.Dockerfile
@@ -23,6 +23,21 @@ ENV LD_LIBRARY_PATH=${REX_INSTALL_DIR}/lib:/usr/lib/llvm-${LLVM_VERSION}/lib
 FROM rex-base AS builder
 
 ARG REX_BUILD_NUM_JOBS=4
+ARG REX_ENABLE_VALGRIND=0
+
+# CMake registers the Memcheck-only tests only when Valgrind is present at
+# configure time.  Install it in the builder as well as the final test image
+# so the copied build tree and its runtime tools have one exact contract.
+RUN set -eux; \
+    case "${REX_ENABLE_VALGRIND}" in \
+      0) ;; \
+      1) \
+        apt-get update; \
+        apt-get install -y --no-install-recommends valgrind; \
+        rm -rf /var/lib/apt/lists/*; \
+        ;; \
+      *) echo "REX_ENABLE_VALGRIND must be 0 or 1" >&2; exit 2 ;; \
+    esac
 
 WORKDIR ${REX_SOURCE_DIR}
 COPY . ${REX_SOURCE_DIR}

--- a/scripts/run_ctest_name_set.py
+++ b/scripts/run_ctest_name_set.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
-from typing import NoReturn
+from typing import Any, NoReturn
 
 
 def fail(message: str) -> NoReturn:
@@ -36,7 +36,9 @@ def read_manifest(path: Path) -> list[str]:
     return names
 
 
-def ctest_inventory(ctest: str, test_dir: Path, extra: list[str]) -> list[str]:
+def ctest_records(
+    ctest: str, test_dir: Path, extra: list[str]
+) -> list[dict[str, Any]]:
     command = [
         ctest,
         "--test-dir",
@@ -55,13 +57,64 @@ def ctest_inventory(ctest: str, test_dir: Path, extra: list[str]) -> list[str]:
     tests = document.get("tests")
     if not isinstance(tests, list):
         fail("CTest JSON inventory has no test list")
-    names: list[str] = []
+    records: list[dict[str, Any]] = []
     for index, test in enumerate(tests, 1):
         name = test.get("name") if isinstance(test, dict) else None
         if not isinstance(name, str) or not name:
             fail(f"CTest JSON inventory has an invalid test at index {index}")
-        names.append(name)
-    return names
+        records.append(test)
+    return records
+
+
+def ctest_inventory(ctest: str, test_dir: Path, extra: list[str]) -> list[str]:
+    return [test["name"] for test in ctest_records(ctest, test_dir, extra)]
+
+
+def fixture_property(test: dict[str, Any], name: str) -> set[str]:
+    properties = test.get("properties", [])
+    if not isinstance(properties, list):
+        fail(f"CTest test {test['name']} has malformed properties")
+    result: set[str] = set()
+    for prop in properties:
+        if not isinstance(prop, dict) or prop.get("name") != name:
+            continue
+        value = prop.get("value")
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) and item for item in value
+        ):
+            fail(f"CTest test {test['name']} has malformed {name}")
+        result.update(value)
+    return result
+
+
+def fixture_selection_closure(
+    registry: list[dict[str, Any]], directly_selected: set[str]
+) -> set[str]:
+    """Return the tests CTest must add to satisfy selected fixtures exactly."""
+
+    by_name = {test["name"]: test for test in registry}
+    selected = set(directly_selected)
+    while True:
+        required: set[str] = set()
+        for name in selected:
+            test = by_name.get(name)
+            if test is None:
+                fail(f"fixture closure references absent CTest test: {name}")
+            required.update(fixture_property(test, "FIXTURES_REQUIRED"))
+
+        support = {
+            test["name"]
+            for test in registry
+            if required
+            & (
+                fixture_property(test, "FIXTURES_SETUP")
+                | fixture_property(test, "FIXTURES_CLEANUP")
+            )
+        }
+        expanded = selected | support
+        if expanded == selected:
+            return selected
+        selected = expanded
 
 
 def main() -> int:
@@ -89,7 +142,8 @@ def main() -> int:
     manifest = args.manifest.resolve(strict=True)
     requested = read_manifest(manifest)
 
-    registry_names = ctest_inventory(args.ctest, test_dir, [])
+    registry_records = ctest_records(args.ctest, test_dir, [])
+    registry_names = [test["name"] for test in registry_records]
     registry: dict[str, int] = {}
     duplicates: list[str] = []
     for index, name in enumerate(registry_names, 1):
@@ -118,15 +172,31 @@ def main() -> int:
         selection_options = ["-I", handle.name]
         regex_names: list[str] = []
         if args.include_regex:
+            # Ask CTest for direct regex matches without its automatic fixture
+            # expansion.  The exact expansion is computed and checked below.
             regex_names = ctest_inventory(
-                args.ctest, test_dir, ["-R", args.include_regex]
+                args.ctest,
+                test_dir,
+                [
+                    "-R",
+                    args.include_regex,
+                    "-FA",
+                    ".*",
+                    "-FS",
+                    ".*",
+                    "-FC",
+                    ".*",
+                ],
             )
             selection_options.extend(["-R", args.include_regex, "-U"])
         selected_names = ctest_inventory(
             args.ctest, test_dir, selection_options
         )
         requested_set = set(requested)
-        expected_set = requested_set | set(regex_names)
+        directly_selected = requested_set | set(regex_names)
+        expected_set = fixture_selection_closure(
+            registry_records, directly_selected
+        )
         selected_set = set(selected_names)
         if selected_set != expected_set or len(selected_names) != len(expected_set):
             missing_from_selection = sorted(expected_set - selected_set)
@@ -140,6 +210,7 @@ def main() -> int:
         print(
             "Validated exact CTest selection: "
             f"manifest={len(requested)}, regex={len(regex_names)}, "
+            f"fixture_support={len(expected_set - directly_selected)}, "
             f"union={len(expected_set)}, source={manifest}",
             flush=True,
         )

--- a/src/AstNodes/Expression/SgCastExp.C
+++ b/src/AstNodes/Expression/SgCastExp.C
@@ -190,14 +190,15 @@ void SgCastExp::validate_semantic_conversion() const {
     }
   }
   if (get_cast_type() == e_builtin_bit_cast &&
+      get_semantic_conversion_kind() != e_semantic_conversion_Dependent &&
       get_semantic_conversion_kind() !=
           e_semantic_conversion_LValueToRValueBitCast) {
     fprintf(stderr,
             "REX_AST_INVARIANT[checked-cast]: __builtin_bit_cast surface\n");
     fprintf(stderr,
             "REX_AST_DETAIL[checked-cast]: __builtin_bit_cast surface "
-            "has conversion=%d instead of LLVM 22 "
-            "CK_LValueToRValueBitCast\n",
+            "has conversion=%d outside LLVM 22's exact dependent/concrete "
+            "bit-cast states\n",
             static_cast<int>(get_semantic_conversion_kind()));
     ROSE_ABORT();
   }

--- a/src/AstNodes/Expression/SgExpression.C
+++ b/src/AstNodes/Expression/SgExpression.C
@@ -67,6 +67,7 @@ bool SgExpression::has_semantic_value_type() const {
          isSgSimpleRequirement(this) == nullptr &&
          isSgTypeRequirement(this) == nullptr &&
          isSgCompoundRequirement(this) == nullptr &&
+         isSgRequirementSubstitutionFailure(this) == nullptr &&
          isSgNestedRequirement(this) == nullptr &&
          isSgTypeExpression(this) == nullptr &&
          isSgNullExpression(this) == nullptr &&

--- a/src/AstNodes/Expression/SgStringVal.C
+++ b/src/AstNodes/Expression/SgStringVal.C
@@ -50,7 +50,10 @@ SgType *SgStringVal::get_type(void) const {
                                 isSgTypeSignedChar(elementType) != nullptr ||
                                 isSgTypeUnsignedChar(elementType) != nullptr;
   const bool wideCodeUnit = isSgTypeWchar(elementType) != nullptr ||
-                            isSgTypeInt(elementType) != nullptr;
+                            isSgTypeShort(elementType) != nullptr ||
+                            isSgTypeUnsignedShort(elementType) != nullptr ||
+                            isSgTypeInt(elementType) != nullptr ||
+                            isSgTypeUnsignedInt(elementType) != nullptr;
   const bool utf16CodeUnit = isSgTypeChar16(elementType) != nullptr ||
                              isSgTypeUnsignedShort(elementType) != nullptr;
   const bool utf32CodeUnit = isSgTypeChar32(elementType) != nullptr ||

--- a/src/ROSETTA/Grammar/Expression.code
+++ b/src/ROSETTA/Grammar/Expression.code
@@ -2044,6 +2044,17 @@ void set_global_qualification_required(
     bool global_qualification_required) override;
 HEADER_TYPE_REQUIREMENT_END
 
+HEADER_REQUIREMENT_SUBSTITUTION_FAILURE_START
+
+enum failure_kind_enum {
+  e_simple_expression_failure = 0,
+  e_compound_expression_failure,
+  e_type_requirement_failure,
+  e_compound_return_type_failure
+};
+
+HEADER_REQUIREMENT_SUBSTITUTION_FAILURE_END
+
 // NOTES: SgAggregateInitializer, SgConstructorInitializer, and
 //        SgAssignInitializer all have different set_type functions
 //        (is this a bug?).

--- a/src/ROSETTA/Grammar/Type.code
+++ b/src/ROSETTA/Grammar/Type.code
@@ -676,6 +676,24 @@ static SgTypeDefault *createType(const SgName &nameOfType);
 
 HEADER_TYPE_DEFAULT_TYPE_END
 
+HEADER_TYPE_TARGET_BUILTIN_TYPE_START
+
+enum target_family_enum {
+  e_target_builtin_aarch64 = 0,
+  e_target_builtin_powerpc,
+  e_target_builtin_riscv,
+  e_target_builtin_webassembly,
+  e_target_builtin_amdgpu,
+  e_target_builtin_opencl,
+  e_target_builtin_hlsl
+};
+
+//! Intern one exact target-defined compiler builtin type.
+static SgTypeTargetBuiltin *createType(const SgName &spelling,
+                                       target_family_enum targetFamily);
+
+HEADER_TYPE_TARGET_BUILTIN_TYPE_END
+
 HEADER_TYPE_LABEL_TYPE_START
 
 // Generated a mangled name that accounts for the stored name internally.
@@ -2001,6 +2019,61 @@ SgTypeDefault *SgTypeDefault::createType(const SgName &nameOfType) {
 }
 
 SOURCE_TYPE_DEFAULT_TYPE_END
+
+SOURCE_TYPE_TARGET_BUILTIN_TYPE_START
+
+SgName SgTypeTargetBuiltin::get_mangled(void) const {
+  if (p_spelling.is_null() ||
+      p_target_family < e_target_builtin_aarch64 ||
+      p_target_family > e_target_builtin_hlsl) {
+    fprintf(stderr,
+            "REX_AST_INVARIANT[target-builtin-type]: type=%p has invalid "
+            "spelling or target family=%d\n",
+            static_cast<const void *>(this), static_cast<int>(p_target_family));
+    ROSE_ABORT();
+  }
+
+  const std::string spelling = p_spelling.getString();
+  SgName mangled_name;
+  mangled_name << "__target_builtin_" << static_cast<int>(p_target_family)
+               << "_" << spelling.size() << "_" << spelling;
+  return mangled_name;
+}
+
+SgTypeTargetBuiltin *SgTypeTargetBuiltin::createType(
+    const SgName &spelling, target_family_enum targetFamily) {
+  if (spelling.is_null() || targetFamily < e_target_builtin_aarch64 ||
+      targetFamily > e_target_builtin_hlsl) {
+    fprintf(stderr,
+            "REX_AST_INVARIANT[target-builtin-type]: cannot intern empty "
+            "spelling or invalid target family=%d\n",
+            static_cast<int>(targetFamily));
+    ROSE_ABORT();
+  }
+
+  SgTypeTargetBuiltin *candidate = new SgTypeTargetBuiltin();
+  candidate->set_spelling(spelling);
+  candidate->set_target_family(targetFamily);
+  const SgName mangled = candidate->get_mangled();
+  SgType *existing = get_globalTypeTable()->lookup_type(mangled);
+  if (existing == nullptr) {
+    get_globalTypeTable()->insert_type(mangled, candidate);
+    return candidate;
+  }
+
+  SgTypeTargetBuiltin *result = isSgTypeTargetBuiltin(existing);
+  if (result == nullptr || result->get_spelling() != spelling ||
+      result->get_target_family() != targetFamily) {
+    fprintf(stderr,
+            "REX_AST_INVARIANT[target-builtin-type]: mangled identity "
+            "collision for spelling=%s family=%d\n",
+            spelling.getString().c_str(), static_cast<int>(targetFamily));
+    ROSE_ABORT();
+  }
+  return result;
+}
+
+SOURCE_TYPE_TARGET_BUILTIN_TYPE_END
 
 SOURCE_TYPE_LABEL_TYPE_START
 

--- a/src/ROSETTA/astNodeList
+++ b/src/ROSETTA/astNodeList
@@ -297,6 +297,7 @@ SgNewExp
 SgNode
 SgNoexceptOp
 SgRequiresExpr
+SgRequirementSubstitutionFailure
 SgSimpleRequirement
 SgTypeRequirement
 SgCompoundRequirement
@@ -708,6 +709,7 @@ SgTypeSignedLong
 SgTypeSignedLongLong
 SgTypeSignedShort
 SgTypeString
+SgTypeTargetBuiltin
 SgTypeUnknown
 SgTypeUnsigned128bitInteger
 SgTypeUnsignedChar

--- a/src/ROSETTA/src/expression.C
+++ b/src/ROSETTA/src/expression.C
@@ -2242,6 +2242,30 @@ void Grammar::setUpExpressions() {
       BUILD_ACCESS_FUNCTIONS, DEF_TRAVERSAL, NO_DELETE, COPY_DATA,
       OPTIONAL_TRAVERSAL_MEMBER);
 
+  // A failed template substitution has no Clang expression/type node to
+  // translate.  Preserve that semantic state as its own typed requirement
+  // record instead of manufacturing a null child or recovering source text.
+  NEW_TERMINAL_MACRO(RequirementSubstitutionFailure,
+                     "RequirementSubstitutionFailure",
+                     "REQUIREMENT_SUBSTITUTION_FAILURE");
+  RequirementSubstitutionFailure.setFunctionSource(
+      "SOURCE_EMPTY_POST_CONSTRUCTION_INITIALIZATION",
+      "../Grammar/Expression.code");
+  RequirementSubstitutionFailure.setFunctionSource(
+      "SOURCE_SYNTAX_ONLY_GET_TYPE", "../Grammar/Expression.code");
+  RequirementSubstitutionFailure.setFunctionPrototype(
+      "HEADER_REQUIREMENT_SUBSTITUTION_FAILURE", "../Grammar/Expression.code");
+  RequirementSubstitutionFailure.setDataPrototype(
+      "SgRequirementSubstitutionFailure::failure_kind_enum", "failure_kind",
+      "= SgRequirementSubstitutionFailure::e_simple_expression_failure",
+      CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+  RequirementSubstitutionFailure.setDataPrototype(
+      "std::string", "substituted_entity", "= \"\"", CONSTRUCTOR_PARAMETER,
+      BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+  RequirementSubstitutionFailure.setDataPrototype(
+      "std::string", "diagnostic_message", "= \"\"", CONSTRUCTOR_PARAMETER,
+      BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+
   NEW_TERMINAL_MACRO(NestedRequirement, "NestedRequirement",
                      "NESTED_REQUIREMENT");
   NestedRequirement.setFunctionSource(
@@ -4286,9 +4310,9 @@ void Grammar::setUpExpressions() {
           RangeExp | TypeTraitBuiltinOperator | CompoundLiteralExp |
           TypeExpression | ClassExp | FunctionParameterRefExp | LambdaExp |
           NoexceptOp | RequiresExpr | SimpleRequirement | TypeRequirement |
-          CompoundRequirement | NestedRequirement | NonrealRefExp |
-          FoldExpression | Designator | PackExpansionExpr | AwaitExpression |
-          ChooseExpression,
+          CompoundRequirement | RequirementSubstitutionFailure |
+          NestedRequirement | NonrealRefExp | FoldExpression | Designator |
+          PackExpansionExpr | AwaitExpression | ChooseExpression,
       "Expression", "ExpressionTag", false);
 
   // DQ (5/20/2004): Add need_paren to all expression objects so that we can

--- a/src/ROSETTA/src/type.C
+++ b/src/ROSETTA/src/type.C
@@ -57,6 +57,8 @@ void Grammar::setUpTypes() {
   NEW_TERMINAL_MACRO(TypeComplex, "TypeComplex", "T_COMPLEX");
   NEW_TERMINAL_MACRO(TypeImaginary, "TypeImaginary", "T_IMAGINARY");
   NEW_TERMINAL_MACRO(TypeDefault, "TypeDefault", "T_DEFAULT");
+  NEW_TERMINAL_MACRO(TypeTargetBuiltin, "TypeTargetBuiltin",
+                     "T_TARGET_BUILTIN");
   NEW_TERMINAL_MACRO(TypeFortranAssumed, "TypeFortranAssumed",
                      "T_FORTRAN_ASSUMED");
   NEW_TERMINAL_MACRO(TypeFortranUnlimitedPolymorphic,
@@ -232,10 +234,10 @@ void Grammar::setUpTypes() {
       TypeUnknown | TypeVoid | TypeGlobalVoid | TypeString | PointerType |
           ReferenceType | NamedType | ModifierType | FunctionType | ArrayType |
           TypeEllipse | TemplateType | QualifiedNameType | TypeComplex |
-          TypeImaginary | TypeDefault | TypeCAFTeam | TypeCrayPointer |
-          TypeLabel | TypeFortranAssumed | TypeFortranUnlimitedPolymorphic |
-          RvalueReferenceType | TypeNullptr | DeclType | TypeOfType | AutoType |
-          IntegralType | FloatingPointType,
+          TypeImaginary | TypeDefault | TypeTargetBuiltin | TypeCAFTeam |
+          TypeCrayPointer | TypeLabel | TypeFortranAssumed |
+          TypeFortranUnlimitedPolymorphic | RvalueReferenceType | TypeNullptr |
+          DeclType | TypeOfType | AutoType | IntegralType | FloatingPointType,
       "Type", "TypeTag", false);
 
   // ***********************************************************************
@@ -396,6 +398,11 @@ void Grammar::setUpTypes() {
                                          "../Grammar/Type.code");
   TypeImaginary.excludeFunctionSource("SOURCE_COMMON_CREATE_TYPE",
                                       "../Grammar/Type.code");
+
+  TypeTargetBuiltin.excludeFunctionPrototype("HEADER_COMMON_CREATE_TYPE",
+                                             "../Grammar/Type.code");
+  TypeTargetBuiltin.excludeFunctionSource("SOURCE_COMMON_CREATE_TYPE",
+                                          "../Grammar/Type.code");
 
   // DQ (8/17/2010): Don't use the static builtin type for the SgTypeString IR
   // node.
@@ -1137,6 +1144,20 @@ void Grammar::setUpTypes() {
                                NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS,
                                NO_TRAVERSAL, NO_DELETE);
 
+  // Target-defined Clang builtin types (SVE, RVV, PPC MMA, WebAssembly,
+  // AMDGPU, OpenCL, and HLSL) are semantic types in their own right.  They
+  // must not be collapsed to a scalar, vector, or unknown-type surrogate.
+  TypeTargetBuiltin.setFunctionPrototype("HEADER_TYPE_TARGET_BUILTIN_TYPE",
+                                         "../Grammar/Type.code");
+  TypeTargetBuiltin.setDataPrototype(
+      "SgName", "spelling", "= \"\"", NO_CONSTRUCTOR_PARAMETER,
+      BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL, NO_DELETE);
+  TypeTargetBuiltin.setDataPrototype(
+      "SgTypeTargetBuiltin::target_family_enum", "target_family",
+      "= SgTypeTargetBuiltin::e_target_builtin_aarch64",
+      NO_CONSTRUCTOR_PARAMETER, BUILD_ACCESS_FUNCTIONS, NO_TRAVERSAL,
+      NO_DELETE);
+
   // DQ (2/1/2011): Added label type to support Fortran alternative return
   // arguments in function declarations.
   TypeLabel.setFunctionPrototype("HEADER_TYPE_LABEL_TYPE",
@@ -1387,6 +1408,11 @@ void Grammar::setUpTypes() {
                                     "../Grammar/Type.code");
   TypeDefault.setFunctionSource("SOURCE_TYPE_DEFAULT_TYPE",
                                 "../Grammar/Type.code");
+
+  TypeTargetBuiltin.excludeFunctionSource("SOURCE_GET_MANGLED",
+                                          "../Grammar/Type.code");
+  TypeTargetBuiltin.setFunctionSource("SOURCE_TYPE_TARGET_BUILTIN_TYPE",
+                                      "../Grammar/Type.code");
   // TypeDefault.setFunctionSource         ( "SOURCE_GET_MANGLED_STRING_TYPE",
   // "../Grammar/Type.code");
 

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_expressions.C
@@ -1257,6 +1257,15 @@ void Unparse_ExprStmt::unparseRequiresExpr(SgExpression *expr,
       curprint("requires ");
       unparseExpression(nested->get_constraint(), requirement_info);
       curprint("; ");
+    } else if (SgRequirementSubstitutionFailure *failure =
+                   isSgRequirementSubstitutionFailure(requirement)) {
+      fprintf(stderr,
+              "REX_UNPARSE_INVARIANT[requirement-substitution-failure]: "
+              "semantic-only failure kind=%d entity=%s has no source "
+              "expression to emit\n",
+              static_cast<int>(failure->get_failure_kind()),
+              failure->get_substituted_entity().c_str());
+      ROSE_ABORT();
     } else {
       fprintf(stderr,
               "REX_UNPARSE_INVARIANT[requires-requirement]: unsupported "

--- a/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
+++ b/src/backend/unparser/CxxCodeGeneration/unparseCxx_types.C
@@ -1091,6 +1091,25 @@ void Unparse_Type::unparseType(SgType *type, SgUnparse_Info &info) {
     ROSE_ABORT();
   }
 
+  case T_TARGET_BUILTIN: {
+    if ((info.isWithType() && info.SkipBaseType()) || info.isTypeSecondPart()) {
+      break;
+    }
+    SgTypeTargetBuiltin *target_type = isSgTypeTargetBuiltin(type);
+    if (target_type == nullptr || target_type->get_spelling().is_null() ||
+        target_type->get_target_family() <
+            SgTypeTargetBuiltin::e_target_builtin_aarch64 ||
+        target_type->get_target_family() >
+            SgTypeTargetBuiltin::e_target_builtin_hlsl) {
+      fprintf(stderr,
+              "REX_UNPARSE_INVARIANT[target-builtin-type]: malformed exact "
+              "target builtin type\n");
+      ROSE_ABORT();
+    }
+    printTypeToken(this, target_type->get_spelling().getString(), info);
+    break;
+  }
+
   case T_IMAGINARY: {
     fprintf(stderr,
             "REX_UNPARSE_INVARIANT[imaginary-type]: legacy imaginary type "

--- a/src/backend/unparser/languageIndependenceSupport/unparseLanguageIndependentConstructs.C
+++ b/src/backend/unparser/languageIndependenceSupport/unparseLanguageIndependentConstructs.C
@@ -15696,6 +15696,7 @@ UnparseLanguageIndependentConstructs::getPrecedence(SgExpression *expr) {
   case V_SgSimpleRequirement:
   case V_SgTypeRequirement:
   case V_SgCompoundRequirement:
+  case V_SgRequirementSubstitutionFailure:
   case V_SgNestedRequirement:
     precedence_value = 0;
     break;

--- a/src/frontend/Clang/clang-frontend-decl.cpp
+++ b/src/frontend/Clang/clang-frontend-decl.cpp
@@ -52,6 +52,37 @@
 
 #include <vector>
 
+const clang::Module *clangFrontendImportedNamespaceModule(
+    const clang::NamespaceDecl *namespace_decl) {
+  if (namespace_decl == nullptr || !namespace_decl->isFromASTFile()) {
+    return nullptr;
+  }
+
+  const clang::Module *module = namespace_decl->getImportedOwningModule();
+  const std::string module_name =
+      module != nullptr
+          ? module->getFullModuleName(/*AllowStringLiterals=*/true)
+          : std::string();
+  if (namespace_decl->hasOwningModule() &&
+      (module == nullptr || module_name.empty())) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
+            "namespace=%s advertises module ownership but has no exact "
+            "owning module\n",
+            namespace_decl->getQualifiedNameAsString().c_str());
+    ROSE_ABORT();
+  }
+  if (!namespace_decl->hasOwningModule() && module != nullptr) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
+            "namespace=%s has a module pointer without Clang module "
+            "ownership\n",
+            namespace_decl->getQualifiedNameAsString().c_str());
+    ROSE_ABORT();
+  }
+  return module;
+}
+
 namespace {
 
 static bool clangFrontendRunningOnValgrind() {
@@ -3023,10 +3054,11 @@ bool declIsFromApplicationHeader(clang::Decl *decl, clang::CompilerInstance *ci,
         module != nullptr
             ? module->getFullModuleName(/*AllowStringLiterals=*/true)
             : std::string();
-    if (module == nullptr || module_name.empty()) {
+    if (decl->hasOwningModule() && (module == nullptr || module_name.empty())) {
       fprintf(stderr,
               "REX_FRONTEND_INVARIANT[module-ownership]: imported "
-              "declaration=%p/%s has no exact owning module\n",
+              "declaration=%p/%s advertises module ownership but has no "
+              "exact owning module\n",
               static_cast<void *>(decl), decl->getDeclKindName());
       ROSE_ABORT();
     }
@@ -3041,6 +3073,20 @@ bool declIsFromApplicationHeader(clang::Decl *decl, clang::CompilerInstance *ci,
       preprocessor_record->recordExternalOwnershipPath(
           normalizedDeclFilePath(decl, sm),
           "declIsFromApplicationHeader:imported-declaration-source");
+    } else if (module == nullptr) {
+      fprintf(stderr,
+              "REX_FRONTEND_INVARIANT[module-ownership]: unowned imported "
+              "declaration=%p/%s has no exact physical source identity\n",
+              static_cast<void *>(decl), decl->getDeclKindName());
+      ROSE_ABORT();
+    }
+    if (module == nullptr) {
+      // Clang explicitly permits a declaration loaded from an AST file to
+      // retain ModuleOwnershipKind::Unowned.  Header units use this for
+      // declarations in their global module fragment.  Their exact physical
+      // source path above is the ownership identity; inventing an owning
+      // module would misrepresent Clang's semantic state.
+      return false;
     }
     if (auto ast_file = module->getASTFile()) {
       std::string ast_path =
@@ -8756,6 +8802,53 @@ preferredDeclSourceRange(clang::Decl *decl, SgNode *node,
 
   clang::SourceRange range =
       readClangApiValueDefined([&]() { return decl->getSourceRange(); });
+  if (clang::ImportDecl *import_decl = llvm::dyn_cast<clang::ImportDecl>(decl);
+      import_decl != nullptr && source_manager != nullptr && !range.isValid() &&
+      range.getBegin().isValid()) {
+    // Clang 22 represents a source-written header-unit import with the exact
+    // `import` location but an invalid ImportDecl endpoint.  Recover the one
+    // missing endpoint from the terminating token in the same physical file;
+    // the declaration remains a lexical source surface rather than being
+    // misclassified as an implicit semantic declaration.
+    clang::SourceManager &mutable_source_manager =
+        const_cast<clang::SourceManager &>(*source_manager);
+    clang::SourceLocation begin =
+        mutable_source_manager.getFileLoc(range.getBegin());
+    const clang::LangOptions &language_options =
+        import_decl->getASTContext().getLangOpts();
+    clang::SourceLocation cursor = begin;
+    std::optional<clang::Token> token;
+    while (cursor.isValid()) {
+      token = clang::Lexer::findNextToken(cursor, mutable_source_manager,
+                                          language_options,
+                                          /*IncludeComments=*/false);
+      if (!token.has_value() || !token->getLocation().isValid()) {
+        break;
+      }
+      clang::SourceLocation token_location =
+          mutable_source_manager.getFileLoc(token->getLocation());
+      if (!token_location.isValid() ||
+          !mutable_source_manager.isWrittenInSameFile(begin, token_location) ||
+          !mutable_source_manager.isBeforeInTranslationUnit(cursor,
+                                                            token_location)) {
+        break;
+      }
+      cursor = token_location;
+      if (token->is(clang::tok::semi)) {
+        return clang::SourceRange(range.getBegin(), token->getLocation());
+      }
+    }
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[import-declaration-source-range]: "
+            "source-written import=%s has no exact same-file terminating "
+            "semicolon\n",
+            import_decl->getImportedModule() != nullptr
+                ? import_decl->getImportedModule()
+                      ->getFullModuleName(/*AllowStringLiterals=*/true)
+                      .c_str()
+                : "<null>");
+    ROSE_ABORT();
+  }
   if (!llvm::isa<clang::VarDecl>(decl) || source_manager == nullptr ||
       !range.isValid() || !range.getBegin().isValid() ||
       !range.getEnd().isValid()) {
@@ -23859,30 +23952,42 @@ static SgNamespaceDefinitionStatement *selectNamespaceFragmentBySourceOrder(
   return selected;
 }
 
-static const clang::Module *
-importedNamespaceModule(const clang::NamespaceDecl *namespace_decl) {
-  if (namespace_decl == nullptr || !namespace_decl->isFromASTFile()) {
-    return nullptr;
+static bool
+isFrontendSupportNamespace(const clang::NamespaceDecl *namespace_decl,
+                           const clang::CompilerInstance *compiler_instance,
+                           const SagePreprocessorRecord *preprocessor_record) {
+  if (namespace_decl == nullptr || namespace_decl->isFromASTFile()) {
+    return false;
   }
 
-  const clang::Module *module = namespace_decl->getImportedOwningModule();
-  const std::string module_name =
-      module != nullptr
-          ? module->getFullModuleName(/*AllowStringLiterals=*/true)
-          : std::string();
-  if (module == nullptr || module_name.empty()) {
+  const clang::SourceLocation begin = namespace_decl->getBeginLoc();
+  if (!is_frontend_support_location(begin, compiler_instance,
+                                    preprocessor_record)) {
+    return false;
+  }
+
+  const clang::SourceLocation close = namespace_decl->getRBraceLoc();
+  const clang::SourceLocation name = namespace_decl->getLocation();
+  if (!close.isValid() ||
+      !is_frontend_support_location(close, compiler_instance,
+                                    preprocessor_record) ||
+      (!namespace_decl->isAnonymousNamespace() &&
+       (!name.isValid() ||
+        !is_frontend_support_location(name, compiler_instance,
+                                      preprocessor_record)))) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
-            "namespace=%s has no exact owning module\n",
+            "REX_FRONTEND_INVARIANT[namespace-frontend-support-owner]: "
+            "namespace=%s crosses or lacks its exact registered "
+            "frontend-support source owner\n",
             namespace_decl->getQualifiedNameAsString().c_str());
     ROSE_ABORT();
   }
-  return module;
+  return true;
 }
 
 static SgScopeStatement *validateImportedNamespaceOwnership(
-    SgNamespaceDeclarationStatement *namespace_decl,
-    const clang::Module *module, const char *context) {
+    const clang::NamespaceDecl *clang_namespace,
+    SgNamespaceDeclarationStatement *namespace_decl, const char *context) {
   SgAuxiliaryDeclarationList *container =
       namespace_decl != nullptr
           ? isSgAuxiliaryDeclarationList(namespace_decl->get_parent())
@@ -23890,11 +23995,14 @@ static SgScopeStatement *validateImportedNamespaceOwnership(
   SgScopeStatement *owner = container != nullptr
                                 ? isSgScopeStatement(container->get_parent())
                                 : nullptr;
-  const std::string module_name =
+  const clang::Module *module =
+      clangFrontendImportedNamespaceModule(clang_namespace);
+  const std::string owner_name =
       module != nullptr
           ? module->getFullModuleName(/*AllowStringLiterals=*/true)
-          : std::string();
-  if (namespace_decl == nullptr || module == nullptr || module_name.empty() ||
+          : "<physical-source>";
+  if (clang_namespace == nullptr || !clang_namespace->isFromASTFile() ||
+      namespace_decl == nullptr || owner_name.empty() ||
       namespace_decl->get_definition() == nullptr ||
       namespace_decl->get_definition()->get_parent() != namespace_decl ||
       namespace_decl->has_source_fragments() || container == nullptr ||
@@ -23903,9 +24011,9 @@ static SgScopeStatement *validateImportedNamespaceOwnership(
       std::count(container->get_declarations().begin(),
                  container->get_declarations().end(), namespace_decl) != 1) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: context=%s "
-            "module=%s namespace=%p has malformed semantic-only ownership\n",
-            context != nullptr ? context : "<unknown>", module_name.c_str(),
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: context=%s "
+            "owner=%s namespace=%p has malformed semantic-only ownership\n",
+            context != nullptr ? context : "<unknown>", owner_name.c_str(),
             static_cast<void *>(namespace_decl));
     ROSE_ABORT();
   }
@@ -23915,6 +24023,39 @@ static SgScopeStatement *validateImportedNamespaceOwnership(
   validate_semantic_provenance(
       namespace_decl->get_definition(), true,
       "validateImportedNamespaceOwnership:definition-provenance");
+  return owner;
+}
+
+static SgScopeStatement *validateFrontendSupportNamespaceOwnership(
+    SgNamespaceDeclarationStatement *namespace_decl, const char *context) {
+  SgAuxiliaryDeclarationList *container =
+      namespace_decl != nullptr
+          ? isSgAuxiliaryDeclarationList(namespace_decl->get_parent())
+          : nullptr;
+  SgScopeStatement *owner = container != nullptr
+                                ? isSgScopeStatement(container->get_parent())
+                                : nullptr;
+  if (namespace_decl == nullptr ||
+      namespace_decl->get_definition() == nullptr ||
+      namespace_decl->get_definition()->get_parent() != namespace_decl ||
+      namespace_decl->has_source_fragments() || container == nullptr ||
+      owner == nullptr || owner->get_auxiliary_declarations() != container ||
+      namespace_decl->get_scope() != owner ||
+      std::count(container->get_declarations().begin(),
+                 container->get_declarations().end(), namespace_decl) != 1) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-frontend-support-owner]: "
+            "context=%s namespace=%p has malformed semantic-only ownership\n",
+            context != nullptr ? context : "<unknown>",
+            static_cast<void *>(namespace_decl));
+    ROSE_ABORT();
+  }
+  validate_semantic_provenance(
+      namespace_decl, true,
+      "validateFrontendSupportNamespaceOwnership:declaration-provenance");
+  validate_semantic_provenance(
+      namespace_decl->get_definition(), true,
+      "validateFrontendSupportNamespaceOwnership:definition-provenance");
   return owner;
 }
 
@@ -36191,11 +36332,9 @@ bool ClangToSageTranslator::VisitDecl(clang::Decl *decl, SgNode **node) {
               decl != nullptr ? decl->getDeclKindName() : "<null>");
       ROSE_ABORT();
     }
-    const clang::Module *imported_module =
-        importedNamespaceModule(clang_namespace);
-    if (imported_module != nullptr) {
-      (void)validateImportedNamespaceOwnership(namespace_statement,
-                                               imported_module, "VisitDecl");
+    if (clang_namespace->isFromASTFile()) {
+      (void)validateImportedNamespaceOwnership(
+          clang_namespace, namespace_statement, "VisitDecl");
     } else {
       if (!namespace_statement->has_source_fragments()) {
         fprintf(stderr,
@@ -42916,9 +43055,9 @@ ClangToSageTranslator::namespaceSourceRanges(
             "and compiler instance are required\n");
     ROSE_ABORT();
   }
-  if (importedNamespaceModule(namespace_decl) != nullptr) {
+  if (namespace_decl->isFromASTFile()) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: imported "
             "namespace=%s cannot consume the importing translation unit's "
             "expanded token stream\n",
             namespace_decl->getQualifiedNameAsString().c_str());
@@ -43175,7 +43314,7 @@ void ClangToSageTranslator::applyNamespaceSourceFragments(
   sage_declaration->validate_source_fragments();
 }
 
-void ClangToSageTranslator::publishImportedNamespaceModuleProvenance(
+void ClangToSageTranslator::publishImportedNamespaceProvenance(
     const clang::NamespaceDecl *clang_declaration,
     SgNamespaceDeclarationStatement *sage_declaration) {
   if (sage_declaration == nullptr ||
@@ -43191,7 +43330,7 @@ void ClangToSageTranslator::publishImportedNamespaceModuleProvenance(
       p_lexical_source_nodes.count(sage_declaration->get_definition()) != 0 ||
       p_synthesized_source_nodes.count(sage_declaration->get_definition()) !=
           0) {
-    fprintf(stderr, "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
+    fprintf(stderr, "REX_FRONTEND_INVARIANT[namespace-import-owner]: imported "
                     "namespace producer did not provide one fresh semantic "
                     "declaration/definition pair\n");
     ROSE_ABORT();
@@ -43201,37 +43340,65 @@ void ClangToSageTranslator::publishImportedNamespaceModuleProvenance(
   mark_compiler_generated_frontend_specific(sage_declaration);
   setSynthesizedFileInfo(sage_declaration->get_definition());
   mark_compiler_generated_frontend_specific(sage_declaration->get_definition());
-  validateImportedNamespaceModuleProvenance(clang_declaration,
-                                            sage_declaration);
+  validateImportedNamespaceProvenance(clang_declaration, sage_declaration);
 }
 
-void ClangToSageTranslator::validateImportedNamespaceModuleProvenance(
+void ClangToSageTranslator::validateImportedNamespaceProvenance(
     const clang::NamespaceDecl *clang_declaration,
     SgNamespaceDeclarationStatement *sage_declaration) {
-  const clang::Module *module = importedNamespaceModule(clang_declaration);
-  if (module == nullptr || sage_declaration == nullptr ||
+  const clang::Module *module =
+      clangFrontendImportedNamespaceModule(clang_declaration);
+  if (clang_declaration == nullptr || !clang_declaration->isFromASTFile() ||
+      sage_declaration == nullptr ||
       sage_declaration->get_definition() == nullptr ||
       sage_declaration->has_source_fragments() ||
-      p_compiler_instance == nullptr) {
+      p_compiler_instance == nullptr ||
+      p_sage_preprocessor_recorder == nullptr) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: imported "
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: imported "
             "namespace has no exact semantic declaration/definition pair\n");
+    ROSE_ABORT();
+  }
+
+  if (declIsFromApplicationHeader(
+          const_cast<clang::NamespaceDecl *>(clang_declaration),
+          p_compiler_instance, p_sage_preprocessor_recorder)) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: imported "
+            "namespace=%s was misclassified as an application textual "
+            "header declaration\n",
+            clang_declaration->getQualifiedNameAsString().c_str());
     ROSE_ABORT();
   }
 
   const clang::SourceRange source_range = clang_declaration->getSourceRange();
   clang::SourceManager &source_manager =
       p_compiler_instance->getSourceManager();
-  if (!source_range.isValid() ||
-      !source_manager.getFileLoc(source_range.getBegin()).isValid() ||
-      !source_manager.getFileLoc(source_range.getEnd()).isValid() ||
-      source_manager.isWrittenInMainFile(source_range.getBegin()) ||
-      source_manager.isWrittenInMainFile(source_range.getEnd())) {
+  const clang::SourceLocation physical_begin =
+      source_manager.getFileLoc(source_range.getBegin());
+  const clang::SourceLocation physical_end =
+      source_manager.getFileLoc(source_range.getEnd());
+  const std::string physical_path =
+      normalizedDeclFilePath(clang_declaration, source_manager);
+  const std::string owner_name =
+      module != nullptr
+          ? module->getFullModuleName(/*AllowStringLiterals=*/true)
+          : physical_path;
+  if (!source_range.isValid() || !physical_begin.isValid() ||
+      !physical_end.isValid() ||
+      source_manager.getFileID(physical_begin).isInvalid() ||
+      source_manager.getFileID(physical_begin) !=
+          source_manager.getFileID(physical_end) ||
+      source_manager.isWrittenInMainFile(physical_begin) ||
+      source_manager.isWrittenInMainFile(physical_end) ||
+      physical_path.empty() || owner_name.empty() ||
+      p_sage_preprocessor_recorder->includeOwnershipForPath(physical_path) !=
+          SagePreprocessorRecord::IncludeOwnership::external) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: module=%s "
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: owner=%s "
             "namespace=%s does not identify exact non-importer source "
             "provenance\n",
-            module->getFullModuleName(/*AllowStringLiterals=*/true).c_str(),
+            owner_name.c_str(),
             clang_declaration->getQualifiedNameAsString().c_str());
     ROSE_ABORT();
   }
@@ -43242,19 +43409,84 @@ void ClangToSageTranslator::validateImportedNamespaceModuleProvenance(
       p_synthesized_source_nodes.count(sage_declaration->get_definition()) !=
           1) {
     fprintf(stderr,
-            "REX_FRONTEND_INVARIANT[namespace-module-owner]: module=%s "
+            "REX_FRONTEND_INVARIANT[namespace-import-owner]: owner=%s "
             "namespace=%s does not own one exact synthesized semantic "
             "declaration/definition role\n",
-            module->getFullModuleName(/*AllowStringLiterals=*/true).c_str(),
+            owner_name.c_str(),
             clang_declaration->getQualifiedNameAsString().c_str());
     ROSE_ABORT();
   }
   validate_semantic_provenance(
       sage_declaration, true,
-      "validateImportedNamespaceModuleProvenance:declaration");
+      "validateImportedNamespaceProvenance:declaration");
   validate_semantic_provenance(
       sage_declaration->get_definition(), true,
-      "validateImportedNamespaceModuleProvenance:definition");
+      "validateImportedNamespaceProvenance:definition");
+}
+
+void ClangToSageTranslator::publishFrontendSupportNamespaceProvenance(
+    const clang::NamespaceDecl *clang_declaration,
+    SgNamespaceDeclarationStatement *sage_declaration) {
+  if (sage_declaration == nullptr ||
+      sage_declaration->get_definition() == nullptr ||
+      sage_declaration->get_file_info() != nullptr ||
+      sage_declaration->get_startOfConstruct() != nullptr ||
+      sage_declaration->get_endOfConstruct() != nullptr ||
+      sage_declaration->get_definition()->get_file_info() != nullptr ||
+      sage_declaration->get_definition()->get_startOfConstruct() != nullptr ||
+      sage_declaration->get_definition()->get_endOfConstruct() != nullptr ||
+      p_lexical_source_nodes.count(sage_declaration) != 0 ||
+      p_synthesized_source_nodes.count(sage_declaration) != 0 ||
+      p_lexical_source_nodes.count(sage_declaration->get_definition()) != 0 ||
+      p_synthesized_source_nodes.count(sage_declaration->get_definition()) !=
+          0) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-frontend-support-owner]: "
+            "frontend-support namespace producer did not provide one fresh "
+            "semantic declaration/definition pair\n");
+    ROSE_ABORT();
+  }
+
+  setSynthesizedFileInfo(sage_declaration);
+  mark_compiler_generated_frontend_specific(sage_declaration);
+  setSynthesizedFileInfo(sage_declaration->get_definition());
+  mark_compiler_generated_frontend_specific(sage_declaration->get_definition());
+  validateFrontendSupportNamespaceProvenance(clang_declaration,
+                                             sage_declaration);
+}
+
+void ClangToSageTranslator::validateFrontendSupportNamespaceProvenance(
+    const clang::NamespaceDecl *clang_declaration,
+    SgNamespaceDeclarationStatement *sage_declaration) {
+  if (!isFrontendSupportNamespace(clang_declaration, p_compiler_instance,
+                                  p_sage_preprocessor_recorder) ||
+      sage_declaration == nullptr ||
+      sage_declaration->get_definition() == nullptr ||
+      sage_declaration->has_source_fragments()) {
+    fprintf(stderr, "REX_FRONTEND_INVARIANT[namespace-frontend-support-owner]: "
+                    "frontend-support namespace has no exact semantic "
+                    "declaration/definition pair\n");
+    ROSE_ABORT();
+  }
+
+  if (p_lexical_source_nodes.count(sage_declaration) != 0 ||
+      p_synthesized_source_nodes.count(sage_declaration) != 1 ||
+      p_lexical_source_nodes.count(sage_declaration->get_definition()) != 0 ||
+      p_synthesized_source_nodes.count(sage_declaration->get_definition()) !=
+          1) {
+    fprintf(stderr,
+            "REX_FRONTEND_INVARIANT[namespace-frontend-support-owner]: "
+            "namespace=%s does not own one exact synthesized semantic "
+            "declaration/definition role\n",
+            clang_declaration->getQualifiedNameAsString().c_str());
+    ROSE_ABORT();
+  }
+  validate_semantic_provenance(
+      sage_declaration, true,
+      "validateFrontendSupportNamespaceProvenance:declaration");
+  validate_semantic_provenance(
+      sage_declaration->get_definition(), true,
+      "validateFrontendSupportNamespaceProvenance:definition");
 }
 
 namespace {
@@ -43425,8 +43657,9 @@ bool ClangToSageTranslator::VisitNamespaceDecl(
             << std::endl;
 #endif
 
-  const clang::Module *imported_module =
-      importedNamespaceModule(namespace_decl);
+  const bool imported_namespace = namespace_decl->isFromASTFile();
+  const bool frontend_support_namespace = isFrontendSupportNamespace(
+      namespace_decl, p_compiler_instance, p_sage_preprocessor_recorder);
 
   // Capture any existing namespace declaration for this canonical namespace so
   // we can wire up first-nondefining links across re-openings.
@@ -43464,7 +43697,7 @@ bool ClangToSageTranslator::VisitNamespaceDecl(
   if (existing_it != p_namespace_canonical_decl_map.end()) {
     canonical_sg_decl = existing_it->second;
   } else if (canonical_ns != nullptr && canonical_ns != namespace_decl &&
-             imported_module == nullptr) {
+             !imported_namespace) {
     canonical_sg_decl = ensureNamespaceDeclaration(canonical_ns);
   }
   canonical_sg_decl = resolveCanonicalNamespaceRoot(
@@ -43493,13 +43726,17 @@ bool ClangToSageTranslator::VisitNamespaceDecl(
     // - Setting up global_definition to link all instances
     // - Inserting the symbol (only for first declaration)
     // We don't need to manually duplicate any of this logic
-    if (imported_module != nullptr) {
+    if (imported_namespace || frontend_support_namespace) {
       sg_namespace_decl = SageBuilder::buildNamespaceDeclaration_nfi(
           name, isAnonymous, scope,
           SageBuilder::e_namespace_declaration_semantic_auxiliary, nullptr,
           nullptr, nullptr, std::nullopt);
-      publishImportedNamespaceModuleProvenance(namespace_decl,
-                                               sg_namespace_decl);
+      if (imported_namespace) {
+        publishImportedNamespaceProvenance(namespace_decl, sg_namespace_decl);
+      } else {
+        publishFrontendSupportNamespaceProvenance(namespace_decl,
+                                                  sg_namespace_decl);
+      }
     } else {
       const NamespaceSourceRanges ranges =
           namespaceSourceRanges(namespace_decl);
@@ -43626,22 +43863,29 @@ bool ClangToSageTranslator::VisitNamespaceDecl(
   // The _nfi suffix means "no file info" not "no insertion"
   // REMOVED: SageInterface::appendStatement(sg_namespace_decl, scope);
 
-  if (imported_module != nullptr) {
-    validateImportedNamespaceModuleProvenance(namespace_decl,
-                                              sg_namespace_decl);
-    if (validateImportedNamespaceOwnership(sg_namespace_decl, imported_module,
+  if (imported_namespace) {
+    validateImportedNamespaceProvenance(namespace_decl, sg_namespace_decl);
+    if (validateImportedNamespaceOwnership(namespace_decl, sg_namespace_decl,
                                            "VisitNamespaceDecl") != scope) {
+      ROSE_ABORT();
+    }
+  } else if (frontend_support_namespace) {
+    validateFrontendSupportNamespaceProvenance(namespace_decl,
+                                               sg_namespace_decl);
+    if (validateFrontendSupportNamespaceOwnership(
+            sg_namespace_decl, "VisitNamespaceDecl") != scope) {
       ROSE_ABORT();
     }
   } else {
     applyNamespaceSourceFragments(namespace_decl, sg_namespace_decl);
   }
 
-  if (imported_module != nullptr) {
-    // Imported module declarations contribute semantic lookup state, not
-    // lexical source children of the importing translation unit.  Individual
-    // referenced declarations are translated on demand under this exact
-    // auxiliary namespace scope.
+  if (imported_namespace || frontend_support_namespace) {
+    // Deserialized and registered frontend-support declarations contribute
+    // semantic lookup state, not lexical source children of this translation
+    // unit. Individual referenced declarations are translated on demand under
+    // this exact auxiliary namespace scope. A deserialized declaration's exact
+    // owner is either its Clang module or its recorded physical source path.
     *node = sg_namespace_decl;
     return VisitNamedDecl(namespace_decl, node);
   }
@@ -64643,7 +64887,9 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
                     "construction requires a nonnull Clang NamespaceDecl\n");
     ROSE_ABORT();
   }
-  const clang::Module *imported_module = importedNamespaceModule(ns_decl);
+  const bool imported_namespace = ns_decl->isFromASTFile();
+  const bool frontend_support_namespace = isFrontendSupportNamespace(
+      ns_decl, p_compiler_instance, p_sage_preprocessor_recorder);
 
   auto exact_it = p_decl_translation_map.find(ns_decl);
   if (exact_it != p_decl_translation_map.end()) {
@@ -64656,9 +64902,14 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
               ns_decl->getQualifiedNameAsString().c_str());
       ROSE_ABORT();
     }
-    if (imported_module != nullptr) {
+    if (imported_namespace) {
+      validateImportedNamespaceProvenance(ns_decl, existing);
       (void)validateImportedNamespaceOwnership(
-          existing, imported_module, "ensureNamespaceDeclaration:cached");
+          ns_decl, existing, "ensureNamespaceDeclaration:cached");
+    } else if (frontend_support_namespace) {
+      validateFrontendSupportNamespaceProvenance(ns_decl, existing);
+      (void)validateFrontendSupportNamespaceOwnership(
+          existing, "ensureNamespaceDeclaration:cached");
     } else {
       if (!existing->has_source_fragments()) {
         fprintf(stderr,
@@ -64745,12 +64996,16 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
   // Create the namespace stub using SageBuilder
   // This will handle symbol table lookups and creating/reusing definitions
   SgNamespaceDeclarationStatement *sg_ns_decl = nullptr;
-  if (imported_module != nullptr) {
+  if (imported_namespace || frontend_support_namespace) {
     sg_ns_decl = SageBuilder::buildNamespaceDeclaration_nfi(
         name, isAnonymous, scope,
         SageBuilder::e_namespace_declaration_semantic_auxiliary, nullptr,
         nullptr, nullptr, std::nullopt);
-    publishImportedNamespaceModuleProvenance(ns_decl, sg_ns_decl);
+    if (imported_namespace) {
+      publishImportedNamespaceProvenance(ns_decl, sg_ns_decl);
+    } else {
+      publishFrontendSupportNamespaceProvenance(ns_decl, sg_ns_decl);
+    }
   } else {
     const NamespaceSourceRanges ranges = namespaceSourceRanges(ns_decl);
     SgNamespaceSourceFragment *opening_introducer = nullptr;
@@ -64846,11 +65101,15 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
   sg_ns_decl->set_isInlinedNamespace(
       readClangApiValueDefined([&]() { return ns_decl->isInline(); }));
 
-  if (imported_module != nullptr) {
-    // A deserialized namespace belongs to its imported module.  It provides
-    // semantic lookup state but has no lexical source fragment in this
-    // importing translation unit.
-    validateImportedNamespaceModuleProvenance(ns_decl, sg_ns_decl);
+  if (imported_namespace) {
+    // A deserialized namespace provides semantic lookup state but has no
+    // lexical source fragment in this importing translation unit. Its exact
+    // owner is either its Clang module or its recorded physical source path.
+    validateImportedNamespaceProvenance(ns_decl, sg_ns_decl);
+  } else if (frontend_support_namespace) {
+    // The mandatory frontend preinclude contributes semantic lookup state but
+    // is not a lexical fragment of the user's translation unit.
+    validateFrontendSupportNamespaceProvenance(ns_decl, sg_ns_decl);
   } else {
     // A local Clang NamespaceDecl denotes one exact source fragment. Missing
     // source locations are malformed frontend input, not permission to publish
@@ -64862,10 +65121,14 @@ ClangToSageTranslator::ensureNamespaceDeclaration(
   publishCanonicalNamespaceMapping(p_namespace_canonical_decl_map, canonical_ns,
                                    actual_canonical_sg_decl, name,
                                    "ensureNamespaceDeclaration:publish");
-  if (imported_module != nullptr) {
-    if (validateImportedNamespaceOwnership(sg_ns_decl, imported_module,
-                                           "ensureNamespaceDeclaration") !=
-        scope) {
+  if (imported_namespace) {
+    if (validateImportedNamespaceOwnership(
+            ns_decl, sg_ns_decl, "ensureNamespaceDeclaration") != scope) {
+      ROSE_ABORT();
+    }
+  } else if (frontend_support_namespace) {
+    if (validateFrontendSupportNamespaceOwnership(
+            sg_ns_decl, "ensureNamespaceDeclaration") != scope) {
       ROSE_ABORT();
     }
   }
@@ -83499,7 +83762,8 @@ bool ClangToSageTranslator::translateFunctionDeclCommon(
       std::optional<clang::TemplateArgumentListInfo>
           exact_current_written_arguments;
       if (args_as_written != nullptr) {
-        bool arguments_belong_to_current_source = true;
+        bool arguments_belong_to_current_source =
+            current_declaration_has_source_surface;
         if (explicit_instantiation_source_surface.has_value()) {
           arguments_belong_to_current_source = false;
           if (explicit_instantiation_source_surface->template_id_was_written) {

--- a/src/frontend/Clang/clang-frontend-private.hpp
+++ b/src/frontend/Clang/clang-frontend-private.hpp
@@ -67,6 +67,8 @@ void requireClangFunctionDeclSourceProvenanceForFrontend(
     const SagePreprocessorRecord *preprocessor_record);
 bool clangFrontendDeclarationHasExactCompletedSourceSurfaceOwnership(
     SgDeclarationStatement *declaration);
+const clang::Module *clangFrontendImportedNamespaceModule(
+    const clang::NamespaceDecl *namespace_decl);
 
 struct ClangOrderedDeclarationProvenance {
   enum class Kind { e_source_lexical, e_canonical_generated_namespace_shell };
@@ -5457,10 +5459,16 @@ protected:
   void applyNamespaceSourceFragments(
       const clang::NamespaceDecl *clang_declaration,
       SgNamespaceDeclarationStatement *sage_declaration);
-  void publishImportedNamespaceModuleProvenance(
+  void publishImportedNamespaceProvenance(
       const clang::NamespaceDecl *clang_declaration,
       SgNamespaceDeclarationStatement *sage_declaration);
-  void validateImportedNamespaceModuleProvenance(
+  void validateImportedNamespaceProvenance(
+      const clang::NamespaceDecl *clang_declaration,
+      SgNamespaceDeclarationStatement *sage_declaration);
+  void publishFrontendSupportNamespaceProvenance(
+      const clang::NamespaceDecl *clang_declaration,
+      SgNamespaceDeclarationStatement *sage_declaration);
+  void validateFrontendSupportNamespaceProvenance(
       const clang::NamespaceDecl *clang_declaration,
       SgNamespaceDeclarationStatement *sage_declaration);
 

--- a/src/frontend/Clang/clang-frontend-stmt.cpp
+++ b/src/frontend/Clang/clang-frontend-stmt.cpp
@@ -16405,6 +16405,39 @@ bool ClangToSageTranslator::VisitRequiresExpr(
   ROSE_ASSERT(requirements != nullptr);
   applySourceRange(requirements, requires_expr->getSourceRange());
 
+  auto build_substitution_failure =
+      [&](clang::concepts::Requirement::SubstitutionDiagnostic *diagnostic,
+          SgRequirementSubstitutionFailure::failure_kind_enum failure_kind)
+      -> SgRequirementSubstitutionFailure * {
+    if (diagnostic == nullptr) {
+      std::cerr << "REX_FRONTEND_INVARIANT[requirement-substitution-"
+                   "failure]: Clang reported a substitution failure without "
+                   "its exact diagnostic record"
+                << std::endl;
+      ROSE_ABORT();
+    }
+    const std::string substituted_entity = readClangApiValueDefined(
+        [&]() { return diagnostic->SubstitutedEntity.str(); });
+    const std::string diagnostic_message = readClangApiValueDefined(
+        [&]() { return diagnostic->DiagMessage.str(); });
+    const clang::SourceLocation diagnostic_location =
+        readClangApiValueDefined([&]() { return diagnostic->DiagLoc; });
+    if (substituted_entity.empty() || diagnostic_location.isInvalid()) {
+      fprintf(stderr,
+              "REX_FRONTEND_INVARIANT[requirement-substitution-failure]: "
+              "kind=%d has empty substituted entity or invalid diagnostic "
+              "location\n",
+              static_cast<int>(failure_kind));
+      ROSE_ABORT();
+    }
+    SgRequirementSubstitutionFailure *failure =
+        SageBuilder::buildRequirementSubstitutionFailure_nfi(
+            failure_kind, substituted_entity, diagnostic_message);
+    applySourceRange(
+        failure, clang::SourceRange(diagnostic_location, diagnostic_location));
+    return failure;
+  };
+
   for (clang::concepts::Requirement *requirement :
        requires_expr->getRequirements()) {
     if (local_parameter_scope != nullptr) {
@@ -16422,10 +16455,16 @@ bool ClangToSageTranslator::VisitRequiresExpr(
     case clang::concepts::Requirement::RK_Type: {
       clang::concepts::TypeRequirement *type_requirement =
           llvm::cast<clang::concepts::TypeRequirement>(requirement);
-      if (type_requirement->isSubstitutionFailure() ||
-          type_requirement->getType() == nullptr) {
+      if (type_requirement->isSubstitutionFailure()) {
+        translated_requirement = build_substitution_failure(
+            type_requirement->getSubstitutionDiagnostic(),
+            SgRequirementSubstitutionFailure::e_type_requirement_failure);
+        break;
+      }
+      if (type_requirement->getType() == nullptr) {
         std::cerr << "REX_FRONTEND_INVARIANT[type-requirement]: Clang type "
-                     "requirement has no exact source type"
+                     "requirement has neither an exact source type nor an "
+                     "explicit substitution failure"
                   << std::endl;
         ROSE_ABORT();
       }
@@ -16457,10 +16496,13 @@ bool ClangToSageTranslator::VisitRequiresExpr(
       clang::concepts::ExprRequirement *expr_requirement =
           llvm::cast<clang::concepts::ExprRequirement>(requirement);
       if (expr_requirement->isExprSubstitutionFailure()) {
-        std::cerr << "REX_FRONTEND_INVARIANT[expression-requirement]: Clang "
-                     "requirement has no exact expression"
-                  << std::endl;
-        ROSE_ABORT();
+        translated_requirement = build_substitution_failure(
+            expr_requirement->getExprSubstitutionDiagnostic(),
+            expr_requirement->isSimple()
+                ? SgRequirementSubstitutionFailure::e_simple_expression_failure
+                : SgRequirementSubstitutionFailure::
+                      e_compound_expression_failure);
+        break;
       }
       clang::Expr *clang_expression = expr_requirement->getExpr();
       SgExpression *sage_expression =
@@ -16482,87 +16524,94 @@ bool ClangToSageTranslator::VisitRequiresExpr(
         const clang::concepts::ExprRequirement::ReturnTypeRequirement
             &return_requirement = expr_requirement->getReturnTypeRequirement();
         if (!return_requirement.isEmpty()) {
-          if (return_requirement.isSubstitutionFailure() ||
-              !return_requirement.isTypeConstraint()) {
+          if (return_requirement.isSubstitutionFailure()) {
+            type_constraint = build_substitution_failure(
+                return_requirement.getSubstitutionDiagnostic(),
+                SgRequirementSubstitutionFailure::
+                    e_compound_return_type_failure);
+          } else if (!return_requirement.isTypeConstraint()) {
             std::cerr << "REX_FRONTEND_INVARIANT[compound-requirement]: "
-                         "return type requirement has no exact type constraint"
+                         "return type requirement has neither an exact type "
+                         "constraint nor an explicit substitution failure"
                       << std::endl;
             ROSE_ABORT();
-          }
-          const clang::TypeConstraint *clang_constraint =
-              return_requirement.getTypeConstraint();
-          const clang::ConceptReference *concept_reference =
-              clang_constraint != nullptr
-                  ? clang_constraint->getConceptReference()
-                  : nullptr;
-          clang::TemplateDecl *named_concept =
-              concept_reference != nullptr
-                  ? concept_reference->getNamedConcept()
-                  : nullptr;
-          if (concept_reference == nullptr || named_concept == nullptr) {
-            std::cerr << "REX_FRONTEND_INVARIANT[compound-requirement]: "
-                         "type constraint has no exact named concept"
-                      << std::endl;
-            ROSE_ABORT();
-          }
-
-          auto concept_translation = p_decl_translation_map.find(named_concept);
-          if (concept_translation == p_decl_translation_map.end() &&
-              p_decl_translation_in_progress.find(named_concept) ==
-                  p_decl_translation_in_progress.end() &&
-              p_decl_translation_on_demand.find(named_concept) ==
-                  p_decl_translation_on_demand.end()) {
-            TraverseOnDemand(named_concept);
-            concept_translation = p_decl_translation_map.find(named_concept);
-          }
-          SgNonrealDecl *sage_concept =
-              concept_translation != p_decl_translation_map.end()
-                  ? isSgNonrealDecl(concept_translation->second)
-                  : nullptr;
-          SgNonrealSymbol *concept_symbol =
-              sage_concept != nullptr
-                  ? isSgNonrealSymbol(
-                        sage_concept->get_symbol_from_symbol_table())
-                  : nullptr;
-          if (concept_symbol == nullptr) {
-            std::cerr
-                << "REX_FRONTEND_INVARIANT[compound-requirement]: concept="
-                << named_concept->getNameAsString()
-                << " has no exact translated SgNonrealSymbol" << std::endl;
-            ROSE_ABORT();
-          }
-
-          SgNonrealRefExp *sage_constraint =
-              SageBuilder::buildNonrealRefExp_nfi(concept_symbol);
-          const clang::ASTTemplateArgumentListInfo *written_arguments =
-              concept_reference->getTemplateArgsAsWritten();
-          if (written_arguments != nullptr) {
-            if (!written_arguments->getLAngleLoc().isValid() ||
-                !written_arguments->getRAngleLoc().isValid()) {
+          } else {
+            const clang::TypeConstraint *clang_constraint =
+                return_requirement.getTypeConstraint();
+            const clang::ConceptReference *concept_reference =
+                clang_constraint != nullptr
+                    ? clang_constraint->getConceptReference()
+                    : nullptr;
+            clang::TemplateDecl *named_concept =
+                concept_reference != nullptr
+                    ? concept_reference->getNamedConcept()
+                    : nullptr;
+            if (concept_reference == nullptr || named_concept == nullptr) {
               std::cerr << "REX_FRONTEND_INVARIANT[compound-requirement]: "
-                           "explicit type constraint arguments have no exact "
-                           "angle-bracket range"
+                           "type constraint has no exact named concept"
                         << std::endl;
               ROSE_ABORT();
             }
-            SgTemplateArgumentPtrList exact_arguments;
-            for (const clang::TemplateArgumentLoc &argument :
-                 written_arguments->arguments()) {
-              appendTemplateArguments(exact_arguments, argument, true);
+
+            auto concept_translation =
+                p_decl_translation_map.find(named_concept);
+            if (concept_translation == p_decl_translation_map.end() &&
+                p_decl_translation_in_progress.find(named_concept) ==
+                    p_decl_translation_in_progress.end() &&
+                p_decl_translation_on_demand.find(named_concept) ==
+                    p_decl_translation_on_demand.end()) {
+              TraverseOnDemand(named_concept);
+              concept_translation = p_decl_translation_map.find(named_concept);
             }
-            sage_constraint->get_templateArguments() =
-                std::move(exact_arguments);
-            sage_constraint->set_explicit_template_argument_list(true);
-            SageBuilder::setTemplateArgumentParents(sage_constraint);
+            SgNonrealDecl *sage_concept =
+                concept_translation != p_decl_translation_map.end()
+                    ? isSgNonrealDecl(concept_translation->second)
+                    : nullptr;
+            SgNonrealSymbol *concept_symbol =
+                sage_concept != nullptr
+                    ? isSgNonrealSymbol(
+                          sage_concept->get_symbol_from_symbol_table())
+                    : nullptr;
+            if (concept_symbol == nullptr) {
+              std::cerr
+                  << "REX_FRONTEND_INVARIANT[compound-requirement]: concept="
+                  << named_concept->getNameAsString()
+                  << " has no exact translated SgNonrealSymbol" << std::endl;
+              ROSE_ABORT();
+            }
+
+            SgNonrealRefExp *sage_constraint =
+                SageBuilder::buildNonrealRefExp_nfi(concept_symbol);
+            const clang::ASTTemplateArgumentListInfo *written_arguments =
+                concept_reference->getTemplateArgsAsWritten();
+            if (written_arguments != nullptr) {
+              if (!written_arguments->getLAngleLoc().isValid() ||
+                  !written_arguments->getRAngleLoc().isValid()) {
+                std::cerr << "REX_FRONTEND_INVARIANT[compound-requirement]: "
+                             "explicit type constraint arguments have no "
+                             "exact angle-bracket range"
+                          << std::endl;
+                ROSE_ABORT();
+              }
+              SgTemplateArgumentPtrList exact_arguments;
+              for (const clang::TemplateArgumentLoc &argument :
+                   written_arguments->arguments()) {
+                appendTemplateArguments(exact_arguments, argument, true);
+              }
+              sage_constraint->get_templateArguments() =
+                  std::move(exact_arguments);
+              sage_constraint->set_explicit_template_argument_list(true);
+              SageBuilder::setTemplateArgumentParents(sage_constraint);
+            }
+            const clang::NestedNameSpecifierLoc qualifier =
+                concept_reference->getNestedNameSpecifierLoc();
+            attachExplicitQualifierFromNestedName(
+                sage_constraint, qualifier.getNestedNameSpecifier(),
+                qualifier ? &qualifier : nullptr, p_compiler_instance);
+            applySourceRange(sage_constraint,
+                             concept_reference->getSourceRange());
+            type_constraint = sage_constraint;
           }
-          const clang::NestedNameSpecifierLoc qualifier =
-              concept_reference->getNestedNameSpecifierLoc();
-          attachExplicitQualifierFromNestedName(
-              sage_constraint, qualifier.getNestedNameSpecifier(),
-              qualifier ? &qualifier : nullptr, p_compiler_instance);
-          applySourceRange(sage_constraint,
-                           concept_reference->getSourceRange());
-          type_constraint = sage_constraint;
         }
         translated_requirement = SageBuilder::buildCompoundRequirement_nfi(
             sage_expression, expr_requirement->hasNoexceptRequirement(),

--- a/src/frontend/Clang/clang-frontend-type.cpp
+++ b/src/frontend/Clang/clang-frontend-type.cpp
@@ -9945,6 +9945,23 @@ bool ClangToSageTranslator::VisitBuiltinType(clang::BuiltinType *builtin_type,
   std::cerr << "ClangToSageTranslator::VisitBuiltinType" << std::endl;
 #endif
 
+  auto build_target_builtin = [&](SgTypeTargetBuiltin::target_family_enum
+                                      target_family) {
+    if (p_compiler_instance == nullptr) {
+      failExactTypeTranslation("target-builtin-compiler-state", builtin_type);
+    }
+    clang::PrintingPolicy policy(p_compiler_instance->getLangOpts());
+    const std::string spelling = builtin_type->getName(policy).str();
+    if (spelling.empty() || spelling.front() == '<' || spelling.back() == '>') {
+      std::cerr << "REX_FRONTEND_INVARIANT[target-builtin-type]: Clang kind="
+                << static_cast<unsigned>(builtin_type->getKind())
+                << " has no exact target source spelling" << std::endl;
+      ROSE_ABORT();
+    }
+    *node =
+        SageBuilder::buildTargetBuiltinType(SgName(spelling), target_family);
+  };
+
   switch (builtin_type->getKind()) {
   case clang::BuiltinType::Void:
     *node = SageBuilder::buildVoidType();
@@ -10072,6 +10089,50 @@ bool ClangToSageTranslator::VisitBuiltinType(clang::BuiltinType *builtin_type,
     *node = nrtype;
     break;
   }
+
+  case clang::BuiltinType::OCLSampler:
+  case clang::BuiltinType::OCLEvent:
+  case clang::BuiltinType::OCLClkEvent:
+  case clang::BuiltinType::OCLQueue:
+  case clang::BuiltinType::OCLReserveID:
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix)                   \
+  case clang::BuiltinType::Id:
+#include <clang/Basic/OpenCLImageTypes.def>
+#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) case clang::BuiltinType::Id:
+#include <clang/Basic/OpenCLExtensionTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_opencl);
+    break;
+
+#define SVE_TYPE(Name, Id, SingletonId) case clang::BuiltinType::Id:
+#include <clang/Basic/AArch64ACLETypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_aarch64);
+    break;
+
+#define PPC_VECTOR_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
+#include <clang/Basic/PPCTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_powerpc);
+    break;
+
+#define RVV_TYPE(Name, Id, SingletonId) case clang::BuiltinType::Id:
+#include <clang/Basic/RISCVVTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_riscv);
+    break;
+
+#define WASM_TYPE(Name, Id, SingletonId) case clang::BuiltinType::Id:
+#include <clang/Basic/WebAssemblyReferenceTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_webassembly);
+    break;
+
+#define AMDGPU_TYPE(Name, Id, SingletonId, Width, Align)                       \
+  case clang::BuiltinType::Id:
+#include <clang/Basic/AMDGPUTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_amdgpu);
+    break;
+
+#define HLSL_INTANGIBLE_TYPE(Name, Id, SingletonId) case clang::BuiltinType::Id:
+#include <clang/Basic/HLSLIntangibleTypes.def>
+    build_target_builtin(SgTypeTargetBuiltin::e_target_builtin_hlsl);
+    break;
 
   case clang::BuiltinType::ObjCId:
   case clang::BuiltinType::ObjCClass:

--- a/src/frontend/Clang/clang-frontend.cpp
+++ b/src/frontend/Clang/clang-frontend.cpp
@@ -711,7 +711,6 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
     }
     raw_clang_args.push_back(argv[i]);
   }
-
   unsigned missing_arg_index = 0;
   unsigned missing_arg_count = 0;
   llvm::opt::InputArgList parsed_clang_args =
@@ -1685,6 +1684,26 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
            "invocation has no target triple\n";
     ROSE_ABORT();
   }
+  const clang::PreprocessorOptions &parsed_preprocessor_opts =
+      invocation.getPreprocessorOpts();
+  const bool forces_intel_intrinsics = std::any_of(
+      parsed_preprocessor_opts.Includes.begin(),
+      parsed_preprocessor_opts.Includes.end(),
+      [](const std::string &forced_include) {
+        return llvm::sys::path::filename(forced_include) == "immintrin.h";
+      });
+  if (forces_intel_intrinsics) {
+    const llvm::Triple target_triple(target_opts.Triple);
+    if (target_triple.getArch() != llvm::Triple::x86 &&
+        target_triple.getArch() != llvm::Triple::x86_64) {
+      llvm::errs()
+          << "REX_FRONTEND_INVARIANT[intel-simd-target]: forced "
+             "immintrin.h requires an exact x86 or x86_64 frontend target, "
+             "but Clang selected '"
+          << target_opts.Triple << "'\n";
+      ROSE_ABORT();
+    }
+  }
   // CreateFromArgs must retain the exact resource and system-header state
   // selected by the validated driver job. Validate that state below; do not
   // rebuild it from host defaults.
@@ -1915,6 +1934,20 @@ int clang_main(int argc, char **argv, SgSourceFile &sageFile,
   }
 
   compiler_instance->setASTConsumer(std::move(translator_ptr));
+
+  // FrontendAction eagerly loads every unnamed module file before Sema starts.
+  // REX owns the equivalent in-process lifecycle, so it must perform the same
+  // step explicitly; named prebuilt modules load lazily, but C++20 header-unit
+  // files in FrontendOptions::ModuleFiles do not.
+  for (const std::string &module_file : fe_opts.ModuleFiles) {
+    clang::serialization::ModuleFile *loaded_module = nullptr;
+    if (!compiler_instance->loadModuleFile(module_file, loaded_module)) {
+      llvm::errs() << "REX_FRONTEND_INVARIANT[clang-module-file]: cannot load "
+                      "exact frontend module file '"
+                   << module_file << "'\n";
+      ROSE_ABORT();
+    }
+  }
 
   if (!compiler_instance->hasSema())
     compiler_instance->createSema(clang::TU_Complete, NULL);

--- a/src/frontend/SageIII/astJson/sageAstJsonCollect.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonCollect.cpp
@@ -510,7 +510,21 @@ rawTypeJson(SgType *type,
           rawBoolField("has_type_kind_star", type->get_hasTypeKindStar()));
     }
 
-    if (SgAutoType *auto_type = isSgAutoType(type)) {
+    if (SgTypeTargetBuiltin *target_builtin = isSgTypeTargetBuiltin(type)) {
+      if (target_builtin->get_spelling().is_null() ||
+          target_builtin->get_target_family() <
+              SgTypeTargetBuiltin::e_target_builtin_aarch64 ||
+          target_builtin->get_target_family() >
+              SgTypeTargetBuiltin::e_target_builtin_hlsl) {
+        throw std::runtime_error(
+            "AST JSON target builtin type has invalid exact identity");
+      }
+      fields.push_back(rawStringField(
+          "spelling", target_builtin->get_spelling().getString()));
+      fields.push_back(rawIntegerField(
+          "target_family",
+          static_cast<int64_t>(target_builtin->get_target_family())));
+    } else if (SgAutoType *auto_type = isSgAutoType(type)) {
       const bool is_constrained = auto_type->get_is_constrained();
       const std::string &source_constraint_spelling =
           auto_type->get_source_constraint_spelling();

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeFinalize.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeFinalize.cpp
@@ -4462,6 +4462,7 @@ SgSourceFile *reconstructSourceFile(const AstFileRecord &ast,
 
   publishTemplateParameterCanonicalTypes(ast, nodes);
   restoreAvailableSourcePositionsAndScopes(ast, nodes);
+  restoreAvailableAuxiliaryNamespaceOwnership(ast, nodes);
   std::unordered_set<uint64_t> restored_declaration_identities;
   restoreDeclarationIdentityEdges(ast, nodes, project,
                                   restored_declaration_identities, false);

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeNodes.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeNodes.cpp
@@ -1275,6 +1275,25 @@ SgNode *createNodeFromRecordImpl(const NodeRecord &record, SgProject *project,
     return new SgSimpleRequirement(static_cast<Sg_File_Info *>(nullptr),
                                    static_cast<SgExpression *>(nullptr));
   }
+  if (kind == "SgRequirementSubstitutionFailure") {
+    const int64_t failure_kind = p.requiredInt("failure_kind");
+    const std::string substituted_entity =
+        p.requiredString("substituted_entity");
+    if (failure_kind <
+            SgRequirementSubstitutionFailure::e_simple_expression_failure ||
+        failure_kind >
+            SgRequirementSubstitutionFailure::e_compound_return_type_failure ||
+        substituted_entity.empty()) {
+      throw std::runtime_error(
+          "AST JSON SgRequirementSubstitutionFailure has malformed exact "
+          "semantic state");
+    }
+    return new SgRequirementSubstitutionFailure(
+        static_cast<Sg_File_Info *>(nullptr),
+        static_cast<SgRequirementSubstitutionFailure::failure_kind_enum>(
+            failure_kind),
+        substituted_entity, p.requiredString("diagnostic_message"));
+  }
   if (kind == "SgTypeRequirement") {
     return new SgTypeRequirement(static_cast<Sg_File_Info *>(nullptr),
                                  static_cast<SgType *>(nullptr));
@@ -3926,6 +3945,76 @@ void restoreAvailableSourcePositionsAndScopes(const AstFileRecord &ast,
   }
 }
 
+void restoreAvailableAuxiliaryNamespaceOwnership(const AstFileRecord &ast,
+                                                 const NodeMap &nodes) {
+  std::unordered_map<uint64_t, const NodeRecord *> records;
+  records.reserve(ast.nodes.size());
+  for (const NodeRecord &record : ast.nodes) {
+    if (!records.emplace(record.id, &record).second) {
+      throw std::runtime_error(
+          "AST JSON auxiliary namespace ownership pass found a duplicate "
+          "node ID");
+    }
+  }
+
+  for (const NodeRecord &record : ast.nodes) {
+    auto restored = nodes.find(record.id);
+    if (restored == nodes.end() ||
+        isSgNamespaceDeclarationStatement(restored->second) == nullptr) {
+      continue;
+    }
+    const uint64_t container_id = singleEdgeTarget(record, "parent");
+    auto container_node = nodes.find(container_id);
+    SgAuxiliaryDeclarationList *container =
+        container_node != nodes.end()
+            ? isSgAuxiliaryDeclarationList(container_node->second)
+            : nullptr;
+    if (container == nullptr) {
+      continue;
+    }
+
+    auto container_record = records.find(container_id);
+    if (container_record == records.end()) {
+      throw std::runtime_error(
+          "AST JSON auxiliary namespace references an unknown container");
+    }
+    const uint64_t owner_id =
+        requiredSingleEdgeTarget(*container_record->second, "parent");
+    SgScopeStatement *owner = nodeByIdAs<SgScopeStatement>(nodes, owner_id);
+    auto owner_record = records.find(owner_id);
+    if (owner_record == records.end() ||
+        requiredSingleEdgeTarget(*owner_record->second,
+                                 "auxiliary_declarations") != container_id) {
+      throw std::runtime_error(
+          "AST JSON auxiliary namespace container disagrees with its exact "
+          "scope owner");
+    }
+    if ((owner->get_auxiliary_declarations() != nullptr &&
+         owner->get_auxiliary_declarations() != container) ||
+        container->get_parent() != owner ||
+        restored->second->get_parent() != container) {
+      throw std::runtime_error(
+          "AST JSON auxiliary namespace has conflicting early structural "
+          "ownership");
+    }
+    owner->set_auxiliary_declarations(container);
+
+    SgDeclarationStatement *declaration =
+        isSgDeclarationStatement(restored->second);
+    SgDeclarationStatementPtrList &declarations = container->get_declarations();
+    const size_t occurrences =
+        std::count(declarations.begin(), declarations.end(), declaration);
+    if (occurrences > 1) {
+      throw std::runtime_error(
+          "AST JSON auxiliary namespace was published more than once during "
+          "early ownership restoration");
+    }
+    if (occurrences == 0) {
+      declarations.push_back(declaration);
+    }
+  }
+}
+
 void attachPreprocessingInfo(SgNode *node, const NodeRecord &record) {
   if (record.preprocessing.kind != JsonValue::Kind::Array) {
     throw std::runtime_error(
@@ -4170,6 +4259,12 @@ void linkNodeEdges(const NodeRecord &record, const NodeMap &nodes) {
     if (uint64_t target = singleEdgeTarget(record, "auxiliary_declarations")) {
       SgAuxiliaryDeclarationList *container =
           nodeByIdAs<SgAuxiliaryDeclarationList>(nodes, target);
+      if (scope->get_auxiliary_declarations() != nullptr &&
+          scope->get_auxiliary_declarations() != container) {
+        throw std::runtime_error(
+            "AST JSON scope has conflicting auxiliary declaration "
+            "containers");
+      }
       scope->set_auxiliary_declarations(container);
       container->set_parent(scope);
     }
@@ -4184,6 +4279,25 @@ void linkNodeEdges(const NodeRecord &record, const NodeMap &nodes) {
   }
   if (SgAuxiliaryDeclarationList *container =
           isSgAuxiliaryDeclarationList(node)) {
+    const std::vector<EdgeRecord> serialized_edges =
+        edgesFor(record, "declarations");
+    size_t serialized_index = 0;
+    for (SgDeclarationStatement *existing : container->get_declarations()) {
+      while (serialized_index < serialized_edges.size() &&
+             nodeByIdAs<SgDeclarationStatement>(
+                 nodes, serialized_edges[serialized_index].target) !=
+                 existing) {
+        ++serialized_index;
+      }
+      if (existing == nullptr || existing->get_parent() != container ||
+          serialized_index == serialized_edges.size()) {
+        throw std::runtime_error(
+            "AST JSON early auxiliary declaration ownership is not an exact "
+            "ordered subset of its serialized list");
+      }
+      ++serialized_index;
+    }
+    container->get_declarations().clear();
     appendEdgeList<SgDeclarationStatementPtrList, SgDeclarationStatement>(
         container->get_declarations(), record, "declarations", nodes, container,
         false);

--- a/src/frontend/SageIII/astJson/sageAstJsonDeserializeTypes.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonDeserializeTypes.cpp
@@ -887,6 +887,23 @@ SgType *primitiveTypeFromKind(const std::string &kind) {
   return nullptr;
 }
 
+SgTypeTargetBuiltin *targetBuiltinTypeFromJson(const JsonValue &json) {
+  const int64_t family = json.requiredInt("target_family");
+  if (family < SgTypeTargetBuiltin::e_target_builtin_aarch64 ||
+      family > SgTypeTargetBuiltin::e_target_builtin_hlsl) {
+    throw std::runtime_error(
+        "AST JSON target builtin type has invalid target family");
+  }
+  const std::string spelling = json.requiredString("spelling");
+  if (spelling.empty()) {
+    throw std::runtime_error(
+        "AST JSON target builtin type has empty exact spelling");
+  }
+  return SageBuilder::buildTargetBuiltinType(
+      SgName(spelling),
+      static_cast<SgTypeTargetBuiltin::target_family_enum>(family));
+}
+
 SgAutoType *autoTypeFromJson(const JsonValue &json) {
   const bool is_constrained = json.requiredBool("is_constrained");
   const std::string source_constraint_spelling =
@@ -910,6 +927,9 @@ SgType *earlyTypeFromJson(const JsonValue &type) {
   const std::string kind = type.requiredString("kind");
   if (kind == "SgTypeDefault") {
     return SgTypeDefault::createType();
+  }
+  if (kind == "SgTypeTargetBuiltin") {
+    return targetBuiltinTypeFromJson(type);
   }
   if (kind == "SgTypeFortranAssumed") {
     if (type.requiredBool("fortran_source_syntax")) {
@@ -3446,6 +3466,9 @@ SgType *typeFromJsonUncached(const JsonValue &json, const NodeMap &nodes) {
   }
   if (kind == "SgTypeDefault") {
     return SgTypeDefault::createType();
+  }
+  if (kind == "SgTypeTargetBuiltin") {
+    return targetBuiltinTypeFromJson(json);
   }
   if (kind == "SgTypeFortranAssumed") {
     if (fortran_source_syntax) {

--- a/src/frontend/SageIII/astJson/sageAstJsonPrivate.h
+++ b/src/frontend/SageIII/astJson/sageAstJsonPrivate.h
@@ -853,6 +853,8 @@ void setNodeSourcePosition(SgNode *node, const NodeRecord &record);
 void setNodeFlags(SgNode *node, const NodeRecord &record);
 void restoreAvailableSourcePositionsAndScopes(const AstFileRecord &ast,
                                               const NodeMap &nodes);
+void restoreAvailableAuxiliaryNamespaceOwnership(const AstFileRecord &ast,
+                                                 const NodeMap &nodes);
 void attachPreprocessingInfo(SgNode *node, const NodeRecord &record);
 void attachAstAttributes(SgNode *node, const NodeRecord &record);
 void restoreFunctionCallSourceMetadata(SgFunctionCallExp *call,

--- a/src/frontend/SageIII/astJson/sageAstJsonSerializeExternal.cpp
+++ b/src/frontend/SageIII/astJson/sageAstJsonSerializeExternal.cpp
@@ -3627,6 +3627,23 @@ rawNodeProperties(SgNode *node,
       throw std::runtime_error(
           "AST JSON SgSimpleRequirement has no exact owned expression");
     }
+  } else if (SgRequirementSubstitutionFailure *failure =
+                 isSgRequirementSubstitutionFailure(node)) {
+    if (failure->get_failure_kind() <
+            SgRequirementSubstitutionFailure::e_simple_expression_failure ||
+        failure->get_failure_kind() >
+            SgRequirementSubstitutionFailure::e_compound_return_type_failure ||
+        failure->get_substituted_entity().empty()) {
+      throw std::runtime_error(
+          "AST JSON SgRequirementSubstitutionFailure has malformed exact "
+          "semantic state");
+    }
+    fields.push_back(
+        rawIntegerField("failure_kind", failure->get_failure_kind()));
+    fields.push_back(rawStringField("substituted_entity",
+                                    failure->get_substituted_entity()));
+    fields.push_back(rawStringField("diagnostic_message",
+                                    failure->get_diagnostic_message()));
   } else if (SgTypeRequirement *requirement = isSgTypeRequirement(node)) {
     if (requirement->get_required_type() == nullptr) {
       throw std::runtime_error(

--- a/src/frontend/SageIII/astTokenStream/frontierDetection.C
+++ b/src/frontend/SageIII/astTokenStream/frontierDetection.C
@@ -3120,18 +3120,38 @@ FrontierDetectionForTokenStreamMapping::evaluateSynthesizedAttribute(
       }
       ROSE_ABORT();
     }
-    for (const auto &childAttribute : synthesizedAttributeList) {
-      if (childAttribute.node != nullptr || childAttribute.isFrontier ||
-          childAttribute.unparseUsingTokenStream ||
-          childAttribute.unparseFromTheAST ||
-          childAttribute.containsNodesToBeUnparsedFromTheAST ||
-          childAttribute.containsNodesToBeUnparsedFromTheTokenStream ||
-          childAttribute.sourceFile != inheritedAttribute.sourceFile) {
+    for (size_t childIndex = 0; childIndex < synthesizedAttributeList.size();
+         ++childIndex) {
+      const auto &childAttribute = synthesizedAttributeList[childIndex];
+      const bool neutralSemanticChild =
+          childAttribute.node == nullptr && !childAttribute.isFrontier &&
+          !childAttribute.unparseUsingTokenStream &&
+          !childAttribute.unparseFromTheAST &&
+          !childAttribute.containsNodesToBeUnparsedFromTheAST &&
+          !childAttribute.containsNodesToBeUnparsedFromTheTokenStream;
+      const bool exactOrAbsentSourceContext =
+          childAttribute.sourceFile == nullptr ||
+          childAttribute.sourceFile == inheritedAttribute.sourceFile;
+      if (!neutralSemanticChild || !exactOrAbsentSourceContext) {
         fprintf(stderr,
                 "REX_UNPARSE_INVARIANT[frontier-auxiliary-emission]: "
-                "node=%p/%s has a non-neutral semantic child frontier "
-                "attribute\n",
-                static_cast<void *>(n), n->class_name().c_str());
+                "node=%p/%s child-index=%zu child=%p/%s has a non-neutral "
+                "semantic child frontier attribute "
+                "[node=%p,frontier=%d,tokens=%d,ast=%d,contains-ast=%d,"
+                "contains-tokens=%d,source=%p,expected-source=%p]\n",
+                static_cast<void *>(n), n->class_name().c_str(), childIndex,
+                static_cast<void *>(traversalSuccessors[childIndex]),
+                traversalSuccessors[childIndex] != nullptr
+                    ? traversalSuccessors[childIndex]->class_name().c_str()
+                    : "<null>",
+                static_cast<void *>(childAttribute.node),
+                childAttribute.isFrontier,
+                childAttribute.unparseUsingTokenStream,
+                childAttribute.unparseFromTheAST,
+                childAttribute.containsNodesToBeUnparsedFromTheAST,
+                childAttribute.containsNodesToBeUnparsedFromTheTokenStream,
+                static_cast<void *>(childAttribute.sourceFile),
+                static_cast<void *>(inheritedAttribute.sourceFile));
         ROSE_ABORT();
       }
     }
@@ -3142,6 +3162,8 @@ FrontierDetectionForTokenStreamMapping::evaluateSynthesizedAttribute(
     returnAttribute.unparseFromTheAST = false;
     returnAttribute.containsNodesToBeUnparsedFromTheAST = false;
     returnAttribute.containsNodesToBeUnparsedFromTheTokenStream = false;
+    returnAttribute.sourceFile = inheritedAttribute.sourceFile;
+    ASSERT_not_null(returnAttribute.sourceFile);
     return returnAttribute;
   }
 

--- a/src/frontend/SageIII/fixupCopy_references.C
+++ b/src/frontend/SageIII/fixupCopy_references.C
@@ -1030,7 +1030,28 @@ void SgLocatedNode::fixupCopy_references(SgNode *copy, SgCopyHelp &help) const {
               copied_symbol->get_declaration() != copied_source) {
             fprintf(stderr,
                     "REX_AST_INVARIANT[template-function-copy-reference]: "
-                    "copied source template has no exact copied symbol\n");
+                    "source=%p/%s name=%s scope=%p parent=%p copy=%p/%s "
+                    "scope=%p parent=%p symbol=%p declaration=%p has no "
+                    "exact copied symbol\n",
+                    static_cast<void *>(original_source),
+                    original_source->class_name().c_str(),
+                    original_source->get_name().getString().c_str(),
+                    static_cast<void *>(original_source->get_scope()),
+                    static_cast<void *>(original_source->get_parent()),
+                    static_cast<void *>(copied_source),
+                    copied_source != nullptr
+                        ? copied_source->class_name().c_str()
+                        : "<null>",
+                    static_cast<void *>(copied_source != nullptr
+                                            ? copied_source->get_scope()
+                                            : nullptr),
+                    static_cast<void *>(copied_source != nullptr
+                                            ? copied_source->get_parent()
+                                            : nullptr),
+                    static_cast<void *>(copied_symbol),
+                    static_cast<void *>(copied_symbol != nullptr
+                                            ? copied_symbol->get_declaration()
+                                            : nullptr));
             ROSE_ABORT();
           }
           reference->set_symbol(copied_symbol);

--- a/src/frontend/SageIII/fixupCopy_scopes.C
+++ b/src/frontend/SageIII/fixupCopy_scopes.C
@@ -4087,6 +4087,7 @@ bool isGloballyCanonicalBuiltinType(const SgNode *node) {
   case V_SgTypeChar32:
   case V_SgTypeChar8:
   case V_SgTypeNullptr:
+  case V_SgTypeTargetBuiltin:
     return true;
 
   default:

--- a/src/frontend/SageIII/fixupCopy_symbols.C
+++ b/src/frontend/SageIII/fixupCopy_symbols.C
@@ -1037,11 +1037,24 @@ void SgGlobal::fixupCopy_symbols(SgNode *copy, SgCopyHelp &help) const {
   SgGlobal *global_copy = isSgGlobal(copy);
   ROSE_ASSERT(global_copy != NULL);
 
+  // Rebuild the global scope and its auxiliary semantic scopes before
+  // visiting source-emission declarations.  A namespace reopening mirrors
+  // its local symbols into the namespace's global definition.  When that
+  // global definition is an auxiliary declaration (for example the frontend
+  // support namespace), processing reopenings first would leave a non-empty
+  // but incomplete destination table.  The generic scope fixup quite
+  // deliberately treats a non-empty table as an already completed copy, so
+  // that partial publication would prevent the exact source inventory from
+  // ever being installed.
+  //
+  // The copied-node map is complete before symbol fixup starts.  Therefore
+  // the exact symbol-table builder can materialize every auxiliary symbol and
+  // its copied basis now; subsequent namespace-fragment mirroring is
+  // idempotent and must find those same basis identities.
+  SgScopeStatement::fixupCopy_symbols(copy, help);
+
   fixupCanonicalDeclarationCopiesForSymbols(this->getDeclarationList(),
                                             global_copy, help);
-
-  // Call the base class fixupCopy member function
-  SgScopeStatement::fixupCopy_symbols(copy, help);
 
   // printf ("\nLeaving SgGlobal::fixupCopy_symbols() this = %p = %s  copy = %p
   // \n",this,this->class_name().c_str(),copy);

--- a/src/frontend/SageIII/sageInterface/sageBuilder.C
+++ b/src/frontend/SageIII/sageInterface/sageBuilder.C
@@ -18303,6 +18303,15 @@ SgTypeFloat64 *SageBuilder::buildFloat64Type() {
   return result;
 }
 
+SgTypeTargetBuiltin *SageBuilder::buildTargetBuiltinType(
+    const SgName &spelling,
+    SgTypeTargetBuiltin::target_family_enum target_family) {
+  SgTypeTargetBuiltin *result =
+      SgTypeTargetBuiltin::createType(spelling, target_family);
+  ROSE_ASSERT(result != nullptr);
+  return result;
+}
+
 SgTypeSignedInt *SageBuilder::buildSignedIntType() {
   SgTypeSignedInt *result = SgTypeSignedInt::createType();
   ROSE_ASSERT(result);
@@ -19317,6 +19326,30 @@ SageBuilder::buildCompoundRequirement_nfi(SgExpression *expression,
   expression->set_parent(result);
   if (type_constraint != nullptr)
     type_constraint->set_parent(result);
+  setOneSourcePositionNull(result);
+  return result;
+}
+
+SgRequirementSubstitutionFailure *
+SageBuilder::buildRequirementSubstitutionFailure_nfi(
+    SgRequirementSubstitutionFailure::failure_kind_enum failure_kind,
+    const std::string &substituted_entity,
+    const std::string &diagnostic_message) {
+  if (failure_kind <
+          SgRequirementSubstitutionFailure::e_simple_expression_failure ||
+      failure_kind >
+          SgRequirementSubstitutionFailure::e_compound_return_type_failure ||
+      substituted_entity.empty()) {
+    fprintf(stderr,
+            "REX_AST_INVARIANT[requirement-substitution-failure]: invalid "
+            "kind=%d or empty substituted entity\n",
+            static_cast<int>(failure_kind));
+    ROSE_ABORT();
+  }
+  SgRequirementSubstitutionFailure *result =
+      new SgRequirementSubstitutionFailure(
+          NULL, failure_kind, substituted_entity, diagnostic_message);
+  ROSE_ASSERT(result != nullptr);
   setOneSourcePositionNull(result);
   return result;
 }

--- a/src/frontend/SageIII/sageInterface/sageBuilder.h
+++ b/src/frontend/SageIII/sageInterface/sageBuilder.h
@@ -158,6 +158,9 @@ ROSE_DLL_API SgTypeFloat32x *buildFloat32xType();
 ROSE_DLL_API SgTypeFloat64x *buildFloat64xType();
 ROSE_DLL_API SgTypeFloat32 *buildFloat32Type();
 ROSE_DLL_API SgTypeFloat64 *buildFloat64Type();
+ROSE_DLL_API SgTypeTargetBuiltin *
+buildTargetBuiltinType(const SgName &spelling,
+                       SgTypeTargetBuiltin::target_family_enum target_family);
 
 //! DQ (8/21/2010): We want to move to the new buildStringType(
 //! SgExpression*,size_t) function over the older buildStringType() function.
@@ -1108,6 +1111,11 @@ ROSE_DLL_API SgTypeRequirement *buildTypeRequirement_nfi(SgType *required_type);
 ROSE_DLL_API SgCompoundRequirement *
 buildCompoundRequirement_nfi(SgExpression *expression, bool noexcept_required,
                              SgExpression *type_constraint);
+ROSE_DLL_API SgRequirementSubstitutionFailure *
+buildRequirementSubstitutionFailure_nfi(
+    SgRequirementSubstitutionFailure::failure_kind_enum failure_kind,
+    const std::string &substituted_entity,
+    const std::string &diagnostic_message);
 ROSE_DLL_API SgNestedRequirement *
 buildNestedRequirement_nfi(SgExpression *constraint);
 

--- a/src/frontend/SageIII/sageInterface/sageInterface_type.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface_type.C
@@ -1091,6 +1091,13 @@ std::string getTypeName(SgType *type) {
   case V_SgTypeDefault:
     typeName = "default";
     break;
+  case V_SgTypeTargetBuiltin: {
+    SgTypeTargetBuiltin *targetBuiltin = isSgTypeTargetBuiltin(type);
+    ROSE_ASSERT(targetBuiltin != nullptr);
+    ROSE_ASSERT(!targetBuiltin->get_spelling().is_null());
+    typeName = targetBuiltin->get_spelling().getString();
+    break;
+  }
   case V_SgTypeFortranAssumed:
     typeName = "type(*)";
     break;
@@ -1613,6 +1620,7 @@ bool isDefaultConstructible(SgType *type) {
     // using new automated generation of builtin functions for ROSE.
   case V_SgTypeSigned128bitInteger:
   case V_SgTypeUnsigned128bitInteger:
+  case V_SgTypeTargetBuiltin:
 
     // DQ (8/27/2006): Changed name of SgComplex to make it more consistant with
     // other type names and added SgTypeImaginary IR node (for C99 complex
@@ -1778,6 +1786,7 @@ bool isCopyConstructible(SgType *type) {
     // using new automated generation of builtin functions for ROSE.
   case V_SgTypeSigned128bitInteger:
   case V_SgTypeUnsigned128bitInteger:
+  case V_SgTypeTargetBuiltin:
 
   case V_SgReferenceType:
   case V_SgRvalueReferenceType:
@@ -1927,6 +1936,7 @@ bool isAssignable(SgType *type) {
     // using new automated generation of builtin functions for ROSE.
   case V_SgTypeSigned128bitInteger:
   case V_SgTypeUnsigned128bitInteger:
+  case V_SgTypeTargetBuiltin:
 
   case V_SgTypeComplex: // C99 complex is assignable
   case V_SgTypeImaginary:

--- a/tests/nonsmoke/functional/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CMakeLists.txt
@@ -66,6 +66,12 @@ function(rex_get_cxx_specimen_extra_flags out_var specimen)
   if(specimen STREQUAL "rex_test2025_issue148_system_header_mutation.cpp")
     list(APPEND _flags -isystem ${REX_FUNCTIONAL_SYSTEM_HEADER_LIKE_DIR})
   endif()
+  if(_specimen_name STREQUAL "rex_unparser_asm_clobber_identity.cpp")
+    # This specimen intentionally names x86 registers.  Keep that source
+    # contract explicit so it exercises the same frontend semantics on every
+    # architecture runner.
+    list(APPEND _flags -target x86_64-unknown-linux-gnu)
+  endif()
   set(${out_var} "${_flags}" PARENT_SCOPE)
 endfunction()
 

--- a/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT BASH_EXECUTABLE)
 endif()
 
 set(C_TESTCODES
+  rex_frontend_aarch64_wide_literal_semantic_type.c
   rex_frontend_designated_initializer_chain.c
   rex_frontend_expression_tag_ownership.c
   rex_frontend_if_asm_source_provenance.c
@@ -1190,6 +1191,22 @@ list(REMOVE_ITEM C_TESTCODES test2012_145.c test2015_153.c)
 foreach(file_to_test ${C_TESTCODES})
   compile_test(${file_to_test} "C_tests")
 endforeach()
+
+add_test(
+  NAME C_tests_rex_frontend_aarch64_wide_literal_semantic_type
+  WORKING_DIRECTORY ${_c_tests_special_dir}
+  COMMAND ${C_TEST_TRANSLATOR}
+    ${C_TEST_ROSE_FLAGS}
+    -rose:skipfinalCompileStep
+    -rose:skip_unparse
+    -target aarch64-unknown-linux-gnu
+    -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_aarch64_wide_literal_semantic_type.c
+)
+set_tests_properties(
+  C_tests_rex_frontend_aarch64_wide_literal_semantic_type
+  PROPERTIES LABELS "C_tests;rex;CFE"
+)
 
 foreach(file_to_test ${C_TESTCODES_NEGATIVE})
   if(file_to_test STREQUAL "test2017_02.c")

--- a/tests/nonsmoke/functional/CompileTests/C_tests/rex_frontend_aarch64_wide_literal_semantic_type.c
+++ b/tests/nonsmoke/functional/CompileTests/C_tests/rex_frontend_aarch64_wide_literal_semantic_type.c
@@ -1,0 +1,3 @@
+typedef __WCHAR_TYPE__ rex_target_wchar_type;
+
+const rex_target_wchar_type *rex_aarch64_wide_literal = L"wide";

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/CMakeLists.txt
@@ -125,6 +125,7 @@ set(CXX20_TESTCODES
   test2020_119.C
   test2020_121.C
   rex_cxx20_char8_type_identity.cpp
+  rex_frontend_dependent_builtin_bit_cast.cpp
   rex_frontend_constrained_overload_identity.cpp
   rex_frontend_range_init_declarator_identity.cpp
   rex_test2026_coreturn_valgrind_defined_reads.cpp
@@ -237,6 +238,66 @@ rex_lock_test_for_input(
   test2020_45.C
 )
 
+set(_rex_unowned_namespace_source
+    "${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_unowned_imported_namespace.cpp")
+set(_rex_unowned_namespace_header
+    "${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_unowned_imported_namespace.hpp")
+set(_rex_unowned_namespace_module_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/rex_frontend_unowned_imported_namespace_modules")
+set(_rex_unowned_namespace_module_pcm
+    "${_rex_unowned_namespace_module_dir}/rex_frontend_unowned_imported_namespace.pcm")
+
+string(CONCAT _rex_unowned_namespace_command
+  "set -eu; "
+  "module_dir=\"${_rex_unowned_namespace_module_dir}\"; "
+  "mkdir -p \"$module_dir\"; "
+  "${CMAKE_CXX_COMPILER} -std=c++20 -fmodule-header=user "
+  "\"${_rex_unowned_namespace_header}\" "
+  "-o \"${_rex_unowned_namespace_module_pcm}\"; "
+  "translator=\"$1\"; shift; "
+  "exec \"$translator\" "
+  "-fmodule-file=\"${_rex_unowned_namespace_module_pcm}\" \"$@\"")
+
+add_executable(
+  rex_frontend_unowned_imported_namespace_translator
+  rex_frontend_unowned_imported_namespace_translator.cpp
+)
+target_include_directories(
+  rex_frontend_unowned_imported_namespace_translator
+  PRIVATE ${ROSE_TOP_SRC_DIR}/src/frontend/Clang
+)
+rose_force_system_include_dirs(
+  rex_frontend_unowned_imported_namespace_translator
+  ${LLVM_INCLUDE_DIRS}
+  ${CLANG_INCLUDE_DIRS}
+)
+target_link_libraries(
+  rex_frontend_unowned_imported_namespace_translator
+  ROSE_DLL
+  ${link_with_libraries}
+)
+add_test(
+  NAME Cxx20_tests_rex_frontend_unowned_imported_namespace
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    sh -c
+    "${_rex_unowned_namespace_command}"
+    dummy
+    $<TARGET_FILE:rex_frontend_unowned_imported_namespace_translator>
+    ${ROSE_FLAGS} -rose:skipfinalCompileStep -rose:skip_unparse
+    ${ROSE_INCLUDE_FLAGS}
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -c ${_rex_unowned_namespace_source}
+)
+set_tests_properties(
+  Cxx20_tests_rex_frontend_unowned_imported_namespace
+  PROPERTIES LABELS "rex;CFE;Cxx20_tests"
+)
+rex_lock_test_for_input(
+  Cxx20_tests_rex_frontend_unowned_imported_namespace
+  rex_frontend_unowned_imported_namespace.cpp
+)
+
 set(_rex_export_context_source
     "${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_export_context_scope.cpp")
 set(_rex_export_context_module_source
@@ -290,6 +351,75 @@ target_link_libraries(
   ROSE_DLL
   ${link_with_libraries}
 )
+
+add_executable(
+  rex_frontend_target_builtin_type_translator
+  rex_frontend_target_builtin_type_translator.cpp
+)
+target_link_libraries(
+  rex_frontend_target_builtin_type_translator
+  ROSE_DLL
+  ${link_with_libraries}
+)
+
+add_executable(
+  rex_frontend_requirement_substitution_failure_translator
+  rex_frontend_requirement_substitution_failure_translator.cpp
+)
+target_link_libraries(
+  rex_frontend_requirement_substitution_failure_translator
+  ROSE_DLL
+  ${link_with_libraries}
+)
+
+add_test(
+  NAME Cxx20_tests_rex_frontend_requirement_substitution_failure
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    $<TARGET_FILE:rex_frontend_requirement_substitution_failure_translator>
+    ${ROSE_FLAGS} -rose:skipfinalCompileStep -rose:skip_unparse
+    -rex:ast-json-checkpoint=pre-omp-construction
+    -rex:ast-json-dir=rex_frontend_requirement_substitution_failure_json
+    -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_requirement_substitution_failure.cpp
+)
+set_tests_properties(
+  Cxx20_tests_rex_frontend_requirement_substitution_failure
+  PROPERTIES LABELS "Cxx20_tests;rex;CFE;ASTJSON"
+)
+rex_lock_test_for_input(
+  Cxx20_tests_rex_frontend_requirement_substitution_failure
+  rex_frontend_requirement_substitution_failure.cpp
+)
+
+set(_rex_target_builtin_type_source
+    "${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_target_builtin_type.cpp")
+foreach(_rex_target_builtin_arch IN ITEMS aarch64 riscv64)
+  if(_rex_target_builtin_arch STREQUAL "aarch64")
+    set(_rex_target_builtin_triple aarch64-unknown-linux-gnu)
+  else()
+    set(_rex_target_builtin_triple riscv64-unknown-linux-gnu)
+  endif()
+  add_test(
+    NAME Cxx20_tests_rex_frontend_target_builtin_type_${_rex_target_builtin_arch}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND
+      $<TARGET_FILE:rex_frontend_target_builtin_type_translator>
+      ${ROSE_FLAGS} -rose:skipfinalCompileStep -rose:skip_unparse
+      -rex:ast-json-checkpoint=pre-omp-construction
+      -rex:ast-json-dir=rex_frontend_target_builtin_type_${_rex_target_builtin_arch}_json
+      -target ${_rex_target_builtin_triple}
+      -c ${_rex_target_builtin_type_source}
+  )
+  set_tests_properties(
+    Cxx20_tests_rex_frontend_target_builtin_type_${_rex_target_builtin_arch}
+    PROPERTIES LABELS "Cxx20_tests;rex;CFE;ASTJSON"
+  )
+  rex_lock_test_for_input(
+    Cxx20_tests_rex_frontend_target_builtin_type_${_rex_target_builtin_arch}
+    rex_frontend_target_builtin_type.cpp
+  )
+endforeach()
 
 add_executable(
   rex_frontend_constrained_overload_identity_translator
@@ -600,7 +730,8 @@ add_test(
     "${_rex_unparser_asm_clobber_command}"
     dummy
     $<TARGET_FILE:${translator}>
-    ${ROSE_FLAGS} -rose:skipfinalCompileStep ${ROSE_INCLUDE_FLAGS}
+    ${ROSE_FLAGS} -target x86_64-unknown-linux-gnu
+    -rose:skipfinalCompileStep ${ROSE_INCLUDE_FLAGS}
     -I${CMAKE_CURRENT_SOURCE_DIR}
     -c ${_rex_unparser_asm_clobber_source}
 )

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_dependent_builtin_bit_cast.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_dependent_builtin_bit_cast.cpp
@@ -1,0 +1,13 @@
+template <typename To, typename From>
+To rex_dependent_builtin_bit_cast(const From &value) {
+  return __builtin_bit_cast(To, value);
+}
+
+struct rex_bit_pattern {
+  unsigned value;
+};
+
+int main() {
+  rex_bit_pattern source{7};
+  return rex_dependent_builtin_bit_cast<unsigned>(source) == 7 ? 0 : 1;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_requirement_substitution_failure.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_requirement_substitution_failure.cpp
@@ -1,0 +1,27 @@
+template <typename First, typename Second>
+concept rex_same_type_surface = true;
+
+template <typename T> bool rex_simple_failure() {
+  return requires(T value) { value.missing(); };
+}
+
+template <typename T> bool rex_type_failure() {
+  return requires { typename T::missing; };
+}
+
+template <typename T> bool rex_compound_expression_failure() {
+  return requires(T value) {
+    { value.missing() };
+  };
+}
+
+template <typename T> bool rex_compound_return_type_failure() {
+  return requires(T value) {
+    { value } -> rex_same_type_surface<typename T::missing>;
+  };
+}
+
+bool rex_simple_result = rex_simple_failure<int>();
+bool rex_type_result = rex_type_failure<int>();
+bool rex_compound_expression_result = rex_compound_expression_failure<int>();
+bool rex_compound_return_type_result = rex_compound_return_type_failure<int>();

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_requirement_substitution_failure_translator.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_requirement_substitution_failure_translator.cpp
@@ -1,0 +1,43 @@
+#include "RoseAst.h"
+#include "rose.h"
+
+#include <array>
+
+int main(int argc, char **argv) {
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(frontendExitStatus(project) == 0);
+
+  std::array<std::size_t, 4> counts{};
+  RoseAst ast(project);
+  for (SgNode *node : ast) {
+    SgRequirementSubstitutionFailure *failure =
+        isSgRequirementSubstitutionFailure(node);
+    if (failure == nullptr)
+      continue;
+
+    const int kind = static_cast<int>(failure->get_failure_kind());
+    ROSE_ASSERT(kind >=
+                SgRequirementSubstitutionFailure::e_simple_expression_failure);
+    ROSE_ASSERT(
+        kind <=
+        SgRequirementSubstitutionFailure::e_compound_return_type_failure);
+    ROSE_ASSERT(!failure->get_substituted_entity().empty());
+    ROSE_ASSERT(failure->get_startOfConstruct() != nullptr);
+    ROSE_ASSERT(failure->get_startOfConstruct()->isCompilerGenerated());
+    ROSE_ASSERT(failure->get_startOfConstruct()->get_physical_file_id() ==
+                Sg_File_Info::COMPILER_GENERATED_FILE_ID);
+
+    if (failure->get_failure_kind() ==
+        SgRequirementSubstitutionFailure::e_compound_return_type_failure) {
+      ROSE_ASSERT(isSgCompoundRequirement(failure->get_parent()) != nullptr);
+    } else {
+      ROSE_ASSERT(isSgExprListExp(failure->get_parent()) != nullptr);
+    }
+    ++counts[static_cast<std::size_t>(kind)];
+  }
+
+  for (std::size_t count : counts)
+    ROSE_ASSERT(count == 1);
+  return 0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_target_builtin_type.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_target_builtin_type.cpp
@@ -1,0 +1,8 @@
+#if defined(__aarch64__)
+typedef __SVFloat32_t rex_aarch64_vector_type;
+typedef __mfp8 rex_aarch64_scalar_type;
+#elif defined(__riscv)
+typedef __rvv_int8mf8_t rex_riscv_vector_type;
+#else
+#error "this target-builtin specimen requires AArch64 or RISC-V"
+#endif

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_target_builtin_type_translator.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_target_builtin_type_translator.cpp
@@ -1,0 +1,71 @@
+#include "nodeQuery.h"
+#include "rose.h"
+
+#include <string>
+
+namespace {
+struct ExpectedType {
+  const char *declaration_name;
+  const char *spelling;
+  SgTypeTargetBuiltin::target_family_enum family;
+};
+
+const ExpectedType *expectedType(const std::string &name) {
+  static const ExpectedType expected[] = {
+      {"rex_aarch64_vector_type", "__SVFloat32_t",
+       SgTypeTargetBuiltin::e_target_builtin_aarch64},
+      {"rex_aarch64_scalar_type", "__mfp8",
+       SgTypeTargetBuiltin::e_target_builtin_aarch64},
+      {"rex_riscv_vector_type", "__rvv_int8mf8_t",
+       SgTypeTargetBuiltin::e_target_builtin_riscv},
+  };
+  for (const ExpectedType &type : expected) {
+    if (name == type.declaration_name)
+      return &type;
+  }
+  return nullptr;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(frontendExitStatus(project) == 0);
+
+  std::size_t matched = 0;
+  SgTypeTargetBuiltin::target_family_enum observed_family =
+      SgTypeTargetBuiltin::e_target_builtin_hlsl;
+  for (SgNode *node :
+       NodeQuery::querySubTree(project, V_SgTypedefDeclaration)) {
+    SgTypedefDeclaration *declaration = isSgTypedefDeclaration(node);
+    ROSE_ASSERT(declaration != nullptr);
+    const ExpectedType *expected =
+        expectedType(declaration->get_name().getString());
+    if (expected == nullptr)
+      continue;
+
+    SgType *written_type = declaration->get_base_type();
+    ROSE_ASSERT(written_type != nullptr);
+    SgTypeTargetBuiltin *type = isSgTypeTargetBuiltin(written_type->stripType(
+        SgType::STRIP_TYPEDEF_TYPE | SgType::STRIP_MODIFIER_TYPE));
+    ROSE_ASSERT(type != nullptr);
+    ROSE_ASSERT(type->get_spelling().getString() == expected->spelling);
+    ROSE_ASSERT(type->get_target_family() == expected->family);
+    ROSE_ASSERT(SageInterface::getTypeName(type) == expected->spelling);
+    ROSE_ASSERT(SageInterface::isDefaultConstructible(type));
+    ROSE_ASSERT(SageInterface::isCopyConstructible(type));
+    ROSE_ASSERT(SageInterface::isAssignable(type));
+    if (matched != 0)
+      ROSE_ASSERT(observed_family == type->get_target_family());
+    observed_family = type->get_target_family();
+    ++matched;
+  }
+
+  if (observed_family == SgTypeTargetBuiltin::e_target_builtin_aarch64)
+    ROSE_ASSERT(matched == 2);
+  else {
+    ROSE_ASSERT(observed_family == SgTypeTargetBuiltin::e_target_builtin_riscv);
+    ROSE_ASSERT(matched == 1);
+  }
+  return 0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace.cpp
@@ -1,0 +1,5 @@
+import "rex_frontend_unowned_imported_namespace.hpp";
+
+using namespace rex_unowned_imported_namespace;
+
+marker make_marker() { return {42}; }

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace.hpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace.hpp
@@ -1,0 +1,5 @@
+namespace rex_unowned_imported_namespace {
+struct marker {
+  int value;
+};
+} // namespace rex_unowned_imported_namespace

--- a/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace_translator.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx20_tests/rex_frontend_unowned_imported_namespace_translator.cpp
@@ -1,0 +1,92 @@
+#include "clang-frontend-private.hpp"
+#include "nodeQuery.h"
+#include "rose.h"
+
+#include <algorithm>
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/Builtins.h>
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Basic/DiagnosticOptions.h>
+#include <clang/Basic/FileManager.h>
+#include <clang/Basic/IdentifierTable.h>
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
+#include <string>
+
+namespace {
+bool hasSuffix(const SgStringList &paths, const std::string &suffix) {
+  return std::count_if(paths.begin(), paths.end(),
+                       [&](const std::string &path) {
+                         return path.size() >= suffix.size() &&
+                                path.compare(path.size() - suffix.size(),
+                                             suffix.size(), suffix) == 0;
+                       }) == 1;
+}
+
+void validateUnownedImportedNamespaceClassification() {
+  clang::LangOptions language_options;
+  clang::DiagnosticOptions diagnostic_options;
+  auto diagnostic_ids = llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>();
+  clang::DiagnosticsEngine diagnostics(diagnostic_ids, diagnostic_options);
+  clang::FileSystemOptions file_system_options;
+  clang::FileManager file_manager(file_system_options);
+  clang::SourceManager source_manager(diagnostics, file_manager);
+  clang::IdentifierTable identifiers(language_options);
+  clang::SelectorTable selectors;
+  clang::Builtin::Context builtins;
+  clang::ASTContext ast_context(language_options, source_manager, identifiers,
+                                selectors, builtins, clang::TU_Complete);
+  clang::IdentifierInfo &identifier =
+      identifiers.get("rex_synthetic_unowned_imported_namespace");
+  clang::NamespaceDecl *namespace_decl = clang::NamespaceDecl::Create(
+      ast_context, ast_context.getTranslationUnitDecl(), false,
+      clang::SourceLocation(), clang::SourceLocation(), &identifier, nullptr,
+      false);
+  ROSE_ASSERT(namespace_decl != nullptr);
+  namespace_decl->setFromASTFile();
+  ROSE_ASSERT(namespace_decl->isFromASTFile());
+  ROSE_ASSERT(!namespace_decl->hasOwningModule());
+  ROSE_ASSERT(clangFrontendImportedNamespaceModule(namespace_decl) == nullptr);
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  validateUnownedImportedNamespaceClassification();
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(frontendExitStatus(project) == 0);
+  ROSE_ASSERT(project->get_fileList().size() == 1);
+  SgSourceFile *source = isSgSourceFile(project->get_fileList().front());
+  ROSE_ASSERT(source != nullptr);
+
+  std::size_t namespace_count = 0;
+  for (SgNode *node :
+       NodeQuery::querySubTree(project, V_SgNamespaceDeclarationStatement)) {
+    SgNamespaceDeclarationStatement *declaration =
+        isSgNamespaceDeclarationStatement(node);
+    if (declaration == nullptr ||
+        declaration->get_name() != "rex_unowned_imported_namespace") {
+      continue;
+    }
+    ++namespace_count;
+    SgNamespaceDefinitionStatement *definition = declaration->get_definition();
+    ROSE_ASSERT(definition != nullptr);
+    ROSE_ASSERT(!declaration->has_source_fragments());
+    SgAuxiliaryDeclarationList *owner =
+        isSgAuxiliaryDeclarationList(declaration->get_parent());
+    ROSE_ASSERT(owner != nullptr);
+    ROSE_ASSERT(owner->get_parent() == declaration->get_scope());
+    ROSE_ASSERT(declaration->get_file_info() != nullptr);
+    ROSE_ASSERT(declaration->get_file_info()->isCompilerGenerated());
+    ROSE_ASSERT(declaration->get_file_info()->isFrontendSpecific());
+    ROSE_ASSERT(definition->get_file_info() != nullptr);
+    ROSE_ASSERT(definition->get_file_info()->isCompilerGenerated());
+    ROSE_ASSERT(definition->get_file_info()->isFrontendSpecific());
+  }
+  ROSE_ASSERT(namespace_count == 1);
+  const SgStringList &externals =
+      source->get_frontendExternalOwnershipPathList();
+  ROSE_ASSERT(
+      hasSuffix(externals, "rex_frontend_unowned_imported_namespace.hpp"));
+  return 0;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/CMakeLists.txt
@@ -4218,6 +4218,16 @@ target_link_libraries(
 )
 
 add_executable(
+  rex_frontend_support_namespace_semantic_root_translator
+  rex_frontend_support_namespace_semantic_root_translator.cpp
+)
+target_link_libraries(
+  rex_frontend_support_namespace_semantic_root_translator
+  ROSE_DLL
+  ${link_with_libraries}
+)
+
+add_executable(
   rex_frontend_injected_class_nttp_provenance_translator
   rex_frontend_injected_class_nttp_provenance_translator.cpp
 )
@@ -4982,6 +4992,27 @@ set_tests_properties(
 rex_lock_test_for_input(
   Cxx_tests_rex_frontend_namespace_source_fragments_structure
   rex_frontend_namespace_source_fragments.cpp)
+
+add_test(
+  NAME Cxx_tests_rex_frontend_support_namespace_semantic_root
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    $<TARGET_FILE:rex_frontend_support_namespace_semantic_root_translator>
+    ${ROSE_FLAGS} -rose:skipfinalCompileStep
+    ${ROSE_INCLUDE_FLAGS}
+    -std=c++17
+    -target aarch64-unknown-linux-gnu
+    -rose:output
+    ${CMAKE_CURRENT_BINARY_DIR}/rose_rex_frontend_support_namespace_semantic_root.cpp
+    -c
+    ${CMAKE_CURRENT_SOURCE_DIR}/rex_frontend_support_namespace_semantic_root.cpp
+)
+set_tests_properties(
+  Cxx_tests_rex_frontend_support_namespace_semantic_root
+  PROPERTIES LABELS "Cxx_tests;rex;CFE;UNPARSER")
+rex_lock_test_for_input(
+  Cxx_tests_rex_frontend_support_namespace_semantic_root
+  rex_frontend_support_namespace_semantic_root.cpp)
 
 add_test(
   NAME Cxx_tests_rex_frontend_dependent_member_typedef_identity

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_frontend_support_namespace_semantic_root.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_frontend_support_namespace_semantic_root.cpp
@@ -1,0 +1,10 @@
+namespace std {
+struct rex_frontend_support_namespace_member {
+  int value;
+};
+} // namespace std
+
+int main() {
+  std::rex_frontend_support_namespace_member member{7};
+  return member.value == 7 ? 0 : 1;
+}

--- a/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_frontend_support_namespace_semantic_root_translator.cpp
+++ b/tests/nonsmoke/functional/CompileTests/Cxx_tests/rex_frontend_support_namespace_semantic_root_translator.cpp
@@ -1,0 +1,148 @@
+#include "rose.h"
+
+#include <algorithm>
+
+namespace {
+SgNamespaceDeclarationStatement *findSemanticRoot(SgGlobal *global) {
+  ROSE_ASSERT(global != nullptr);
+  SgAuxiliaryDeclarationList *auxiliary = global->get_auxiliary_declarations();
+  ROSE_ASSERT(auxiliary != nullptr);
+  ROSE_ASSERT(auxiliary->get_parent() == global);
+
+  SgNamespaceDeclarationStatement *semanticRoot = nullptr;
+  for (SgDeclarationStatement *declaration : auxiliary->get_declarations()) {
+    SgNamespaceDeclarationStatement *candidate =
+        isSgNamespaceDeclarationStatement(declaration);
+    if (candidate == nullptr || candidate->get_name() != "std")
+      continue;
+    ROSE_ASSERT(semanticRoot == nullptr);
+    semanticRoot = candidate;
+  }
+  ROSE_ASSERT(semanticRoot != nullptr);
+  return semanticRoot;
+}
+
+void requireSemanticProvenance(SgLocatedNode *node) {
+  ROSE_ASSERT(node != nullptr);
+  for (Sg_File_Info *position :
+       {node->get_file_info(), node->get_startOfConstruct(),
+        node->get_endOfConstruct()}) {
+    ROSE_ASSERT(position != nullptr);
+    ROSE_ASSERT(position->get_parent() == node);
+    ROSE_ASSERT(position->isCompilerGenerated());
+    ROSE_ASSERT(position->isFrontendSpecific());
+    ROSE_ASSERT(!position->isTransformation());
+    ROSE_ASSERT(position->get_file_id() ==
+                Sg_File_Info::COMPILER_GENERATED_FILE_ID);
+    ROSE_ASSERT(position->get_physical_file_id() ==
+                Sg_File_Info::COMPILER_GENERATED_FILE_ID);
+  }
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  SgProject *project = frontend(argc, argv);
+  ROSE_ASSERT(project != nullptr);
+  ROSE_ASSERT(frontendExitStatus(project) == 0);
+  ROSE_ASSERT(project->get_fileList().size() == 1);
+
+  SgSourceFile *source = isSgSourceFile(project->get_fileList().front());
+  ROSE_ASSERT(source != nullptr);
+  SgGlobal *global = source->get_globalScope();
+  ROSE_ASSERT(global != nullptr);
+  SgAuxiliaryDeclarationList *auxiliary = global->get_auxiliary_declarations();
+  ROSE_ASSERT(auxiliary != nullptr);
+  ROSE_ASSERT(auxiliary->get_parent() == global);
+
+  SgNamespaceDeclarationStatement *semantic_root = findSemanticRoot(global);
+  ROSE_ASSERT(!semantic_root->has_source_fragments());
+  ROSE_ASSERT(semantic_root->get_parent() == auxiliary);
+  ROSE_ASSERT(semantic_root->get_scope() == global);
+  ROSE_ASSERT(semantic_root->get_firstNondefiningDeclaration() ==
+              semantic_root);
+  ROSE_ASSERT(semantic_root->get_definition() != nullptr);
+  ROSE_ASSERT(semantic_root->get_definition()->get_parent() == semantic_root);
+  requireSemanticProvenance(semantic_root);
+  requireSemanticProvenance(semantic_root->get_definition());
+
+  SgNamespaceDeclarationStatement *source_reopening = nullptr;
+  for (SgDeclarationStatement *declaration : global->get_declarations()) {
+    SgNamespaceDeclarationStatement *candidate =
+        isSgNamespaceDeclarationStatement(declaration);
+    if (candidate == nullptr || candidate->get_name() != "std")
+      continue;
+    ROSE_ASSERT(source_reopening == nullptr);
+    source_reopening = candidate;
+  }
+  ROSE_ASSERT(source_reopening != nullptr);
+  ROSE_ASSERT(source_reopening->has_source_fragments());
+  source_reopening->validate_source_fragments();
+  ROSE_ASSERT(source_reopening->get_parent() == global);
+  ROSE_ASSERT(source_reopening->get_scope() == global);
+  ROSE_ASSERT(source_reopening->get_firstNondefiningDeclaration() ==
+              semantic_root);
+  ROSE_ASSERT(source_reopening->get_definition() != nullptr);
+  ROSE_ASSERT(source_reopening->get_definition()->get_parent() ==
+              source_reopening);
+  ROSE_ASSERT(source_reopening->get_definition()->get_global_definition() ==
+              semantic_root->get_definition());
+  ROSE_ASSERT(
+      source_reopening->get_definition()->get_previousNamespaceDefinition() ==
+      semantic_root->get_definition());
+  ROSE_ASSERT(semantic_root->get_definition()->get_nextNamespaceDefinition() ==
+              source_reopening->get_definition());
+  ROSE_ASSERT(std::count(global->get_declarations().begin(),
+                         global->get_declarations().end(),
+                         source_reopening) == 1);
+
+  SgNamespaceSymbol *symbol = global->get_symbol_table()->find_namespace("std");
+  ROSE_ASSERT(symbol != nullptr);
+  ROSE_ASSERT(symbol->get_declaration() == semantic_root);
+  ROSE_ASSERT(symbol->get_symbol_basis() == semantic_root);
+
+  // Deep-copy the global scope to exercise the symbol construction order for
+  // a semantic namespace root plus its lexical reopenings.  Every symbol in
+  // the root's union table must be copied exactly once before reference fixup;
+  // a non-empty partial table is not a completed copy transaction.
+  SgTreeCopy copy_help;
+  SgGlobal *copied_global = isSgGlobal(global->copy(copy_help));
+  ROSE_ASSERT(copied_global != nullptr);
+  ROSE_ASSERT(copied_global != global);
+  SgNamespaceDeclarationStatement *copied_semantic_root =
+      findSemanticRoot(copied_global);
+  ROSE_ASSERT(copied_semantic_root != semantic_root);
+  ROSE_ASSERT(copy_help.get_copiedNodeMap().at(semantic_root) ==
+              copied_semantic_root);
+
+  SgNamespaceDefinitionStatement *semantic_definition =
+      semantic_root->get_definition();
+  SgNamespaceDefinitionStatement *copied_semantic_definition =
+      copied_semantic_root->get_definition();
+  ROSE_ASSERT(semantic_definition != nullptr);
+  ROSE_ASSERT(copied_semantic_definition != nullptr);
+  ROSE_ASSERT(copied_semantic_definition != semantic_definition);
+  ROSE_ASSERT(copy_help.get_copiedNodeMap().at(semantic_definition) ==
+              copied_semantic_definition);
+  ROSE_ASSERT(copied_semantic_definition->symbol_table_size() ==
+              semantic_definition->symbol_table_size());
+
+  SgSymbolTable *semantic_table = semantic_definition->get_symbol_table();
+  SgSymbolTable *copied_semantic_table =
+      copied_semantic_definition->get_symbol_table();
+  ROSE_ASSERT(semantic_table != nullptr);
+  ROSE_ASSERT(copied_semantic_table != nullptr);
+  for (SgNode *entry : semantic_table->get_symbols()) {
+    SgSymbol *semantic_symbol = isSgSymbol(entry);
+    ROSE_ASSERT(semantic_symbol != nullptr);
+    auto mapped = copy_help.get_copiedNodeMap().find(semantic_symbol);
+    ROSE_ASSERT(mapped != copy_help.get_copiedNodeMap().end());
+    SgSymbol *copied_symbol = isSgSymbol(mapped->second);
+    ROSE_ASSERT(copied_symbol != nullptr);
+    ROSE_ASSERT(copied_symbol != semantic_symbol);
+    ROSE_ASSERT(copied_symbol->variantT() == semantic_symbol->variantT());
+    ROSE_ASSERT(copied_symbol->get_parent() == copied_semantic_table);
+    ROSE_ASSERT(copied_semantic_table->exists(copied_symbol));
+  }
+
+  return backend(project);
+}

--- a/tests/nonsmoke/functional/roseTests/ompLoweringTests/CMakeLists.txt
+++ b/tests/nonsmoke/functional/roseTests/ompLoweringTests/CMakeLists.txt
@@ -738,7 +738,7 @@ if(ENABLE-C)
       NAME omp_lowering_rex_simd_length_${_name}
       WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
       COMMAND ${BASH_EXECUTABLE} -c
-        "set -e; output=\"$1\"; expected=\"$2\"; shift 2; rm -f \"$output\"; \"$@\" -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -rose:output \"$output\" -c \"${_omp_test_dir}/${_source}\"; test -s \"$output\"; grep -Fq \"$expected\" \"$output\""
+        "set -e; output=\"$1\"; expected=\"$2\"; shift 2; rm -f \"$output\"; \"$@\" -target x86_64-unknown-linux-gnu -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -rose:output \"$output\" -c \"${_omp_test_dir}/${_source}\"; test -s \"$output\"; grep -Fq \"$expected\" \"$output\""
         dummy
         ${_output}
         ${_intrinsic}
@@ -754,7 +754,7 @@ if(ENABLE-C)
     NAME omp_lowering_rex_simd_two_region_reduction_ownership
     WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
     COMMAND ${BASH_EXECUTABLE} -c
-      "set -e; output=\"$1\"; shift; rm -f \"$output\"; MALLOC_PERTURB_=165 \"$@\" -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -rose:output \"$output\" -c \"${_omp_test_dir}/rex_omp_simd_two_region_reduction.c\"; test -s \"$output\"; test \"$(grep -Fc '_mm512_setzero_ps' \"$output\")\" -eq 2"
+      "set -e; output=\"$1\"; shift; rm -f \"$output\"; MALLOC_PERTURB_=165 \"$@\" -target x86_64-unknown-linux-gnu -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -rose:output \"$output\" -c \"${_omp_test_dir}/rex_omp_simd_two_region_reduction.c\"; test -s \"$output\"; test \"$(grep -Fc '_mm512_setzero_ps' \"$output\")\" -eq 2"
       dummy
       ${_omp_simd_two_region_output}
       $<TARGET_FILE:rex_omp_simd_addr3_translator>)
@@ -782,13 +782,43 @@ if(ENABLE-C)
       NAME omp_lowering_rex_simd_${_name}_is_rejected
       WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
       COMMAND ${BASH_EXECUTABLE} -c
-        "ulimit -c 0; log=rex_simd_${_name}.log; set +e; \"$@\" -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -c \"${_omp_test_dir}/${_source}\" >\"$log\" 2>&1; status=$?; set -e; test $status -eq 134; test \"$(grep -Ec '${_expected_diagnostic}' \"$log\")\" -eq 1"
+        "ulimit -c 0; log=rex_simd_${_name}.log; set +e; \"$@\" -target x86_64-unknown-linux-gnu -rose:simd:intel-avx -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -c \"${_omp_test_dir}/${_source}\" >\"$log\" 2>&1; status=$?; set -e; test $status -eq 134; test \"$(grep -Ec '${_expected_diagnostic}' \"$log\")\" -eq 1"
         dummy
         $<TARGET_FILE:rex_omp_simd_addr3_translator>)
     set_tests_properties(
       omp_lowering_rex_simd_${_name}_is_rejected
       PROPERTIES LABELS "rex;death;OMPLOWERING;OMPLOWERING_SIMD")
   endforeach()
+
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-resource-dir
+    RESULT_VARIABLE _clang_resource_dir_status
+    OUTPUT_VARIABLE _clang_resource_dir
+    ERROR_VARIABLE _clang_resource_dir_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT _clang_resource_dir_status EQUAL 0 OR _clang_resource_dir STREQUAL "")
+    message(FATAL_ERROR
+      "Clang resource directory query failed: ${_clang_resource_dir_error}")
+  endif()
+  set(_clang_immintrin_header
+    "${_clang_resource_dir}/include/immintrin.h")
+  if(NOT EXISTS "${_clang_immintrin_header}")
+    message(FATAL_ERROR
+      "Clang resource directory has no immintrin.h: ${_clang_resource_dir}")
+  endif()
+  file(RELATIVE_PATH _clang_immintrin_relative
+    "${_omp_lowering_test_output_dir}" "${_clang_immintrin_header}")
+
+  add_test(
+    NAME omp_lowering_rex_simd_intel_target_mismatch_is_rejected
+    WORKING_DIRECTORY ${_omp_lowering_test_output_dir}
+    COMMAND ${BASH_EXECUTABLE} -c
+      "ulimit -c 0; set -euo pipefail; translator=\"$1\"; source=\"${_omp_test_dir}/rex_omp_simd_length_absent.c\"; expected=\"REX_FRONTEND_INVARIANT[intel-simd-target]: forced immintrin.h requires an exact x86 or x86_64 frontend target, but Clang selected 'aarch64-unknown-linux-gnu'\"; run_case() { name=\"$1\"; shift; log=\"rex_simd_intel_target_mismatch_$name.log\"; rm -f \"$log\"; set +e; \"$translator\" -target aarch64-unknown-linux-gnu \"$@\" -rose:openmp:lowering -rose:skipfinalCompileStep -rose:verbose 0 -c \"$source\" >\"$log\" 2>&1; status=$?; set -e; test $status -eq 134; test \"$(grep -Fxc \"$expected\" \"$log\")\" -eq 1; }; run_case injected -rose:simd:intel-avx; run_case basename -include immintrin.h; run_case relative -include \"${_clang_immintrin_relative}\"; run_case absolute -include \"${_clang_immintrin_header}\"; run_case joined \"-include${_clang_immintrin_header}\""
+      dummy
+      $<TARGET_FILE:rex_omp_simd_addr3_translator>)
+  set_tests_properties(
+    omp_lowering_rex_simd_intel_target_mismatch_is_rejected
+    PROPERTIES LABELS "rex;death;CFE;OMPLOWERING;OMPLOWERING_SIMD")
 
   set(_omp_integral_constant_death_cases
     "plain_char|rex_omp_unroll_plain_char_invalid.c|^REX_OMP_LOWERING_INVARIANT\\[integral-constant-abi\\]: type=0x[[:xdigit:]]+ kind=SgTypeChar has no persisted target signedness contract$"

--- a/tests/nonsmoke/unit/SageInterface/CMakeLists.txt
+++ b/tests/nonsmoke/unit/SageInterface/CMakeLists.txt
@@ -87,6 +87,27 @@ add_test(
 set_tests_properties(rex_ci_llvm_version_contract
   PROPERTIES LABELS "rex;build-system;CI")
 
+add_test(
+  NAME rex_nightly_image_registration_contract
+  COMMAND ${BASH_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/rex_nightly_image_registration_contract.sh
+    ${ROSE_TOP_SRC_DIR}/.dockerignore
+    ${ROSE_TOP_SRC_DIR}/ci/docker/rex-nightly.Dockerfile)
+set_tests_properties(rex_nightly_image_registration_contract
+  PROPERTIES LABELS "rex;build-system;CI")
+
+add_test(
+  NAME rex_ctest_name_set_fixture_contract
+  COMMAND ${BASH_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/rex_ctest_name_set_fixture_contract.sh
+    ${ROSE_TOP_SRC_DIR}/scripts/run_ctest_name_set.py
+    ${CMAKE_COMMAND}
+    ${CMAKE_CTEST_COMMAND}
+    ${CMAKE_CURRENT_SOURCE_DIR}/ctest_name_set_fixture_project
+    ${CMAKE_CURRENT_BINARY_DIR}/ctest_name_set_fixture_contract)
+set_tests_properties(rex_ctest_name_set_fixture_contract
+  PROPERTIES LABELS "rex;build-system;CI")
+
 set(_openmp_specimens_path
   ${CMAKE_SOURCE_DIR}/tests/nonsmoke/functional/CompileTests/OpenMP_tests)
 set(_dataracebench_path ${_openmp_specimens_path}/dataRaceBench)

--- a/tests/nonsmoke/unit/SageInterface/ctest_name_set_fixture_project/CMakeLists.txt
+++ b/tests/nonsmoke/unit/SageInterface/ctest_name_set_fixture_project/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(rex_ctest_name_set_fixture_contract NONE)
+
+enable_testing()
+
+add_test(NAME rex_fixture_setup COMMAND ${CMAKE_COMMAND} -E true)
+set_tests_properties(rex_fixture_setup
+  PROPERTIES FIXTURES_SETUP rex_exact_selection_fixture)
+
+add_test(NAME rex_fixture_consumer COMMAND ${CMAKE_COMMAND} -E true)
+set_tests_properties(rex_fixture_consumer
+  PROPERTIES FIXTURES_REQUIRED rex_exact_selection_fixture)

--- a/tests/nonsmoke/unit/SageInterface/ctest_name_set_fixture_project/manifest.txt
+++ b/tests/nonsmoke/unit/SageInterface/ctest_name_set_fixture_project/manifest.txt
@@ -1,0 +1,1 @@
+rex_fixture_consumer

--- a/tests/nonsmoke/unit/SageInterface/rex_ctest_name_set_fixture_contract.sh
+++ b/tests/nonsmoke/unit/SageInterface/rex_ctest_name_set_fixture_contract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "usage: $0 runner cmake ctest fixture-project binary-dir" >&2
+  exit 2
+fi
+
+runner=$1
+cmake=$2
+ctest=$3
+source_dir=$4
+binary_dir=$5
+
+rm -rf "$binary_dir"
+"$cmake" -S "$source_dir" -B "$binary_dir"
+output=$(python3 "$runner" \
+  --test-dir "$binary_dir" \
+  --manifest "$source_dir/manifest.txt" \
+  --ctest "$ctest" \
+  --jobs 1 \
+  --dry-run)
+
+expected="Validated exact CTest selection: manifest=1, regex=0, fixture_support=1, union=2, source=$source_dir/manifest.txt"
+if [ "$output" != "$expected" ]; then
+  echo "unexpected exact-selection result: $output" >&2
+  exit 1
+fi

--- a/tests/nonsmoke/unit/SageInterface/rex_nightly_image_registration_contract.sh
+++ b/tests/nonsmoke/unit/SageInterface/rex_nightly_image_registration_contract.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 .dockerignore ci/docker/rex-nightly.Dockerfile" >&2
+  exit 2
+fi
+
+dockerignore=$1
+dockerfile=$2
+for input in "$dockerignore" "$dockerfile"; do
+  if [ ! -f "$input" ]; then
+    echo "required image input does not exist: $input" >&2
+    exit 2
+  fi
+done
+
+if grep -Eq '^[[:space:]]*(/|\*\*/)?\.github(/(\*\*)?)?[[:space:]]*$' \
+  "$dockerignore"; then
+  echo ".dockerignore excludes workflow sources required by CI-contract tests" >&2
+  exit 1
+fi
+
+builder_start=$(grep -nE '^FROM[[:space:]].*[[:space:]]AS[[:space:]]builder[[:space:]]*$' \
+  "$dockerfile" | cut -d: -f1)
+builder_end=$(awk -v start="$builder_start" \
+  'NR > start && /^FROM[[:space:]]/ { print NR; exit }' "$dockerfile")
+configure_line=$(grep -n 'build-rex\.sh' "$dockerfile" | cut -d: -f1)
+builder_arg_line=$(grep -nE '^ARG[[:space:]]+REX_ENABLE_VALGRIND=0[[:space:]]*$' \
+  "$dockerfile" | awk -F: -v start="$builder_start" -v end="$builder_end" \
+  '$1 > start && $1 < end { print $1 }')
+builder_install_line=$(grep -n 'apt-get install.*valgrind' "$dockerfile" | \
+  awk -F: -v start="$builder_start" -v end="$builder_end" \
+  '$1 > start && $1 < end { print $1 }')
+
+if [ -z "$builder_start" ] || [ -z "$builder_end" ] || \
+   [ -z "$configure_line" ] || [ -z "$builder_arg_line" ] || \
+   [ -z "$builder_install_line" ]; then
+  echo "nightly image has no exact builder-side Valgrind registration contract" >&2
+  exit 1
+fi
+if [ "$builder_arg_line" -ge "$configure_line" ] || \
+   [ "$builder_install_line" -ge "$configure_line" ]; then
+  echo "Valgrind must be selected and installed before CMake registers tests" >&2
+  exit 1
+fi
+
+test_stage_arg_count=$(awk \
+  '/^FROM[[:space:]].*[[:space:]]AS[[:space:]]test[[:space:]]*$/ { in_test=1; next }
+   in_test && /^FROM[[:space:]]/ { in_test=0 }
+   in_test && /^ARG[[:space:]]+REX_ENABLE_VALGRIND=0[[:space:]]*$/ { ++count }
+   END { print count + 0 }' "$dockerfile")
+if [ "$test_stage_arg_count" -ne 1 ]; then
+  echo "nightly test stage must consume the same Valgrind selection" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This change fixes the recent scheduled CI regressions at their frontend, test-selection, and container-registration roots. It does not suppress tests, relax assertions, or add unsupported-AST fallbacks.

- model Clang target-specific builtin types and C++20 requirement substitution failures explicitly in Sage
- preserve Clang's compiler-support namespace as a semantic auxiliary root through translation, AST JSON, deep copy, and token-frontier processing
- make intrinsically x86 test specimens declare their target instead of inheriting the scheduled runner architecture
- make exact CTest manifest execution include CTest's recursive fixture setup/cleanup closure
- make the nightly image register its workflow contracts and Valgrind tests at configure time

## Root causes and fixes

### Cross-architecture frontend failures

The ARM64, RISC-V64, and LoongArch64 scheduled jobs exposed AST forms and target contracts that an x86 host normally hides:

- Clang target-specific builtin types had no typed Sage representation. The frontend now creates `SgTypeTargetBuiltin`, records the exact Clang builtin kind, and carries it through unparsing, AST JSON serialization/deserialization, builders, and generated IR support.
- C++20 requires-expressions can contain a legitimate Clang `Requirement::SubstitutionFailure`. The frontend now represents that state with `SgRequirementSubstitutionFailure` instead of treating the absent expression/type child as malformed input.
- wide character/string literal construction and dependent `__builtin_bit_cast` translation relied on host-oriented assumptions. Translation now uses the source AST's semantic type and preserves the dependent form until Clang supplies a concrete result.
- declarations imported into Clang's global module fragment may be physically attached but have `ModuleOwnershipKind::Unowned`. The declaration path now validates exact physical provenance rather than rejecting that legal ownership state.

Every newly supported form remains hard-validated. Unknown builtin kinds, inconsistent semantic types, malformed substitution states, and conflicting ownership still fail immediately.

### Compiler-support namespace ownership

Clang requires a semantic `std` namespace for builtin support and lookup even when no user spelling emits it. Removing or treating that namespace as an ordinary source declaration caused 87 failures in a complete local run. The frontend now translates the registered support namespace as a compiler-generated semantic auxiliary root, while source-written namespace reopenings retain their source ranges, declaration links, and canonical ownership.

That correction exposed ordering assumptions in downstream consumers:

- AST JSON reconstruction attempted mangling/type work before auxiliary namespace ownership was restored.
- deep-copy symbol repair could encounter lexical namespace reopenings before the auxiliary root and mistake a partial alias table for a complete inventory.
- token-frontier validation required a source file even for a fully neutral semantic-only child.

The fix restores exact ownership before dependent reconstruction, builds the auxiliary semantic scope's symbol table before lexical reopenings, audits the completed symbol inventory, and permits absent source context only for a child whose complete source state is neutral. Conflicting or emitting source state remains a hard error.

### Scheduled image registration

Two container construction details made the scheduled image structurally incomplete:

- `.dockerignore` excluded `.github`, so workflow-source contract tests could not be registered in the image.
- Valgrind was installed only in the final test stage, after the builder-stage CMake configure step, so the 218 Memcheck tests were never generated.

The image now includes the workflow inputs and installs Valgrind in the builder stage when `REX_ENABLE_VALGRIND` is selected. A focused contract test validates both invariants.

### Exact CTest manifests and architecture-specific tests

CTest automatically adds fixture setup and cleanup tests for selected tests. The exact-name runner compared only the direct manifest names, so a valid fixture closure looked like unexpected test execution. It now reads the CTest JSON model, computes the recursive fixture closure, and validates the exact expanded selection. A self-contained fixture project covers setup, required test, and cleanup behavior.

Several legacy specimens use x86 registers or `<immintrin.h>` by design. They now request `x86_64-unknown-linux-gnu` explicitly instead of accidentally inheriting an ARM, RISC-V, or LoongArch scheduled target. Forced inclusion of x86 intrinsics under a non-x86 target also produces an explicit contract diagnostic.

## Reproduction and validation

The failing scheduled selections were reproduced locally before the fixes:

- ARM64: 199 failures out of 2,359 tests
- RISC-V64: 128 failures out of 2,359 tests
- LoongArch64: 53 failures out of 2,359 tests
- cross-architecture union: 199 unique failed tests; 200 exact retained tests including the fixture setup dependency

After the fixes:

- addressing group: 25/25 passed in 353.67 seconds
- cross-architecture retained union: 200/200 passed
- cumulative retained failure set: 2,930/2,930 passed in 423.17 seconds
- strengthened support-namespace deep-copy contract: 1/1 passed
- complete CTest suite: 37,339/37,339 passed in 1,614.70 seconds
- required pre-push selection: 8,888/8,888 passed in 256.44 seconds
- full build: `cmake --build build -j64` passed
- all changed C/C++ files: `clang-format --dry-run --Werror` passed
- `git diff --check`, Python byte compilation, and shell syntax checks passed

The cumulative failure archive remains external to the repository; no generated failure manifest or local log is included in this commit.

## Review follow-up

The Intel-intrinsics target check now consumes Clang's parsed
`PreprocessorOptions::Includes` rather than scanning raw argument spellings.
It classifies the forced include by path filename, so split or joined options
using basename, relative, or absolute paths all reach the same hard non-x86
target invariant. The expanded contract covers the REX SIMD injection and all
four direct include forms; the complete 20-test SIMD group passes.

The public SageInterface type consumers now recognize
`SgTypeTargetBuiltin` directly. `getTypeName` returns the invariant-checked
stored target spelling, while the default-construction, copy-construction, and
assignment queries classify these Clang builtin value types consistently with
the existing builtin-type contract. The target-builtin translator regression
exercises all four APIs for AArch64 SVE/scalar and RISC-V vector types.

Validation for this follow-up passed:

- focused AArch64/RISC-V target-builtin group: 2/2;
- cumulative retained failure set: 2,930/2,930 in 409.29 seconds;
- complete CTest suite: 37,339/37,339 in 1,546.19 seconds; and
- required pre-push selection: 8,888/8,888 in 268.90 seconds.
